### PR TITLE
Deploy support chart for the openscapes hub

### DIFF
--- a/config/hubs/openscapes.cluster.yaml
+++ b/config/hubs/openscapes.cluster.yaml
@@ -6,6 +6,16 @@ aws:
   clusterName: openscapeshub.k8s.local
   region: us-west-2
   stateStore: s3://2i2c-openscapes-kops-state
+support:
+  config:
+    grafana:
+      ingress:
+        hosts:
+          - grafana.openscapes.2i2c.cloud
+        tls:
+          - secretName: grafana-tls
+            hosts:
+              - grafana.openscapes.2i2c.cloud
 hubs:
   - name: staging
     domain: staging.openscapes.2i2c.cloud


### PR DESCRIPTION
After this PR is merged and the support chart is deployed, we should manually trigger the [grafana deployer action](https://github.com/2i2c-org/infrastructure/actions/workflows/deploy-grafana-dashboards.yaml) in order to have the grafana dashboards available for this hub.

Ref: https://github.com/2i2c-org/infrastructure/issues/810

### Note:
(from  [jupyterhub/grafana-dashboards](https://github.com/jupyterhub/grafana-dashboards#deployment))

*NOTE: ANY CHANGES YOU MAKE VIA THE GRAFANA UI WILL BE OVERWRITTEN NEXT TIME YOU RUN deploy.bash. TO MAKE CHANGES, EDIT THE JSONNET FILE AND DEPLOY AGAIN*

So just a heads up that if we deploy the dashboards through the action, any changes made to the other's hub grafanas will be ovewriten.