### PR TITLE
MAINT: Improve PR approve reminder workday check

### DIFF
--- a/.github/workflows/approved_prs_reminder.py
+++ b/.github/workflows/approved_prs_reminder.py
@@ -30,7 +30,7 @@ for pr in open_prs:
             msg += f"- [{pr['title']}]({pr['html_url']}) - {n_workdays} workdays old."
 if msg:
     msg = (
-        "**The following PRs are more than 24 hours old, have approval, and should be merged!**\n\n"
+        "**The following PRs were approved more than 2 business days ago and should be merged!**\n\n"
         + msg
     )
     # Print to output in a way that will store as an environment variable

--- a/.github/workflows/approved_prs_reminder.py
+++ b/.github/workflows/approved_prs_reminder.py
@@ -8,6 +8,7 @@ This script helps remind our team when it's time to merge a PR. It does these th
 """
 from ghapi.all import GhApi
 import pandas as pd
+from datetime import datetime
 
 api = GhApi()
 
@@ -21,13 +22,12 @@ for pr in open_prs:
         # Only care about reviews that caused approvals
         if review["state"] != "APPROVED":
             continue
-        # Check whether we've had an approval for > 24 hours, and if so add to message list
+        # Check whether we've had an approval for > 2 business days
         today = pd.to_datetime(datetime.today()).tz_localize("US/Pacific")
         review_time = pd.to_datetime(review["submitted_at"]).astimezone("US/Pacific")
-        age = today - review_time
-        hours_old = age.seconds // 60 // 60  # Convert to hours
-        if hours_old > 24:
-            msg += f"- [{pr['title']}]({pr['html_url']}) - {hours_old} hours old."
+        n_workdays = len(pd.bdate_range(review_time.date(), today.date()))
+        if n_workdays > 2:
+            msg += f"- [{pr['title']}]({pr['html_url']}) - {n_workdays} workdays old."
 if msg:
     msg = (
         "**The following PRs are more than 24 hours old, have approval, and should be merged!**\n\n"


### PR DESCRIPTION
This is a small improvement after a suggestion from @GeorgianaElena - it does 2 things:

- Makes our check for "PRs with approval that need a merge" to be 2 days rather than 1 day (to avoid unnecessary nagging by the bot if something gets a quick review)
- Uses business days only instead of including weekends