### PR TITLE
Enable scratch buckets on Pangeo staging and prod hubs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -47,6 +47,12 @@ hubs:
             https:
               enabled: false
           custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: pangeo-integration-te-3eea
+              scratchBucket:
+                enabled: true
             homepage:
               templateVars:
                 org:
@@ -166,6 +172,12 @@ hubs:
             https:
               enabled: false
           custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: pangeo-integration-te-3eea
+              scratchBucket:
+                enabled: true
             homepage:
               templateVars:
                 org:


### PR DESCRIPTION
This adds missing config required to enable scratch buckets on the Pangeo hubs