### PR TITLE
Update Decommission Hub template: Delete a hub's authentication app

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_decommission-hub.md
+++ b/.github/ISSUE_TEMPLATE/4_decommission-hub.md
@@ -34,7 +34,7 @@ Usually, it is because it was a hub that we created for a workshop/conference an
 - [ ] Remove the hub deployment
   - `helm --namespace HUB_NAME delete HUB_NAME`
   - `kubectl delete namespace HUB_NAME`
-- [ ] Delete the hub's authentication application
+- [ ] Delete the hub's authentication application on auth0 or GitHub
 
 #### Phase III - Cluster Removal
 


### PR DESCRIPTION
When we delete a hub, we must also delete the app it used for authentication. Particularly if the hub was using Auth0 as we have a limit of 100 apps.