### PR TITLE
Fix deprecated attributes in terraform config

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -66,7 +66,7 @@ resource "google_container_cluster" "cluster" {
     # just metadata concealment is used
     for_each = var.config_connector_enabled == "" ? [] : [1]
     content {
-      identity_namespace = "${var.project_id}.svc.id.goog"
+      workload_pool = "${var.project_id}.svc.id.goog"
     }
   }
 


### PR DESCRIPTION
While working on #761, I came across the following warning about a deprecated attribute from terraform:

> Warning: Deprecated Attribute
> 
>   with google_container_node_pool.notebook["small"],
>   on cluster.tf line 199, in resource "google_container_node_pool" "notebook":
>  199:       node_metadata = var.config_connector_enabled ? "GKE_METADATA_SERVER" : "SECURE"
> 
> Deprecated in favor of mode.

And then subsequently, the following deprecation warning:

> Warning: Deprecated Attribute
> 
>   with google_container_cluster.cluster,
>   on cluster.tf line 1, in resource "google_container_cluster" "cluster":
>    1: resource "google_container_cluster" "cluster" {
> 
> This field will be removed in a future major release as it has been deprecated in the API. Use `workload_pool` instead.

This PR changes all (2) instances of the `node_metadata` attribute to `mode` and updates the values appropriately. It also changes the `identity_namespace` attribute to `workload_pool`.

See terraform docs here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#mode