### PR TITLE
Update uwhackweeks hub

### DIFF
--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -32,7 +32,7 @@ basehub:
             url: https://2i2c.org
           funded_by:
             name:
-            url: https://www.openscapes.org/
+            url: https://icesat-2.hackweek.io
     singleuser:
       serviceAccountName: cloud-user-sa
       defaultUrl: /lab


### PR DESCRIPTION
- This updates uwhackwweks `funded_by` section as noticed by @damianavila [here](https://github.com/2i2c-org/infrastructure/pull/981#discussion_r808598988)
- Changes the helm chart used by the hub to `basehub` instead of `daskhub` (see [this comment](https://github.com/2i2c-org/infrastructure/issues/998#issuecomment-1041818555) for context)
_Note: Not sure about this last one. Waiting for confirmation if the uwhackweeks hub wasn't meant to be a daskhub as it's my understanding from the initial issue_