### PR TITLE
Allow logins with rmbl.org accounts

### DIFF
--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -23,4 +23,4 @@ jupyterhub:
       Authenticator:
         # We do not define allowed_users here since only usernames matching this regex will be allowed to login into the hub.
         # Ref: https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.username_pattern
-        username_pattern: '^(.+@2i2c\.org|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@rmbl\.org|deployment-service-check)$'


### PR DESCRIPTION
Users should select 'Microsoft' as the way to login,
and try this out.