### PR TITLE
Add a 2i2c demo hub with CILogon enabled

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -94,6 +94,35 @@ hubs:
                   - <staff_google_ids>
                   - colliand@gmail.com
                 admin_users: *dask_staging_users
+  - name: demo
+    domain: demo.pilot.2i2c.cloud
+    template: basehub
+    auth0:
+      connection: CILogon
+    config:
+      jupyterhub:
+        custom:
+          homepage:
+            templateVars:
+              org:
+                name: 2i2c Demo Hub
+                url: https://2i2c.org
+                logo_url: https://2i2c.org/media/logo.png
+              designed_by:
+                name: 2i2c
+                url: https://2i2c.org
+              operated_by:
+                name: 2i2c
+                url: https://2i2c.org
+              funded_by:
+                name: 2i2c
+                url: https://2i2c.org
+        hub:
+          config:
+            Authenticator:
+              admin_users:
+                - <staff_google_ids>
+              username_pattern: '^(.+@2i2c\.org|deployment-service-check)$'
   - name: ohw
     domain: ohw.pilot.2i2c.cloud
     template: daskhub

--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -11,6 +11,13 @@ Here's a list of running hubs.
 
 </div>
 
+```{note}
+About our demo hub
+
+The 2i2c operates a hub for demonstration and experimentation at `demo.pilot.2i2c.org`.
+This hub is primarily for the 2i2c team to try things out, and it may change or break occasionally.
+Team members should feel free to experiment with this hub and try out new functionality and features they'd like to show off to others.
+```
 
 
 <!-- DataTables to make the table above look nice -->


### PR DESCRIPTION
Part of https://github.com/2i2c-org/infrastructure/issues/315 and a continuation of the discussion in https://github.com/2i2c-org/infrastructure/pull/941#discussion_r790184178