### PR TITLE
Add rule to allow traffic from singleuser pods to proxy pod

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -198,6 +198,14 @@ jupyterhub:
                 matchLabels:
                   app: jupyterhub
                   component: autohttps
+        # Allow traffic to the proxy pod from user pods
+        # This is particularly important for daskhubs that utilise the proxy
+        # in order to create clusters (schedulers and workers)
+        - to:
+            - podSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: proxy
   hub:
     extraFiles:
       configurator-schema-default:


### PR DESCRIPTION
This PR fixes the issue raised here https://discourse.pangeo.io/t/trying-to-open-gateway-cluster/1912 that was temporarily mitigated in PR https://github.com/2i2c-org/infrastructure/pull/819

It adds an egress rule to the singleuser pods allowing traffic to the proxy pod, this is particularly important for daskhubs that use the proxy to create clusters (schedulers and workers)