### PR TITLE
Deploying Hubs to Azure cluster for CarbonPlan

### DIFF
--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -183,7 +183,7 @@ hubs:
               memory: 4Gi
             # TODO: figure out a replacement for userLimits.
   - name: prod
-    domain: carbonplan-azure.2i2c.cloud
+    domain: azure.carbonplan.2i2c.cloud
     template: daskhub
     auth0:
       connection: github

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -136,6 +136,7 @@ hubs:
                 allowed_users: &users
                   - <staff_github_ids>
                   - jhamman
+                  - norlandrhagen
                 admin_users: *users
       dask-gateway:
         traefik:

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -183,7 +183,7 @@ hubs:
               memory: 4Gi
             # TODO: figure out a replacement for userLimits.
   - name: prod
-    domain: azure.carbonplan.2i2c.cloud
+    domain: prod.azure.carbonplan.2i2c.cloud
     template: daskhub
     auth0:
       connection: github

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -16,14 +16,14 @@ support:
     grafana:
       ingress:
         hosts:
-          - grafana.carbonplan-azure.2i2c.cloud
+          - grafana.azure.carbonplan.2i2c.cloud
         tls:
           - secretName: grafana-tls
             hosts:
-              - grafana.carbonplan-azure.2i2c.cloud
+              - grafana.azure.carbonplan.2i2c.cloud
 hubs:
   - name: staging
-    domain: staging.carbonplan-azure.2i2c.cloud
+    domain: staging.azure.carbonplan.2i2c.cloud
     template: daskhub
     auth0:
       connection: github

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -144,6 +144,18 @@ hubs:
                   - jhamman
                   - norlandrhagen
                 admin_users: *users
+            extraConfig:
+              10-dynamic-subpath: |
+                import os
+                pod_namespace = os.environ['POD_NAMESPACE']
+                # FIXME: This isn't setting up _shared dirs properly
+                c.KubeSpawner.volume_mounts = [
+                  {
+                    "mountPath": "/home/jovyan",
+                    "name": "home",
+                    "subPath": f"{pod_namespace}/{{username}}"
+                  },
+                ]
       dask-gateway:
         traefik:
           resources:
@@ -170,21 +182,6 @@ hubs:
               cpu: 2
               memory: 4Gi
             # TODO: figure out a replacement for userLimits.
-          extraConfig:
-            idle: |
-              # timeout after 30 minutes of inactivity
-              c.KubeClusterConfig.idle_timeout = 1800
-            10-dynamic-subpath: |
-              import os
-              pod_namespace = os.environ['POD_NAMESPACE']
-              # FIXME: This isn't setting up _shared dirs properly
-              c.KubeSpawner.volume_mounts = [
-                {
-                  "mountPath": "/home/jovyan",
-                  "name": "home",
-                  "subPath": f"{pod_namespace}/{{username}}"
-                },
-              ]
   - name: prod
     domain: carbonplan-azure.2i2c.cloud
     template: daskhub

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -103,6 +103,12 @@ hubs:
                   mem_guarantee: 2000G
                   node_selector:
                     hub.jupyter.org/node-size: Standard_M182s_v2
+            storage:
+              type: none
+              extraVolumes:
+                - name: home
+                  persistentVolumeClaim:
+                    claimName: home-azurefile
           scheduling:
             userPlaceholder:
               enabled: false

--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -1,0 +1,186 @@
+name: carbonplan-azure
+provider: kubeconfig
+kubeconfig:
+  file: secrets/carbonplan-azure.yaml
+support:
+  config:
+    prometheus:
+      server:
+        resources:
+          requests:
+            cpu: 1
+            memory: 4Gi
+          limits:
+            cpu: 4
+            memory: 8Gi
+    grafana:
+      ingress:
+        hosts:
+          - grafana.carbonplan-azure.2i2c.cloud
+        tls:
+          - secretName: grafana-tls
+            hosts:
+              - grafana.carbonplan-azure.2i2c.cloud
+hubs:
+  - name: staging
+    domain: staging.carbonplan-azure.2i2c.cloud
+    template: daskhub
+    auth0:
+      connection: github
+    config: &carbonPlanHubConfig
+      basehub:
+        azureFile:
+          enabled: true
+        nfs:
+          enabled: false
+          shareCreator:
+            enabled: false
+        jupyterhub:
+          custom:
+            homepage:
+              templateVars:
+                org:
+                  name: Carbon Plan
+                  logo_url: https://pbs.twimg.com/profile_images/1262387945971101697/5q_X3Ruk_400x400.jpg
+                  url: https://carbonplan.org
+                designed_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                operated_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                funded_by:
+                  name: Carbon Plan
+                  url: https://carbonplan.org
+          singleuser:
+            image:
+              name: pangeo/pangeo-notebook
+              tag: latest
+            profileList:
+              # The mem-guarantees are here so k8s doesn't schedule other pods
+              # on these nodes.
+              - display_name: "Small: E2s v4"
+                description: "~2 CPU, ~15G RAM"
+                kubespawner_override:
+                  # Explicitly unset mem_limit, so it overrides the default memory limit we set in
+                  # basehub/values.yaml
+                  mem_limit: null
+                  mem_guarantee: 12G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_E2s_v4
+              - display_name: "Medium: E4s v4"
+                description: "~4 CPU, ~30G RAM"
+                kubespawner_override:
+                  mem_limit: null
+                  mem_guarantee: 29G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_E4s_v4
+              - display_name: "Large: E8s v4"
+                description: "~8 CPU, ~60G RAM"
+                kubespawner_override:
+                  mem_limit: null
+                  mem_guarantee: 60G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_E8s_v4
+              - display_name: "Huge: E32s v4"
+                description: "~32 CPU, ~256G RAM"
+                kubespawner_override:
+                  mem_limit: null
+                  mem_guarantee: 240G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_E32s_v4
+              - display_name: "Very Huge: M64s v2"
+                description: "~64 CPU, ~1024G RAM"
+                kubespawner_override:
+                  mem_limit: null
+                  mem_guarantee: 990G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_M64s_v2
+              - display_name: "Very Very Huge: M128s v2"
+                description: "~128 CPU, ~2048G RAM"
+                kubespawner_override:
+                  mem_limit: null
+                  mem_guarantee: 2000G
+                  node_selector:
+                    hub.jupyter.org/node-size: Standard_M182s_v2
+          scheduling:
+            userPlaceholder:
+              enabled: false
+              replicas: 0
+            userScheduler:
+              enabled: false
+          proxy:
+            chp:
+              resources:
+                requests:
+                  cpu: 0.5
+                  memory: 256Mi
+                limits:
+                  cpu: 1
+                  memory: 4Gi
+              nodeSelector: {}
+          hub:
+            resources:
+              requests:
+                cpu: 0.5
+                memory: 256Mi
+              limits:
+                cpu: 1
+                memory: 4Gi
+            allowNamedServers: true
+            readinessProbe:
+              enabled: false
+            nodeSelector: {}
+            config:
+              Authenticator:
+                allowed_users: &users
+                  - <staff_github_ids>
+                  - jhamman
+                admin_users: *users
+      dask-gateway:
+        traefik:
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 512Mi
+            limits:
+              cpu: 2
+              memory: 4Gi
+        controller:
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 512Mi
+            limits:
+              cpu: 2
+              memory: 4Gi
+        gateway:
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 512Mi
+            limits:
+              cpu: 2
+              memory: 4Gi
+            # TODO: figure out a replacement for userLimits.
+          extraConfig:
+            idle: |
+              # timeout after 30 minutes of inactivity
+              c.KubeClusterConfig.idle_timeout = 1800
+            10-dynamic-subpath: |
+              import os
+              pod_namespace = os.environ['POD_NAMESPACE']
+              # FIXME: This isn't setting up _shared dirs properly
+              c.KubeSpawner.volume_mounts = [
+                {
+                  "mountPath": "/home/jovyan",
+                  "name": "home",
+                  "subPath": f"{pod_namespace}/{{username}}"
+                },
+              ]
+  - name: prod
+    domain: carbonplan-azure.2i2c.cloud
+    template: daskhub
+    auth0:
+      connection: github
+    config: *carbonPlanHubConfig

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -42,6 +42,8 @@ class Cluster:
             yield from self.auth_gcp()
         elif self.spec['provider'] == 'aws':
             yield from self.auth_aws()
+        elif self.spec['provider'] == 'kubeconfig':
+            yield from self.auth_kubeconfig()
         else:
             raise ValueError(f'Provider {self.spec["provider"]} not supported')
 
@@ -122,6 +124,23 @@ class Cluster:
                 '--wait'
             ])
         print("Done!")
+
+    def auth_kubeconfig(self):
+        """
+        Context manager for authenticating with just a kubeconfig file
+
+        For the duration of the contextmanager, we:
+        1. Decrypt the file specified in kubeconfig.file with sops
+        2. Set `KUBECONFIG` env var to our decrypted file path, so applications
+           we call (primarily helm) will use that as config
+        """
+        config = self.spec['kubeconfig']
+        config_path = config['file']
+
+        with decrypt_file(config_path) as decrypted_key_path:
+            # FIXME: Unset this after our yield
+            os.environ['KUBECONFIG'] = decrypted_key_path
+            yield
 
     def auth_aws(self):
         """


### PR DESCRIPTION
This is a first pass at hub config for CarbonPlan's Azure setup. It's a mish-mash of the [Justice Innovation Lab config](https://github.com/2i2c-org/infrastructure/blob/master/config/hubs/justiceinnovationlab.cluster.yaml) for Azure stuff, and the [AWS CarbonPlan deployment](https://github.com/2i2c-org/infrastructure/blob/master/config/hubs/carbonplan.cluster.yaml) for CarbonPlan stuff. I would appreciate early eyes on this to see if I've missed anything major.

~~I am particularly thinking about a couple of cases of `serviceAccountName: cloud-user-sa` that I missed out from from the original AWS CarbonPlan config. Mostly because I'm not sure what it is or what the Azure equivalent is.~~ This isn't critical yet and can be addressed in other issues/PRs.

**Note:** This PR also reverts a commit that removed support for `kubeconfig` in the deployer as part of the work on AWS