### PR TITLE
Use the right registry repo for the user image

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -1,5 +1,5 @@
 name: 2i2c
-image_repo: "us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user"
+image_repo: "quay.io/2i2c/2i2c-hubs-image"
 provider: gcp
 gcp:
   key: secrets/2i2c.json

--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -1,5 +1,5 @@
 name: cloudbank
-image_repo: "us-central1-docker.pkg.dev/cb-1003-1696/low-touch-hubs/base-user"
+image_repo: "quay.io/2i2c/2i2c-hubs-image"
 provider: gcp
 gcp:
   key: secrets/cloudbank.json


### PR DESCRIPTION
When testing out https://github.com/2i2c-org/infrastructure/pull/922 on staging, this was the log when I tried to start a server:

```
2022-01-11T16:09:55Z [Normal] Pulling image "us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user:532c5eab47a1"
2022-01-11T16:09:55Z [Warning] Failed to pull image "us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user:532c5eab47a1": rpc error: code = NotFound desc = failed to pull and unpack image "us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user:532c5eab47a1": failed to resolve reference "us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user:532c5eab47a1": us-central1-docker.pkg.dev/two-eye-two-see/pilot-hubs-registry/base-user:532c5eab47a1: not found
```

I believe `image_repo` is overwriting what we have in the basehub template as the image repo.