### PR TITLE
Add GPU nodepools to CarbonPlan's Azure cluster

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -123,7 +123,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
   os_disk_size_gb       = 200
   vnet_subnet_id        = azurerm_subnet.node_subnet.id
 
-  orchestrator_version = var.kubernetes_version
+  orchestrator_version = each.value.kubernetes_version == "" ? var.kubernetes_version : each.value.kubernetes_version
 
   vm_size = each.value.vm_size
   node_labels = merge({
@@ -152,7 +152,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
   os_disk_size_gb       = 200
   vnet_subnet_id        = azurerm_subnet.node_subnet.id
 
-  orchestrator_version = var.kubernetes_version
+  orchestrator_version = each.value.kubernetes_version == "" ? var.kubernetes_version : each.value.kubernetes_version
 
   vm_size = each.value.vm_size
   node_labels = merge({

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -126,15 +126,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
   orchestrator_version = var.kubernetes_version
 
   vm_size = each.value.vm_size
-  node_labels = {
+  node_labels = merge({
     "hub.jupyter.org/node-purpose" = "user",
     "k8s.dask.org/node-purpose"    = "scheduler"
     "hub.jupyter.org/node-size"    = each.value.vm_size
-  }
+  }, each.value.labels)
 
-  node_taints = [
+  node_taints = merge([
     "hub.jupyter.org_dedicated=user:NoSchedule"
-  ]
+  ], each.value.taints)
 
 
   min_count = each.value.min
@@ -155,14 +155,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
   orchestrator_version = var.kubernetes_version
 
   vm_size = each.value.vm_size
-  node_labels = {
+  node_labels = merge({
     "k8s.dask.org/node-purpose" = "worker",
     "hub.jupyter.org/node-size" = each.value.vm_size
-  }
+  }, each.value.labels)
 
-  node_taints = [
+  node_taints = merge([
     "k8s.dask.org_dedicated=worker:NoSchedule"
-  ]
+  ], each.value.taints)
 
 
   min_count = each.value.min

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -132,7 +132,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
     "hub.jupyter.org/node-size"    = each.value.vm_size
   }, each.value.labels)
 
-  node_taints = merge([
+  node_taints = concat([
     "hub.jupyter.org_dedicated=user:NoSchedule"
   ], each.value.taints)
 
@@ -160,7 +160,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
     "hub.jupyter.org/node-size" = each.value.vm_size
   }, each.value.labels)
 
-  node_taints = merge([
+  node_taints = concat([
     "k8s.dask.org_dedicated=worker:NoSchedule"
   ], each.value.taints)
 

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -13,37 +13,53 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E2s_v4"
+    vm_size : "Standard_E2s_v4",
+    labels: { },
+    taints: [ ],
   },
   "medium" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E4s_v4"
+    vm_size : "Standard_E4s_v4",
+    labels: { },
+    taints: [ ],
   },
   "large" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E8s_v4"
+    vm_size : "Standard_E8s_v4",
+    labels: { },
+    taints: [ ],
   },
   "huge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E32s_v4"
+    vm_size : "Standard_E32s_v4",
+    labels: { },
+    taints: [ ],
   },
   "vhuge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_M64s_v2"
+    vm_size : "Standard_M64s_v2",
+    labels: { },
+    taints: [ ],
   },
   "vvhuge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_M128s_v2"
+    vm_size : "Standard_M128s_v2",
+    labels: { },
+    taints: [ ],
   },
     "gpu" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_NC16as_T4_v3"
+    vm_size : "Standard_NC16as_T4_v3",
+    labels: { },
+    taints: [
+      "sku=gpu:NoSchedule",
+    ],
   },
 }
 
@@ -51,36 +67,52 @@ dask_nodes = {
   "small" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E2s_v4"
+    vm_size : "Standard_E2s_v4",
+    labels: { },
+    taints: [ ],
   },
   "medium" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E4s_v4"
+    vm_size : "Standard_E4s_v4",
+    labels: { },
+    taints: [ ],
   },
   "large" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E8s_v4"
+    vm_size : "Standard_E8s_v4",
+    labels: { },
+    taints: [ ],
   },
   "huge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_E32s_v4"
+    vm_size : "Standard_E32s_v4",
+    labels: { },
+    taints: [ ],
   },
   "vhuge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_M64s_v2"
+    vm_size : "Standard_M64s_v2",
+    labels: { },
+    taints: [ ],
   },
   "vvhuge" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_M128s_v2"
+    vm_size : "Standard_M128s_v2",
+    labels: { },
+    taints: [ ],
   },
   "gpu" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_NC16as_T4_v3"
+    vm_size : "Standard_NC16as_T4_v3",
+    labels: { },
+    taints: [
+      "sku=gpu:NoSchedule",
+    ],
   },
 }

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -16,6 +16,7 @@ notebook_nodes = {
     vm_size : "Standard_E2s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "medium" : {
     min : 0,
@@ -23,6 +24,7 @@ notebook_nodes = {
     vm_size : "Standard_E4s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "large" : {
     min : 0,
@@ -30,6 +32,7 @@ notebook_nodes = {
     vm_size : "Standard_E8s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "huge" : {
     min : 0,
@@ -37,6 +40,7 @@ notebook_nodes = {
     vm_size : "Standard_E32s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "vhuge" : {
     min : 0,
@@ -44,6 +48,7 @@ notebook_nodes = {
     vm_size : "Standard_M64s_v2",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "vvhuge" : {
     min : 0,
@@ -51,6 +56,7 @@ notebook_nodes = {
     vm_size : "Standard_M128s_v2",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
     "gpu" : {
     min : 0,
@@ -60,6 +66,7 @@ notebook_nodes = {
     taints: [
       "sku=gpu:NoSchedule",
     ],
+    kubernetes_version = "1.19.13",
   },
 }
 
@@ -70,6 +77,7 @@ dask_nodes = {
     vm_size : "Standard_E2s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "medium" : {
     min : 0,
@@ -77,6 +85,7 @@ dask_nodes = {
     vm_size : "Standard_E4s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "large" : {
     min : 0,
@@ -84,6 +93,7 @@ dask_nodes = {
     vm_size : "Standard_E8s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "huge" : {
     min : 0,
@@ -91,6 +101,7 @@ dask_nodes = {
     vm_size : "Standard_E32s_v4",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "vhuge" : {
     min : 0,
@@ -98,6 +109,7 @@ dask_nodes = {
     vm_size : "Standard_M64s_v2",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "vvhuge" : {
     min : 0,
@@ -105,6 +117,7 @@ dask_nodes = {
     vm_size : "Standard_M128s_v2",
     labels: { },
     taints: [ ],
+    kubernetes_version = "",
   },
   "gpu" : {
     min : 0,
@@ -114,5 +127,6 @@ dask_nodes = {
     taints: [
       "sku=gpu:NoSchedule",
     ],
+    kubernetes_version = "1.19.13",
   },
 }

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -40,6 +40,11 @@ notebook_nodes = {
     max : 20,
     vm_size : "Standard_M128s_v2"
   },
+    "gpu" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_NC16as_T4_v3"
+  },
 }
 
 dask_nodes = {
@@ -72,5 +77,10 @@ dask_nodes = {
     min : 0,
     max : 20,
     vm_size : "Standard_M128s_v2"
+  },
+  "gpu" : {
+    min : 0,
+    max : 20,
+    vm_size : "Standard_NC16as_T4_v3"
   },
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -94,13 +94,13 @@ variable "ssh_pub_key" {
 }
 
 variable "notebook_nodes" {
-  type        = map(map(string))
+  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string) }))
   description = "Notebook node pools to create"
   default     = {}
 }
 
 variable "dask_nodes" {
-  type        = map(map(string))
+  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string) }))
   description = "Dask node pools to create"
   default     = {}
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -94,13 +94,13 @@ variable "ssh_pub_key" {
 }
 
 variable "notebook_nodes" {
-  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string) }))
+  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string), kubernetes_version : string }))
   description = "Notebook node pools to create"
   default     = {}
 }
 
 variable "dask_nodes" {
-  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string) }))
+  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string), kubernetes_version : string }))
   description = "Dask node pools to create"
   default     = {}
 }


### PR DESCRIPTION
This PR is the first step towards https://github.com/2i2c-org/infrastructure/issues/930 and provides GPU machines to notebook and dask workers. It also adds support for adding labels and taints to specific nodepools in a similar manner to what is implemented in our GCP config.

**NOTE:** Due to https://github.com/2i2c-org/infrastructure/issues/890, I had to run a bespoke `terraform plan` command that only targeted the cluster and nodepools.

Full `terraform plan` command (with some escaping to make `[]` and `"` work with my shell):

```
terraform plan \
-var-file projects/carbonplan.tfvars \
-out carbonplan \
-target azurerm_kubernetes_cluster.jupyterhub \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"small\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"medium\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"large\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"huge\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"vhuge\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"vvhuge\"\] \
-target azurerm_kubernetes_cluster_node_pool.user_pool\[\"gpu\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"small\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"medium\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"large\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"huge\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"vhuge\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"vvhuge\"\] \
-target azurerm_kubernetes_cluster_node_pool.dask_pool\[\"gpu\"\]
```

Full output:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_kubernetes_cluster_node_pool.dask_pool["gpu"] will be created
  + resource "azurerm_kubernetes_cluster_node_pool" "dask_pool" {
      + enable_auto_scaling   = true
      + eviction_policy       = (known after apply)
      + id                    = (known after apply)
      + kubelet_disk_type     = (known after apply)
      + kubernetes_cluster_id = "/subscriptions/c5e7a734-3dbf-4285-80e5-4c0afb1f65dc/resourcegroups/2i2c-carbonplan-cluster/providers/Microsoft.ContainerService/managedClusters/hub-cluster"
      + max_count             = 20
      + max_pods              = (known after apply)
      + min_count             = 0
      + mode                  = "User"
      + name                  = "daskgpu"
      + node_count            = (known after apply)
      + node_labels           = {
          + "hub.jupyter.org/node-size" = "Standard_NC16as_T4_v3"
          + "k8s.dask.org/node-purpose" = "worker"
        }
      + node_taints           = [
          + "k8s.dask.org_dedicated=worker:NoSchedule",
          + "sku=gpu:NoSchedule",
        ]
      + orchestrator_version  = "1.20.7"
      + os_disk_size_gb       = 200
      + os_disk_type          = "Managed"
      + os_sku                = (known after apply)
      + os_type               = "Linux"
      + priority              = "Regular"
      + spot_max_price        = -1
      + ultra_ssd_enabled     = false
      + vm_size               = "Standard_NC16as_T4_v3"
      + vnet_subnet_id        = "/subscriptions/c5e7a734-3dbf-4285-80e5-4c0afb1f65dc/resourceGroups/2i2c-carbonplan-cluster/providers/Microsoft.Network/virtualNetworks/k8s-network/subnets/k8s-nodes-subnet"
    }

  # azurerm_kubernetes_cluster_node_pool.user_pool["gpu"] will be created
  + resource "azurerm_kubernetes_cluster_node_pool" "user_pool" {
      + enable_auto_scaling   = true
      + eviction_policy       = (known after apply)
      + id                    = (known after apply)
      + kubelet_disk_type     = (known after apply)
      + kubernetes_cluster_id = "/subscriptions/c5e7a734-3dbf-4285-80e5-4c0afb1f65dc/resourcegroups/2i2c-carbonplan-cluster/providers/Microsoft.ContainerService/managedClusters/hub-cluster"
      + max_count             = 20
      + max_pods              = (known after apply)
      + min_count             = 0
      + mode                  = "User"
      + name                  = "nbgpu"
      + node_count            = (known after apply)
      + node_labels           = {
          + "hub.jupyter.org/node-purpose" = "user"
          + "hub.jupyter.org/node-size"    = "Standard_NC16as_T4_v3"
          + "k8s.dask.org/node-purpose"    = "scheduler"
        }
      + node_taints           = [
          + "hub.jupyter.org_dedicated=user:NoSchedule",
          + "sku=gpu:NoSchedule",
        ]
      + orchestrator_version  = "1.20.7"
      + os_disk_size_gb       = 200
      + os_disk_type          = "Managed"
      + os_sku                = (known after apply)
      + os_type               = "Linux"
      + priority              = "Regular"
      + spot_max_price        = -1
      + ultra_ssd_enabled     = false
      + vm_size               = "Standard_NC16as_T4_v3"
      + vnet_subnet_id        = "/subscriptions/c5e7a734-3dbf-4285-80e5-4c0afb1f65dc/resourceGroups/2i2c-carbonplan-cluster/providers/Microsoft.Network/virtualNetworks/k8s-network/subnets/k8s-nodes-subnet"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current
│ configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform
│ specifically suggests to use it as part of an error message.
```