### PR TITLE
Hardcode the docs service into basehub

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -498,18 +498,6 @@ class Hub:
             "services", {}
         )["hub-health"] = {"apiToken": hub_health_token, "admin": True}
 
-        docs_token = hmac.new(
-            secret_key, f'docs-{self.spec["name"]}'.encode(), hashlib.sha256
-        ).hexdigest()
-        if (
-            "docs_service" in self.spec["config"].keys()
-            and self.spec["config"]["docs_service"]["enabled"]
-        ):
-            generated_config["jupyterhub"]["hub"]["services"]["docs"] = {
-                "url": f'http://docs-service.{self.spec["name"]}',
-                "apiToken": docs_token,
-            }
-
         # FIXME: Have a templates config somewhere? Maybe in Chart.yaml
         # FIXME: This is a hack. Fix it.
         if hub_helm_chart != "basehub":

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -270,7 +270,7 @@ jupyterhub:
                     description: An IDE For R, created by the RStudio company
 
     services:
-      docs_service:
+      docs:
         url: http://docs-service
       configurator:
         url: http://configurator:10101

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -270,6 +270,8 @@ jupyterhub:
                     description: An IDE For R, created by the RStudio company
 
     services:
+      docs_service:
+        url: http://docs-service
       configurator:
         url: http://configurator:10101
         command:


### PR DESCRIPTION
Previously, the deployer needed to read the helm chart values of a hub, generate a token for the docs service, and insert this into the rest of the helm chart values. This became tricky when we decided to split each hub into a set of files that uniquely describe it since the deployer would then have to read in the helm chart values files and find which one, if any, the docs-service was defined in.

However, this PR to jupyterhub https://github.com/jupyterhub/jupyterhub/pull/3531 means that the z2jh helm chart can find previously generated api tokens for services, or create them if they don't exist. Hence there is no more need to generate a token within the deployer. We can hardcode the docs-service into basehub's default values the same way we do with the configurator. We do not need to specify the full namespace of the URL so long as the proxy pod is in the same namespace.