### PR TITLE
Bump utoronto image tag

### DIFF
--- a/config/clusters/utoronto/staging.values.yaml
+++ b/config/clusters/utoronto/staging.values.yaml
@@ -76,7 +76,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: f3069be5964c
+      tag: 18b55a7bcb96
   hub:
     db:
       pvc:


### PR DESCRIPTION
This PR bumps the U of T image tag to the most recent build to include some packages they requested via support.

@yuvipanda can you check the configurator on prod to make sure it won't override this tag please?