### PR TITLE
Update machine type for GPU node pools

### DIFF
--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -62,6 +62,10 @@ notebook_nodes = {
     min : 0,
     max : 20,
     vm_size : "Standard_NC24s_v3",
+    labels: {
+      "hub.jupyter.org/sku=gpu",
+    },
+    taints: [ ],
     kubernetes_version = "1.19.13",
   },
 }
@@ -119,6 +123,10 @@ dask_nodes = {
     min : 0,
     max : 20,
     vm_size : "Standard_NC24s_v3",
+    labels: {
+      "hub.jupyter.org/sku=gpu",
+    },
+    taints: [ ],
     kubernetes_version = "1.19.13",
   },
 }

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -61,11 +61,7 @@ notebook_nodes = {
     "gpu" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_NC16as_T4_v3",
-    labels: { },
-    taints: [
-      "sku=gpu:NoSchedule",
-    ],
+    vm_size : "Standard_NC24s_v3",
     kubernetes_version = "1.19.13",
   },
 }
@@ -122,11 +118,7 @@ dask_nodes = {
   "gpu" : {
     min : 0,
     max : 20,
-    vm_size : "Standard_NC16as_T4_v3",
-    labels: { },
-    taints: [
-      "sku=gpu:NoSchedule",
-    ],
+    vm_size : "Standard_NC24s_v3",
     kubernetes_version = "1.19.13",
   },
 }

--- a/terraform/azure/projects/carbonplan.tfvars
+++ b/terraform/azure/projects/carbonplan.tfvars
@@ -63,7 +63,7 @@ notebook_nodes = {
     max : 20,
     vm_size : "Standard_NC24s_v3",
     labels: {
-      "hub.jupyter.org/sku=gpu",
+      "hub.jupyter.org/sku": "gpu",
     },
     taints: [ ],
     kubernetes_version = "1.19.13",
@@ -124,7 +124,7 @@ dask_nodes = {
     max : 20,
     vm_size : "Standard_NC24s_v3",
     labels: {
-      "hub.jupyter.org/sku=gpu",
+      "hub.jupyter.org/sku": "gpu",
     },
     taints: [ ],
     kubernetes_version = "1.19.13",


### PR DESCRIPTION
This PR changes the machine type for the GPU node pools to a family we have quota for, according to https://github.com/2i2c-org/infrastructure/issues/930#issuecomment-1028205052

It also removes the node taint and uses a label to identify gpu nodes instead