### PR TITLE
Pin sops to 3.7.1 in GitHub actions

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup sops
         uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
 
       - name: Deploy grafana dashboards for ${{ matrix.cluster_name }}
         run: |

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -98,6 +98,8 @@ jobs:
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
         uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
 
       - name: Setup kops
         if: |


### PR DESCRIPTION
sops 3.7.2, released yesterday, had a corrupted linux
binary https://github.com/mozilla/sops/issues/1023.
This causes all our actions needing sops to fail.
We pin to 3.7.1 until sops upstream fixes it
https://github.com/mdgreenwald/mozilla-sops-action/issues/105#issuecomment-1064018419