### PR TITLE
Fix new hub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_new-hub.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub.yml
@@ -197,9 +197,9 @@ body:
       required: false        
 
   - type: input
-    id: hub-id
+    id: hub-url
     attributes:
-      label: Hub ID
+      label: Hub URL
       description: |
         The URL of the hub, should be `<hub ID>.<hub cluster>.2i2c.cloud`.
     validations:


### PR DESCRIPTION
This should fix our new hub template form so that the "engineer follow up" sections make it into the issue that's created