### PR TITLE
dask-gateway & dask-distributed: set SCRATCH_BUCKET env on workers, partially fix dashboard link

### DIFF
--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -55,6 +55,11 @@ basehub:
         # DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT makes some environment
         # variables be copied over to the worker nodes from the user nodes.
         DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT: '{"SCRATCH_BUCKET": "$(SCRATCH_BUCKET)", "PANGEO_SCRATCH": "$(PANGEO_SCRATCH)"}'
+        # DASK_DISTRIBUTED__DASHBOARD_LINK makes the suggested link to the
+        # dashboard account for the /user/<username> prefix in the path. Note
+        # that this still misbehave if you have a named server but now its at
+        # least functional for non-named servers.
+        DASK_DISTRIBUTED__DASHBOARD_LINK: "/user/{JUPYTERHUB_USER}/proxy/{port}/status"
 
     hub:
       networkPolicy:

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -25,8 +25,36 @@ basehub:
         blockWithIptables: false
       serviceAccountName: user-sa
       extraEnv:
-        # The default worker image matches the singleuser image.
+        # About DASK_ prefixed variables we set:
+        #
+        # 1. k8s native variable expansion is applied with $(MY_ENV) syntax. The
+        #    order variables are defined matters though and we are under the
+        #    mercy of how KubeSpawner renders our passed dictionaries.
+        #
+        # 2. Dask loads local YAML config.
+        #
+        # 3. Dask loads environment variables prefixed DASK_.
+        #    - DASK_ is stripped
+        #    - Capitalization is ignored
+        #    - Double underscore means a nested configuration
+        #    - `ast.literal_eval` is used to parse values
+        #
+        # 4. dask-gateway and dask-distributed looks at its config and expands
+        #    expressions in {} again, sometimes only with the environment
+        #    variables as context but sometimes also with additional variables.
+        #
+        # References:
+        # - K8s expansion:     https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/
+        # - KubeSpawner issue: https://github.com/jupyterhub/kubespawner/issues/491
+        # - Dask config:       https://docs.dask.org/en/latest/configuration.html
+        # - Exploration issue: https://github.com/2i2c-org/pilot-hubs/issues/442
+        #
+        # DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE makes the default worker image
+        # match the singleuser image.
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: "{JUPYTER_IMAGE_SPEC}"
+        # DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT makes some environment
+        # variables be copied over to the worker nodes from the user nodes.
+        DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT: '{"SCRATCH_BUCKET": "$(SCRATCH_BUCKET)", "PANGEO_SCRATCH": "$(PANGEO_SCRATCH)"}'
 
     hub:
       networkPolicy:


### PR DESCRIPTION
This PR automatically sets the `SCRATCH_BUCKET` and `PANGEO_SCRATCH` environment variables on dask-gateway worker pods based on the user pod that spawned them. This can help the users' scripts running on dask-gateway worker pods also make use of these convenience environment variables set on the user pods.

This PR also adds a environment variable that configures dask distributed to provide a better suggestion on the dashboard link it sometimes provides. This link otherwise fail to account for the JupyterHub prefix in the path (`/user/<username>`, or `/user/<username>/<servername>` for named servers). I've made a note that this adjustment only works for non-named servers, and I don't have a suggestion to make it work for the named servers as well.

This PR has been demonstrated to function well in the JMTE hub, and with JupyterHub 1.1.3 on all hubs, this can now work for all the infrastructure hubs.

Closes #442 - Note that this PR doesn't include environment variables seen in that issue about configuring the dask-labextension to create dask-gateway cluster's via the buttons because that would be a breaking change and it didn't work well in general to do so in JMTE.