### PR TITLE
Allow singleuser pods to talk to ingress controller

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -154,16 +154,26 @@ jupyterhub:
       # Allow unrestricted access to the internet but not local cluster network
       enabled: true
       egress:
-      - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-            # Don't allow network access to private IP ranges
-            # Listed in https://datatracker.ietf.org/doc/html/rfc1918
-            - 10.0.0.0/8
-            - 172.16.0.0/12
-            - 192.168.0.0/16
-            - 169.254.169.254/32
+        - to:
+          - ipBlock:
+              cidr: 0.0.0.0/0
+              except:
+              # Don't allow network access to private IP ranges
+              # Listed in https://datatracker.ietf.org/doc/html/rfc1918
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              # Don't allow network access to the metadata IP
+              - 169.254.169.254/32
+        # Allow code in hubs to talk to ingress provider, so they can talk to
+        # the hub via its public URL
+        - to:
+          - namespaceSelector:
+              matchLabels:
+                name: support
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: ingress-nginx
   hub:
     extraFiles:
       configurator-schema-default:


### PR DESCRIPTION
This allows code in hubs to talk to the ingress provider, and hence talk
to the hub via it's public URL

Thanks to @yuvipanda for spotting this and their code from here:
https://github.com/yuvipanda/datahub/commit/e8544b0931fa33a5ecc282290fea1281dccce6f1#diff-c7ff155658f0273e3fd2df49dee1551363b934660d0cb6e169938288442eba05R97-R105

`curl` request working on Pangeo staging hub:

<img width="599" alt="Screenshot 2021-10-27 at 10 43 46" src="https://user-images.githubusercontent.com/44771837/139042056-ad982f79-1fa2-4445-8294-ec56403fa146.png">
