### PR TITLE
Fix shared directory ownership and enable w+r on it

### DIFF
--- a/config/hubs/openscapes.cluster.yaml
+++ b/config/hubs/openscapes.cluster.yaml
@@ -60,7 +60,7 @@ hubs:
                   [
                     "sh",
                     "-c",
-                    "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
+                    "id && chown 1000:1000 /home/jovyan /home/jovyan/shared && ls -lhd /home/jovyan",
                   ]
                 securityContext:
                   runAsUser: 0
@@ -68,10 +68,19 @@ hubs:
                   - name: home
                     mountPath: /home/jovyan
                     subPath: "{username}"
+                  - name: home
+                    mountPath: /home/jovyan/shared
+                    subPath: _shared
 
             image:
               name: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image
               tag: "d78bb6c"
+            storage:
+              extraVolumeMounts:
+                - name: home
+                  mountPath: /home/jovyan/shared
+                  subPath: _shared
+                  readOnly: false
             profileList:
               # The mem-guarantees are here so k8s doesn't schedule other pods
               # on these nodes.


### PR DESCRIPTION
The first piece of this commit is executing on the workaround described
in [1] for the missing ownership on the _shared directory [2].
The second pieces essentially disable the ReadOnly attribute on the
mounted _shared directory so it is writable by everyone (admin and
users)[3].

[1] https://github.com/2i2c-org/infrastructure/issues/440
[2] https://github.com/2i2c-org/infrastructure/issues/810#issuecomment-968307309
[3] https://github.com/2i2c-org/infrastructure/issues/810#issuecomment-968308530