### PR TITLE
Add extra admins to Pangeo hubs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -74,6 +74,9 @@ hubs:
                 admin_users:
                   - <staff_github_ids>
                   - rabernat
+                  - jhamman
+                  - scottyhq
+                  - TomAugspurger
               JupyterHub: &staging_jhub_jupyterhub
                 authenticator_class: github
               GitHubOAuthenticator:


### PR DESCRIPTION
This PR adds the following folk as admins on the Pangeo hubs:

- @jhamman 
- @scottyhq
- @TomAugspurger

This reflects who had admin access to the old hubs listed here: https://github.com/pangeo-data/pangeo-cloud-federation/blob/9832e62ef8f7e743f73349e1c71701c4b126f1d3/deployments/gcp-uscentral1b/config/common.yaml#L158-L164

You can find our Administrator's guide here: https://docs.2i2c.org/en/latest/#hub-administration-topics
I think the section you will all find most useful is how to update the Docker image via the Configurator: https://docs.2i2c.org/en/latest/admin/howto/configurator.html