### PR TITLE
More dependabot bugfixes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,4 +28,4 @@ updates:
     ignore:
       # Ignore patch upgrades to further reduce noise
       - update-types: "patch"
-        dependency-name: "*"  # Match all packages
+        dependency-name: "*" # Match all packages

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,5 +27,5 @@ updates:
       interval: "weekly"
     ignore:
       # Ignore patch upgrades to further reduce noise
-      update-types:
-        - "patch"
+      - update-types: "patch"
+        dependency-name: "*"  # Match all packages


### PR DESCRIPTION
`dependency-name` is a required option, we use a wildcard to match all dependencies