### PR TITLE
Reenable singleuser networkpolicy for Pangeo hubs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -84,8 +84,6 @@ hubs:
                 scope: &staging_jhub_scope
                   - read:org
           singleuser: &staging_jhub_singleuser
-            networkPolicy:
-              enabled: false
             image:
               name: pangeo/pangeo-notebook
               tag: bcfacc5


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#819 Bug was fixed in #822 