### PR TITLE
Bugfix: deploy action 

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -33,9 +33,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          export_default_credentials: true
 
       - name: Setup sops
         uses: mdgreenwald/mozilla-sops-action@v1

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -91,9 +91,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          export_default_credentials: true
 
       - name: Setup helm
         if: steps.decision.outputs.continue-job == 'true'


### PR DESCRIPTION
Merging #1059 caused our GCP clusters to fail in CI with the below error

```
Activated service account credentials for: [pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com]
Fetching cluster endpoint and auth data.
ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=403, message=Required "container.clusters.get" permission(s) for "projects/two-eye-two-see/zones/us-central1-b/clusters/pilot-hubs-cluster".
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/infrastructure/infrastructure/deployer/__main__.py", line 8, in <module>
    cli.main()
  File "/home/runner/work/infrastructure/infrastructure/deployer/cli.py", line 111, in main
    deploy_support(args.cluster_name)
  File "/home/runner/work/infrastructure/infrastructure/deployer/deploy_actions.py", line 66, in deploy_support
    with cluster.auth():
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/runner/work/infrastructure/infrastructure/deployer/cluster.py", line 28, in auth
    yield from self.auth_gcp()
  File "/home/runner/work/infrastructure/infrastructure/deployer/cluster.py", line 316, in auth_gcp
    subprocess.check_call(
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess
```

I'm not quite sure what has caused this.

This PR removes some extra args to the goggle-github-actions/setup-gcloud action to see if they were in some way overriding what our Cluster class is trying to do

- export_default_credentials: google-github-actions/auth exports
  credentials by default
- project_id: wondering if this will allow our class to override