### PR TITLE
Reduce guarantee memory to avoid going beyond the allocatable value

### DIFF
--- a/config/hubs/meom-ige.cluster.yaml
+++ b/config/hubs/meom-ige.cluster.yaml
@@ -75,7 +75,7 @@ hubs:
                 description: "~32 CPU, ~128G RAM"
                 kubespawner_override:
                   mem_limit: 128G
-                  mem_guarantee: 110G
+                  mem_guarantee: 100G
                   node_selector:
                     node.kubernetes.io/instance-type: n1-standard-32
               - display_name: "Huge"


### PR DESCRIPTION
Each node has some allocatable resources [1]
If you try to schedule a pod with guarantee requirements above the
allocatable values, it will fail to be spawned.
With the "very large" option, we are requesting 110G at a minimum and that
is dangerously close to the theoretical allocatable memory for the
n1-standard-32 node. Then, let's give that guarantee value some
breath ;-)

[1] https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu

More details about the whole debugging lives on the corresponding freshdesk-support thread