### PR TITLE
Support values refactor

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -2,8 +2,9 @@
 # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
 # Runs the deployer script to validate clusters. This will both validate
-# cluster.yaml files as well as each hubs passed non-encrypted values files
-# against the Helm charts' values schema.
+# cluster.yaml files, any non-encrypted values files for the support chart (if they
+# exist), as well as each hubs passed non-encrypted values files against the Helm
+# charts' values schema.
 #
 name: Validate clusters
 
@@ -14,6 +15,7 @@ on:
       - deployer/**
       - helm-charts/basehub/**
       - helm-charts/daskhub/**
+      - helm-charts/support/**
       - requirements.txt
       - .github/workflows/validate-hubs.yaml
   push:
@@ -22,6 +24,7 @@ on:
       - deployer/**
       - helm-charts/basehub/**
       - helm-charts/daskhub/**
+      - helm-charts/support/**
       - requirements.txt
       - .github/workflows/validate-hubs.yaml
     branches-ignore:
@@ -32,7 +35,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  validate-hubs-values-files:
+  validate-helm-charts-values-files:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -61,6 +64,7 @@ jobs:
               - deployer/**
               - helm-charts/basehub/**
               - helm-charts/daskhub/**
+              - helm-charts/support/**
               - requirements.txt
               - .github/workflows/validate-hubs.yaml
 

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -7,15 +7,8 @@ gcp:
   cluster: pilot-hubs-cluster
   zone: us-central1-b
 support:
-  config:
-    grafana:
-      ingress:
-        hosts:
-          - grafana.pilot.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.pilot.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.pilot.2i2c.cloud

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -1,0 +1,8 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.pilot.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.pilot.2i2c.cloud

--- a/config/clusters/azure.carbonplan/cluster.yaml
+++ b/config/clusters/azure.carbonplan/cluster.yaml
@@ -3,27 +3,8 @@ provider: kubeconfig
 kubeconfig:
   file: enc-deployer-credentials.secret.yaml
 support:
-  config:
-    nvidiaDevicePlugin:
-      azure:
-        enabled: true
-    prometheus:
-      server:
-        resources:
-          requests:
-            cpu: 1
-            memory: 4Gi
-          limits:
-            cpu: 4
-            memory: 8Gi
-    grafana:
-      ingress:
-        hosts:
-          - grafana.azure.carbonplan.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.azure.carbonplan.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.azure.carbonplan.2i2c.cloud

--- a/config/clusters/azure.carbonplan/support.values.yaml
+++ b/config/clusters/azure.carbonplan/support.values.yaml
@@ -1,0 +1,20 @@
+nvidiaDevicePlugin:
+  azure:
+    enabled: true
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
+grafana:
+  ingress:
+    hosts:
+      - grafana.azure.carbonplan.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.azure.carbonplan.2i2c.cloud

--- a/config/clusters/carbonplan/cluster.yaml
+++ b/config/clusters/carbonplan/cluster.yaml
@@ -6,29 +6,8 @@ aws:
   clusterName: carbonplanhub
   region: us-west-2
 support:
-  config:
-    prometheus:
-      server:
-        resources:
-          requests:
-            cpu: 1
-            memory: 4Gi
-          limits:
-            cpu: 4
-            memory: 8Gi
-    cluster-autoscaler:
-      enabled: true
-      autoDiscovery:
-        clusterName: carbonplanhub
-      awsRegion: us-west-2
-    grafana:
-      ingress:
-        hosts:
-          - grafana.carbonplan.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.carbonplan.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.carbonplan.2i2c.cloud

--- a/config/clusters/carbonplan/support.values.yaml
+++ b/config/clusters/carbonplan/support.values.yaml
@@ -1,0 +1,22 @@
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
+cluster-autoscaler:
+  enabled: true
+  autoDiscovery:
+    clusterName: carbonplanhub
+  awsRegion: us-west-2
+grafana:
+  ingress:
+    hosts:
+      - grafana.carbonplan.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.carbonplan.2i2c.cloud

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -7,15 +7,8 @@ gcp:
   cluster: cb-cluster
   zone: us-central1-b
 support:
-  config:
-    grafana:
-      ingress:
-        hosts:
-          - grafana.cloudbank.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.cloudbank.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: spelman
     domain: spelman.cloudbank.2i2c.cloud

--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -1,0 +1,8 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.cloudbank.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.cloudbank.2i2c.cloud

--- a/config/clusters/openscapes/cluster.yaml
+++ b/config/clusters/openscapes/cluster.yaml
@@ -6,29 +6,8 @@ aws:
   clusterName: openscapeshub
   region: us-west-2
 support:
-  config:
-    prometheus:
-      server:
-        resources:
-          requests:
-            cpu: 1
-            memory: 4Gi
-          limits:
-            cpu: 4
-            memory: 8Gi
-    cluster-autoscaler:
-      enabled: true
-      autoDiscovery:
-        clusterName: openscapeshub
-      awsRegion: us-west-2
-    grafana:
-      ingress:
-        hosts:
-          - grafana.openscapes.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.openscapes.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.openscapes.2i2c.cloud

--- a/config/clusters/openscapes/support.values.yaml
+++ b/config/clusters/openscapes/support.values.yaml
@@ -1,0 +1,22 @@
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
+cluster-autoscaler:
+  enabled: true
+  autoDiscovery:
+    clusterName: openscapeshub
+  awsRegion: us-west-2
+grafana:
+  ingress:
+    hosts:
+      - grafana.openscapes.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.openscapes.2i2c.cloud

--- a/config/clusters/pangeo-hubs/cluster.yaml
+++ b/config/clusters/pangeo-hubs/cluster.yaml
@@ -6,27 +6,8 @@ gcp:
   cluster: pangeo-hubs-cluster
   zone: us-central1-b
 support:
-  config:
-    grafana:
-      ingress:
-        hosts:
-          - grafana.gcp.pangeo.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.gcp.pangeo.2i2c.cloud
-    # Disable the Admissions Validation Webhook and the port is not
-    # permitted on private GKE clusters
-    ingress-nginx:
-      controller:
-        admissionWebhooks:
-          enabled: false
-    prometheus:
-      server:
-        resources:
-          limits:
-            cpu: 2
-            memory: 12Gi
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.us-central1-b.gcp.pangeo.io

--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -1,0 +1,20 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.gcp.pangeo.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.gcp.pangeo.2i2c.cloud
+# Disable the Admissions Validation Webhook and the port is not
+# permitted on private GKE clusters
+ingress-nginx:
+  controller:
+    admissionWebhooks:
+      enabled: false
+prometheus:
+  server:
+    resources:
+      limits:
+        cpu: 2
+        memory: 12Gi

--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -3,24 +3,8 @@ provider: kubeconfig
 kubeconfig:
   file: enc-deployer-credentials.secret.yaml
 support:
-  config:
-    prometheus:
-      server:
-        resources:
-          requests:
-            cpu: 0.5
-            memory: 4Gi
-          limits:
-            cpu: 2
-            memory: 16Gi
-    grafana:
-      ingress:
-        hosts:
-          - grafana.utoronto.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.utoronto.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.utoronto.2i2c.cloud

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -1,0 +1,17 @@
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 0.5
+        memory: 4Gi
+      limits:
+        cpu: 2
+        memory: 16Gi
+grafana:
+  ingress:
+    hosts:
+      - grafana.utoronto.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.utoronto.2i2c.cloud

--- a/config/clusters/uwhackweeks/cluster.yaml
+++ b/config/clusters/uwhackweeks/cluster.yaml
@@ -6,29 +6,8 @@ aws:
   clusterName: uwhackweeks
   region: us-west-2
 support:
-  config:
-    prometheus:
-      server:
-        resources:
-          requests:
-            cpu: 1
-            memory: 4Gi
-          limits:
-            cpu: 4
-            memory: 8Gi
-    cluster-autoscaler:
-      enabled: true
-      autoDiscovery:
-        clusterName: uwhackweeks
-      awsRegion: us-west-2
-    grafana:
-      ingress:
-        hosts:
-          - grafana.uwhackweeks.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.uwhackweeks.2i2c.cloud
+  helm_chart_values_files:
+    - support.values.yaml
 hubs:
   - name: staging
     domain: staging.uwhackweeks.2i2c.cloud

--- a/config/clusters/uwhackweeks/support.values.yaml
+++ b/config/clusters/uwhackweeks/support.values.yaml
@@ -1,0 +1,22 @@
+prometheus:
+  server:
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
+cluster-autoscaler:
+  enabled: true
+  autoDiscovery:
+    clusterName: uwhackweeks
+  awsRegion: us-west-2
+grafana:
+  ingress:
+    hosts:
+      - grafana.uwhackweeks.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.uwhackweeks.2i2c.cloud

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -279,9 +279,7 @@ def validate_support_config(cluster_name):
     with open(config_file_path) as f:
         cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    print_colour(
-        f"Validating non-encrypted support values files for {cluster_name}..."
-    )
+    print_colour(f"Validating non-encrypted support values files for {cluster_name}...")
 
     cmd = [
         "helm",

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -104,16 +104,20 @@ def deploy_grafana_dashboards(cluster_name):
             f"`grafana_token` not provided in secret file! Please add it and try again: {grafana_token_file}"
         )
 
-    # Get the url where grafana is running from the cluster config
+    # FIXME: We assume grafana_url and uses_tls config will be defined in the first
+    #        file listed under support.helm_chart_values_files.
+    support_values_file = cluster.support.get("helm_chart_values_files", [])[0]
+    with open(config_file_path.parent.joinpath(support_values_file)) as f:
+        support_values_config = yaml.load(f)
+
+    # Get the url where grafana is running from the support values file
     grafana_url = (
-        cluster.support.get("config", {})
-        .get("grafana", {})
+        support_values_config.get("grafana", {})
         .get("ingress", {})
         .get("hosts", {})
     )
     uses_tls = (
-        cluster.support.get("config", {})
-        .get("grafana", {})
+        support_values_config.get("grafana", {})
         .get("ingress", {})
         .get("tls", {})
     )

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -279,22 +279,25 @@ def validate_support_config(cluster_name):
     with open(config_file_path) as f:
         cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    print_colour(f"Validating non-encrypted support values files for {cluster_name}...")
+    if cluster.support:
+        print_colour(f"Validating non-encrypted support values files for {cluster_name}...")
 
-    cmd = [
-        "helm",
-        "template",
-        str(helm_charts_dir.joinpath("support")),
-    ]
+        cmd = [
+            "helm",
+            "template",
+            str(helm_charts_dir.joinpath("support")),
+        ]
 
-    for values_file in cluster.support["helm_chart_values_files"]:
-        cmd.append(f"--values={config_file_path.parent.joinpath(values_file)}")
+        for values_file in cluster.support["helm_chart_values_files"]:
+            cmd.append(f"--values={config_file_path.parent.joinpath(values_file)}")
 
-        try:
-            subprocess.check_output(cmd, text=True)
-        except subprocess.CalledProcessError as e:
-            print(e.stdout)
-            sys.exit(1)
+            try:
+                subprocess.check_output(cmd, text=True)
+            except subprocess.CalledProcessError as e:
+                print(e.stdout)
+                sys.exit(1)
+    else:
+        print_colour(f"No support defined for {cluster_name}. Nothing to validate!")
 
 
 def main():

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -389,6 +389,7 @@ def main():
         )
     elif args.action == "validate":
         validate_cluster_config(args.cluster_name)
+        validate_support_config(args.cluster_name)
         validate_hub_config(args.cluster_name, args.hub_name)
     elif args.action == "deploy-support":
         deploy_support(args.cluster_name)

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -127,6 +127,10 @@ class Cluster:
         subprocess.check_call(["helm", "dep", "up", support_dir])
 
         support_secrets_file = support_dir.joinpath("enc-support.secret.yaml")
+        # TODO: Update this with statement to handle any number of context managers
+        #       containing decrypted support values files. Not critical right now as
+        #       no individual cluster has specific support secrets, but it's possible
+        #       to support that if we want to in the future.
         with get_decrypted_file(support_secrets_file) as secret_file:
             cmd = [
                 "helm",

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -127,25 +127,25 @@ class Cluster:
         subprocess.check_call(["helm", "dep", "up", support_dir])
 
         support_secrets_file = support_dir.joinpath("enc-support.secret.yaml")
-        with tempfile.NamedTemporaryFile(mode="w") as f, get_decrypted_file(
-            support_secrets_file
-        ) as secret_file:
-            yaml.dump(self.support.get("config", {}), f)
-            f.flush()
-            subprocess.check_call(
-                [
-                    "helm",
-                    "upgrade",
-                    "--install",
-                    "--create-namespace",
-                    "--namespace=support",
-                    "support",
-                    str(support_dir),
-                    f"--values={secret_file}",
-                    f"--values={f.name}",
-                    "--wait",
-                ]
-            )
+        with get_decrypted_file(support_secrets_file) as secret_file:
+            cmd = [
+                "helm",
+                "upgrade",
+                "--install",
+                "--create-namespace",
+                "--namespace=support",
+                "--wait",
+                "support",
+                str(support_dir),
+                f"--values={secret_file}",
+            ]
+
+            for values_file in self.support["helm_chart_values_files"]:
+                cmd.append(f"--values={self.config_path.joinpath(values_file)}")
+
+            print_colour(f"Running {' '.join([str(c) for c in cmd])}")
+            subprocess.check_call(cmd)
+
         print_colour("Done!")
 
     def auth_kubeconfig(self):

--- a/deployer/utils.py
+++ b/deployer/utils.py
@@ -187,6 +187,10 @@ def prepare_helm_charts_dependencies_and_schemas():
     _generate_values_schema_json(daskhub_dir)
     subprocess.check_call(["helm", "dep", "up", daskhub_dir])
 
+    support_dir = helm_charts_dir.joinpath("support")
+    _generate_values_schema_json(support_dir)
+    subprocess.check_call(["helm", "dep", "up", support_dir])
+
 
 def print_colour(msg: str):
     """Print messages in colour to be distinguishable in CI logs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,8 @@ def render_hubs():
         yaml = cluster_info.read_text()
         cluster = safe_load(yaml)
 
+        # FIXME: This is broken by https://github.com/2i2c-org/infrastructure/pull/1047
+        #        Work to fix this is tracked in https://github.com/2i2c-org/infrastructure/issues/1009
         # Pull support chart information to populate fields (if it exists)
         support = cluster.get("support", {}).get("config", {})
         grafana_url = support.get("grafana", {}).get("ingress", {}).get("hosts", "")

--- a/helm-charts/support/.helmignore
+++ b/helm-charts/support/.helmignore
@@ -1,0 +1,30 @@
+# Non default entries manually added by support developers
+
+# Ignore the .yaml that generates the .json, only the .json is relevant to
+# bundle with the Helm chart when it is packaged or "helm dep up" is used to
+# copy it over to another location where it is referenced.
+values.schema.yaml
+
+# -----------------------------------------------------------------------------
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -1,0 +1,42 @@
+# This schema (a jsonschema in YAML format) is used to generate
+# values.schema.json which is, when available, used by the helm CLI for client
+# side validation by Helm of the chart's values before template rendering.
+#
+# We look to document everything we have default values for in values.yaml, but
+# we don't look to enforce the perfect validation logic within this file.
+#
+# ref: https://json-schema.org/learn/getting-started-step-by-step.html
+#
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+additionalProperties: false
+required:
+  - cluster-autoscaler
+  - ingress-nginx
+  - prometheus
+  - grafana
+  - nfs-server-provisioner
+  - nvidiaDevicePlugin
+  - global
+properties:
+  cluster-autoscaler:
+    type: object
+    additionalProperties: true
+  ingress-nginx:
+    type: object
+    additionalProperties: true
+  prometheus:
+    type: object
+    additionalProperties: true
+  grafana:
+    type: object
+    additionalProperties: true
+  nfs-server-provisioner:
+    type: object
+    additionalProperties: true
+  nvidiaDevicePlugin:
+    type: object
+    additionalProperties: true
+  global:
+    type: object
+    additionalProperties: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -107,3 +107,8 @@ nvidiaDevicePlugin:
   # For Azure-specific image, default to false
   azure:
     enabled: false
+
+# A placeholder as global values that can be referenced from the same location
+# of any chart should be possible to provide, but aren't necessarily provided or
+# used.
+global: {}

--- a/shared/deployer/cluster.schema.yaml
+++ b/shared/deployer/cluster.schema.yaml
@@ -6,8 +6,7 @@ properties:
     type: string
     description: |
       Name of the cluster, used primarily to identify it in
-      the deploy script. The file should be named as
-      {name}.cluster.yaml
+      the deploy script. This value should match the parent folder name.
   image_repo:
     type: string
   support:
@@ -17,10 +16,13 @@ properties:
       Configuration for support components (ingress, monitoring, etc)
       to be enabled for this cluster.
     properties:
-      config:
-        type: object
+      helm_chart_values_files:
+        type: array
         description: |
-          Additional YAML values to be deployed with the support chart
+          A list of *.values.yaml files which, together, describe the complete
+          helm chart values to configure the support chart. These filepaths are defined
+          RELATIVE to the location of the cluster.yaml file. They have the naming
+          convention 'support.values.yaml'.
   provider:
     type: string
     description: |
@@ -267,4 +269,6 @@ properties:
             type: array
             description: |
               A list of *.values.yaml files which, together, describe the complete
-              helm chart values for a single hub deployment.
+              helm chart values for a single hub deployment. These filepaths are defined
+              RELATIVE to the location of the cluster.yaml file and have the naming
+              convention '{{ hub name }}.values.yaml'.


### PR DESCRIPTION
- Move support values or each cluster from the `cluster.yaml` file to a `support.values.yaml` file
- Adds `.helmignore`, `values.schema.yaml` to `support` chart
- Updates `cluster.schema.yaml`
- Refactors `deploy-support` and `deploy-grafana-dashbaords` to handle being passed files instead of straight values
- Adds a `validate_support_config` function when `deploy-support` is called