### PR TITLE
Fix dask test notebook

### DIFF
--- a/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
+++ b/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -42,7 +42,7 @@
        "1.0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -89,11 +89,9 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "bcf5e6d76628400b55d9e91ffa96cc03bef334d71970bae200110c27921047dd"
-  },
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit ('pilot-hubs': conda)",
+   "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -106,7 +104,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In #776, I mistakenly cleared the output of the test notebook which is needed for the test to successfully pass. This PR reinstates the output so tests on daskhubs can now pass.