### PR TITLE
Verify cluster names

### DIFF
--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import subprocess
 from pathlib import Path
+import warnings
 
 import jsonschema
 from ruamel.yaml import YAML
@@ -226,8 +227,17 @@ def validate(cluster_name):
     cluster_dir = Path(os.getcwd()).joinpath("config", "clusters")
     schema_file = cluster_dir.joinpath("schema.yaml")
     config_file = cluster_dir.joinpath(cluster_name, "cluster.yaml")
+
     with open(config_file) as cf, open(schema_file) as sf:
         cluster_config = yaml.load(cf)
+
+        if not os.path.dirname(config_file).endswith(cluster_config["name"]):
+            warnings.warn(
+                "Cluster Name Mismatch: It is convention that the cluster name defined "
+                + "in cluster.yaml matches the name of the parent directory. "
+                + "Deployment won't be halted but please update this for consistency!"
+            )
+
         schema = yaml.load(sf)
         # Raises useful exception if validation fails
         jsonschema.validate(cluster_config, schema)


### PR DESCRIPTION
Check that the cluster name listed in cluster.yaml matches the name of
the parent directory. Raise a warning if it doesn't.