### PR TITLE
Re-order steps in hub decommissioning checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_decommission-hub.md
+++ b/.github/ISSUE_TEMPLATE/4_decommission-hub.md
@@ -30,10 +30,10 @@ Usually, it is because it was a hub that we created for a workshop/conference an
 #### Phase II - Hub Removal
 
 - [ ] (Optional) Migrate data from the hub
-- [ ] Remove the hub deployment
-  - `helm delete --namespace HUB_NAME HUB_NAME`
-  - `kubectl delete namespace HUB_NAME`
 - [ ] Remove hub entry from the appropriate `*.cluster.yaml` file
+- [ ] Remove the hub deployment
+  - `helm --namespace HUB_NAME delete HUB_NAME`
+  - `kubectl delete namespace HUB_NAME`
 
 #### Phase III - Cluster Removal
 


### PR DESCRIPTION
If you delete the release before removing the hub
config from our repo, it is possible that an (unrelated)
merge of a different PR will automatically deploy the hub again before
you remove it.

By changing the order of operations, we ensure this doesn't
happen.