### PR TITLE
Enable interface selector on UToronto home page

### DIFF
--- a/config/clusters/utoronto/staging.values.yaml
+++ b/config/clusters/utoronto/staging.values.yaml
@@ -22,6 +22,7 @@ jupyterhub:
   custom:
     homepage:
       templateVars:
+        interface_selector: true
         org:
           name: University of Toronto
           logo_url: https://raw.githubusercontent.com/utoronto-2i2c/homepage/master/extra-assets/images/home-hero.png

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -141,6 +141,8 @@ properties:
                     type: array
                     items:
                       type: string
+                  interface_selector:
+                    type: boolean
                   org:
                     type: object
                     additionalProperties: false


### PR DESCRIPTION
Requires https://github.com/2i2c-org/pilot-homepage/pull/11

Ref https://2i2c.freshdesk.com/a/tickets/97