### PR TITLE
Update memory guarantees for Carbon Plan's nodes

### DIFF
--- a/config/hubs/azure.carbonplan.cluster.yaml
+++ b/config/hubs/azure.carbonplan.cluster.yaml
@@ -116,14 +116,14 @@ hubs:
                 description: "~64 CPU, ~1024G RAM"
                 kubespawner_override:
                   mem_limit: null
-                  mem_guarantee: 990G
+                  mem_guarantee: 950G
                   node_selector:
                     hub.jupyter.org/node-size: Standard_M64s_v2
               - display_name: "Very Very Huge: M128s v2"
                 description: "~128 CPU, ~2048G RAM"
                 kubespawner_override:
                   mem_limit: null
-                  mem_guarantee: 2000G
+                  mem_guarantee: 1950G
                   node_selector:
                     hub.jupyter.org/node-size: Standard_M182s_v2
           scheduling:

--- a/config/hubs/azure.carbonplan.cluster.yaml
+++ b/config/hubs/azure.carbonplan.cluster.yaml
@@ -125,7 +125,7 @@ hubs:
                   mem_limit: null
                   mem_guarantee: 1950G
                   node_selector:
-                    hub.jupyter.org/node-size: Standard_M182s_v2
+                    hub.jupyter.org/node-size: Standard_M128s_v2
           scheduling:
             userPlaceholder:
               enabled: false


### PR DESCRIPTION
This PR tweaks Carbon Plan's node memory guarantees to ensure the pods will fit and fixes a typo in the node selector