### PR TITLE
Pin gcp provider versions

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,5 +1,15 @@
 terraform {
   backend "gcs" {}
+  required_providers {
+    google = {
+      source  = "google"
+      version = "4.11.0"
+    }
+    google-beta = {
+      source  = "google-beta"
+      version = "4.11.0"
+    }
+  }
 }
 
 // Service account used by all the nodes and pods in our cluster


### PR DESCRIPTION
Otherwise the versions on different people's machines might not
always match - I think my `terraform plan` was behaving differently
than it does on other people's.