### PR TITLE
Add egress rule to traefik from single user

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -84,8 +84,6 @@ hubs:
                 scope: &staging_jhub_scope
                   - read:org
           singleuser: &staging_jhub_singleuser
-            networkPolicy:
-              enabled: false
             image:
               name: pangeo/pangeo-notebook
               tag: bcfacc5

--- a/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
+++ b/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
@@ -113,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
+++ b/deployer/tests/test-notebooks/daskhub/dask_test_notebook.ipynb
@@ -86,6 +86,15 @@
    "source": [
     "client.wait_for_workers(1)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.scale(0)"
+   ]
   }
  ],
  "metadata": {
@@ -104,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -206,6 +206,11 @@ jupyterhub:
                 matchLabels:
                   app: jupyterhub
                   component: proxy
+        # Allow traffic to the traefik pod from user pods. Needed for daskhubs.
+        - to:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/component: traefik
   hub:
     extraFiles:
       configurator-schema-default:


### PR DESCRIPTION
This PR does the following things:

- Adds an egress rule to allow traffic from the singleuser pods to talk to the traefik pod. This mitigates the bug raised in #825.
- Adds a cluster scale down command to the dask test notebook. I found the tests were hanging for a long time, this addition makes them exit cleanly in a timely fashion.
- Reenables singleuser network policies for Pangeo hubs. A reversion of #826 

I have deployed this to Pangeo staging and verified that it works

<img width="580" alt="Screenshot 2021-11-11 at 11 48 16" src="https://user-images.githubusercontent.com/44771837/141294015-9e5a98d6-142f-43f8-8b5c-95b45ff35d3c.png">
