### PR TITLE
Update jhub-client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ chartpress
 six # temp workaround for docker==5.0.0, used by chartpress, that failed to depend on six
 ruamel.yaml
 auth0-python
-jhub-client==0.1.2
+jhub-client==0.1.4
 jsonschema


### PR DESCRIPTION
The new version comes with [a few improvements](https://github.com/Quansight/jhub-client/compare/v0.1.2...v0.1.4), that could help the current effort of improving the testing infra.