### PR TITLE
Update docs on migrating NFS home directories

### DIFF
--- a/docs/howto/operate/move-hub.md
+++ b/docs/howto/operate/move-hub.md
@@ -57,6 +57,34 @@ The trailing slashes are important to copy the contents of the directory, withou
 
 See the [`rsync` man page](https://ss64.com/bash/rsync.html) to understand these options.
 
+### GCP Filestores
+
+We also use GCP Filestores as in-cluster NFS storage and can transfer the home directories between them in a similar fashion to the NFS servers described above.
+
+The filestores must be mounted in order to be accessed.
+
+1. Create VMs in the projects of the source and target filestores.
+2. For **both** filestores, get the server address from the [GCP console](https://cloud.google.com/filestore/docs/mounting-fileshares).
+3. On each VM for the source and target filestores:
+   1. Install `nfs-common`:
+      ```bash
+      sudo apt-get -y update && sudo apt-get -y install nfs-common
+      ```
+   2. Create a mount point:
+      ```bash
+      sudo mkdir -p /mnt/filestore
+      ```
+   3. Mount the Filestore:
+      ```bash
+      sudo mount SERVER_ADDRESS /mnt/filestore
+      ```
+
+The user directories can then be transferred in the same manner as [NFS Servers](#nfs-servers) with the locations updated to be the following:
+
+```bash
+ubuntu@nfs-source-server-public-IP:/mnt/filestore/<hub-name> /mnt/filestore/<hub-name>
+```
+
 ### EFS
 
 [AWS DataSync](https://aws.amazon.com/datasync/)

--- a/docs/howto/operate/move-hub.md
+++ b/docs/howto/operate/move-hub.md
@@ -48,7 +48,11 @@ Primarily used with GKE right now.
 As an alternative to `scp` you can use `rsync` as follows:
 
 ```bash
-rsync -e 'ssh -i nfs-transfer-key' -rougvhP ubuntu@nfs-source-server-public-IP:/export/home-01/homes/<hub-name> /export/home-01/homes/<hub-name>
+rsync -e 'ssh -i nfs-transfer-key' -rougvhP ubuntu@nfs-source-server-public-IP:/export/home-01/homes/<hub-name>/ /export/home-01/homes/<hub-name>/
+```
+
+```{note}
+The trailing slashes are important to copy the contents of the directory, without copying the directory itself.
 ```
 
 See the [`rsync` man page](https://ss64.com/bash/rsync.html) to understand these options.

--- a/docs/howto/operate/move-hub.md
+++ b/docs/howto/operate/move-hub.md
@@ -28,8 +28,8 @@ Primarily used with GKE right now.
 2. In the target NFS server, create a new ssh key-pair, with
    `ssh-keygen -f nfs-transfer-key`
 3. Append the public key `nfs-transfer-key.pub` to the source NFS
-   server's `/home/ubuntu/.ssh/authorized_keys` file, so the target
-   NFS server can open SSH connections to the source NFS server.
+   server's `/home/ubuntu/.ssh/authorized_keys` file. This way, the target
+   NFS server will be able to open SSH connections to the source NFS server.
 4. Copy the NFS home directories from the source NFS server to
    the target NFS server, making sure that the NFS exports locations
    match up appopriately. For example, if the source NFS server has

--- a/docs/howto/operate/move-hub.md
+++ b/docs/howto/operate/move-hub.md
@@ -48,7 +48,7 @@ Primarily used with GKE right now.
 As an alternative to `scp` you can use `rsync` as follows:
 
 ```bash
-rsync -e 'ssh -i nfs-transfer-key' -rougvhP ubuntu@nfs-source-server-public-IP:/export/home-01/homes/<hub-name>/ /export/home-01/homes/<hub-name>/
+rsync -e 'ssh -i nfs-transfer-key' -rouglvhP ubuntu@nfs-source-server-public-IP:/export/home-01/homes/<hub-name>/ /export/home-01/homes/<hub-name>/
 ```
 
 ```{note}


### PR DESCRIPTION
This PR clarifies the steps required to migrate user home directories for hubs. It also documents an `rsync` command as an alternative to `scp`, and explains the process for migrating GCP filestores.