### PR TITLE
Grant FTP access to Pangeo hubs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -81,6 +81,34 @@ hubs:
                 scope:
                   - read:org
           singleuser:
+            networkPolicy:
+              egress:
+                # Needed to talk to metadata server.
+                # see https://github.com/2i2c-org/pilot-hubs/issues/280
+                - to:
+                    - ipBlock:
+                        cidr: 127.0.0.1/32
+                  ports:
+                    - port: 988
+                      protocol: TCP
+                # Needed for talking to the proxy pod
+                - ports:
+                    - port: 8000
+                      protocol: TCP
+                - ports:
+                    - port: 80
+                      protocol: TCP
+                - ports:
+                    - port: 443
+                      protocol: TCP
+                # Enable outgoing ssh by default on these hubs
+                - ports:
+                    - port: 22
+                      protocol: TCP
+                # Allow FTP access for hub
+                - ports:
+                    - port: 21
+                      protocol: TCP
             image:
               name: pangeo/pangeo-notebook
               tag: bcfacc5


### PR DESCRIPTION
In https://github.com/2i2c-org/pilot-hubs/issues/740 we were debugging FTP access for the Pangeo hub required for Ryan's class. This produced https://github.com/2i2c-org/pilot-hubs/issues/741 for discussion around long-term fixes for how we handle network policies.

This PR represents part of the work we did to debug the FTP issue. It brings the singleuser network policies from the daskhub values file into the the pangeo-hubs config file and add the FTP port (21 with TCP protocol).

**Note:** It is necessary to copy the whole network policy block as helm does not allow _appending_ of array items, only over-writing. So we have to redefine everything we want to keep. This will be easier to maintain if/when we move to having a permissive network policy by default and allowing an opt-in model for restrictions on a per-hub basis, as discussed [here](https://github.com/2i2c-org/pilot-hubs/issues/741#issuecomment-936595067).

**Note:** This PR currently **does not fix** the FTP issue but has made some progress towards a solution.

Error message **without** this PR:

```
$ wget ftp://ftp.ncdc.noaa.gov/pub/data/uscrn/products/daily01/HEADERS.txt
--2021-10-06 14:16:23--  ftp://ftp.ncdc.noaa.gov/pub/data/uscrn/products/daily01/HEADERS.txt
           => 'HEADERS.txt'
Resolving ftp.ncdc.noaa.gov (ftp.ncdc.noaa.gov)... 205.167.25.137, 2610:20:8040:2::137
Connecting to ftp.ncdc.noaa.gov (ftp.ncdc.noaa.gov)|205.167.25.137|:21... 
```

Error message **with** this PR:

```
--2021-10-06 15:44:57--  ftp://ftp.ncdc.noaa.gov/pub/data/uscrn/products/daily01/HEADERS.txt
  (try: 9) => 'HEADERS.txt'
Connecting to ftp.ncdc.noaa.gov (ftp.ncdc.noaa.gov)|205.167.25.137|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/data/uscrn/products/daily01 ... done.
==> SIZE HEADERS.txt ... 730
==> PASV ... couldn't connect to 205.167.25.137 port 64983: Connection timed out
Retrying.
```

This is because the FTP request is working [passive mode](https://www.lifewire.com/definition-of-passive-mode-ftp-816441) where a second, random port connection is opened for the data. https://github.com/berkeley-dsep-infra/datahub/issues/2825 contains some info on this issue for me to follow up on.

**Update:** Reading [this thread](https://github.com/berkeley-dsep-infra/datahub/issues/1789), seems like the only viable option is to open **all** outbound ports due to random port allocation FTP does.