### PR TITLE
Revert "Upgrade to z2jh 1.2.0"

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 1.2.0
+    version: 1.1.3
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -288,7 +288,7 @@ jupyterhub:
           - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n2453.h7734a80"
+      tag: "0.0.1-n1159.h5b045cd"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -6,7 +6,7 @@
 # quay.io container registry credentials configured to have access to
 # https://quay.io/repository/2i2c/pilot-hub.
 #
-FROM jupyterhub/k8s-hub:1.2.0
+FROM jupyterhub/k8s-hub:1.1.3
 
 ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#1079

Reverting since sops's latest release is broken. Fixed by
https://github.com/2i2c-org/infrastructure/pull/1085, but we'll need to revert the original 
upgrade PR, then revert the revert to actually run the deploy - as our CD only deploys
when files are touched rather than at all times in a reconcilation loop.