### PR TITLE
Use sops --in-place encryption

### DIFF
--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -73,7 +73,7 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
    - The authorisation callback URL is the homepage url appended with `/hub/oauth_callback`. For example, `staging.pilot.2i2c.cloud/hub/oauth_callback`.
    - Once you have created the OAuth app, make a new of the client ID, generate a client secret and then hold on to these values for a future step
 
-2. **Create or update the appropriate secret config file under `config/clusters/<cluster_name>/<hub_name>.secret.values.yaml`.**
+2. **Create or update the appropriate secret config file under `config/clusters/<cluster_name>/enc-<hub_name>.secret.values.yaml`.**
    You should add the following config to this file, pasting in the client ID and secret you generated in step 1.
 
     ```yaml
@@ -96,11 +96,9 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
     ```
     ````
 
-    ```{note}
     Make sure this is encrypted with `sops` before committing it to the repository!
 
-    `sops --output config/clusters/<cluster_name>/enc-<hub_name>.secret.values.yaml --encrypt config/clusters/<cluster_name>/<hub_name>.secret.values.yaml`
-    ```
+    `sops --in-place --encrypt config/clusters/<cluster_name>/enc-<hub_name>.secret.values.yaml`
 
 3. **Set the hub to _not_ configure Auth0 in the `config/clusters/<cluster_name>/cluster.yaml` file.**
    To ensure the deployer does not provision and configure an OAuth app from Auth0, the following config should be added to the appropriate hub in the cluster's `cluster.yaml` file.

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -90,7 +90,7 @@ The key you create needs admin permissions.
 
 **Keep this key safe as you won't be able to retrieve it!**
 
-Create the file `config/clusters/<cluster>/grafana-token.secret.yaml` with the following content.
+Create the file `config/clusters/<cluster>/enc-grafana-token.secret.yaml` with the following content.
 
 ```yaml
 grafana_token: PASTE_YOUR_API KEY HERE
@@ -99,7 +99,7 @@ grafana_token: PASTE_YOUR_API KEY HERE
 Then encrypt this file using `sops` like so:
 
 ```bash
-sops --output config/clusters/<cluster>/enc-grafana-token.secret.yaml --encrypt config/clusters/<cluster>/grafana-token.secret.yaml
+sops --in-place --encrypt config/clusters/<cluster>/enc-grafana-token.secret.yaml
 ```
 
 The encrypted file can now be committed to the repository.

--- a/docs/howto/operate/new-cluster/aws.md
+++ b/docs/howto/operate/new-cluster/aws.md
@@ -169,13 +169,13 @@ have least amount of permissions possible.
    they are accessible from our automatic deployment.
 
    ```bash
-   terraform output -raw continuous_deployer_creds > ../../config/clusters/<your-cluster-name>/deployer-credentials.secret.json
-   sops --output config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json --encrypt ../../config/clusters/<your-cluster-name>/deployer-credentials.secret.json
+   terraform output -raw continuous_deployer_creds > ../../config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json
+   sops --in-place --encrypt ../../config/clusters/<your-cluster-name>/deployer-credentials.secret.json
    ```
 
    Double check to make sure that the `config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json` file is
    actually encrypted by `sops` before checking it in to the git repo. Otherwise
-   this can be a serious security leak!
+   this will be a serious security leak!
 
 5. Grant the freshly created IAM user access to the kubernetes cluster.
 

--- a/docs/howto/operate/new-cluster/new-cluster.md
+++ b/docs/howto/operate/new-cluster/new-cluster.md
@@ -206,13 +206,13 @@ Then, output the credentials created by terraform to a file under the `secrets` 
 
 ````{tabbed} Google Cloud
 ```bash
-terraform output -raw ci_deployer_key > ../../config/clusters/<cluster_name>/deployer-credentials.secret.json
+terraform output -raw ci_deployer_key > ../../config/clusters/<cluster_name>/enc-deployer-credentials.secret.json
 ```
 ````
 
 ````{tabbed} Azure
 ```bash
-terraform output -raw kubeconfig > ../../config/clusters/<cluster_name>/deployer-credentials.secret.yaml
+terraform output -raw kubeconfig > ../../config/clusters/<cluster_name>/enc-deployer-credentials.secret.yaml
 ```
 ````
 
@@ -225,7 +225,7 @@ You must be logged into Google with your `@2i2c.org` account at this point so `s
 
 ```bash
 cd ../..
-sops --output config/clusters/<cluster_name>/enc-deployer-credentials.secret.{{ json | yaml }} --encrypt config/clusters/<cluster_name>/deployer-credentials.secret.{{ json | yaml }}
+sops --in-place  --encrypt config/clusters/<cluster_name>/enc-deployer-credentials.secret.{{ json | yaml }}
 ```
 
 This key can now be committed to the `infrastructure` repo and used to deploy and manage hubs hosted on that cluster.

--- a/docs/howto/operate/override-domain.md
+++ b/docs/howto/operate/override-domain.md
@@ -16,7 +16,8 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
 
 ## How-To Guide
 
-1. Create a new file with the path `config/clusters/<cluster_name>/<hub_name>.domain_override.secret.yaml` where `<hub_name>` is the name of the hub we are targeting, and `<cluster_name>` is the name of the cluster upon which the hub is running.
+1. Create a new file with the path `config/clusters/<cluster_name>/enc-<hub_name>.domain_override.secret.yaml` where `<hub_name>` is the name of the hub we are targeting, and `<cluster_name>` is the name of the cluster upon which the hub is running.
+
    ```{note}
    We have included `secret` in the filename since we will be encrypting this file with `sops` so that the new domain name cannot be discovered by someone checking the GitHub repository.
    However, it is worth noting that our deployment infrastructure does not _enforce_ the domain override file to be encrypted and an unencrypted file can be provided, if necessary.
@@ -31,10 +32,10 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
    The new domain still still follow the convention `foo.<cluster_name>.2i2c.cloud`, but `foo` can be replaced with anything that is not the current top-level domain of the hub.
    A randomly generated string is probably best to avoid the new domain being guessable.
    ```
-3. (Optional) Encrypt the file with `sops`.
+3. (Optional but recommended) Encrypt the file with `sops`.
 
    ```bash
-   sops --output config/clusters/<cluster_name>/enc-<hub_name>.domain_override.secret.yaml --encrypt config/clusters/<cluster_name>/<hub_name>.domain_override.secret.yaml
+   sops --in-place --encrypt config/clusters/<cluster_name>/enc-<hub_name>.domain_override.secret.yaml
    ```
 
    The file can now be safely committed to the repository.


### PR DESCRIPTION
This prevents the possibility of unencrypted secrets left
in our current working checkout. .gitignore prevents these
from being committed, but it's nice to not have those lying
around regardless.

Relies on https://github.com/2i2c-org/infrastructure/pull/1097 to
prevent unencrypted files from being committed.