### PR TITLE
Revert "Stop auto-deploying openscapes"

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -37,6 +37,8 @@ jobs:
             provider: aws
           - cluster_name: farallon
             provider: aws
+          - cluster_name: openscapes
+            provider: aws
           - cluster_name: meom-ige
             provider: gcp
           - cluster_name: pangeo-hubs


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#911

Now that https://github.com/2i2c-org/infrastructure/pull/885 is merged.