### PR TITLE
Use JupyterHub specific terminology for setting resource guarantees

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -371,10 +371,10 @@ hubs:
                 url: "https://www.nsf.gov/funding/pgm_summ.jsp?pims_id=5750"
         singleuser:
           memory:
-            requests: 256M
+            guarantee: 256M
             limit: 4G
           cpu:
-            requests: 0.1
+            guarantee: 0.1
             limit: 2
           image:
             name: quay.io/2i2c/paleohack-2021


### PR DESCRIPTION
I think z2jh should support the kubernetes native terminology
(requests) as well

Ref https://github.com/2i2c-org/infrastructure/issues/790