### PR TITLE
Bumping prometheus server resource limits for pangeo-hubs

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -25,7 +25,8 @@ support:
       server:
         resources:
           limits:
-            memory: 3Gi
+            cpu: 2
+            memory: 12Gi
 hubs:
   - name: staging
     domain: staging.us-central1-b.gcp.pangeo.io


### PR DESCRIPTION
pangeo-hubs prometheus server was in a `OOMKilled`/`CrashLoopBackOff` state again, so this PR bumps the resource limits for the server. This has already been deployed to the cluster and the server is running again.