### PR TITLE
Use helm_chart key instead of template in deployer

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -19,7 +19,7 @@ support:
 hubs:
   - name: staging
     domain: staging.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -55,7 +55,7 @@ hubs:
               admin_users: *staging_users
   - name: dask-staging
     domain: dask-staging.pilot.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: google-oauth2
     config:
@@ -96,7 +96,7 @@ hubs:
                 admin_users: *dask_staging_users
   - name: demo
     domain: demo.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: CILogon
     config:
@@ -125,7 +125,7 @@ hubs:
               username_pattern: '^(.+@2i2c\.org|deployment-service-check)$'
   - name: ohw
     domain: ohw.pilot.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config:
@@ -196,7 +196,7 @@ hubs:
                 admin_users: *ohw_users
   - name: justiceinnovationlab
     domain: justiceinnovationlab.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: github
     config:
@@ -226,7 +226,7 @@ hubs:
                 - JILPulvino
   - name: pfw
     domain: pfw.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: github
     config:
@@ -258,7 +258,7 @@ hubs:
               admin_users: *pfw_users
   - name: peddie
     domain: peddie.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -290,7 +290,7 @@ hubs:
               admin_users: *peddie_users
   - name: catalyst-cooperative
     domain: catalyst-cooperative.pilot.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: google-oauth2
     config:
@@ -336,7 +336,7 @@ hubs:
                 admin_users: *catalyst_users
   - name: earthlab
     domain: earthlab.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: github
     config:
@@ -366,7 +366,7 @@ hubs:
               admin_users: *earthlab_users
   - name: paleohack2021
     domain: paleohack2021.hackathon.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: github
     config:
@@ -417,7 +417,7 @@ hubs:
               admin_users: *paleohack_users
   - name: aup
     domain: aup.pilot.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: github
     config:

--- a/config/hubs/azure.carbonplan.cluster.yaml
+++ b/config/hubs/azure.carbonplan.cluster.yaml
@@ -24,7 +24,7 @@ support:
 hubs:
   - name: staging
     domain: staging.azure.carbonplan.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &carbonPlanHubConfig
@@ -188,7 +188,7 @@ hubs:
               memory: 4Gi
   - name: prod
     domain: prod.azure.carbonplan.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *carbonPlanHubConfig

--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -32,7 +32,7 @@ support:
 hubs:
   - name: staging
     domain: staging.carbonplan.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &carbonPlanHubConfig
@@ -211,7 +211,7 @@ hubs:
               c.KubeClusterConfig.idle_timeout = 1800
   - name: prod
     domain: carbonplan.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *carbonPlanHubConfig

--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -19,7 +19,7 @@ support:
 hubs:
   - name: spelman
     domain: spelman.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -52,7 +52,7 @@ hubs:
               admin_users: *spelman_users
   - name: ccsf
     domain: ccsf.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -86,7 +86,7 @@ hubs:
               admin_users: *ccsf_users
   - name: elcamino
     domain: elcamino.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -123,7 +123,7 @@ hubs:
               admin_users: *elcamino_users
   - name: howard
     domain: howard.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -155,7 +155,7 @@ hubs:
               admin_users: *howard_users
   - name: skyline
     domain: skyline.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -188,7 +188,7 @@ hubs:
               admin_users: *skyline_users
   - name: demo
     domain: demo.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: password
       password:
@@ -237,7 +237,7 @@ hubs:
           maxAge: 43200
   - name: lassen
     domain: lassen.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -269,7 +269,7 @@ hubs:
               admin_users: *lassen_users
   - name: clovis
     domain: clovis.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -301,7 +301,7 @@ hubs:
               admin_users: *clovis_users
   - name: sbcc
     domain: sbcc.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -333,7 +333,7 @@ hubs:
               admin_users: *sbcc_users
   - name: mills
     domain: datahub.mills.edu
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -366,7 +366,7 @@ hubs:
               username_pattern: '^(.+@mills\.edu|.+@2i2c\.org|aculich@berkeley\.edu|jpercy@berkeley\.edu|deployment-service-check)$'
   - name: palomar
     domain: palomar.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -399,7 +399,7 @@ hubs:
               admin_users: *palomar_users
   - name: sjcc
     domain: sjcc.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -432,7 +432,7 @@ hubs:
               admin_users: *sjcc_users
   - name: avc
     domain: avc.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: google-oauth2
     config:
@@ -467,7 +467,7 @@ hubs:
               admin_users: *avc_users
   - name: csu
     domain: csu.cloudbank.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       connection: password
       password:

--- a/config/hubs/farallon.cluster.yaml
+++ b/config/hubs/farallon.cluster.yaml
@@ -9,7 +9,7 @@ aws:
 hubs:
   - name: staging
     domain: staging.farallon.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &hubConfig
@@ -155,7 +155,7 @@ hubs:
               c.KubeClusterConfig.idle_timeout = 1800
   - name: prod
     domain: farallon.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *hubConfig

--- a/config/hubs/justiceinnovationlab.cluster.yaml
+++ b/config/hubs/justiceinnovationlab.cluster.yaml
@@ -5,7 +5,7 @@ kubeconfig:
 hubs:
   - name: staging
     domain: staging.justiceinnovationlab.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &hubConfig
@@ -121,7 +121,7 @@ hubs:
             nodeSelector: {}
   - name: prod
     domain: justiceinnovationlab.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *hubConfig

--- a/config/hubs/meom-ige.cluster.yaml
+++ b/config/hubs/meom-ige.cluster.yaml
@@ -8,7 +8,7 @@ gcp:
 hubs:
   - name: staging
     domain: staging.meom-ige.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &meomConfig
@@ -136,7 +136,7 @@ hubs:
             c.KubeClusterConfig.idle_timeout = 1800
   - name: prod
     domain: meom-ige.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *meomConfig

--- a/config/hubs/openscapes.cluster.yaml
+++ b/config/hubs/openscapes.cluster.yaml
@@ -32,7 +32,7 @@ support:
 hubs:
   - name: staging
     domain: staging.openscapes.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: &openscapesHubConfig
@@ -163,7 +163,7 @@ hubs:
             c.KubeClusterConfig.idle_timeout = 1800
   - name: prod
     domain: openscapes.2i2c.cloud
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       connection: github
     config: *openscapesHubConfig

--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -30,7 +30,7 @@ support:
 hubs:
   - name: staging
     domain: staging.us-central1-b.gcp.pangeo.io
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       enabled: false
     config:
@@ -160,7 +160,7 @@ hubs:
                 limit: 2G
   - name: prod
     domain: us-central1-b.gcp.pangeo.io
-    template: daskhub
+    helm_chart: daskhub
     auth0:
       enabled: false
     config:

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -153,7 +153,7 @@ properties:
       - name
       - domain
       - auth0
-      - template
+      - helm_chart
       - config
     items:
       - type: object
@@ -163,7 +163,7 @@ properties:
             type: string
             description: |
               Name of the hub. This will be used to determine
-              the namespace the hub is deployed to
+              the kubernetes namespace the hub is deployed into.
           domain:
             type: string
             description: |
@@ -174,12 +174,12 @@ properties:
               For example, there's a entry for '*.pilot.2i2c.cloud' pointing to
               the ingress controller of the cluster running hubs in `2i2c.cluster.yaml`.
               Similar for '*.cloudbank.2i2c.cloud', etc.
-          template:
+          helm_chart:
             type: string
             description: |
-              Template to deploy the hub with. This refers to a directory under
-              `helm-charts` containing a helm chart with base values and dependencies
-              that determine the kind of hub deployed.
+              Hub helm chart to deploy. This refers to a directory under `helm-charts`
+              containing a helm chart with base values and dependencies that
+              determines the kind of hub deployed.
             enum:
               - basehub
               - daskhub

--- a/config/hubs/utoronto.cluster.yaml
+++ b/config/hubs/utoronto.cluster.yaml
@@ -24,7 +24,7 @@ support:
 hubs:
   - name: staging
     domain: staging.utoronto.2i2c.cloud
-    template: basehub
+    helm_chart: basehub
     auth0:
       enabled: false
     config:
@@ -129,7 +129,7 @@ hubs:
               tenant_id: 78aac226-2f03-4b4d-9037-b46d56c55210
   - name: prod
     domain: jupyter.utoronto.ca
-    template: basehub
+    helm_chart: basehub
     auth0:
       enabled: false
     config:

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -167,11 +167,11 @@ def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):
         hubs = cluster.hubs
         if hub_name:
             hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
-            update_authenticator_config(hub.spec["config"], hub.spec["template"])
+            update_authenticator_config(hub.spec["config"], hub.spec["helm_chart"])
             hub.deploy(k, SECRET_KEY, skip_hub_health_test)
         else:
             for hub in hubs:
-                update_authenticator_config(hub.spec["config"], hub.spec["template"])
+                update_authenticator_config(hub.spec["config"], hub.spec["helm_chart"])
                 hub.deploy(k, SECRET_KEY, skip_hub_health_test)
 
 

--- a/deployer/utils.py
+++ b/deployer/utils.py
@@ -72,13 +72,13 @@ def replace_staff_placeholder(user_list, staff):
     return custom_users
 
 
-def update_authenticator_config(config, template):
+def update_authenticator_config(config, helm_chart):
     """Prepare a hub's configuration file for deployment."""
     # Load the staff config file
     with open("config/hubs/staff.yaml") as f:
         staff = yaml.load(f)
 
-    if "basehub" in template:
+    if "basehub" in helm_chart:
         authenticator = (
             config.get("jupyterhub", {})
             .get("hub", {})
@@ -86,7 +86,7 @@ def update_authenticator_config(config, template):
             .get("Authenticator", {})
         )
     else:
-        # Right now all the other templates inherit from basehub, fix this if things change
+        # Right now all the other helm charts inherit from basehub, fix this if things change
         authenticator = (
             config.get("basehub", {})
             .get("jupyterhub", {})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ def render_hubs():
             "name": "University of Toronto",
             "domain": "jupyter.utoronto.ca",
             "id": "utoronto",
-            "template": "base-hub ([deployment repo](https://github.com/utoronto-2i2c/jupyterhub-deploy/))",
+            "hub_type": "base-hub ([deployment repo](https://github.com/utoronto-2i2c/jupyterhub-deploy/))",
         }
     ]
     for cluster_info in clusters:
@@ -123,7 +123,7 @@ def render_hubs():
                     ],
                     "domain": f"[{hub['domain']}](https://{hub['domain']})",
                     "id": hub["name"],
-                    "template": hub["helm_chart"],
+                    "hub_type": hub["helm_chart"],
                     "grafana": grafana_url,
                 }
             )
@@ -139,7 +139,7 @@ def render_tfdocs():
     # Output path is relative to terraform directory
     output_path = Path("../docs/reference/terraform.md")
 
-    # Template for output file is in ../terraform/.terraform-docs.yml
+    # hub_type for output file is in ../terraform/.terraform-docs.yml
     subprocess.check_call(
         [
             "terraform-docs",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ def render_hubs():
                     ],
                     "domain": f"[{hub['domain']}](https://{hub['domain']})",
                     "id": hub["name"],
-                    "template": hub["template"],
+                    "template": hub["helm_chart"],
                     "grafana": grafana_url,
                 }
             )

--- a/docs/howto/operate/new-hub/index.md
+++ b/docs/howto/operate/new-hub/index.md
@@ -51,7 +51,7 @@ To deploy a new hub, follow these steps:
    For example, see the entries in [the 2i2c Google Cloud cluster configuration file](https://github.com/2i2c-org/infrastructure/blob/master/config/hubs/2i2c.cluster.yaml).
 
    :::{seealso}
-   See [](/topic/config.md) for more information about template configuration.
+   See [](/topic/config.md) for more information about hub helm chart configuration.
    :::
 5. Create a Pull Request with the new hub entry, and get a team member to review it.
 6. Once you merge the pull request, the GitHub Workflow will detect that a new entry has been added to the configuration file.


### PR DESCRIPTION
This PR changes the `template` key in the deployer and cluster config files to `helm_chart`, in keeping with the new folder name. I have ran the modified deployer against the 2i2c staging hub and it executed successfully.