### PR TITLE
Specify the logout_redirect_url for the utoronto hubs

### DIFF
--- a/config/clusters/utoronto.cluster.yaml
+++ b/config/clusters/utoronto.cluster.yaml
@@ -154,3 +154,4 @@ hubs:
               login_service: "University of Toronto ID"
               oauth_callback_url: https://jupyter.utoronto.ca/hub/oauth_callback
               tenant_id: 78aac226-2f03-4b4d-9037-b46d56c55210
+              logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://jupyter.utoronto.ca

--- a/config/clusters/utoronto.cluster.yaml
+++ b/config/clusters/utoronto.cluster.yaml
@@ -127,6 +127,7 @@ hubs:
               login_service: "University of Toronto ID"
               oauth_callback_url: https://staging.utoronto.2i2c.cloud/hub/oauth_callback
               tenant_id: 78aac226-2f03-4b4d-9037-b46d56c55210
+              logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://staging.utoronto.2i2c.cloud
   - name: prod
     domain: jupyter.utoronto.ca
     helm_chart: basehub


### PR DESCRIPTION
This PR uses the `logout_redirect_url` config option of OAuthenticator to log users out of Azure AD, otherwise, state is not cleared and a user that has recently logged out of their hub, won't be presented with the option to choose what UofT account to login with and be automatically logged in with whatever account they used before. 

*Note:* We're doing something similiar for the other hubs that use Auth0 https://github.com/2i2c-org/infrastructure/blob/066f166de3b40af7dfcec9565a788163db5416a8/deployer/auth.py#L164-L167

Fixes https://github.com/2i2c-org/infrastructure/issues/956 