### PR TITLE
Bump utexas memory limit

### DIFF
--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -68,6 +68,9 @@ jupyterhub:
           - jameshowison
         admin_users: *utexas_demo_users
   singleuser:
+    memory:
+      guarantee: 2G
+      limit: 2G
     storage:
       extraVolumes:
         - name: postgres-db


### PR DESCRIPTION
Users were running into 'kernel dying' errors, which almost always
mean memory limits. The default memory *request* of 256Mi might not
be enough (see image attached to PR), so am giving it a generous
bump. We can tone it down after seeing usage.

Ref https://github.com/2i2c-org/leads/issues/52#issuecomment-1044801431