### PR TITLE
Bump memory limit for prometheus server

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -24,6 +24,11 @@ support:
       controller:
         admissionWebhooks:
           enabled: false
+    prometheus:
+      server:
+        resources:
+          limits:
+            memory: 3Gi
 hubs:
   - name: staging
     domain: staging.us-central1-b.gcp.pangeo.io


### PR DESCRIPTION
This resolves the OOM/CrashLoopBackOff issue for Pangeo hubs reported in https://github.com/2i2c-org/infrastructure/issues/845