### PR TITLE
Enable pre-pullers on UToronto hubs

### DIFF
--- a/config/hubs/utoronto.cluster.yaml
+++ b/config/hubs/utoronto.cluster.yaml
@@ -40,6 +40,15 @@ hubs:
           # Trailing slash is important!
           baseShareName: /2i2cutorontohubstorage/homes/
       jupyterhub:
+        # pre-puller is necessary as the image is pretty big, and
+        # pulling during first user spawn might cause timeouts.
+        # Only required on staging hub though, as they share the same
+        # cluster, and staging is always deployed before prod
+        prePuller:
+          continuous:
+            enabled: false
+          hook:
+            enabled: false
         custom: &staging_jhub_custom
           homepage:
             templateVars:


### PR DESCRIPTION
pre-puller is necessary as the image is pretty big, and
pulling during first user spawn might cause timeouts.
Only required on staging hub though, as they share the same
cluster, and staging is always deployed before prod