### PR TITLE
Additional safeguards against accidental cluster deletion

### DIFF
--- a/terraform/aws/efs.tf
+++ b/terraform/aws/efs.tf
@@ -45,6 +45,12 @@ resource "aws_efs_file_system" "homedirs" {
   tags = {
     Name = "hub-homedirs"
   }
+
+  lifecycle {
+    # Additional safeguard against deleting the EFS
+    # as this causes irreversible data loss!
+    prevent_destroy = true
+  }
 }
 
 resource "aws_efs_mount_target" "homedirs" {

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -62,6 +62,13 @@ resource "azurerm_kubernetes_cluster" "jupyterhub" {
   kubernetes_version  = var.kubernetes_version
   dns_prefix          = "k8s"
 
+  lifecycle {
+    # An additional safeguard against accidentally deleting the cluster.
+    # The databases for the hubs are held in PVCs managed by the cluster,
+    # so cluster deletion will cause data loss!
+    prevent_destroy = true
+  }
+
   linux_profile {
     admin_username = "hub-admin"
     ssh_key {

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -23,6 +23,11 @@ resource "azurerm_storage_share" "homes" {
   storage_account_name = azurerm_storage_account.homes.name
   quota                = 100
   enabled_protocol     = var.storage_protocol
+  lifecycle {
+    # Additional safeguard against deleting the share
+    # as this causes irreversible data loss!
+    prevent_destroy = true
+  }
 }
 
 output "azure_fileshare_url" {

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -17,6 +17,11 @@ resource "google_container_cluster" "cluster" {
     ignore_changes = [
       node_config
     ]
+
+    # An additional safeguard against accidentally deleting the cluster.
+    # The databases for the hubs are held in PVCs managed by the cluster,
+    # so cluster deletion will cause data loss!
+    prevent_destroy = true
   }
 
   // For private clusters, pass the name of the network and subnetwork created

--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -7,6 +7,12 @@ resource "google_filestore_instance" "homedirs" {
 
   count = var.enable_filestore ? 1 : 0
 
+  lifecycle {
+    # Additional safeguard against deleting the filestore
+    # as this causes irreversible data loss!
+    prevent_destroy = true
+  }
+
   file_shares {
     capacity_gb = var.filestore_capacity_gb
     name        = "homes"


### PR DESCRIPTION
I ran `terraform workspace new` to create a new workspace,
and somehow assumed it also switched me to the new workspace -
which it *does not*. So just running `terraform apply` almost
deleted a bunch of running clusters.

This lifecycle hook will *prevent* any of these from being
deleted ever. To delete these resources (as part of a decomission),
you'll need to edit the files to set it to false. This is a manual
step, but very appropriate for irreversible data loss.