### PR TITLE
Set default shell to /bin/bash

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -110,6 +110,9 @@ jupyterhub:
       # /tmp. This is ok in our case, since no two users are on the same
       # container.
       JUPYTER_RUNTIME_DIR: /tmp/.jupyter-runtime
+      # By default, /bin/sh is used as shell for terminals, not /bin/bash
+      # Most people do not expect this, so let's match expectation
+      SHELL: /bin/bash
     extraFiles:
       jupyter_notebook_config.json:
         mountPath: /usr/local/etc/jupyter/jupyter_notebook_config.json


### PR DESCRIPTION
Without this, it defaults to /bin/sh, which isn't what
most people expect. Basic shell things like arrow keys
don't work here, which is annoying.