### PR TITLE
Swap pip dependencies for GitHub Actions in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,10 +18,9 @@
 
 version: 2
 updates:
-  # Bump pip dependencies for docs
-  - package-ecosystem: "pip"
-    # Only check the pip dependencies listed in our docs folder
-    directory: "/docs"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       # Check for updates once a week. By default, this check happens on a Monday.
       interval: "weekly"


### PR DESCRIPTION
Dependabot was not opening Pull Requests because we don't pin the dependencies in `docs/requirements.txt` so as far as it could see, there was nothing to update.

This PR swaps out the check for our GitHub Actions workflows instead, many of which are pinned.