### PR TITLE
Remove allowed_users key from uwhackweeks

### DIFF
--- a/config/clusters/uwhackweeks.cluster.yaml
+++ b/config/clusters/uwhackweeks.cluster.yaml
@@ -156,11 +156,9 @@ hubs:
                   - read:user
                   - read:org
               Authenticator:
-                admin_users: &users
+                admin_users:
                   - <staff_github_ids>
                   - scottyhq
-                # Without this, any GitHub user can authenticate
-                allowed_users: *users
       dask-gateway:
         extraConfig:
           idle: |


### PR DESCRIPTION
When using GitHub Org or Teams authentication, you **MUST NOT** provide the `allowed_users` key in the helm chart config. Since enabling `allowed_users` will block access to anyone who has not been added via the admin panel **even if** they are valid members of the team. In this case, it is **NOT TRUE** that anyone on GitHub will be able to login  without the `allowed_users` key.

This behaviour is documented in the Note block under step 3 in our docs here: https://infrastructure.2i2c.org/en/latest/howto/configure/auth-management.html#native-jupyterhub-oauthenticator-for-github-orgs-and-teams

This PR should resolve the authentication issues discussed by @scottyhq here: https://github.com/2i2c-org/infrastructure/issues/962#issuecomment-1032871676