### PR TITLE
Stop auto-deploying openscapes

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -37,8 +37,6 @@ jobs:
             provider: aws
           - cluster_name: farallon
             provider: aws
-          - cluster_name: openscapes
-            provider: aws
           - cluster_name: meom-ige
             provider: gcp
           - cluster_name: pangeo-hubs


### PR DESCRIPTION
I've deleted the ingress objects to prevent external
access to the hubs.

k -n prod delete ingress jupyterhub
k -n staging delete ingress jupyterhub

Ref https://github.com/2i2c-org/infrastructure/issues/908