### PR TITLE
Use google-github-actions/auth to authenticate against Google Cloud in CI/CD

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install jsonnet
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
           # This is used for KMS only

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -24,14 +24,16 @@ jobs:
           python3 -m pip install -r requirements.txt
           sudo apt install jsonnet
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          project_id: two-eye-two-see
+          credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
-          export_default_credentials: true
 
       - name: Setup sops
         uses: mdgreenwald/mozilla-sops-action@v1

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check if any of our base files have changed
         uses: dorny/paths-filter@v2
-        id: base_files
+        id: cluster_common_files
         with:
           filters: |
             files:
@@ -69,43 +69,42 @@ jobs:
 
       - name: Check which cluster directory has changes (if any)
         uses: dorny/paths-filter@v2
-        id: config_files
+        id: cluster_specific_files
         with:
           filters: |
-            hub_config:
+            changes:
               - "config/clusters/${{ matrix.cluster_name }}/**"
 
+      # To continue this cluster specific job, there should have been
+      # changes to the cluster common files or cluster specific files.
+      - name: Decide if the job should continue
+        id: decision
+        run: |
+          echo ::set-output name=continue-job::${{ steps.cluster_common_files.outputs.files == 'true' || steps.cluster_specific_files.outputs.changes == 'true' }}
+
       - name: Authenticate to Google Cloud
+        if: steps.decision.outputs.continue-job == 'true'
         uses: google-github-actions/auth@v0.6.0
         with:
           project_id: two-eye-two-see
           credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
 
       - name: Setup gcloud
-        if: |
-          (steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')
+        if: steps.decision.outputs.continue-job == 'true'
         uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
 
       - name: Setup helm
-        if: |
-          (steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')
+        if: steps.decision.outputs.continue-job == 'true'
         uses: azure/setup-helm@v2.0
 
       - name: Setup sops
-        if: |
-          (steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')
+        if: steps.decision.outputs.continue-job == 'true'
         uses: mdgreenwald/mozilla-sops-action@v1
 
       - name: Setup kops
-        if: |
-          ((steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')) &&
-          (matrix.provider == 'aws')
+        if: steps.decision.outputs.continue-job == 'true' && matrix.provider == 'aws'
         run: |
           curl -Lo /tmp/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
           chmod +x /tmp/kops
@@ -114,9 +113,7 @@ jobs:
           KOPS_VERSION: "v1.21.1"
 
       - name: Deploy ${{ matrix.cluster_name }}
-        if: |
-          (steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')
+        if: steps.decision.outputs.continue-job == 'true'
         uses: ./.github/actions/deploy
         with:
           cluster: ${{ matrix.cluster_name }}

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -8,8 +8,6 @@ on:
       - deployer/**
       - helm-charts/**
       - requirements.txt
-      - dev-requirements.txt
-      - config/secrets.yaml
       - config/clusters/**
       - .github/workflows/deploy-hubs.yaml
       - .github/actions/deploy/**

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -75,6 +75,12 @@ jobs:
             hub_config:
               - "config/clusters/${{ matrix.cluster_name }}/**"
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          project_id: two-eye-two-see
+          credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+
       - name: Setup gcloud
         if: |
           (steps.base_files.outputs.files == 'true') ||
@@ -82,10 +88,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
-          export_default_credentials: true
 
       - name: Setup helm
         if: |

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -79,7 +79,7 @@ jobs:
         if: |
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.5.1
         with:
           version: "290.0.1"
           # This is used for KMS only


### PR DESCRIPTION
> This is a reimplementation of #1059 

fixes #903 

As reported in #903, the functionality of the google-github-actions/gcloud-setup action changed such that authenticating using service account keys was being deprecated and the google-github-actions/auth action should be used instead. This PR adds in the step to authenticate to GCP using the google-github-actions/auth action in our `deploy-hubs.yaml` and `deploy-grafana-dashboards.yaml` workflow files. A few other minor changes come with this PR also:

- Versions of the google-github-actions/auth and google-github-actions/gcloud-setup actions have been pinned to the latest version releases. Updating these versions will be handled by dependabot.
- An extra "decision" step has been added to the `deploy-hubs.yaml` workflow to shorten if statements and improve readability
- Some unnecessary path triggers were removed from `deploy-hubs.yaml` also: config/secrets.yaml no longer exists, and dev-requirements.txt does not contain packages required for deployment