### PR TITLE
Bump tag of utoronto image

### DIFF
--- a/config/clusters/utoronto/staging.values.yaml
+++ b/config/clusters/utoronto/staging.values.yaml
@@ -76,7 +76,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: f3069be5964c
+      tag: 18b55a7bcb96
   hub:
     db:
       pvc:


### PR DESCRIPTION
Brings in https://github.com/2i2c-org/utoronto-image/pull/19
and https://github.com/2i2c-org/utoronto-image/pull/17