### PR TITLE
Provide persistent storage for postgres db

### DIFF
--- a/config/clusters/2i2c.cluster.yaml
+++ b/config/clusters/2i2c.cluster.yaml
@@ -528,7 +528,7 @@ hubs:
             extraVolumes:
               - name: postgres-db
                 persistentVolumeClaim:
-                  claimName: 'postgres-{username}'
+                  claimName: "postgres-{username}"
             extraVolumeMounts:
               - name: postgres-db
                 mountPath: /var/lib/postgresql/data

--- a/config/clusters/2i2c.cluster.yaml
+++ b/config/clusters/2i2c.cluster.yaml
@@ -474,6 +474,49 @@ hubs:
                 name: JROST & IOI
                 url: https://investinopen.org/blog/jrost-rapid-response-fund-awardees
         hub:
+          extraConfig:
+            # Create persistent disks for each user in the hub to store postgresql data in
+            100-create-postgres-pvc: |
+              from jupyterhub.utils import exponential_backoff
+              from kubespawner.objects import make_pvc
+              from functools import partial
+
+              def make_extra_pvc(component, name_template, storage_class, storage_capacity, spawner):
+                  """
+                  Create a PVC resource for storing database contents
+                  """
+                  labels = spawner._build_common_labels({})
+                  labels.update({
+                      'component': component
+                  })
+                  annotations = spawner._build_common_annotations({})
+                  storage_selector = spawner._expand_all(spawner.storage_selector)
+                  return make_pvc(
+                      name=spawner._expand_all(name_template),
+                      storage_class=storage_class,
+                      access_modes=['ReadWriteOnce'],
+                      selector={},
+                      storage=storage_capacity,
+                      labels=labels,
+                      annotations=annotations
+                  )
+
+              # 1Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
+              make_db_pvc = partial(make_extra_pvc, 'postgres-storage', 'postgres-{username}', 'standard-rwo', '1Gi')
+
+              async def ensure_db_pvc(spawner):
+                  """"
+                  Ensure a PVC is created for this user's database volume
+                  """
+                  pvc = make_db_pvc(spawner)
+                  # If there's a timeout, just let it propagate to the user
+                  await exponential_backoff(
+                      partial(spawner._make_create_pvc_request, pvc, spawner.k8s_api_request_timeout),
+                      f'Could not create pvc {pvc.metadata.name}',
+                      # Each req should be given k8s_api_request_timeout seconds.
+                      timeout=spawner.k8s_api_request_retry_timeout
+                  )
+              c.Spawner.pre_spawn_hook = ensure_db_pvc
           config:
             Authenticator:
               allowed_users: &utexas_demo_users
@@ -484,8 +527,14 @@ hubs:
           storage:
             extraVolumes:
               - name: postgres-db
-                # No persistence for now, will be backed by a PVC later
-                emptyDir: {}
+                persistentVolumeClaim:
+                  claimName: 'postgres-{username}'
+            extraVolumeMounts:
+              - name: postgres-db
+                mountPath: /var/lib/postgresql/data
+                # postgres recommends against mounting a volume directly here
+                # So we put data in a subpath
+                subPath: data
           initContainers:
             # /var/lib/postgresql should be writeable by uid 1000, so students
             # can blow out their db directories if need to. Also lets postgres actually


### PR DESCRIPTION
- For each user, we create a 1Gi persistent standard non-ssd
  disk, and put the postgresql data on it. This way, it survives
  user pod restarts!
- 1Gi seems to be the smallest individual disk we can get. We
  can resize it up automatically if needed.
- Code adapted from common.yaml in
  https://github.com/berkeley-dsep-infra/datahub/pull/2651.

Ref https://github.com/2i2c-org/infrastructure/issues/968