### PR TITLE
Add issue template for event hubs

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_event-hub.md
+++ b/.github/ISSUE_TEMPLATE/5_event-hub.md
@@ -30,7 +30,8 @@ assignees: ''
 - [ ] **1 day before event** Hub nodes are pre-cooked.
 - [ ] Event in progress.
 - [ ] Confirm event is finished.
-- [ ] Hub pre-cooked nodes are wound down.
+- [ ] Nodegroup created for the hub is decommissioned.
+
 - [ ] Hub decommissioned (if needed).
 - [ ] Debrief with community representative.
   - Did the infrastructure behave as expected?

--- a/.github/ISSUE_TEMPLATE/5_event-hub.md
+++ b/.github/ISSUE_TEMPLATE/5_event-hub.md
@@ -27,7 +27,8 @@ assignees: ''
   - Log-in and authentication works as-expected
   - Any `nbgitpuller` links resolve properly
   - Notebooks run as-expected
-- [ ] **1 day before event** Hub nodes are pre-cooked.
+- [ ] **1 day before event** A separate nodegroup is provisioned for the event
+
 - [ ] Event in progress.
 - [ ] Confirm event is finished.
 - [ ] Nodegroup created for the hub is decommissioned.

--- a/.github/ISSUE_TEMPLATE/5_event-hub.md
+++ b/.github/ISSUE_TEMPLATE/5_event-hub.md
@@ -1,0 +1,40 @@
+---
+name: "\U0001F4C5 Event for a community"
+about: Coordination and planning around an event for a community
+title: "[EVENT] {{ HUB NAME }}"
+labels: ''
+assignees: ''
+
+---
+
+### Summary
+
+<!-- Please provide a short, one-sentence summary about this event. -->
+
+### Info
+
+- **Event begin:** <!-- The date that the event will start. -->
+- **Event end:** <!-- The date that the event will end. -->
+- **Community Representative:** <!-- The GitHub ID of the current representative for the Hub and Community, e.g. @octocat -->
+- **Hub URL**: <!-- The URL of the hub that will be used for the event -->
+- **Hub decommisioned after event?**: <!-- Will this hub be decommissioned after the event is over? -->
+
+### Task List
+
+- [ ] Dates confirmed with the community representative
+- [ ] **One week before event** Hub is running.
+- [ ] Confirm with Community Representative that their workflows function as expected.
+  - Log-in and authentication works as-expected
+  - Any `nbgitpuller` links resolve properly
+  - Notebooks run as-expected
+- [ ] **1 day before event** Hub nodes are pre-cooked.
+- [ ] Event in progress.
+- [ ] Confirm event is finished.
+- [ ] Hub pre-cooked nodes are wound down.
+- [ ] Hub decommissioned (if needed).
+- [ ] Debrief with community representative.
+  - Did the infrastructure behave as expected?
+  - Anything that was confusing or could be improved?
+  - Any extra functionality you wish you would have had?
+  - Are you willing to share a story about how you used the hub?
+


### PR DESCRIPTION
This adds an issue template for event-based hubs. This is part of #790 , where we could have avoided some issues by having a set list of tasks to follow before the hub, to make sure things were behaving as expected.

### Feedback

I'd love feedback about whether the information that's in there is the "right" information to ask for, and whether the tasks look correct to folks.
