### PR TITLE
Rename utexas-demo to utexas

### DIFF
--- a/config/clusters/2i2c.cluster.yaml
+++ b/config/clusters/2i2c.cluster.yaml
@@ -450,8 +450,8 @@ hubs:
                 - swalker
                 - shaolintl
               admin_users: *aup_users
-  - name: utexas-demo
-    domain: utexas-demo.pilot.2i2c.cloud
+  - name: utexas
+    domain: utexas.pilot.2i2c.cloud
     helm_chart: basehub
     auth0:
       connection: github


### PR DESCRIPTION
This will lose the old hub, but that's ok.

Ref https://github.com/2i2c-org/infrastructure/issues/968