### PR TITLE
Use correct domain for UToronto prod hub

### DIFF
--- a/config/hubs/utoronto.cluster.yaml
+++ b/config/hubs/utoronto.cluster.yaml
@@ -101,7 +101,7 @@ hubs:
               oauth_callback_url: https://staging.utoronto.2i2c.cloud/hub/oauth_callback
               tenant_id: 78aac226-2f03-4b4d-9037-b46d56c55210
   - name: prod
-    domain: utoronto.2i2c.cloud
+    domain: jupyter.utoronto.ca
     template: basehub
     auth0:
       enabled: false


### PR DESCRIPTION
This is a CNAME to utoronto.2i2c.cloud. So we just set the
DNS for utoronto.2i2c.cloud, but *HTTPS* will work with the
new domain