### PR TITLE
our hosting URL changed, so link to repository

### DIFF
--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -20,7 +20,7 @@ basehub:
         templateVars:
           org:
             name: ICESat Hackweek
-            logo_url: https://icesat-2hackweek.github.io/assets/images/ICESat2.png
+            logo_url: https://github.com/ICESAT-2HackWeek/icesat-2hackweek.github.io/raw/2022.03.01/assets/images/ICESat2.png
             url: https://icesat-2hackweek.github.io
           designed_by:
             name: 2i2c


### PR DESCRIPTION
We recently did some URL changes and disabled last year's website. Since the logo was tied to the hosted github pages, it's no longer visible at https://uwhackweeks.2i2c.cloud .

This switches to using the raw link to the logo image on github