### PR TITLE
Chart schemas, deployer script validation, and ci integration

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -19,7 +19,6 @@ runs:
     - name: Setup dependencies
       run: |
         python3 -m pip install -r requirements.txt
-        python3 -m pip install -r dev-requirements.txt
       shell: bash
     - name: Deploy support components
       run: |

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup dependencies
         run: |
           python3 -m pip install -r requirements.txt
-          python3 -m pip install -r dev-requirements.txt
           sudo apt install jsonnet
 
       - name: Setup gcloud

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -63,7 +63,6 @@ jobs:
               - "deployer/**"
               - "helm-charts/**"
               - "requirements.txt"
-              - "dev-requirements.txt"
               - "config/secrets.yaml"
               - ".github/workflows/deploy-hubs.yaml"
               - ".github/actions/deploy/*"

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -13,11 +13,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          # chartpress is used by doc/conf.py,
-          # and requires information about the latest tagged commit, which
-          # requires the git history.
-          fetch-depth: 0
 
       - name: Install environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -1,0 +1,96 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps. ref:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# Runs the deployer script to validate clusters. This will both validate
+# cluster.yaml files as well as each hubs passed non-encrypted values files
+# against the Helm charts' values schema.
+#
+name: Validate clusters
+
+on:
+  pull_request:
+    paths:
+      - config/clusters/**
+      - deployer/**
+      - helm-charts/basehub/**
+      - helm-charts/daskhub/**
+      - requirements.txt
+      - .github/workflows/validate-hubs.yaml
+  push:
+    paths:
+      - config/clusters/**
+      - deployer/**
+      - helm-charts/basehub/**
+      - helm-charts/daskhub/**
+      - requirements.txt
+      - .github/workflows/validate-hubs.yaml
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  validate-hubs-values-files:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cluster_name: 2i2c
+          - cluster_name: azure.carbonplan
+          - cluster_name: carbonplan
+          - cluster_name: cloudbank
+          - cluster_name: farallon
+          - cluster_name: meom-ige
+          - cluster_name: openscapes
+          - cluster_name: pangeo-hubs
+          - cluster_name: utoronto
+          - cluster_name: uwhackweeks
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check if any cluster common files has changed
+        uses: dorny/paths-filter@v2
+        id: cluster_common_files
+        with:
+          filters: |
+            files:
+              - deployer/**
+              - helm-charts/basehub/**
+              - helm-charts/daskhub/**
+              - requirements.txt
+              - .github/workflows/validate-hubs.yaml
+
+      - name: Check if cluster specific files has changes
+        uses: dorny/paths-filter@v2
+        id: cluster_specific_files
+        with:
+          filters: |
+            changes:
+              - config/clusters/${{ matrix.cluster_name }}/**
+
+      # To continue this cluster specific job we must either have manually
+      # invoked this workflow to run for all clusters, or there should have been
+      # changes to the cluster common files or cluster specific files.
+      - name: Decide if the job should continue
+        id: decision
+        run: |
+          echo ::set-output name=continue-job::${{ github.event_name == 'workflow_dispatch' || (steps.cluster_common_files.outputs.files == 'true' || steps.cluster_specific_files.outputs.changes == 'true') }}
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+
+      - name: Install deployer script dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: "Validate cluster: ${{ matrix.cluster_name }}"
+        if: steps.decision.outputs.continue-job == 'true'
+        env:
+          TERM: xterm
+        run: |
+          python deployer validate ${{ matrix.cluster_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 # have secret in their name.
 !**/templates/**/*secret*.yaml
 
+# Ignore the .json version of our Helm chart's schema files so we only version
+# control the .yaml file that we use to generate the .json file.
+values.schema.json
+
 # Ignore helm chart generated outputs
 Chart.lock
 **/charts/*.tgz

--- a/config/clusters/farallon/staging.values.yaml
+++ b/config/clusters/farallon/staging.values.yaml
@@ -35,7 +35,7 @@ basehub:
             url: https://2i2c.org
           funded_by:
             name: Farallon Institute
-            urL: http://www.faralloninstitute.org/
+            url: http://www.faralloninstitute.org/
     singleuser:
       initContainers:
         # Need to explicitly fix ownership here, since EFS doesn't do anonuid

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -1,5 +1,3 @@
-scratchBucket:
-  enabled: false
 basehub:
   nfs:
     pv:

--- a/config/clusters/utoronto/staging.values.yaml
+++ b/config/clusters/utoronto/staging.values.yaml
@@ -47,6 +47,10 @@ jupyterhub:
     extraFiles:
       github-app-private-key.pem:
         mountPath: /etc/github/github-app-private-key.pem
+        # stringData field will be set via encrypted values files but added here
+        # to meet the chart schema validation requirements without the need to
+        # use secret values during the validation.
+        stringData: "dummy"
       gitconfig:
         mountPath: /etc/gitconfig
         # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner

--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -1,5 +1,3 @@
-scratchBucket:
-  enabled: false
 basehub:
   nfs:
     pv:

--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -29,7 +29,7 @@ basehub:
             name: 2i2c
             url: https://2i2c.org
           funded_by:
-            name:
+            name: ICESat Hackweek
             url: https://icesat-2.hackweek.io
     singleuser:
       serviceAccountName: cloud-user-sa

--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -1,8 +1,8 @@
+import re
+
 from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
-
 from yarl import URL
-import re
 
 # What key in the authenticated user's profile to use as hub username
 # This shouldn't be changeable by the user!

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,13 @@
-pytest
-pytest-asyncio
+# These requirements represents the needs for doing various tasks in this git
+# repo besides using the deployer script.
+#
+
+# chartpress is relevant to build and push helm-charts/images/hub/Dockerfile and
+# update basehub's default values to reference the new image.
+chartpress
+
+# requests is used by extra_scripts/rsync-active-users.py
 requests
-beautifulsoup4
+
+# rich is used by extra_scripts/count-auth0-apps.py
 rich

--- a/docs/reference/ci-cd.md
+++ b/docs/reference/ci-cd.md
@@ -11,7 +11,6 @@ following paths are modified:
 - deployer/**
 - helm-charts/**
 - requirements.txt
-- dev-requirements.txt
 - config/secrets.yaml
 - config/clusters/**
 - .github/workflows/deploy-hubs.yaml

--- a/helm-charts/basehub/.helmignore
+++ b/helm-charts/basehub/.helmignore
@@ -1,3 +1,12 @@
+# Non default entries manually added by basehub developers
+
+# Ignore the .yaml that generates the .json, only the .json is relevant to
+# bundle with the Helm chart when it is packaged or "helm dep up" is used to
+# copy it over to another location where it is referenced.
+values.schema.yaml
+
+# -----------------------------------------------------------------------------
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/helm-charts/basehub/templates/azure-file.yaml
+++ b/helm-charts/basehub/templates/azure-file.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.azureFile.enabled }}
+{{- if .Values.azureFile.enabled -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -26,4 +26,4 @@ spec:
   resources:
     requests:
       storage: 1Mi
-{{ end }}
+{{- end }}

--- a/helm-charts/basehub/templates/cloud-resources/gcp/_helpers.tpl
+++ b/helm-charts/basehub/templates/cloud-resources/gcp/_helpers.tpl
@@ -1,9 +1,9 @@
 {{- define "cloudResources.gcp.serviceAccountName" -}}
-{{.Release.Name}}-user-sa
+{{ .Release.Name }}-user-sa
 {{- end }}
 
 {{- define "cloudResources.scratchBucket.name" -}}
 {{- if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" -}}
 {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}-{{ .Release.Name }}-scratch-bucket
-{{- end -}}
+{{- end }}
 {{- end }}

--- a/helm-charts/basehub/templates/cloud-resources/gcp/service-account.yaml
+++ b/helm-charts/basehub/templates/cloud-resources/gcp/service-account.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled}}
+{{- if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled -}}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:

--- a/helm-charts/basehub/templates/cloud-resources/gcp/storage-bucket.yaml
+++ b/helm-charts/basehub/templates/cloud-resources/gcp/storage-bucket.yaml
@@ -1,5 +1,5 @@
-{{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled  }}
-{{ if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" }}
+{{- if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled -}}
+{{- if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" -}}
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:

--- a/helm-charts/basehub/templates/nfs-share-creator.yaml
+++ b/helm-charts/basehub/templates/nfs-share-creator.yaml
@@ -1,5 +1,5 @@
-{{ if .Values.nfs.enabled }}
-{{ if .Values.nfs.shareCreator.enabled }}
+{{- if .Values.nfs.enabled -}}
+{{- if .Values.nfs.shareCreator.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -49,5 +49,5 @@ spec:
           nfs:
             server: {{ .Values.nfs.pv.serverIP | quote }}
             path: {{ .Values.nfs.pv.baseShareName | quote }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/basehub/templates/nfs.yaml
+++ b/helm-charts/basehub/templates/nfs.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.nfs.enabled }}
+{{- if .Values.nfs.enabled -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -9,7 +9,7 @@ spec:
   accessModes:
     - ReadWriteMany
   nfs:
-    server: {{ .Values.nfs.pv.serverIP | quote}}
+    server: {{ .Values.nfs.pv.serverIP | quote }}
     path: "{{ .Values.nfs.pv.baseShareName }}{{ .Release.Name }}"
   mountOptions: {{ .Values.nfs.pv.mountOptions | toJson }}
 ---
@@ -25,4 +25,4 @@ spec:
   resources:
     requests:
       storage: 1Mi
-{{ end }}
+{{- end }}

--- a/helm-charts/basehub/templates/user-sa.yaml
+++ b/helm-charts/basehub/templates/user-sa.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    {{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled}}
-    {{ if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" }}
+    {{- if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled }}
+    {{- if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" }}
     iam.gke.io/gcp-service-account: {{ include "cloudResources.gcp.serviceAccountName" .}}@{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}.iam.gserviceaccount.com
     {{- end }}
     {{- end }}

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -1,0 +1,254 @@
+# This schema (a jsonschema in YAML format) is used to generate
+# values.schema.json which is, when available, used by the helm CLI for client
+# side validation by Helm of the chart's values before template rendering.
+#
+# We look to document everything we have default values for in values.yaml, but
+# we don't look to enforce the perfect validation logic within this file.
+#
+# ref: https://json-schema.org/learn/getting-started-step-by-step.html
+#
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+additionalProperties: false
+required:
+  - azureFile
+  - nfs
+  - inClusterNFS
+  - global
+  - jupyterhub
+properties:
+  azureFile:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+      - pv
+    properties:
+      enabled:
+        type: boolean
+      pv:
+        type: object
+        additionalProperties: false
+        required:
+          - secretNamespace
+          - secretName
+          - shareName
+          - mountOptions
+        properties:
+          secretNamespace:
+            type: string
+          secretName:
+            type: string
+          shareName:
+            type: string
+          mountOptions:
+            type: array
+            items:
+              type: string
+  nfs:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+      - shareCreator
+      - pv
+    properties:
+      enabled:
+        type: boolean
+      shareCreator:
+        type: object
+        additionalProperties: false
+        required:
+          - enabled
+          - tolerations
+        properties:
+          enabled:
+            type: boolean
+          tolerations:
+            type: array
+            items:
+              type: object
+              additionalProperties: true
+      pv:
+        type: object
+        additionalProperties: false
+        required:
+          - mountOptions
+          - serverIP
+          - baseShareName
+        properties:
+          mountOptions:
+            type: array
+            items:
+              type: string
+          serverIP:
+            type: string
+          baseShareName:
+            type: string
+  inClusterNFS:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+      - size
+    properties:
+      enabled:
+        type: boolean
+      size:
+        type: string
+  global:
+    type: object
+    additionalProperties: true
+  jupyterhub:
+    type: object
+    additionalProperties: true
+    required:
+      - custom
+    properties:
+      custom:
+        type: object
+        additionalProperties: true
+        required:
+          - singleuserAdmin
+          - cloudResources
+          - docs_service
+          - 2i2c
+        properties:
+          homepage:
+            type: object
+            additionalProperties: false
+            required:
+              - templateVars
+            properties:
+              templateVars:
+                type: object
+                additionalProperties: false
+                required:
+                  - org
+                  - designed_by
+                  - operated_by
+                  - funded_by
+                properties:
+                  announcements:
+                    type: array
+                    items:
+                      type: string
+                  org:
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - name
+                      - logo_url
+                      - url
+                    properties:
+                      name:
+                        type: string
+                      logo_url:
+                        type: string
+                      url:
+                        type: string
+                  designed_by:
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - name
+                      - url
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  operated_by:
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - name
+                      - url
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                  funded_by:
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - name
+                      - url
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+          singleuserAdmin:
+            type: object
+            additionalProperties: false
+            required:
+              - extraVolumeMounts
+            properties:
+              extraVolumeMounts:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+          cloudResources:
+            type: object
+            additionalProperties: false
+            required:
+              - provider
+              - gcp
+              - scratchBucket
+            properties:
+              provider:
+                enum: ["", gcp]
+              gcp:
+                type: object
+                additionalProperties: false
+                required:
+                  - projectId
+                properties:
+                  projectId:
+                    type: string
+              scratchBucket:
+                type: object
+                additionalProperties: false
+                required:
+                  - enabled
+                properties:
+                  enabled:
+                    type: boolean
+          docs_service:
+            type: object
+            additionalProperties: false
+            required:
+              - enabled
+              - repo
+              - branch
+            properties:
+              enabled:
+                type: boolean
+              repo:
+                type: string
+              branch:
+                type: string
+          2i2c:
+            type: object
+            additionalProperties: false
+            required:
+              - add_staff_user_ids_to_admin_users
+              - add_staff_user_ids_of_type
+              - staff_github_ids
+              - staff_google_ids
+            properties:
+              add_staff_user_ids_to_admin_users:
+                type: boolean
+              add_staff_user_ids_of_type:
+                type: string
+              staff_github_ids:
+                type: array
+                items:
+                  type: string
+              staff_google_ids:
+                type: array
+                items:
+                  type: string

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -30,6 +30,11 @@ inClusterNFS:
   enabled: false
   size: 100Gi
 
+# A placeholder as global values that can be referenced from the same location
+# of any chart should be possible to provide, but aren't necessarily provided or
+# used.
+global: {}
+
 jupyterhub:
   custom:
     singleuserAdmin:
@@ -38,9 +43,9 @@ jupyterhub:
           mountPath: /home/jovyan/shared-readwrite
           subPath: _shared
     cloudResources:
-      provider:
+      provider: ""
       gcp:
-        projectId:
+        projectId: ""
       scratchBucket:
         enabled: false
     docs_service:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -353,7 +353,7 @@ jupyterhub:
         c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/']
 
         c.JupyterHub.template_vars = {
-          'custom':get_config('custom.homepage.templateVars')
+          'custom': get_config('custom.homepage.templateVars')
         }
       05-custom-admin: |
         from z2jh import get_config

--- a/helm-charts/daskhub/.helmignore
+++ b/helm-charts/daskhub/.helmignore
@@ -1,3 +1,12 @@
+# Non default entries manually added by basehub developers
+
+# Ignore the .yaml that generates the .json, only the .json is relevant to
+# bundle with the Helm chart when it is packaged or "helm dep up" is used to
+# copy it over to another location where it is referenced.
+values.schema.yaml
+
+# -----------------------------------------------------------------------------
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/helm-charts/daskhub/values.schema.yaml
+++ b/helm-charts/daskhub/values.schema.yaml
@@ -1,0 +1,26 @@
+# This schema (a jsonschema in YAML format) is used to generate
+# values.schema.json which is, when available, used by the helm CLI for client
+# side validation by Helm of the chart's values before template rendering.
+#
+# We look to document everything we have default values for in values.yaml, but
+# we don't look to enforce the perfect validation logic within this file.
+#
+# ref: https://json-schema.org/learn/getting-started-step-by-step.html
+#
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+additionalProperties: false
+required:
+  - basehub
+  - dask-gateway
+  - global
+properties:
+  basehub:
+    type: object
+    additionalProperties: true
+  dask-gateway:
+    type: object
+    additionalProperties: true
+  global:
+    type: object
+    additionalProperties: true

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -1,10 +1,3 @@
-scratchBucket:
-  # Enable a 'scratch' bucket per-hub, with read-write permissions for all
-  # users. This will set a `SCRATCH_BUCKET` env variable (and a PANGEO_SCRATCH variable
-  # too, for backwards compatibility). Users can share data with each other using
-  # this bucket.
-  enabled: true
-
 basehub:
   # Copied from https://github.com/dask/helm-chart/blob/master/daskhub/values.yaml
   # FIXME: Properly use the upstream chart.

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -201,3 +201,8 @@ dask-gateway:
       k8s.dask.org/node-purpose: core
     service:
       type: ClusterIP # Access Dask Gateway through JupyterHub. To access the Gateway from outside JupyterHub, this must be changed to a `LoadBalancer`.
+
+# A placeholder as global values that can be referenced from the same location
+# of any chart should be possible to provide, but aren't necessarily provided or
+# used.
+global: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,18 @@
-backoff
-chartpress
-six # temp workaround for docker==5.0.0, used by chartpress, that failed to depend on six
+# This file represents the needs for the deployer script to function, while the
+# dev-requirements.txt file represents the needs in this repo in general.
+#
+
+# ruamel.yaml is used to read and write .yaml files.
 ruamel.yaml
+
+# auth0 is used to communicate with Auth0's REST API that we integrate with in
+# various ways.
 auth0-python
-jhub-client==0.1.4
+
+# jsonschema is used for validating cluster.yaml configurations
 jsonschema
+
+# jhub_client, pytest, and pytest_asyncio are used for our health checks
+jhub-client==0.1.4
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary

- Closes #937 by adding values.schema.yaml files, which if converted to values.schema.json files will be recognized by the `helm` CLI that will validate any passed helm chart values.
- Adds helm chart schema validation of our clusters' hubs' configuration by trialing the `helm template` command against the chart in question with the non-encrypted helm chart values files.
- Closes #279 by adding a workflow to trial our deployer scripts `validate` command by using the non-encrypted helm chart values files.
- Closes #994 by manually ensuring and using the new schemas to ensure we don't have Helm chart values our templates rely on, but that we don't provide default values for in the Helm chart's values.yaml file
- Cleans up helm chart configuration that wasn't correct, as identified by the schema files
- Cleaned up logic associated with and content of requirements.txt and dev-requirements.txt
  - `requirements.txt` is now purely dependencies for the deployer script
  - `dev-requirements.txt` is now purely dependencies for scripts in the extra_scripts folder etc
  - Both files have inline comments to clarify the situation
  
## Test failure unrelated

The test failure is unrelated and is resolved by #1044.