### PR TITLE
Add info about the grafana deployer action and api key

### DIFF
--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -80,7 +80,7 @@ The key you create needs admin permissions.
 
 Encrypt and store this key using `sops` in `secrets/config/hubs/<cluster>.yaml` under `grafana_token` key.
 
-This key will be used by the [`deploy-grafana-dashboards` Github Action](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
+This key will be used by the [`deploy-grafana-dashboards` workflow](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
 Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboards.
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -82,7 +82,7 @@ Encrypt and store this key using `sops` in `secrets/config/hubs/<cluster>.yaml` 
 
 This key will be used by the [`deploy-grafana-dashboards` workflow](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
-Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboards.
+Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the `deploy-grafana-dashboards` workflow using the "Run workflow" button [from here](https://github.com/2i2c-org/infrastructure/actions/workflows/deploy-grafana-dashboards.yaml) to deploy the dashboards.
 
 ```{note}
 The action only runs when manually triggered.

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -80,7 +80,7 @@ The key you create needs admin permissions.
 
 Encrypt and store this key using `sops` in `secrets/config/hubs/<cluster>.yaml` under `grafana_token` key.
 
-This key will be used by the [`deploy-grafana-dashboards` Github Action](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using[`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
+This key will be used by the [`deploy-grafana-dashboards` Github Action](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
 Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboards.
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -78,18 +78,14 @@ The key you create needs admin permissions.
 
 **Keep this key safe as you won't be able to retrieve it!**
 
-```{note}
-In the future, we should define the scenarios where other engineers need this API key after the initial deployment and decide how to store and share it.
-```
+Encrypt and store this key using `sops` in `secrets/config/hubs/<cluster>.yaml` under `grafana_token` key.
 
-Some default grafana dashboards for JupyterHub can then be deployed using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
+This key will be used by the [`deploy-grafana-dashboards` Github Action](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using[`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
-1. Create a local clone of the repository
-2. Install the [`jsonnet` binary](https://github.com/google/jsonnet#packages).
+Once you've pushed the ecrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboads.
 
 ```{note}
-Homebrew is the best option if you're on MacOS.
-The Python package will not suffice here as we directly call the `jsonnet` library.
-```
+The action only runs when manually triggered.
 
-3. Follow the instructions in the [Deployment](https://github.com/jupyterhub/grafana-dashboards/blob/main/README.md#deployment) section of the README to create the grafana dashboards
+Any re-triggering of the action after the initial deployment will overwrite any dashboard created from the Grafana UI and not stored in the [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards) repository.
+```

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -85,7 +85,7 @@ This key will be used by the [`deploy-grafana-dashboards` workflow](https://gith
 Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the `deploy-grafana-dashboards` workflow using the "Run workflow" button [from here](https://github.com/2i2c-org/infrastructure/actions/workflows/deploy-grafana-dashboards.yaml) to deploy the dashboards.
 
 ```{note}
-The action only runs when manually triggered.
+The workflow only runs when manually triggered.
 
 Any re-triggering of the action after the initial deployment will overwrite any dashboard created from the Grafana UI and not stored in the [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards) repository.
 ```

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -82,7 +82,7 @@ Encrypt and store this key using `sops` in `secrets/config/hubs/<cluster>.yaml` 
 
 This key will be used by the [`deploy-grafana-dashboards` Github Action](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using[`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
-Once you've pushed the ecrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboads.
+Once you've pushed the encrypted `grafana_token` to the GitHub repository, manually trigger the GitHub Action to deploy the dashboards.
 
 ```{note}
 The action only runs when manually triggered.

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -87,5 +87,5 @@ Once you've pushed the encrypted `grafana_token` to the GitHub repository, manua
 ```{note}
 The workflow only runs when manually triggered.
 
-Any re-triggering of the action after the initial deployment will overwrite any dashboard created from the Grafana UI and not stored in the [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards) repository.
+Any re-triggering of the workflow after the initial deployment will overwrite any dashboard created from the Grafana UI and not stored in the [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards) repository.
 ```


### PR DESCRIPTION
When researching about https://github.com/2i2c-org/infrastructure/issues/328 realized that we haven't documented the grafana deployer action and where the api key is stored right now. 

I believe it closes https://github.com/2i2c-org/team-compass/issues/176

Probably this will change when we'll have one grafana for all the clusters.

