### PR TITLE
Check for homepage template branch name including clustername

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -400,8 +400,8 @@ class Hub:
                                 dedent(
                                     f"""\
                                     while true; do git fetch origin;
-                                    if [[ $(git ls-remote --heads origin {self.spec["name"]} | wc -c) -ne 0 ]]; then
-                                        git reset --hard origin/{self.spec["name"]};
+                                    if [[ $(git ls-remote --heads origin {self.cluster}-{self.spec["name"]} | wc -c) -ne 0 ]]; then
+                                        git reset --hard origin/{self.cluster}-{self.spec["name"]};
                                     else
                                         git reset --hard origin/master;
                                     fi

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -400,8 +400,8 @@ class Hub:
                                 dedent(
                                     f"""\
                                     while true; do git fetch origin;
-                                    if [[ $(git ls-remote --heads origin {self.cluster}-{self.spec["name"]} | wc -c) -ne 0 ]]; then
-                                        git reset --hard origin/{self.cluster}-{self.spec["name"]};
+                                    if [[ $(git ls-remote --heads origin {self.cluster.spec["name"]}-{self.spec["name"]} | wc -c) -ne 0 ]]; then
+                                        git reset --hard origin/{self.cluster.spec["name"]}-{self.spec["name"]};
                                     else
                                         git reset --hard origin/master;
                                     fi


### PR DESCRIPTION
This changes `templates-sync` behavior so that it searches for a https://github.com/2i2c-org/pilot-homepage branch that matches `<cluster-name>-<hub-name>` to update the homepage, before using the main branch.

Before this it would only matched `<hub-name>` which is not ok, since we have multiple hubs with the same name (staging, prod).