### PR TITLE
Revert "Add allowed users to OpenScapes hub"

### DIFF
--- a/config/hubs/openscapes.cluster.yaml
+++ b/config/hubs/openscapes.cluster.yaml
@@ -148,11 +148,10 @@ hubs:
                 effect: "NoSchedule"
             config:
               Authenticator:
-                allowed_users: &openscapes_admins
+                admin_users:
                   - <staff_github_ids>
                   - amfriesz
                   - jules32
-                admin_users: *openscapes_admins
       dask-gateway:
         traefik:
           tolerations:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#909

because the deploy failed and I'm not sure why