### PR TITLE
Add CSU Demonstration hub to pilot hubs

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -466,3 +466,52 @@ hubs:
                 - wkitto1@avc.edu
                 - rbiritwum@gmail.com
               admin_users: *avc_users
+  - name: csu
+    domain: csu.cloudbank.2i2c.cloud
+    template: basehub
+    auth0:
+      connection: password
+      password:
+        database_name: database-csu
+    config:
+      jupyterhub:
+        prePuller:
+          continuous:
+            enabled: true
+          hook:
+            enabled: true
+        singleuser:
+          memory:
+            guarantee: 512M
+            limit: 1G
+        custom:
+          homepage:
+            templateVars:
+              org:
+                name: California State Universities demonstration hubs
+                logo_url: https://www.calstate.edu/_catalogs/masterpage/assets/images/logo.png
+                url: https://www.calstate.edu/
+              designed_by:
+                name: 2i2c
+                url: https://2i2c.org
+              operated_by:
+                name: CloudBank
+                url: http://cloudbank.org/
+              funded_by:
+                name: CloudBank
+                url: http://cloudbank.org/
+        hub:
+          config:
+            Authenticator:
+              # Everyone should be able to sign up, so we don't set allowed_users
+              # These folks should still have admin though
+              admin_users:
+                - <staff_google_ids>
+                - ericvd@gmail.com
+                - sean.smorris@berkeley.edu
+        cull:
+          # Cull after 30min of inactivity
+          every: 300
+          timeout: 1800
+          # No pods over 12h long
+          maxAge: 43200


### PR DESCRIPTION
The CSU demonstration hub is configured like the demo
hub currently deployed.