### PR TITLE
Tidy up the Pangeo URLs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -10,14 +10,11 @@ support:
     grafana:
       ingress:
         hosts:
-          # This domain should be updated to just grafana.pangeo.2i2c.cloud
-          # after the COESSING hub has been brought down and no longer requires
-          # grafana.pangeo.2i2c.cloud
-          - pangeo-grafana.pangeo.2i2c.cloud
+          - grafana.gcp.pangeo.2i2c.cloud
         tls:
           - secretName: grafana-tls
             hosts:
-              - pangeo-grafana.pangeo.2i2c.cloud
+              - grafana.gcp.pangeo.2i2c.cloud
     # Disable the Admissions Validation Webhook and the port is not
     # permitted on private GKE clusters
     ingress-nginx:


### PR DESCRIPTION
This PR primarily makes the grafana for `pangeo-hubs` available at `grafana.gcp.pangeo.2i2c.cloud`

Adresses https://github.com/2i2c-org/infrastructure/issues/821