### PR TITLE
Increase pangeo's filestore capacity to 2TB

### DIFF
--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -11,6 +11,7 @@ config_connector_enabled = true
 
 # Setup a filestore for in-cluster NFS
 enable_filestore = true
+filestore_capacity_gb = 2048
 
 user_buckets = [
   "pangeo-scratch"


### PR DESCRIPTION
This PR reflects a change I made in the Google Cloud console to alleviate storage issues reported via FreshDesk