### PR TITLE
Default dask nodes to be same config as notebook nodes in azure

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -118,7 +118,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
-  for_each = var.dask_nodes
+  # If dask_nodes is set, we use that. If it isn't, we use notebook_nodes.
+  # This lets us set dask_nodes to an empty array to get no dask nodes
+  for_each = try(var.dask_nodes, var.notebook_nodes)
 
   name                  = "dask${each.key}"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.jupyterhub.id

--- a/terraform/azure/projects/justiceinnovationlab.tfvars
+++ b/terraform/azure/projects/justiceinnovationlab.tfvars
@@ -29,3 +29,6 @@ notebook_nodes = {
     vm_size : "Standard_E32s_v4"
   },
 }
+
+# JIL doesn't use dask-gateway
+dask_nodes = {}


### PR DESCRIPTION
The documentation said this is what already happens, but
the documentation was a lie.

This helps us keep config simple and easy to manage.