### PR TITLE
Document how to enable CILogon for a hub

### DIFF
--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -169,7 +169,7 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
 
 ## CILogon
 
-For communities that require authenticating users against their campus identity providers, [CILogon](https://www.cilogon.org) can be used. CILogon authentication is managed through [auth0](https://auth0.com), similar with how the Google and GitHub authentication is setup.
+[CILogon](https://www.cilogon.org) allows us to authenticate users against their campus identity providers. It is managed through [auth0](https://auth0.com), similar to Google and GitHub authentication.
 
 ```{note}
   The `USERNAME_KEY` used for the CILogon login is the email, so the JupyterHub username will be set to the email address associated with the CILogon connection and not the CILogon user_id!

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -172,7 +172,7 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
 [CILogon](https://www.cilogon.org) allows us to authenticate users against their campus identity providers. It is managed through [auth0](https://auth0.com), similar to Google and GitHub authentication.
 
 ```{note}
-  The `USERNAME_KEY` used for the CILogon login is the email, so the JupyterHub username will be set to the email address associated with the CILogon connection and not the CILogon user_id!
+The JupyterHub username will be the email address that users provide when authenticating in CILogon connection. It will not be the CILogon `user_id`! This is because the `USERNAME_KEY` used for the CILogon login is the email address.
 ```
 
 To enable CILogon authentication:

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -180,7 +180,7 @@ The JupyterHub username will be the email address that users provide when authen
 
 To enable CILogon authentication:
 
-1. Explicitly list CILogon as the type of connection we want for a hub, via `auth0.connection`:
+1. List CILogon as the type of connection we want for a hub, via `auth0.connection`:
 
    ```yaml
    auth0:

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -171,6 +171,9 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
 
 [CILogon](https://www.cilogon.org) allows us to authenticate users against their campus identity providers. It is managed through [auth0](https://auth0.com), similar to Google and GitHub authentication.
 
+```{seealso}
+See the [CILogon documentation on `Auth0`](https://www.cilogon.org/auth0) for more configuration information.
+```
 ```{note}
 The JupyterHub username will be the email address that users provide when authenticating in CILogon connection. It will not be the CILogon `user_id`! This is because the `USERNAME_KEY` used for the CILogon login is the email address.
 ```

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -167,7 +167,7 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
 
 4. Run the deployer as normal to apply the config.
 
-# CILogon
+## CILogon
 
 For communities that require authenticating users against their campus identity providers, [CILogon](https://www.cilogon.org) can be used. CILogon authentication is managed through [auth0](https://auth0.com), similar with how the Google and GitHub authentication is setup.
 

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -193,35 +193,37 @@ To enable CILogon authentication:
   Don't forget to allow login to the test user (`deployment-service-check`), otherwise the hub health check performed during deployment will fail.
   ```
 
-  ```yaml
-    config:
-      jupyterhub:
-        hub:
-          config:
-            Authenticator:
-              admin_users:
-                - user1@campus.edu
-                - user2@gmail.com
-                # This will be replaced with the staff's google addresses
-                - <staff_google_ids>
-              username_pattern: '^(.+@2i2c\.org|.+@campus\.edu|deployment-service-check)$'
-   ```
 
-  This example does two things:
+### Example config for CILogon
 
-  1. Sets the hub admins to be:
+The following configuration example shows off how to configure hub admins and allowed users:
 
-    - the 2i2c staff (identified through their 2i2c email address)
-    - one `@campus.edu` user
-    - one `@gmail.com` user
+1. **Hub admins** are these explicit emails:
+  - one `@campus.edu` user
+  - one `@gmail.com` user
+  - the 2i2c staff (identified through their 2i2c email address)
 
-  2. Allows logging in only the users that match the `username_pattern` expression:
+2. **Allowed users** are matched against a pattern, with a few specific addresses added in as well
+  - all `@2i2c.org` email adresses
+  - all `@campus.edu` email addresses
+  - `user2@gmail.com`
+  - the test username, `deployment-service-check`
 
-    - all `@2i2c.org` email adresses
-    - all `@campus.edu` email addresses
-    - `user2@gmail.com`
-    - the test username, `deployment-service-check`
+```yaml
+config:
+  jupyterhub:
+    hub:
+      config:
+        Authenticator:
+          admin_users:
+            - user1@campus.edu
+            - user2@gmail.com
+            # This will be replaced with the staff's google addresses
+            - <staff_google_ids>
+          username_pattern: '^(.+@2i2c\.org|.+@campus\.edu|user2@gmail\.com|deployment-service-check)$'
+```
 
-  ```{note}
-  All the users listed under `admin_users` need to match the `username_pattern` expression otherwise they won't be allowed to login!
-  ```
+
+```{note}
+All the users listed under `admin_users` need to match the `username_pattern` expression otherwise they won't be allowed to login!
+```

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -187,7 +187,7 @@ To enable CILogon authentication:
       connection: CILogon
    ```
 
-2. Explicitly list *admin users* for a given hub and only allow the users that match specific identity providers to login into the hub.
+2. Add **admin users** to the hub by explicitly listing their email addresses. Add **allowed users** for the hub by providing a regex pattern that will match to an institutional email address. (see example below)
 
   ```{note}
   Don't forget to allow login to the test user (`deployment-service-check`), otherwise the hub health check performed during deployment will fail.

--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -166,3 +166,59 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
     ```
 
 4. Run the deployer as normal to apply the config.
+
+# CILogon
+
+For communities that require authenticating users against their campus identity providers, [CILogon](https://www.cilogon.org) can be used. CILogon authentication is managed through [auth0](https://auth0.com), similar with how the Google and GitHub authentication is setup.
+
+```{note}
+  The `USERNAME_KEY` used for the CILogon login is the email, so the JupyterHub username will be set to the email address associated with the CILogon connection and not the CILogon user_id!
+```
+
+To enable CILogon authentication:
+
+1. Explicitly list CILogon as the type of connection we want for a hub, via `auth0.connection`:
+
+   ```yaml
+   auth0:
+      connection: CILogon
+   ```
+
+2. Explicitly list *admin users* for a given hub and only allow the users that match specific identity providers to login into the hub.
+
+  ```{note}
+  Don't forget to allow login to the test user (`deployment-service-check`), otherwise the hub health check performed during deployment will fail.
+  ```
+
+  ```yaml
+    config:
+      jupyterhub:
+        hub:
+          config:
+            Authenticator:
+              admin_users:
+                - user1@campus.edu
+                - user2@gmail.com
+                # This will be replaced with the staff's google addresses
+                - <staff_google_ids>
+              username_pattern: '^(.+@2i2c\.org|.+@campus\.edu|deployment-service-check)$'
+   ```
+
+  This example does two things:
+
+  1. Sets the hub admins to be:
+
+    - the 2i2c staff (identified through their 2i2c email address)
+    - one `@campus.edu` user
+    - one `@gmail.com` user
+
+  2. Allows logging in only the users that match the `username_pattern` expression:
+
+    - all `@2i2c.org` email adresses
+    - all `@campus.edu` email addresses
+    - `user2@gmail.com`
+    - the test username, `deployment-service-check`
+
+  ```{note}
+  All the users listed under `admin_users` need to match the `username_pattern` expression otherwise they won't be allowed to login!
+  ```


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/315

I added a commit that enables CILogon for the staging hub, just as an example. I deployed the change manually however if anybody wants to test tat, but will be overwritten when a new deploy from the CI will happen.

On the staging hub right now we have:
- staff 2i2c emails are admins
- anyone with an `@2i2c.org` and `@berkeley.edu` address is allowed to login the hub.