### PR TITLE
Disable line-length warning because it it too noisy

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -35,9 +35,7 @@ rules:
   indentation:
     level: warning
     indent-sequences: consistent
-  line-length:
-    level: warning
-    allow-non-breakable-inline-mappings: true
+  line-length: disable
   new-line-at-end-of-file:
     level: warning
   trailing-spaces:


### PR DESCRIPTION
From some previous discussion: https://github.com/2i2c-org/infrastructure/pull/773#pullrequestreview-788224148

And, in fact, I am now +1 on disabling... no need to incite any flame 😜  .