### PR TITLE
Standardize issue template titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_new-hub.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub.yml
@@ -1,6 +1,6 @@
 name: 💻  New Hub
 description: Creating a new hub for 2i2c to operate
-title: "[New Hub] <Hub name>"
+title: "[New Hub] {{ HUB NAME }}"
 labels: ["type: hub"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2_new-hub.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub.yml
@@ -1,6 +1,6 @@
 name: 💻  New Hub
 description: Creating a new hub for 2i2c to operate
-title: "New Hub: <Hub name>"
+title: "[New Hub] <Hub name>"
 labels: ["type: hub"]
 body:
   - type: markdown


### PR DESCRIPTION
This is a minor change to our issue template titles so that they all follow the same pattern of [Issue Type] {{ TITLE PLACEHOLDER }}