### PR TITLE
Add concurrency to deploy hubs workflow

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -14,6 +14,11 @@ on:
       - .github/workflows/deploy-hubs.yaml
       - .github/actions/deploy/**
 
+# When multiple PRs triggering this workflow are merged, queue them instead
+# of running them in parallel
+# https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
+concurrency: deploy
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have a GitHub Action workflow that automatically deploys upgrades to all our automated hubs when certain filepaths are updated. Presently if multiple PRs affecting those filepaths are merged in a short time frame, GitHub Actions will set off multiple runs in parallel. This could get confusing for helm if it's asked to upgrade the same hub in two separate ways simultaneously.

This PR adds the "concurrency" key to our `deploy-hubs` workflow. This tells GitHub Actions to check for any currently running versions of this job, if any exist, it waits until those are finished before triggering the run for the next PR merge (it queues the jobs, rather than runs them in parallel).

This means we are less likely to run into the scenario when helm is trying to deploy two different upgrades to the same infrastructure simultaneously.

Ref: https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/