### PR TITLE
Support and automate Azure deployments

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -106,20 +106,6 @@ jobs:
         env:
           KOPS_VERSION: "v1.21.1"
 
-      # Borrowed from mybinder.org-deploy config, couldn't find a nice action to install the CLI on the Marketplace :(
-      # https://github.com/jupyterhub/mybinder.org-deploy/blob/90c5f558c8d0f18a6e62b08ec367fe80d4304a0b/.github/workflows/cd.yml#L229-L232
-      - name: Setup Azure CLI
-        if: |
-          ((steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')) &&
-          (matrix.provider == 'azure')
-        run: |
-          sudo apt-get update && sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg && \
-            curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \
-            sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && AZ_REPO=$(lsb_release -cs) && \
-            echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
-            sudo tee /etc/apt/sources.list.d/azure-cli.list && sudo apt-get update && sudo apt-get install azure-cli
-
       - name: Deploy ${{ matrix.cluster_name }}
         if: |
           (steps.base_files.outputs.files == 'true') ||

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -106,6 +106,20 @@ jobs:
         env:
           KOPS_VERSION: "v1.21.1"
 
+      # Borrowed from mybinder.org-deploy config, couldn't find a nice action to install the CLI on the Marketplace :(
+      # https://github.com/jupyterhub/mybinder.org-deploy/blob/90c5f558c8d0f18a6e62b08ec367fe80d4304a0b/.github/workflows/cd.yml#L229-L232
+      - name: Setup Azure CLI
+        if: |
+          ((steps.base_files.outputs.files == 'true') ||
+          (steps.config_files.outputs.hub_config == 'true')) &&
+          (matrix.provider == 'azure')
+        run: |
+          sudo apt-get update && sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg && \
+            curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \
+            sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && AZ_REPO=$(lsb_release -cs) && \
+            echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
+            sudo tee /etc/apt/sources.list.d/azure-cli.list && sudo apt-get update && sudo apt-get install azure-cli
+
       - name: Deploy ${{ matrix.cluster_name }}
         if: |
           (steps.base_files.outputs.files == 'true') ||

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -25,12 +25,13 @@ properties:
     type: string
     description: |
       Cloud provider this cluster is running on. Used to perform
-      authentication against the cluster. Currently supports gcp
+      authentication against the cluster. Currently supports gcp, aws, azure,
       and raw kubeconfig files.
     enum:
       - gcp
       - kubeconfig
       - aws
+      - azure
   kubeconfig:
     type: object
     description: |
@@ -119,6 +120,31 @@ properties:
     then:
       required:
         - stateStore
+  azure:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration to connect to a cluster on Azure. Is used when
+      provider is set to `azure`
+    properties:
+      key:
+        type: string
+        description: |
+          Path to a `sops` encrypted service principal JSON key that
+          can be used by `az` to authenticate to Azure, with
+          enough rights to get full access to the kubernetes cluster
+      resource_group:
+        type: string
+        description: |
+          The name of the Azure Resource Group that contains this cluster
+      cluster:
+        type: string
+        description: |
+          Name of the cluster inside this Azure Resource Group
+    required:
+      - key
+      - resource_group
+      - cluster
   hubs:
     type: array
     description: |

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -222,6 +222,13 @@ class Cluster:
                 os.environ['KUBECONFIG'] = kubeconfig.name
 
                 with decrypt_file(key_path) as decrypted_key_path:
+
+                    decrypted_key_abspath = os.path.abspath(decrypted_key_path)
+                    if not os.path.isfile(decrypted_key_abspath):
+                        raise FileNotFoundError(
+                            'The decrypted key file does not exist'
+                        )
+
                     with open(decrypted_key_path) as f:
                         service_principal = json.load(f)
 

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -42,6 +42,8 @@ class Cluster:
             yield from self.auth_gcp()
         elif self.spec['provider'] == 'aws':
             yield from self.auth_aws()
+        elif self.spec['provider'] == 'azure':
+            yield from self.auth_azure()
         elif self.spec['provider'] == 'kubeconfig':
             yield from self.auth_kubeconfig()
         else:
@@ -201,6 +203,53 @@ class Cluster:
                     os.environ['AWS_ACCESS_KEY_ID'] = orig_access_key_id
                 if orig_kubeconfig is not None:
                     os.environ['AWS_SECRET_ACCESS_KEY'] = orig_secret_access_key
+
+    def auth_azure(self):
+        """
+        Read `azure` nested config, login to Azure with a Service Principal,
+        activate the appropriate subscription, then authenticate against the
+        cluster using `az aks get-credentials`.
+        """
+        config = self.spect['azure']
+        key_path = config['key']
+        cluster = config['cluster']
+        resource_group = config['resource_group']
+
+        with tempfile.NamedTemporaryFile() as kubeconfig:
+            orig_kubeconfig = os.environ.get('KUBECONFIG', None)
+
+            try:
+                os.environ['KUBECONFIG'] = kubeconfig.name
+
+                with decrypt_file(key_path) as decrypted_key_path:
+                    with open(decrypted_key_path) as f:
+                        service_principal = json.load(f)
+
+                # Login to Azure
+                subprocess.check_call([
+                    "az", "login", "--service-principal",
+                    "--username", service_principal["service_principal_id"],
+                    "--password", service_principal["service_principal_password"],
+                    "--tenant", service_principal["tenant_id"],
+                ])
+
+                # Set the Azure subscription
+                subprocess.check_call([
+                    "az", "account", "set",
+                    "--subscription", service_principal["subscription_id"],
+                ])
+
+                # Get cluster creds
+                subprocess.check_call([
+                    "az", "aks", "get-credentials",
+                    "--name", cluster,
+                    "--resource-group", resource_group,
+                ])
+
+                yield
+            finally:
+                if orig_kubeconfig is not None:
+                    os.environ['KUBECONFIG'] = orig_kubeconfig
 
     def auth_gcp(self):
         config = self.spec['gcp']


### PR DESCRIPTION
This PR brings in support for automatically deploying hubs on Azure clusters.

Changes in this PR:

- New function added to `deployer/hub.py` to authenticate against an Azure cluster
- Update to `config/hubs/schema.yaml` to support Azure config
- Update `.github/workflows/deploy-hubs.yaml` to install the Azure CLI for Azure-based hubs. <- I reverted this change since the Azure CLI is already available in GitHub-hosted runners: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#cli-tools

Note that we currently do not have any Azure-based hubs with a Service Principal to run this workflow on yet, so it may need some tweaking in the future.

fixes https://github.com/2i2c-org/infrastructure/issues/841