### PR TITLE
Add grafana token and prod hub AzureAd client creds

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -14,6 +14,7 @@ jobs:
           - cluster_name: cloudbank
           - cluster_name: carbonplan
           - cluster_name: pangeo-hubs
+          - cluster_name: utoronto
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/secrets/config/hubs/utoronto.cluster.yaml
+++ b/secrets/config/hubs/utoronto.cluster.yaml
@@ -7,6 +7,15 @@ hubs:
                     AzureAdOAuthenticator:
                         client_id: ENC[AES256_GCM,data:kJmyGaF8WLDgY2BnlpiR+r9OjWyokNS3GG75dr4JvoPLb1nX,iv:Vdg+HMPWBlez03V369VW2gmdUteZ+MQukH5zihCRho4=,tag:zoI/xRxIXwMxR/25WpVvhQ==,type:str]
                         client_secret: ENC[AES256_GCM,data:slsXySujXX4Q5Gkvj83a3DXxsi98aKFGAPGFulppxs/W8A==,iv:JlUXA28vf0aZcokMwX/2H4LHWHYE0iX6VyyTx1Vl1/k=,tag:VOH2VYHvRpLil/0dxSYZ1g==,type:str]
+-   name: ENC[AES256_GCM,data:hIMyvQ==,iv:jSMZit0o6ai3yxJjRMe6rLRgGYfeqzWtS4ntBbGVst4=,tag:5qp5pzwfB7SLf+ItXekYdQ==,type:str]
+    config:
+        jupyterhub:
+            hub:
+                config:
+                    AzureAdOAuthenticator:
+                        client_id: ENC[AES256_GCM,data:kJmyGaF8WLDgY2BnlpiR+r9OjWyokNS3GG75dr4JvoPLb1nX,iv:Vdg+HMPWBlez03V369VW2gmdUteZ+MQukH5zihCRho4=,tag:zoI/xRxIXwMxR/25WpVvhQ==,type:str]
+                        client_secret: ENC[AES256_GCM,data:slsXySujXX4Q5Gkvj83a3DXxsi98aKFGAPGFulppxs/W8A==,iv:JlUXA28vf0aZcokMwX/2H4LHWHYE0iX6VyyTx1Vl1/k=,tag:VOH2VYHvRpLil/0dxSYZ1g==,type:str]
+grafana_token: ENC[AES256_GCM,data:YTryKM0UCMm0IF9O/4kNpqFWhSgegi5FTQmS4MbRO8sbmgTV3/ExCMZGeWG7CmwWvr0VNpdxcr7K8ykkYDY8V8lMbl8e+XhuhWwP8sKbX8SuKf3plSv5wUfwhqM=,iv:hU5FohKHjEZQHvZuBjzE22POkwBVt4f3XrnXKK/zbgI=,tag:ZZyOLL7P9E/2fdkktO+VLg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -15,8 +24,8 @@ sops:
         enc: CiQA4OM7eOPsuFFNlwtrI+0j6+kZJFl/p2t0LC6ePKzDQ02zTH0SSQC9ZQbLbGzX4ZOsrFbkYAC9644szTsZiwVKRMdwNTzSpSizEwgWN81QUfZaGjoUUCkBEH5409uO9+nq6QHxQ6BSJtBDRQ6t/0w=
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-12-06T17:33:29Z'
-    mac: ENC[AES256_GCM,data:1y0ERvgHm+A9ZFZsH/wdY69f5rJH33GtKEZ7hfVRY5ffbEoA+yF1TBq9AeRa7wbi/KTTFNQDZ3wG1q1kahZRZF8E7Is/okLVpwEORl32LJg0EwV7Y8DcgPYh9e0988JFJ9Xe2sgSvvOmt70w71yo2a6R3SZ+C8RNbbDOa4og2qU=,iv:IyTkx1xil3jqVctImm7sD5y0S1stAJbNyt4MoZGj8To=,tag:zrA8fiCxuPjUEUGbNvEM3A==,type:str]
+    lastmodified: '2021-12-13T08:04:50Z'
+    mac: ENC[AES256_GCM,data:jxAmdBa7zxB2gusCa7Y9LabBo2iSAboHuLcqF2fM8BvPAeA4gVUM0/9Q/aTfVPtCbjFh+4KHcvl54AO1kwwrG4kFhHocpoB0gdJggygEmSS74JwEIW8feFzwuoBDjBE8rC/khzqccqDeBit3oWK0SQTlJCZ3f6PaaVZQ/bK4mHE=,iv:35dsKF7sfmbQW0wowBpuIA6eiI0fHvbwOtqS9pqpIOM=,tag:mUl0Aed3OQtRMga+kdZPiw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1


### PR DESCRIPTION
This adds the grafana token needed to deploy JupyterHub dashboards and copies the AzureAd client credentials from staging