### PR TITLE
Update Pangeo staging hub's domain

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -26,7 +26,7 @@ support:
           enabled: false
 hubs:
   - name: staging
-    domain: staging.pangeo.2i2c.cloud
+    domain: staging.us-central1-b.gcp.pangeo.io
     template: daskhub
     auth0:
       enabled: false
@@ -77,7 +77,7 @@ hubs:
               JupyterHub: &staging_jhub_jupyterhub
                 authenticator_class: github
               GitHubOAuthenticator:
-                oauth_callback_url: https://staging.pangeo.2i2c.cloud/hub/oauth_callback
+                oauth_callback_url: https://staging.us-central1-b.gcp.pangeo.io/hub/oauth_callback
                 allowed_organizations: &staging_jhub_allowed_orgs
                   - pangeo-data:us-central1-b-gcp
                   - 2i2c-org:tech-team


### PR DESCRIPTION
This PR updates the domain of the Pangeo staging hub to point to `staging.us-central1-b.gcp.pangeo.io` and ensures all of our URLs resolve correctly. The OAuth App for GitHub authentication has also been updated.