### PR TITLE
Simplify new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -12,7 +12,7 @@ body:
         - **Who would benefit** from the solution?
       placeholder: |
         It is common for an instructor to want to do X. However, this isn't currently possible because Y.
-        
+
         We could implement X by doing Z, this would allow users to W which would benefit their workflows in the following ways...
     validations:
       required: true
@@ -33,14 +33,14 @@ body:
 
     validations:
       required: false
-      
+
   - type: textarea
     id: timeestimate
     attributes:
       label: Time to spend on this
       description: |
         How much time do we want to spend trying to resolve this problem? This should relate to its
-        importance and its complexity. 
+        importance and its complexity.
 
       placeholder: |
         - We'll spend 4 weeks working on this, and re-assess whether we want to update scope at that time.

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -16,7 +16,7 @@ body:
 
         **Proposed solution**
         So, we should implement X by doing Z.
-        
+
         **What's the value and who would benefit**
         This would allow educational users to do XXX which would benefit their workflows in the following ways...
     validations:

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -4,7 +4,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Problem description and opportunity to solve it
+      label: Description of problem and opportunity to address it
       description: |
         - **What is the problem** that needs to be solved?
         - **What is the solution** that would resolve it?

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -4,16 +4,22 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Problem to solve and opportunity
+      label: Description and opportunity
       description: |
         - **What is the problem** that needs to be solved?
         - **What is the solution** that would resolve it?
         - **What is the opportunity / value** in solving this problem?
         - **Who would benefit** from the solution?
-      placeholder: |
+      value: |
+        <!-- A few ideas to get started -->
+        **Problem description**
         It is common for an instructor to want to do X. However, this isn't currently possible because Y.
 
-        We could implement X by doing Z, this would allow users to W which would benefit their workflows in the following ways...
+        **Proposed solution**
+        So, we should implement X by doing Z.
+        
+        **What's the value and who would benefit**
+        This would allow educational users to do XXX which would benefit their workflows in the following ways...
     validations:
       required: true
 
@@ -23,29 +29,13 @@ body:
       label: Implementation guide and constraints
       description: |
         - Suggestions to reduce risk and guide others who may want to implement a solution.
-        - Pointers to likely place where an implementation would happen.
         - Constraints and "out of scope" ideas that shouldn't be addressed here.
-
+        - Time boxes and work planning.
       placeholder: |
         - The best way to do this would be...
         - This work should *not* include...
         - There are a few ways to do this, we should choose between...
-
-    validations:
-      required: false
-
-  - type: textarea
-    id: timeestimate
-    attributes:
-      label: Time to spend on this
-      description: |
-        How much time do we want to spend trying to resolve this problem? This should relate to its
-        importance and its complexity.
-
-      placeholder: |
-        - We'll spend 4 weeks working on this, and re-assess whether we want to update scope at that time.
-        - This should only take a day or two.
-        - This is a quick fix.
+        - We should try to do XXX in a 2-week time box before moving further.
 
     validations:
       required: false
@@ -55,7 +45,7 @@ body:
     attributes:
       label: Updates and ongoing work
       description: |
-        Use this section to provide updates as we start to plan and do work.
+        Provide updates as we start to plan and do work.
         - Specific tasks to complete
         - Sub-issues to work on
         - Links to project boards

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -4,12 +4,11 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description and opportunity
+      label: Problem description and opportunity to solve it
       description: |
         - **What is the problem** that needs to be solved?
         - **What is the solution** that would resolve it?
-        - **What is the opportunity / value** in solving this problem?
-        - **Who would benefit** from the solution?
+        - **What is the opportunity / value** in solving this problem? And for who?
       value: |
         <!-- A few ideas to get started -->
         **Problem description**
@@ -17,7 +16,7 @@ body:
 
         **Proposed solution**
         So, we should implement X by doing Z.
-
+        
         **What's the value and who would benefit**
         This would allow educational users to do XXX which would benefit their workflows in the following ways...
     validations:
@@ -34,7 +33,6 @@ body:
       placeholder: |
         - The best way to do this would be...
         - This work should *not* include...
-        - There are a few ways to do this, we should choose between...
         - We should try to do XXX in a 2-week time box before moving further.
 
     validations:
@@ -46,8 +44,7 @@ body:
       label: Updates and ongoing work
       description: |
         Provide updates as we start to plan and do work.
-        - Specific tasks to complete
-        - Sub-issues to work on
+        - Sub-issues and tasks to work on
         - Links to project boards
         - Updates over time
 

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -17,7 +17,7 @@ body:
 
         **Proposed solution**
         So, we should implement X by doing Z.
-        
+
         **What's the value and who would benefit**
         This would allow educational users to do XXX which would benefit their workflows in the following ways...
     validations:

--- a/.github/ISSUE_TEMPLATE/1_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-issue.yml
@@ -4,51 +4,48 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Problem to solve and opportunity
       description: |
-        Describe what you are proposing, or the question you're asking. Provide as much context as possible and link to related issues and/or pull requests.
-        This section should contain "what" you are proposing.
-
-        🐛 If this issue is related to a bug, include information about how to reproduce it and add the `bug` label.
-        ✨ If this issue is an enhancement or feature, add the `enhancement` label.
-        ✅ If this issue is a task to complete, add the `task` label.
-
-    validations:
-      required: true
-
-  - type: textarea
-    id: value
-    attributes:
-      label: Value / benefit
-      description: |
-        What is the value in resolving this issue, and who will benefit from it? Include any information that could help us prioritize the issue.
-        This section should contain "why" this issue should be resolved.
-
-        ✨ If this is for a new feature or enhancement, consider adding [user stories](https://www.atlassian.com/agile/project-management/user-stories).
-        🐛 If this is for a bug or problem, estimate the severity and scale of the impact.
-
+        - **What is the problem** that needs to be solved?
+        - **What is the solution** that would resolve it?
+        - **What is the opportunity / value** in solving this problem?
+        - **Who would benefit** from the solution?
       placeholder: |
-        - Many people have requested this feature, as seen in...
-        - This would facilitate XXX which is common for our hub users
-        - This problem affects anybody that does XXX on a hub
-
+        It is common for an instructor to want to do X. However, this isn't currently possible because Y.
+        
+        We could implement X by doing Z, this would allow users to W which would benefit their workflows in the following ways...
     validations:
       required: true
 
   - type: textarea
     id: implementation
     attributes:
-      label: Implementation details
+      label: Implementation guide and constraints
       description: |
-        Anything that will help others understand how this issue could be addressed. Where appropriate, note locations in a codebase where a change would need to be made, or other considerations that should be taken.
-        This section should contain "how" this issue should be resolved.
-
-        _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._
+        - Suggestions to reduce risk and guide others who may want to implement a solution.
+        - Pointers to likely place where an implementation would happen.
+        - Constraints and "out of scope" ideas that shouldn't be addressed here.
 
       placeholder: |
-        - This change would be probably need to be over here...
         - The best way to do this would be...
+        - This work should *not* include...
         - There are a few ways to do this, we should choose between...
+
+    validations:
+      required: false
+      
+  - type: textarea
+    id: timeestimate
+    attributes:
+      label: Time to spend on this
+      description: |
+        How much time do we want to spend trying to resolve this problem? This should relate to its
+        importance and its complexity. 
+
+      placeholder: |
+        - We'll spend 4 weeks working on this, and re-assess whether we want to update scope at that time.
+        - This should only take a day or two.
+        - This is a quick fix.
 
     validations:
       required: false
@@ -56,28 +53,13 @@ body:
   - type: textarea
     id: tasks
     attributes:
-      label: Tasks to complete
+      label: Updates and ongoing work
       description: |
-        Any concrete tasks that should be completed to resolve this issue.
-        The more specific the better. If issues have lots of complex tasks associated with them, consider breaking them up into separate issues with cross-links.
-
-        _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._
-
-      placeholder: |
-        - [ ] Discuss and decide on what to do...
-        - [ ] Implement partial feature A...
-
-    validations:
-      required: false
-
-  - type: textarea
-    id: updates
-    attributes:
-      label: Updates
-      description: |
-        To avoid that others have to read through the full thread of comments, please update the initial issue with important updates (e.g. decisions taken) regularly. You can update any of the sections above directly (this is encouraged!) or add new information below in this new section.
-
-        _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._
+        Use this section to provide updates as we start to plan and do work.
+        - Specific tasks to complete
+        - Sub-issues to work on
+        - Links to project boards
+        - Updates over time
 
     validations:
       required: false


### PR DESCRIPTION
This is an attempt at simplifying our "new issue" template. I've found that many times people are typing both the "description" and the "value" information into a single paragraph. So this PR simplifies things a bit and combines them into a single text box with prompts, rather than using totally different sections for it.

It also updates our "tasks" section to incorporate "updates" into it as well, since both of these are dynamic parts of the issue.