### PR TITLE
Separate notebook nodes from dask nodes in terraform

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -117,7 +117,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
 resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
   # If dask_nodes is set, we use that. If it isn't, we use notebook_nodes.
   # This lets us set dask_nodes to an empty array to get no dask nodes
-  for_each = length(var.dask_nodes) == 0 ? var.notebook_nodes : var.dask_nodes
+  for_each = var.dask_nodes
 
   name                  = "dask${each.key}"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.jupyterhub.id

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -38,3 +38,36 @@ notebook_nodes = {
     vm_size : "Standard_M128s_v2"
   },
 }
+
+dask_nodes = {
+  "small" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_E2s_v4"
+  },
+  "medium" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_E4s_v4"
+  },
+  "large" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_E8s_v4"
+  },
+  "huge" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_E32s_v4"
+  },
+  "vhuge" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_M64s_v2"
+  },
+  "vvhuge" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_M128s_v2"
+  },
+}

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -232,7 +232,7 @@ resource "google_container_node_pool" "dask_worker" {
   location = google_container_cluster.cluster.location
 
   # Default to same config as notebook nodepools config
-  for_each = length(var.dask_nodes) == 0 ? var.notebook_nodes : var.dask_nodes
+  for_each = var.dask_nodes
 
   # WARNING: Do not change this value, it will cause the nodepool
   # to be destroyed & re-created. If you want to increase number of

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -53,6 +53,40 @@ notebook_nodes = {
 
 }
 
+dask_nodes = {
+  "small" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-standard-2",
+    labels: {}
+  },
+  "medium" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-standard-8",
+    labels: {}
+  },
+  "large" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+  "very-large" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-standard-32",
+    labels: {}
+  },
+  "huge" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-standard-64",
+    labels: {}
+  },
+
+}
+
 user_buckets = [
   "scratch",
   "data"

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -38,3 +38,24 @@ notebook_nodes = {
     labels: {}
   },
 }
+
+dask_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-4",
+    labels: {}
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {}
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+}


### PR DESCRIPTION
Do not automatically create dask nodes that match notebook nodes. Instead dask nodes should be explicitly defined.

fixes #849 

### TODO before merge

Run `terraform apply` against each cluster. For most, that should be a noop.