### PR TITLE
Cold down the 2i2c cluster removing the paleo-specific nodes

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -342,9 +342,6 @@ hubs:
       connection: github
     config:
       jupyterhub:
-        prePuller:
-          continuous:
-            enabled: true
         scheduling:
           userPlaceholder:
             # Not needed anymore, hackathon is over
@@ -379,8 +376,6 @@ hubs:
           image:
             name: quay.io/2i2c/paleohack-2021
             tag: 7534858b1098
-          nodeSelector:
-            2i2c.org/community: paleo
         hub:
           config:
             Authenticator:

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -15,14 +15,6 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-highmem-4",
     labels: { }
-  },
-  "paleo": {
-    min: 5,
-    max: 20,
-    machine_type: "n1-highmem-4",
-    labels: {
-      "2i2c.org/community": "paleo"
-    }
   }
 }
 


### PR DESCRIPTION
This is a sort of reversion of #789 but keeping some useful values such as the new image reference.
Since the event is over, there is no need to keep the specific paleo nodes up wasting money.

Terraform plan output:

```
(pilot-hubs) Damians-MacBook-Pro:gcp damian$ terraform plan -var-file=projects/pilot-hubs.tfvars
google_artifact_registry_repository.registry: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1/repositories/pilot-hubs-registry]
google_service_account.cluster_sa: Refreshing state... [id=projects/two-eye-two-see/serviceAccounts/pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_service_account.cd_sa: Refreshing state... [id=projects/two-eye-two-see/serviceAccounts/pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_custom_role.identify_project_role: Refreshing state... [id=projects/two-eye-two-see/roles/pilot_hubs_user_sa_role]
google_service_account_key.cd_sa: Refreshing state... [id=projects/two-eye-two-see/serviceAccounts/pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com/keys/d163d304874c5f2e2b83b20b85782ea82f49af8d]
google_project_iam_member.cd_sa_roles["roles/container.admin"]: Refreshing state... [id=two-eye-two-see/roles/container.admin/serviceaccount:pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cd_sa_roles["roles/artifactregistry.writer"]: Refreshing state... [id=two-eye-two-see/roles/artifactregistry.writer/serviceaccount:pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cluster_sa_roles["roles/monitoring.viewer"]: Refreshing state... [id=two-eye-two-see/roles/monitoring.viewer/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cluster_sa_roles["roles/logging.logWriter"]: Refreshing state... [id=two-eye-two-see/roles/logging.logWriter/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cluster_sa_roles["roles/monitoring.metricWriter"]: Refreshing state... [id=two-eye-two-see/roles/monitoring.metricWriter/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cluster_sa_roles["roles/artifactregistry.reader"]: Refreshing state... [id=two-eye-two-see/roles/artifactregistry.reader/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_project_iam_member.cluster_sa_roles["roles/stackdriver.resourceMetadata.writer"]: Refreshing state... [id=two-eye-two-see/roles/stackdriver.resourceMetadata.writer/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_container_cluster.cluster: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster]
google_project_iam_member.identify_project_binding: Refreshing state... [id=two-eye-two-see/projects/two-eye-two-see/roles/pilot_hubs_user_sa_role/serviceaccount:pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com]
google_container_node_pool.notebook["user"]: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-user]
google_container_node_pool.dask_worker["worker"]: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/dask-worker]
google_container_node_pool.core: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/core-pool]
google_container_node_pool.notebook["paleo"]: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-paleo]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # google_container_node_pool.notebook["user"] has been changed
  ~ resource "google_container_node_pool" "notebook" {
        id                  = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-user"
        name                = "nb-user"
      ~ node_count          = 1 -> 0
        # (7 unchanged attributes hidden)




        # (4 unchanged blocks hidden)
    }
  # google_container_node_pool.notebook["paleo"] has been changed
  ~ resource "google_container_node_pool" "notebook" {
        id                  = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-paleo"
        name                = "nb-paleo"
        # (8 unchanged attributes hidden)

      ~ autoscaling {
          ~ max_node_count = 20 -> 200
            # (1 unchanged attribute hidden)
        }



        # (3 unchanged blocks hidden)
    }
  # google_container_cluster.cluster has been changed
  ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster"
      ~ instance_group_urls         = [
            # (2 unchanged elements hidden)
            "https://www.googleapis.com/compute/beta/projects/two-eye-two-see/zones/us-central1-b/instanceGroups/gke-pilot-hubs-cluster-dask-worker-e1438a35-grp",
          + "https://www.googleapis.com/compute/beta/projects/two-eye-two-see/zones/us-central1-b/instanceGroups/gke-pilot-hubs-cluster-nb-paleo-6499e81d-grp",
        ]
        name                        = "pilot-hubs-cluster"
        # (26 unchanged attributes hidden)











      ~ node_pool {
            name                = "nb-user"
          ~ node_count          = 1 -> 0
            # (5 unchanged attributes hidden)




            # (4 unchanged blocks hidden)
        }
      + node_pool {
          + initial_node_count  = 5
          + instance_group_urls = [
              + "https://www.googleapis.com/compute/v1/projects/two-eye-two-see/zones/us-central1-b/instanceGroupManagers/gke-pilot-hubs-cluster-nb-paleo-6499e81d-grp",
            ]
          + max_pods_per_node   = 0
          + name                = "nb-paleo"
          + node_count          = 5
          + node_locations      = [
              + "us-central1-b",
            ]
          + version             = "1.19.13-gke.1900"

          + autoscaling {
              + max_node_count = 200
              + min_node_count = 5
            }

          + management {
              + auto_repair  = true
              + auto_upgrade = false
            }

          + node_config {
              + disk_size_gb      = 100
              + disk_type         = "pd-standard"
              + guest_accelerator = []
              + image_type        = "COS_CONTAINERD"
              + labels            = {
                  + "2i2c.org/community"           = "paleo"
                  + "hub.jupyter.org/node-purpose" = "user"
                  + "k8s.dask.org/node-purpose"    = "scheduler"
                }
              + local_ssd_count   = 0
              + machine_type      = "n1-highmem-4"
              + metadata          = {
                  + "disable-legacy-endpoints" = "true"
                }
              + oauth_scopes      = [
                  + "https://www.googleapis.com/auth/cloud-platform",
                ]
              + preemptible       = false
              + service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com"
              + tags              = []
              + taint             = [
                  + {
                      + effect = "NO_SCHEDULE"
                      + key    = "hub.jupyter.org_dedicated"
                      + value  = "user"
                    },
                ]

              + shielded_instance_config {
                  + enable_integrity_monitoring = true
                  + enable_secure_boot          = false
                }

              + workload_metadata_config {
                  + mode          = "GKE_METADATA"
                  + node_metadata = "GKE_METADATA_SERVER"
                }
            }

          + upgrade_settings {
              + max_surge       = 1
              + max_unavailable = 0
            }
        }




        # (16 unchanged blocks hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # google_container_node_pool.notebook["paleo"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pilot-hubs-cluster" -> null
      - id                  = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-paleo" -> null
      - initial_node_count  = 5 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/two-eye-two-see/zones/us-central1-b/instanceGroupManagers/gke-pilot-hubs-cluster-nb-paleo-6499e81d-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - name                = "nb-paleo" -> null
      - node_count          = 5 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "two-eye-two-see" -> null
      - version             = "1.19.13-gke.1900" -> null

      - autoscaling {
          - max_node_count = 200 -> null
          - min_node_count = 5 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "2i2c.org/community"           = "paleo"
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-highmem-4" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode          = "GKE_METADATA" -> null
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.
```