### PR TITLE
Add grafana links to hubs list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,13 @@ def render_hubs():
         yaml = cluster_info.read_text()
         cluster = safe_load(yaml)
 
+        # Pull support chart information to populate fields (if it exists)
+        support = cluster.get("support", {}).get("config", {})
+        grafana_url = support.get("grafana", {}).get("ingress", {}).get("hosts", "")
+        if isinstance(grafana_url, list):
+            grafana_url = grafana_url[0]
+            grafana_url = f"[{grafana_url}](http://{grafana_url})"
+
         # For each hub in cluster, grab its metadata and add it to the list
         for hub in cluster['hubs']:
             config = hub['config']
@@ -108,6 +115,7 @@ def render_hubs():
                 'domain': f"[{hub['domain']}](https://{hub['domain']})",
                 "id": hub['name'],
                 "template": hub['template'],
+                "grafana": grafana_url,
             })
     df = pd.DataFrame(hub_list)
     path_tmp = Path("tmp")


### PR DESCRIPTION
The grafana dashboards for our clusters are configured in the cluster-specific files in this repository. Since those exist in a structured space, this PR grabs the grafana configuration for each cluster and generates a grafana link per hub. That way we can more easily reference the grafana URL for a given hub, as this may be a common action and this can help reduce confusion.

you can preview how this looks here: https://2i2c-pilot-hubs--817.org.readthedocs.build/en/817/reference/hubs.html

This is a follow-up to #815.