### PR TITLE
Change CarbonPlan's user image on Azure hubs

### DIFF
--- a/config/hubs/carbonplan-azure.cluster.yaml
+++ b/config/hubs/carbonplan-azure.cluster.yaml
@@ -54,7 +54,7 @@ hubs:
                   url: https://carbonplan.org
           singleuser:
             image:
-              name: pangeo/pangeo-notebook
+              name: carbonplan/cmip6-downscaling-single-user
               tag: latest
             profileList:
               # The mem-guarantees are here so k8s doesn't schedule other pods


### PR DESCRIPTION
As requested in https://github.com/2i2c-org/infrastructure/issues/800#issuecomment-975799504