### PR TITLE
Disable auth0 for uwhackweeks hub

### DIFF
--- a/config/clusters/uwhackweeks/cluster.yaml
+++ b/config/clusters/uwhackweeks/cluster.yaml
@@ -34,9 +34,7 @@ hubs:
     domain: staging.uwhackweeks.2i2c.cloud
     helm_chart: daskhub
     auth0:
-      # connection update? Also ensure the basehub Helm chart is provided a
-      # matching value for jupyterhub.custom.2i2c.add_staff_user_ids_of_type!
-      connection: github
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
@@ -47,9 +45,7 @@ hubs:
     domain: uwhackweeks.2i2c.cloud
     helm_chart: daskhub
     auth0:
-      # connection update? Also ensure the basehub Helm chart is provided a
-      # matching value for jupyterhub.custom.2i2c.add_staff_user_ids_of_type!
-      connection: github
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check


### PR DESCRIPTION
Since the uwhackweeks hub uses the JupyterHub GitHubOAuthenticator and not auth0, then I believe auth0 should be disabled.
https://github.com/2i2c-org/infrastructure/blob/HEAD/config/clusters/uwhackweeks/staging.values.yaml#L113-L115

Not sure exactly why it works right now, but maybe it's because of how the config gets merged and overwritten?