### PR TITLE
Fix pgadmin4 for U Texas

### DIFF
--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -117,6 +117,13 @@ jupyterhub:
             # FIXME: This doesn't work with named servers,
             # https://github.com/jupyterhub/kubespawner/pull/565 fixes this
             value: "/user/{username}/proxy/absolute/5050"
+          # Turn off tying the user session to a particular IP the request
+          # is coming from - in a dynamic environment like kubernetes, this
+          # means users keep getting 'logged out' every minute or so.
+          # Look for `ENHANCED_COOKIE_PROTECTION` in
+          # https://www.pgadmin.org/docs/pgadmin4/development/config_py.html
+          - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
+            value: 'False'
       - name: postgres
         image: postgres:10
         resources:

--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -123,7 +123,7 @@ jupyterhub:
           # Look for `ENHANCED_COOKIE_PROTECTION` in
           # https://www.pgadmin.org/docs/pgadmin4/development/config_py.html
           - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
-            value: 'False'
+            value: "False"
       - name: postgres
         image: postgres:10
         resources:


### PR DESCRIPTION
pgadmin4 was using end user IP in its session cookie for
extra security - however this doesn't work in kubernetes
type environments with a lot of dynamic IPs. The documentation
suggests we turn this off, and we do.

Ref https://github.com/2i2c-org/infrastructure/issues/968