### PR TITLE
Add a separate nodepool for paleohack event

### DIFF
--- a/config/clusters/2i2c/paleohack2021.values.yaml
+++ b/config/clusters/2i2c/paleohack2021.values.yaml
@@ -25,6 +25,11 @@ jupyterhub:
         funded_by:
           name: "NSF Paleo Perspectives on Climate Change program"
           url: "https://www.nsf.gov/funding/pgm_summ.jsp?pims_id=5750"
+  prePuller:
+    continuous:
+      enabled: true
+    hook:
+      enabled: true
   singleuser:
     memory:
       guarantee: 256M
@@ -34,7 +39,7 @@ jupyterhub:
       limit: 2
     image:
       name: quay.io/2i2c/paleohack-2021
-      tag: 7534858b1098
+      tag: 9d557294938e
     nodeSelector:
       2i2c.org/community: paleo
   hub:

--- a/config/clusters/2i2c/paleohack2021.values.yaml
+++ b/config/clusters/2i2c/paleohack2021.values.yaml
@@ -35,6 +35,8 @@ jupyterhub:
     image:
       name: quay.io/2i2c/paleohack-2021
       tag: 7534858b1098
+    nodeSelector:
+      2i2c.org/community: paleo
   hub:
     config:
       Authenticator:

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -15,6 +15,14 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-highmem-4",
     labels: { }
+  },
+  "paleo": {
+    min: 0,
+    max: 20,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "paleo"
+    }
   }
 }
 


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/1032

This reverts commit 20969eb31b62b9dd85cebc6080a6e8c516a3a047.

- I've manually scaled to 20 nodes in the GUI
- Enable the pre-puller so nodes get the latest image pre-pulled for faster user starts
- Specify the image in the config here, so the pre-puller works