### PR TITLE
NEW: Bot to check for old approved PRs

### DIFF
--- a/.github/workflows/approved_prs_reminder.py
+++ b/.github/workflows/approved_prs_reminder.py
@@ -1,0 +1,42 @@
+"""
+This script helps remind our team when it's time to merge a PR. It does these things:
+
+- Grab a list of all open pull requests in our infrastructure repository.
+- For any that have a PR approval, check how long ago that approval was.
+- If the approval was longer than 24 hours ago, add it to a list of PRs we should merge
+- Ping our #hub-development channel with a list of the PRs that are ready to merge
+"""
+from ghapi.all import GhApi
+import pandas as pd
+
+api = GhApi()
+
+open_prs = api.pulls.list("2i2c-org", "infrastructure", state="open")
+
+msg = ""
+for pr in open_prs:
+    print(f"Checking PR: {pr['title']} ({pr['html_url']})")
+    reviews = api.pulls.list_reviews("2i2c-org", "infrastructure", pr["number"])
+    for review in reviews:
+        # Only care about reviews that caused approvals
+        if review["state"] != "APPROVED":
+            continue
+        # Check whether we've had an approval for > 24 hours, and if so add to message list
+        today = pd.to_datetime(datetime.today()).tz_localize("US/Pacific")
+        review_time = pd.to_datetime(review["submitted_at"]).astimezone("US/Pacific")
+        age = today - review_time
+        hours_old = age.seconds // 60 // 60  # Convert to hours
+        if hours_old > 24:
+            msg += f"- [{pr['title']}]({pr['html_url']}) - {hours_old} hours old."
+if msg:
+    msg = (
+        "**The following PRs are more than 24 hours old, have approval, and should be merged!**\n\n"
+        + msg
+    )
+    # Print to output in a way that will store as an environment variable
+    print("Found PRs with old approvals, sending Slack message")
+    print(f"::set-output name=PRS_MESSAGE::{msg}")
+    print(f"::set-output name=DO_SEND_MESSAGE::TRUE")
+else:
+    print("No PRs with old approvals found, not sending Slack message")
+    print(f"::set-output name=DO_SEND_MESSAGE::FALSE")

--- a/.github/workflows/approved_prs_reminder.yaml
+++ b/.github/workflows/approved_prs_reminder.yaml
@@ -1,8 +1,8 @@
 name: Ping slack if we have approved PRs waiting to merge
 on:
   schedule:
-  # Run every MWF at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
-  - cron: "0 07 * * 1,3,5"
+    # Run every MWF at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
+    - cron: "0 07 * * 1,3,5"
 
   workflow_dispatch:
     inputs:
@@ -15,35 +15,35 @@ jobs:
   create-sync-issue:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - name: Install python
-      run: pip install ghapi pandas
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install python
+        run: pip install ghapi pandas
 
-    - name: Pull open PRs and check if they have old approvals
-      id: approved-prs
-      run: python .github/workflows/approved_prs_reminder.py
-    
-    # Decide what message to send
-    - name: Sets env vars for automated message
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo "SLACK_MESSAGE="${{ steps.approved-prs.outputs.PRS_MESSAGE }} >> $GITHUB_ENV
-        echo "DO_SEND_MESSAGE="${{ steps.approved-prs.outputs.DO_SEND_MESSAGE }} >> $GITHUB_ENV
+      - name: Pull open PRs and check if they have old approvals
+        id: approved-prs
+        run: python .github/workflows/approved_prs_reminder.py
 
-    - name: Sets env vars for dispatch message
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        echo "SLACK_MESSAGE="${{ github.event.inputs.message }} >> $GITHUB_ENV
-        echo "DO_SEND_MESSAGE=TRUE" >> $GITHUB_ENV
+      # Decide what message to send
+      - name: Sets env vars for automated message
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "SLACK_MESSAGE="${{ steps.approved-prs.outputs.PRS_MESSAGE }} >> $GITHUB_ENV
+          echo "DO_SEND_MESSAGE="${{ steps.approved-prs.outputs.DO_SEND_MESSAGE }} >> $GITHUB_ENV
 
-    # Ref: https://github.com/slackapi/slack-github-action#technique-2-slack-app
-    - name: Post to a Slack channel
-      if: ${{ env.DO_SEND_MESSAGE == 'TRUE' }} 
-      id: slack
-      uses: slackapi/slack-github-action@v1.16.0
-      with:
-        channel-id: 'C0206KLF76E'  # This is hub-development
-        slack-message: ${{ env.SLACK_MESSAGE }}
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Sets env vars for dispatch message
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "SLACK_MESSAGE="${{ github.event.inputs.message }} >> $GITHUB_ENV
+          echo "DO_SEND_MESSAGE=TRUE" >> $GITHUB_ENV
+
+      # Ref: https://github.com/slackapi/slack-github-action#technique-2-slack-app
+      - name: Post to a Slack channel
+        if: ${{ env.DO_SEND_MESSAGE == 'TRUE' }}
+        id: slack
+        uses: slackapi/slack-github-action@v1.16.0
+        with:
+          channel-id: "C0206KLF76E" # This is hub-development
+          slack-message: ${{ env.SLACK_MESSAGE }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/approved_prs_reminder.yaml
+++ b/.github/workflows/approved_prs_reminder.yaml
@@ -1,0 +1,49 @@
+name: Ping slack if we have approved PRs waiting to merge
+on:
+  schedule:
+  # Run every MWF at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
+  - cron: "0 07 * * 1,3,5"
+
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Message to send to Slack"
+        required: true
+        default: "Here's a test message!"
+
+jobs:
+  create-sync-issue:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install python
+      run: pip install ghapi pandas
+
+    - name: Pull open PRs and check if they have old approvals
+      id: approved-prs
+      run: python .github/workflows/approved_prs_reminder.py
+    
+    # Decide what message to send
+    - name: Sets env vars for automated message
+      if: github.event_name != 'workflow_dispatch'
+      run: |
+        echo "SLACK_MESSAGE="${{ steps.approved-prs.outputs.PRS_MESSAGE }} >> $GITHUB_ENV
+        echo "DO_SEND_MESSAGE="${{ steps.approved-prs.outputs.DO_SEND_MESSAGE }} >> $GITHUB_ENV
+
+    - name: Sets env vars for dispatch message
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "SLACK_MESSAGE="${{ github.event.inputs.message }} >> $GITHUB_ENV
+        echo "DO_SEND_MESSAGE=TRUE" >> $GITHUB_ENV
+
+    # Ref: https://github.com/slackapi/slack-github-action#technique-2-slack-app
+    - name: Post to a Slack channel
+      if: ${{ env.DO_SEND_MESSAGE == 'TRUE' }} 
+      id: slack
+      uses: slackapi/slack-github-action@v1.16.0
+      with:
+        channel-id: 'C0206KLF76E'  # This is hub-development
+        slack-message: ${{ env.SLACK_MESSAGE }}
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
inspired by https://github.com/2i2c-org/infrastructure/issues/913#issuecomment-1005576792 I decided to use this as an excuse to learn a bit about integrating Slack and GitHub Actions, since I figure that might be useful in general.

This adds a little Slack bot that:

- Runs every M / W / F
- Checks `infrastructure/` for open PRs that have approvals that are > 24 hours
- If it finds any, posts a message to our `#hub-development` channel reminding us to merge

I might just merge this one in since I think that's the only way to test if it works (via a workflow_dispatch), so may iterate on some subsequent PRs.

In addition to this, and following [these instructions](https://github.com/slackapi/slack-github-action#technique-2-slack-app), I've:

- Created a Slack app and added it to our Slack's `#hub-development` channel
- Given it a `write` scope
- Added the OAuth token for this bot to our `infrastructure/` repo secrets