### PR TITLE
Implement dask-gateway tests

### DIFF
--- a/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
+++ b/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
@@ -2,7 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a TEMPORARY FIX to avoid a Future Warning when dask_gateway is imported\n",
+    "# We should remove this cell when that warning is removed\n",
+    "import warnings\n",
+    "warnings.simplefilter(action='ignore', category=FutureWarning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,20 +33,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.0"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "a.mean().compute()"
    ]


### PR DESCRIPTION
This PR reimplements a test of dask-gateway from the original Pangeo deployment: https://github.com/pangeo-data/pangeo-cloud-federation/blob/staging/test.py