### PR TITLE
Bump postgres resource limit for utexas

### DIFF
--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -131,13 +131,11 @@ jupyterhub:
         image: postgres:10
         resources:
           limits:
-            # Best effort only. No more than 1 CPU
-            memory: 512Mi
+            memory: 2Gi
             cpu: 1.0
           requests:
-            # If we don't set requests, k8s sets requests == limits!
-            memory: 64Mi
-            cpu: 0.01
+            memory: 1Gi
+            cpu: 0.25
         env:
           - name: POSTGRES_HOST_AUTH_METHOD
             value: "trust"


### PR DESCRIPTION
Increase postgresql limits by a bit - it is possible that
the kernel deaths are caused by the postgres container hitting
its memory limit and dying. The graph in
https://github.com/2i2c-org/infrastructure/issues/1021#issuecomment-1048540620
makes it look like it isn't hitting the limit, but perhaps node
memory pressure is making it get killed just past the request
(which was 64MB) - so the bump might still help.