### PR TITLE
Add pgadmin4 for UTexas hub

### DIFF
--- a/config/clusters/2i2c.cluster.yaml
+++ b/config/clusters/2i2c.cluster.yaml
@@ -508,22 +508,22 @@ hubs:
             - name: pgadmin4
               image: dpage/pgadmin4
               env:
-              # Users use this to login to pgadmin4 itself
-              # Access to that is secured with jupyter-server-proxy
-              - name: PGADMIN_DEFAULT_EMAIL
-                value: jovyan@jovyan.org
-              - name: PGADMIN_DEFAULT_PASSWORD
-                value: jovyan
-              # Don't allow outside users to even connect to pgadmin4
-              - name: PGADMIN_LISTEN_ADDRESS
-                value: "127.0.0.1"
-              - name: PGADMIN_LISTEN_PORT
-                value: "5050"
-              # Tell pgadmin4 what base_url it's running under
-              - name: SCRIPT_NAME
-                # FIXME: This doesn't work with named servers,
-                # https://github.com/jupyterhub/kubespawner/pull/565 fixes this
-                value: "/user/{username}/proxy/absolute/5050"
+                # Users use this to login to pgadmin4 itself
+                # Access to that is secured with jupyter-server-proxy
+                - name: PGADMIN_DEFAULT_EMAIL
+                  value: jovyan@jovyan.org
+                - name: PGADMIN_DEFAULT_PASSWORD
+                  value: jovyan
+                # Don't allow outside users to even connect to pgadmin4
+                - name: PGADMIN_LISTEN_ADDRESS
+                  value: "127.0.0.1"
+                - name: PGADMIN_LISTEN_PORT
+                  value: "5050"
+                # Tell pgadmin4 what base_url it's running under
+                - name: SCRIPT_NAME
+                  # FIXME: This doesn't work with named servers,
+                  # https://github.com/jupyterhub/kubespawner/pull/565 fixes this
+                  value: "/user/{username}/proxy/absolute/5050"
             - name: postgres
               image: postgres:14.1
               resources:

--- a/config/clusters/2i2c.cluster.yaml
+++ b/config/clusters/2i2c.cluster.yaml
@@ -505,8 +505,27 @@ hubs:
                   # So we put data in a subpath
                   subPath: data
           extraContainers:
+            - name: pgadmin4
+              image: dpage/pgadmin4
+              env:
+              # Users use this to login to pgadmin4 itself
+              # Access to that is secured with jupyter-server-proxy
+              - name: PGADMIN_DEFAULT_EMAIL
+                value: jovyan@jovyan.org
+              - name: PGADMIN_DEFAULT_PASSWORD
+                value: jovyan
+              # Don't allow outside users to even connect to pgadmin4
+              - name: PGADMIN_LISTEN_ADDRESS
+                value: "127.0.0.1"
+              - name: PGADMIN_LISTEN_PORT
+                value: "5050"
+              # Tell pgadmin4 what base_url it's running under
+              - name: SCRIPT_NAME
+                # FIXME: This doesn't work with named servers,
+                # https://github.com/jupyterhub/kubespawner/pull/565 fixes this
+                value: "/user/{username}/proxy/absolute/5050"
             - name: postgres
-              image: postgres:9.6
+              image: postgres:14.1
               resources:
                 limits:
                   # Best effort only. No more than 1 CPU


### PR DESCRIPTION
- Sets it up as a sidecar, so initial user setup is done easily.
  When https://github.com/yuvipanda/jupyter-pgadmin4-proxy actually
  works, we might be able to get rid of the sidecar.
- Sets the default username and password to a well known string,
  and protection is offered by jupyter-server-proxy instead.
- Upgrade to a more recent version of postgres while we are at it
 - Once deployed, user can go to https://utexas-demo.pilot.2i2c.cloud/hub/user-redirect/proxy/absolute/5050/
    (note the trailing slash) and login with jovyan@jovyan.org / jovyan
    as username / password. Proper shortcuts will require
    fixing https://github.com/yuvipanda/jupyter-launcher-shortcuts a
    bit

Ref https://github.com/2i2c-org/infrastructure/issues/968