### PR TITLE
Grafana should use the default storageClass on the cluster

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -48,7 +48,6 @@ prometheus:
 grafana:
   persistence:
     enabled: true
-    storageClassName: standard
   deploymentStrategy:
     type: Recreate
   service:


### PR DESCRIPTION
After fixing a duplicated key in the grafana config in #770, we see issues on carbonplan since the default storage class for eks cluster is called `gp2`, not `standard` (see below). This PR removes explicitly setting the `storageClassName` in `support/values.yaml` so we use the default storage class in the cluster for the grafana PVC/PV.

```
Events:
  Type     Reason              Age                From                         Message
  ----     ------              ----               ----                         -------
  Warning  ProvisioningFailed  51s (x26 over 7m)  persistentvolume-controller  storageclass.storage.k8s.io "standard" not found
```