### PR TITLE
Print key messages in deployer in a bold, green font

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -117,3 +117,5 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           cluster: ${{ matrix.cluster_name }}
+        env:
+          TERM: xterm

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -13,7 +13,7 @@ import shutil
 
 from auth import KeyProvider
 from hub import Cluster
-from utils import decrypt_file, update_authenticator_config
+from utils import decrypt_file, update_authenticator_config, print_colour
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)
@@ -54,7 +54,7 @@ def deploy_jupyterhub_grafana(cluster_name):
 
     # If grafana support chart is not deployed, then there's nothing to do
     if not cluster.support:
-        print(
+        print_colour(
             "Support chart has not been deployed. Skipping Grafana dashboards deployment..."
         )
         return
@@ -83,7 +83,7 @@ def deploy_jupyterhub_grafana(cluster_name):
     )
 
     if not grafana_url:
-        print(
+        print_colour(
             "Couldn't find `config.grafana.ingress.hosts`. Skipping Grafana dashboards deployment..."
         )
         return
@@ -93,7 +93,7 @@ def deploy_jupyterhub_grafana(cluster_name):
     )
 
     # Use the jupyterhub/grafana-dashboards deployer to deploy the dashboards to this cluster's grafana
-    print("Cloning jupyterhub/grafana-dashboards...")
+    print_colour("Cloning jupyterhub/grafana-dashboards...")
 
     dashboards_dir = "grafana_dashboards"
 
@@ -111,12 +111,12 @@ def deploy_jupyterhub_grafana(cluster_name):
     deploy_env.update({"GRAFANA_TOKEN": config["grafana_token"]})
 
     try:
-        print(f"Deploying grafana dashboards to {cluster_name}...")
+        print_colour(f"Deploying grafana dashboards to {cluster_name}...")
         subprocess.check_call(
             ["./deploy.py", grafana_url], env=deploy_env, cwd=dashboards_dir
         )
 
-        print(f"Done! Dasboards deployed to {grafana_url}.")
+        print_colour(f"Done! Dasboards deployed to {grafana_url}.")
     finally:
         # Delete the directory where we cloned the repo.
         # The deployer cannot call jsonnet to deploy the dashboards if using a temp directory here.

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 from ruamel.yaml import YAML
 
-from utils import decrypt_file
+from utils import decrypt_file, print_colour
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)
@@ -80,7 +80,7 @@ class Cluster:
         cert_manager_url = "https://charts.jetstack.io"
         cert_manager_version = "v1.3.1"
 
-        print("Adding cert-manager chart repo...")
+        print_colour("Adding cert-manager chart repo...")
         subprocess.check_call(
             [
                 "helm",
@@ -91,7 +91,7 @@ class Cluster:
             ]
         )
 
-        print("Updating cert-manager chart repo...")
+        print_colour("Updating cert-manager chart repo...")
         subprocess.check_call(
             [
                 "helm",
@@ -100,7 +100,7 @@ class Cluster:
             ]
         )
 
-        print("Provisioning cert-manager...")
+        print_colour("Provisioning cert-manager...")
         subprocess.check_call(
             [
                 "helm",
@@ -114,9 +114,9 @@ class Cluster:
                 "--set=installCRDs=true",
             ]
         )
-        print("Done!")
+        print_colour("Done!")
 
-        print("Provisioning support charts...")
+        print_colour("Provisioning support charts...")
         subprocess.check_call(["helm", "dep", "up", "support"])
 
         support_dir = Path(__file__).parent.parent / "support"
@@ -141,7 +141,7 @@ class Cluster:
                     "--wait",
                 ]
             )
-        print("Done!")
+        print_colour("Done!")
 
     def auth_kubeconfig(self):
         """
@@ -595,7 +595,7 @@ class Hub:
                 f"--values={secret_values_file.name}",
             ]
 
-            print(f"Running {' '.join(cmd)}")
+            print_colour(f"Running {' '.join(cmd)}")
             # Can't test without deploying, since our service token isn't set by default
             subprocess.check_call(cmd)
 
@@ -616,7 +616,7 @@ class Hub:
                 # On failure, pytest prints out params to the test that failed.
                 # This can contain sensitive info - so we hide stderr
                 # FIXME: Don't use pytest - just call a function instead
-                print("Running hub health check...")
+                print_colour("Running hub health check...")
                 # Show errors locally but redirect on CI
                 gh_ci = os.environ.get("CI", "false")
                 pytest_args = [
@@ -630,16 +630,16 @@ class Hub:
                     self.spec["template"],
                 ]
                 if gh_ci == "true":
-                    print("Testing on CI, not printing output")
+                    print_colour("Testing on CI, not printing output")
                     with open(os.devnull, "w") as dn, redirect_stderr(
                         dn
                     ), redirect_stdout(dn):
                         exit_code = pytest.main(pytest_args)
                 else:
-                    print("Testing locally, do not redirect output")
+                    print_colour("Testing locally, do not redirect output")
                     exit_code = pytest.main(pytest_args)
                 if exit_code != 0:
-                    print("Health check failed!", file=sys.stderr)
+                    print_colour("Health check failed!", file=sys.stderr)
                     sys.exit(exit_code)
                 else:
-                    print("Health check succeeded!")
+                    print_colour("Health check succeeded!")

--- a/deployer/utils.py
+++ b/deployer/utils.py
@@ -104,3 +104,23 @@ def update_authenticator_config(config, template):
     authenticator["admin_users"] = replace_staff_placeholder(
         authenticator["admin_users"], staff["staff"]
     )
+
+
+def print_colour(msg: str):
+    """Print messages in colour to be distinguishable in CI logs
+
+    See the mybinder.org deploy.py script for more details:
+    https://github.com/jupyterhub/mybinder.org-deploy/blob/master/deploy.py
+
+    Args:
+        msg (str): The message to print in colour
+    """
+    if os.environ.get("TERM"):
+        BOLD = subprocess.check_output(['tput', 'bold']).decode()
+        GREEN = subprocess.check_output(['tput', 'setaf', '2']).decode()
+        NC = subprocess.check_output(['tput', 'sgr0']).decode()
+    else:
+        # no term, no colors
+        BOLD = GREEN = NC = ""
+
+    print(BOLD + GREEN + msg + NC, flush=True)


### PR DESCRIPTION
I often find it difficult to see at which point the deployer is at in CI due to the long scroll of white text on a black background. This PR reuses a bit of code from [mybinder.org's deploy script](https://github.com/jupyterhub/mybinder.org-deploy/blob/f6ad7e1bca60bd688620cbee5f0a92abc51831fe/deploy.py#L12-L18) to print key message in a bold, green font in order to make them stand out more in CI. See also the [setting of the `TERM` environment variable]()https://github.com/jupyterhub/mybinder.org-deploy/blob/f6ad7e1bca60bd688620cbee5f0a92abc51831fe/.github/workflows/cd.yml#L136-L137 in their CI.