### PR TITLE
Revert "Revert "Upgrade to z2jh 1.2.0""

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 1.1.3
+    version: 1.2.0
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -288,7 +288,7 @@ jupyterhub:
           - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n1159.h5b045cd"
+      tag: "0.0.1-n2453.h7734a80"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -6,7 +6,7 @@
 # quay.io container registry credentials configured to have access to
 # https://quay.io/repository/2i2c/pilot-hub.
 #
-FROM jupyterhub/k8s-hub:1.1.3
+FROM jupyterhub/k8s-hub:1.2.0
 
 ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#1086

Should be merged after https://github.com/2i2c-org/infrastructure/pull/1085 is
merged, so sops works and we can deploy to all the hubs.