### PR TITLE
Cleanup duplicated Auth0 apps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-asyncio
 requests
 beautifulsoup4
+rich

--- a/extra_scripts/count-auth0-apps.py
+++ b/extra_scripts/count-auth0-apps.py
@@ -7,9 +7,7 @@ currently have on Auth0
 ### Requirements
 
 All requirements are already listed in `requirements.txt` with the exception of
-rich, which can be installed with:
-
-- pip install rich
+rich, which is listed in `dev-requirements.txt`.
 
 ### Running the script
 


### PR DESCRIPTION
### Summary

This is a helper script that will tell us how many duplicated auth apps we currently have on Auth0

### Requirements

All requirements are already listed in `requirements.txt` with the exception of `rich` (`pip install rich`)

### Running the script

```bash
python extra_scripts/count-auth0-apps.py
```

This will output a list of app names that have more than one client id (i.e. they have duplicates)

```bash
python extra_scripts/count-auth0-apps.py --purge
```

Adding the purge flag will delete apps on Auth0 until each app name only has one client id associated with it

### Current output

This is what the script is currently showing us

```
Clients with duplicated Auth0 apps:
        cloudbank-avc: 8
        carbonplan-prod: 6
        meom-ige-staging: 3
        meom-ige-prod: 2
        farallon-prod: 5
        justiceinnovationlab-staging: 9
```

I have **NOT** purged these as of yet.