### PR TITLE
Shorten mills username_pattern

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -363,7 +363,7 @@ hubs:
                 - jpercy@berkeley.edu
                 - akonrad@mills.edu
                 - wang@mills.edu
-              username_pattern: '^(.+@mills\.edu|yuvipanda@2i2c\.org|choldgraf@2i2c\.org|georgianaelena@2i2c\.org|sgibson@2i2c\.org|erik@2i2c\.org|damianavila@2i2c\.org|aculich@berkeley\.edu|jpercy@berkeley\.edu|deployment-service-check)$'
+              username_pattern: '^(.+@mills\.edu|.+@2i2c\.org|aculich@berkeley\.edu|jpercy@berkeley\.edu|deployment-service-check)$'
   - name: palomar
     domain: palomar.cloudbank.2i2c.cloud
     template: basehub


### PR DESCRIPTION
This allows everyone with a 2i2c address to login into the mills hub instead of listing the entire tech team one by one in an effort to de-uglify a bit the `username_pattern` and make it more understandable.