### PR TITLE
Rename pilot to docs

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -8,7 +8,7 @@ basehub:
         # In clusters with NetworkPolicy enabled, do not
         # allow outbound internet access that's not DNS, HTTP or HTTPS
         # For OHW, we allow 8080 (for DAP) and 22 (for ssh)
-        # https://github.com/2i2c-org/pilot-hubs/issues/549#issuecomment-892276020
+        # https://github.com/2i2c-org/infrastructure/issues/549#issuecomment-892276020
         enabled: true
         egress:
           - ports:
@@ -31,7 +31,7 @@ basehub:
         tag: 9efd4fb
       memory:
         # Increase memory alloted during the workshop
-        #  https://github.com/2i2c-org/pilot-hubs/issues/549#issuecomment-891264570
+        #  https://github.com/2i2c-org/infrastructure/issues/549#issuecomment-891264570
         guarantee: 7G
         limit: 8G
     custom:

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -17,7 +17,7 @@ jupyterhub:
         org:
           name: 2i2c / CloudBank Hubs Demo
           logo_url: https://www.cloudbank.org/sites/default/files/file_fields/logo.png
-          url: https://2i2c.org/pilot/
+          url: https://docs.2i2c.org/
         designed_by:
           name: 2i2c
           url: https://2i2c.org

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
 intersphinx_mapping = {
     "z2jh": ("https://zero-to-jupyterhub.readthedocs.io/en/latest/", None),
     "tc": ("https://team-compass.2i2c.org/en/latest/", None),
-    "pi": ("https://pilot.2i2c.org/en/latest/", None),
+    "dc": ("https://docs.2i2c.org/en/latest/", None),
 }
 
 # -- MyST configuration ---------------------------------------------------

--- a/docs/howto/configure/update-env.md
+++ b/docs/howto/configure/update-env.md
@@ -1,7 +1,7 @@
 # Update environment
 
 The default user environment is specified in its own GitHub repository, located
-at https://github.com/2i2c-org/infrastructure-image.
+at https://github.com/2i2c-org/2i2c-hubs-image.
 
 The image is built and pushed using [jupyterhub/repo2docker-action](https://github.com/jupyterhub/repo2docker-action) to the [pilot-hubs-image quay.io](https://quay.io/repository/2i2c/pilot-hubs-image) registry.
 

--- a/docs/howto/configure/update-env.md
+++ b/docs/howto/configure/update-env.md
@@ -1,7 +1,7 @@
 # Update environment
 
 The default user environment is specified in its own GitHub repository, located
-at https://github.com/2i2c-org/pilot-hubs-image.
+at https://github.com/2i2c-org/infrastructure-image.
 
 The image is built and pushed using [jupyterhub/repo2docker-action](https://github.com/jupyterhub/repo2docker-action) to the [pilot-hubs-image quay.io](https://quay.io/repository/2i2c/pilot-hubs-image) registry.
 

--- a/docs/howto/operate/k8s/cmd-access.md
+++ b/docs/howto/operate/k8s/cmd-access.md
@@ -1,6 +1,6 @@
 # Gain `kubectl` & `helm` access to a hub
 
-Each of the hubs in the 2i2c Pilot runs on Kubernetes.
+All of the hubs that 2i2c operates run on Kubernetes.
 To access the Kubernetes objects (in order to inspect them or make changes), use
 the `kubectl` command line tool.
 

--- a/docs/howto/operate/k8s/node-administration.md
+++ b/docs/howto/operate/k8s/node-administration.md
@@ -1,6 +1,6 @@
 # Manual node administration
 
-The current pilot Kubernetes clusters we run, have two types of group nodes ([node pools](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pools)), configured to run on: `core` and `user` pools.
+The current Kubernetes clusters we run have two types of group nodes ([node pools](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pools)), configured to run on: `core` and `user` pools.
 
 The [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration will ensure the following assignment of pods to nodes:
 

--- a/docs/howto/operate/new-hub/aws.md
+++ b/docs/howto/operate/new-hub/aws.md
@@ -22,10 +22,10 @@ existing cluster.
 
 Follow the steps outlined in [](new-hub:deploy) with the following modifications:
 
-1. Generate a new values file for your hub if there is not an existing one.
+1. Generate a new configuration file for your hub if there is not an existing one.
 
    You can use one of the existing hub values files as a "template" for your hub (for
-   example, [here is the Farallon Institute staging hub values file](https://github.com/2i2c-org/infrastructure/tree/HEAD/config/clusters/farallon/staging.values.yaml)).
+   example, [here are the configuration files for the Farallon Institute cluster](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/farallon/common.values.yaml)).
    You may need to tweak names, `serverIP` and singleuser's images references.
    Make sure you set up the `profileList` section to be compatible with your kops cluster
    (ie. match the `node_selector` with the proper `instance-type`).

--- a/docs/howto/operate/new-hub/aws.md
+++ b/docs/howto/operate/new-hub/aws.md
@@ -25,7 +25,7 @@ Follow the steps outlined in [](new-hub:deploy) with the following modifications
 1. Generate a new configuration file for your hub if there is not an existing one.
 
    You can use one of the existing hub values files as a "template" for your hub (for
-   example, [here are the configuration files for the Farallon Institute cluster](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/farallon/common.values.yaml)).
+   example, [here are the configuration files for the Farallon Institute cluster](https://github.com/2i2c-org/infrastructure/blob/HEAD/config/clusters/farallon/common.values.yaml)).
    You may need to tweak names, `serverIP` and singleuser's images references.
    Make sure you set up the `profileList` section to be compatible with your kops cluster
    (ie. match the `node_selector` with the proper `instance-type`).

--- a/docs/incidents/2020-10-28-memory-overload.md
+++ b/docs/incidents/2020-10-28-memory-overload.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-On 2020-08-28, WER reported [stuck pages](https://github.com/2i2c-org/pilot/issues/27) for students. A total outage, nothing usable.
+On 2020-08-28, WER reported [stuck pages](https://github.com/2i2c-org/docs/issues/27) for students. A total outage, nothing usable.
 
 After investigation, we determined that the core pods didn't have appropriate resource guarantees set. There was also no dedicated core pool, so the WER students overloaded CPU & RAM of the nodes. This starved everything of resources, causing issues.
 
@@ -17,11 +17,11 @@ All times in IST
 
 ### 08:52 PM
 
-Incoming report that many students can not access the hub, and it is [frozen](https://github.com/2i2c-org/pilot/issues/27#issue-731543843)
+Incoming report that many students can not access the hub, and it is [frozen](https://github.com/2i2c-org/docs/issues/27#issue-731543843)
 
 ### 09:02 PM
 
-Activity bump [is noticed](https://github.com/2i2c-org/pilot/issues/27#issuecomment-718014094) but regular
+Activity bump [is noticed](https://github.com/2i2c-org/docs/issues/27#issuecomment-718014094) but regular
 fixes (incognito, restarting servers, etc) don't seem to fix things
 
 ### 09:21 PM
@@ -40,7 +40,7 @@ There were only core nodes - no separate user nodes. The suspicion is that the u
 
 ### 09:23 PM
 
-Based on [tests on how much RAM WER needs](https://github.com/2i2c-org/pilot/issues/15), we had set a limit of 2G but guarantee of only 512M - a 4x overcommit as we often do. However, the tests revealed that users almost always use just under 1G of RAM, so our overcommit should've been just 2x. We just [remove overcommit](https://github.com/2i2c-org/infrastructure/pull/88) for now. This will also probably spawn another node, thus easing pressure on the other existing nodes.
+Based on [tests on how much RAM WER needs](https://github.com/2i2c-org/docs/issues/15), we had set a limit of 2G but guarantee of only 512M - a 4x overcommit as we often do. However, the tests revealed that users almost always use just under 1G of RAM, so our overcommit should've been just 2x. We just [remove overcommit](https://github.com/2i2c-org/infrastructure/pull/88) for now. This will also probably spawn another node, thus easing pressure on the other existing nodes.
 
 ### 09:24 PM
 
@@ -48,7 +48,7 @@ We [bump resource guarantees](https://github.com/2i2c-org/infrastructure/commit/
 
 ### 09:46 PM
 
-The [issue is closed](https://github.com/2i2c-org/pilot/issues/27#issuecomment-718044571) and everything seems fine
+The [issue is closed](https://github.com/2i2c-org/docs/issues/27#issuecomment-718044571) and everything seems fine
 
 ## Action Items
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -45,8 +45,8 @@ We should provide at least the following kinds of documentation:
    with the intricate details of what component does what, so might not be
    able to find the appropriate place to look at.
 
-This documentation should exist in the [2i2c-org/pilot](https://github.com/2i2c-org/pilot)
-repository, available at [2i2c.org/pilot](https://2i2c.org/pilot/)
+This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
+repository, available at [docs.2i2c.org](https://docs.2i2c.org)
 
 ## Hub administrators
 
@@ -72,8 +72,8 @@ of documentaiton.
    the course of hub usage. Their titles should always be of the form
    **How do I `<title>`?**.
 
-This documentation should exist in the [2i2c-org/pilot](https://github.com/2i2c-org/pilot)
-repository, available at [2i2c.org/pilot](https://2i2c.org/pilot/)
+This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
+repository, available at [docs.2i2c.org](https://docs.2i2c.org/)
 
 ## 2i2c engineers
 

--- a/docs/topic/hub-helm-charts.md
+++ b/docs/topic/hub-helm-charts.md
@@ -6,7 +6,7 @@ type can be described by a helm chart, a hierarchy
 of hub types can be built and this makes development and usage easier.
 
 The graphic below, shows the relationship between the hub helm charts and the other
-config files and how they are merged together when deploying a pilot hub.
+config files and how they are merged together when deploying a hub.
 
 ```{figure} ../images/config-flow.png
 ```

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -40,7 +40,7 @@ basehub:
         # - K8s expansion:     https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/
         # - KubeSpawner issue: https://github.com/jupyterhub/kubespawner/issues/491
         # - Dask config:       https://docs.dask.org/en/latest/configuration.html
-        # - Exploration issue: https://github.com/2i2c-org/pilot-hubs/issues/442
+        # - Exploration issue: https://github.com/2i2c-org/infrastructure/issues/442
         #
         # DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE makes the default worker image
         # match the singleuser image.


### PR DESCRIPTION
Renames the use of "pilot" to "docs" where applicable, and cleans up some other small docs things.

ref: https://github.com/2i2c-org/docs/issues/125