### PR TITLE
Block access to howard cloudbank hub

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -148,7 +148,6 @@ hubs:
           config:
             Authenticator:
               allowed_users: &howard_users
-                - <staff_google_ids>
                 - ericvd@berkeley.edu
                 - gwashington@scs.howard.edu
                 - anthony.fgordon64@gmail.com

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -512,8 +512,11 @@ class Hub:
 
             if secret_config.get("hubs", {}):
                 hubs = secret_config["hubs"]
-                secret_hub_config = next((hub for i, hub in enumerate(hubs) if hubs[i]["name"] == self.spec["name"]), {"config": {}})
-                secret_hub_config = secret_hub_config["config"]
+                current_hub = next((hub for hub in hubs if hub["name"] == self.spec["name"]), {})
+                # Support domain name overrides
+                if "domain" in current_hub:
+                    self.spec["domain"] = current_hub["domain"]
+                secret_hub_config = current_hub.get("config", {})
 
         generated_values = self.get_generated_config(auth_provider, secret_key)
 

--- a/secrets/config/hubs/cloudbank.cluster.yaml
+++ b/secrets/config/hubs/cloudbank.cluster.yaml
@@ -1,14 +1,20 @@
 grafana_token: ENC[AES256_GCM,data:rsBkvUihlL5tNCjR1Bzf29OgkuXD/oQNXU023+kNKnzM6AWtq7gUrFsJPXFqi60CJ+PudZO+D01H2HZ8zLcRMO6f7LEiM66DOuplGtTop61F9ckla4PRsXKxOLA=,iv:LNBfC9zD9ZjZVNVmfPMx3JK9DhMG7K9KJsYXEBIemLM=,tag:dP+HnPVdJhTZl20VG1VTMg==,type:str]
+hubs:
+    - name: ENC[AES256_GCM,data:1TiM/HQv,iv:PvlEa0wCmza5mp2qcnspEBFmFXCWZhsO7cLG1n0AhL4=,tag:UJiRuWE5g/+JalbYhMZTiA==,type:str]
+      #ENC[AES256_GCM,data:wkGAfdWTsXxGSCsDxkHaFoJlQyGJ9vkBRjy/4QwGvUtBbRx+LOAnBvUDkgo=,iv:eUd5LLbiWxkVavcTo5ali0AjFWkmnkgyicl1SG+yfGg=,tag:lZ8ksTztJKOj1MZBhfPgdA==,type:comment]
+      #ENC[AES256_GCM,data:dSpHZuV3dqql1uiNMTN+7m8YQK9dI0sTOvK9UZPkbMuGQ4cMVF2ifDudWDTLjYAK0kXODv+nFPyeIyrdWhGOQdpW,iv:aK6YIL8+yB7G+mvQK/Dp3+UkCygy4LlKMMyLt+OnapA=,tag:/JsUBxa6Ri0ufGANTS9YOw==,type:comment]
+      domain: ENC[AES256_GCM,data:i2txXFkNznem4Z35bLbSjdugm0gTSSjxrP6nJE5jowI/3gNp2w==,iv:n1w9dmtdaz2TXO+k9wTXEf6hQ7gDJ15NeugqwVazdpM=,tag:lGrOtIXRkQcOHgAER3MWZQ==,type:str]
 sops:
     kms: []
     gcp_kms:
-    -   resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-        created_at: '2021-10-19T10:16:58Z'
-        enc: CiQA4OM7eFnlYtBjHjQYCacoCokt+zduY6rv7LZWxHjAqJrmu3cSSQC9ZQbLYCsvNkmjwZLIfoJHhMSVS4jMj3h79uTQJ4NIwr8ehSKp3BID37C+2FnJ8wTRhZX/zhLic7+eSTePmbxZ8BdK1UDOPGo=
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2021-10-19T10:16:58Z"
+          enc: CiQA4OM7eFnlYtBjHjQYCacoCokt+zduY6rv7LZWxHjAqJrmu3cSSQC9ZQbLYCsvNkmjwZLIfoJHhMSVS4jMj3h79uTQJ4NIwr8ehSKp3BID37C+2FnJ8wTRhZX/zhLic7+eSTePmbxZ8BdK1UDOPGo=
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-10-27T10:12:26Z'
-    mac: ENC[AES256_GCM,data:AcICScDdakWFXWluA1fzu6sLvD3mvj0iPHCtcu9aOyDLhc2yUulOGOuzrdf4xQmW2+GeQdM7ihBsKLJ1Mh0IsdEnx+LENIta6Sl7uWU2DW4Dso5pLP2wep4W0Z0KPsrJKXF4TcwBpANmYJcB5k/H2ukuS6ns+4fpqYs45YiI0H8=,iv:4HgY0G+eBVVxerhnHk62t+mk+l7AIghAWaByZJAtREI=,tag:ecEkJJrf/ufMBgn79RkSqw==,type:str]
+    age: []
+    lastmodified: "2021-12-24T06:12:48Z"
+    mac: ENC[AES256_GCM,data:s9Inv8rgq9Yepjzf3vUA/6Y5WtJU2lriuvoVf75pspHJXAu0mY0y7+vZD9P1OQ5KyRq+PuObVP7EjQkvqRSbnBZHAwVJM08GsLC92cCPMR7TT/5JzwdBjrSBBQnV7JNIOGmDEgstBdjMLDRn7Vn8zjDtFb8MCe3GWAns7nP1ROk=,iv:fq1ejkQN5KK/TbD6bjIF/ZjeraHELckkcwZb3+N+gN8=,tag:O46TASk74XOVn01ySHnH1g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.6.1
+    version: 3.7.1

--- a/secrets/config/hubs/schema.yaml
+++ b/secrets/config/hubs/schema.yaml
@@ -22,6 +22,16 @@ properties:
             type: object
             description: |
               YAML configuration containing secrets that is passed through to helm.
+          domain:
+            type: string
+            description: |
+              Domain the hub should be running on. This domain should resolve
+              to the IP of the ingress controller on the cluster - most likely
+              via a wildcard DNS entry.
+
+              For example, there's a entry for '*.pilot.2i2c.cloud' pointing to
+              the ingress controller of the cluster running hubs in `2i2c.cluster.yaml`.
+              Similar for '*.cloudbank.2i2c.cloud', etc.
   grafana_token:
     type: string
     description: |


### PR DESCRIPTION
The instructor wants the students to not be able to log in,
while preserving the ability to use the admin panel to access
students' work. By moving the hub to a randomly generated
domain name that is kept secret, the instructor can log in but
students can not.

Longer term, we need better user profile support in JupyterHub
for this. Perhaps the work in JupyterHub 2.0 with groups
will help.

Ref https://2i2c.freshdesk.com/a/tickets/61