### PR TITLE
Swap hard tabs for whitespace in JSON files

### DIFF
--- a/config/clusters/2i2c/enc-deployer-credentials.secret.json
+++ b/config/clusters/2i2c/enc-deployer-credentials.secret.json
@@ -1,30 +1,30 @@
 {
-	"type": "ENC[AES256_GCM,data:aRNvFJjtkTPJfckQAK7B,iv:pzD0TlNSO9CpeGkHUQmPfW6hSVM5rs7fNUX/79NdLU4=,tag:6X2G1z4Z4qOHM84yevLm7g==,type:str]",
-	"project_id": "ENC[AES256_GCM,data:PMhJNDDt6khSCkN4R3/V,iv:LkVOJme32KSg9Dpa0St0wx6VznxyHpSimh4O7nVc30c=,tag:UzOWvmiCi7AewadAr/+JiQ==,type:str]",
-	"private_key_id": "ENC[AES256_GCM,data:NYU4beaWy5vn42d4NHeYHxDQJIL5UIDz9aGTerT5I3GLFDaDv3hnhQ==,iv:SKb36z4/R3a1alQMfv2f6ATRn74UdtOdR/eBc7R1OUo=,tag:TCvk1Yg0nRW5H/DiQ1GNxA==,type:str]",
-	"private_key": "ENC[AES256_GCM,data:LF/jo0q5bAW5CttCBNxIs29hOD81K4FcTo593Mr8hc4MnbKsQaHzf9ccXJBz+f6IezNGjrKLhUuALrYf1EnhvlnbWyEnM1hJGUBJuWYTSkgZ71piTBzklXCTJITH4FQeANtaz7oDCtkRUgigtOXJUDhOmzXrGqWupcujs8+aanVVXKvLnKuhh7lL8doHpW/+H6Z5lAL7j/xp6esD3dUqk40sDxNcFrm/KwwhNBhqs1e4jcSHjY6PuOJlE8bJGbN5dmlcp+23mrNEp6gPiW1mM3y09mzl3c/h+WlRpZl9MRwsHFhI+tntmxiVG8F/D6lQa8yQfP+yy8AcdeDpUaUlzQAkHRPO+hUH7vjntPZBjLYneUTALtx8pGjiegi2rlO+1IleH7nb9GP/5gLDIgOo9GNupFIXGcwLEWvR9LCFdQj9PhJDdEteCxugvgZhiwfKI2D4W+Ffv3VjYxy/KHsMu6OacdtKmMwLVmrs+DdAQpI4MMuW8Ec8K35CTPPYqLLobPtvNiZPO+D1GBinU7vHHvnjDp/IcimKE9LWcUsg52K6Y5/1d6OgZHqxteV/vtP/IHMKWbpB1Ydc18S8jk1GRhYU0b887jzBAGyE9LthHoPqp03DBrlNZNfK7ZZ+NcyTD5mZQCsxJlNhtnT/LW5Y779ojSxg6Ri7uXkwUFfQxUpOJ/jwKyExxrqa+qmt6tnCV52rct2iYaFVAntVKECMe/vIsHVSgkEukGkca/CvZ3/qAgc/F9djsXg7P69Wbv9P442rk7Fm3ipNf8hOYMZUKv67pRBMo0oTEhpvZ11FY9UioU+NBxga7dVbh7jz/zee2AJkZ7HvvosndTfBm21+38Shk67NDD7adyXfr9TAurkqbpRDpZvnbmu2hV6Xe16+RRaLvEyJdoFpZ+/RGE0+b7Ps8XcJVgsFwKgLyD2gUMerJVAhl54hcYDYFxUL7226cIbeuSa9zgefbYTc6cmj+TQ1x4LGxmSAprFy9WRp3Q/PaWo6t1Lvekv3d7jA1lRJ/TifZM3J0y8/Eaud4Z2pqT11gsIdoUYSfO9AVlIqYeIXlADgZnov8bwSAdGM9GyLCNqRTXJmI6+uhYbGs01GUoyvKxGs2NIaUnNEUgOVmxiN52wsf+TKcdWqHFXXHmCLaeQ6/vQNWmApXF5uio1WcZFMn05aM6keODSGfg2JUXxPNssvSdij0dOWbHHq83OjWVkOHuyYsYeUTGTnFabAFwAZ8HiaFFTqa1jZdwQKMyfH+iKcnKxsdJPhqJScorVZnhp/t+JmEeN4wydH48U73mmXrP1v/pV6dglDa+J9rr3UiW9clhUYUuaAwBGy4Ry3BEx6kyTHNnzLCAwHIKwxLEJkWUktVHkHG2GRYTw0bqrsTRfwXlAmZOPT+DlKJ0d7exS16sIpYGzrPuDhnNpFZXiOodrkvf+vkZLcnDkN5/3PxkrKGDNIviZYtPP7IRorCFoz3+BYOuuNwEktkpUq8ONI6hH/yoqMmbgDBETM7Qybih5rDGExGhg0E10uWvzPEnhgFaVxb/7EheXqMyJIiiAD/LM6/u+b4jJsZLxKgWNoNAJmQXFHWKbFGG3BKIE4fzy5frEKo4kOqRXboZLG21EL9VlEwDWd56b6OEszSn990nslr59fbhoHG9ex1g/kM5QArD3W0Yguoo6aHtg1afaAqXaaTAfIScBCgcoAGjbtkOVCIao5Jt/UpoKSRRv2L6uxu+FtvA87Lj7XRGDQ/Fss/xTAABByeWHt1YbxjCZNZorZZnPpLxJ1yAQMFlwYUaKYs2+rwwIicxXqyy20SSy5ulBh4I5oYZGIIZEAOqHZO0Kuhg5Jo1Nejq1s+Oo/mcY9upBDcuvyIadKv7IFGzb5h0IUm/Xxito67G/b5+ylRYWTsMLlWOgTuPxlhh+7usW5OEBq+O3pcV+eUtiqrRy3QKmmbnTyff78btPEdGLFObtqqvvfLkJH1mvJwUaLWXKmmnLRO5r+QZz1JeaLz8zyPhK/CXVPBIHuXyl7vqPZ9HLYeObyoqQesbeS2M2B/im1q8ODLKxzruQJs/0xr9c2gjFhI+DS91G7mO8v0digHDF6uGPwpB7pBxW2Hr5uPIuKbzPgTA9VYQKP8ZCAotcVwwo5IhNfT3om/P7iEluyTzJ8ax4lTFa4dBObsg64NI+Ku8RK1UOh0SvoJa1vexej/17iUTsjEzy940HufUMjNy6RFl3Lh/bMVQJ7afV0nzLKEHwmeyCkkUJn59cswS8NiQQhdJkQ,iv:7tMN1x38NISqyPBaETn8rjIOmW/Wn8jrBLC3xPEPwNs=,tag:AcdHVyBoqimgSdZ2tlwMug==,type:str]",
-	"client_email": "ENC[AES256_GCM,data:EbzbyF+ky6ojmwHZ2Y1a+SMrR6BKqBKwuoUm+xd0uEo0G4ZTPT1PpBjORqxMf/fji91uBRNWksw=,iv:ibdWeIHFKSBYVwrCUnu6ncxF7Z2ohst8Ok/I46YMM/I=,tag:yP7SjDAU4ycg/biuDtRyzQ==,type:str]",
-	"client_id": "ENC[AES256_GCM,data:61CbUgkIBiS3h+Kmq22CZU3p5j1p,iv:d+5T3JinjdS/qFeSi/IqJcViIPa+AJmas7cDgAeNlgU=,tag:yS8mIHWynu0K+iKiEy+jfw==,type:str]",
-	"auth_uri": "ENC[AES256_GCM,data:T2Ee2AB4jo3iIEYvTXDo9PElyv8sFJ9RORXT3q65hQC2hGGVYjLKuJQ=,iv:PCbnb/kWs/z39jxiCudDzcRZYheR7DlmOKAq77E4hZA=,tag:7AmmLigR8ncGTpUQje0lag==,type:str]",
-	"token_uri": "ENC[AES256_GCM,data:iFJBZMBPYJD9U5WHftHgi5vIASW2ZVJQ4Gde8YYqveeeA6w=,iv:Q1NNGMqExCt3PhDoBPiEVqbhFAaYVJHXDJIbT4EhRok=,tag:l24lacVBF0L5+wAKV8B+fw==,type:str]",
-	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:XFZx+XGiTsoeKRkh++BOyr1VipS8HRGgCnbIx4krRqUMYKKeKI02PrX0,iv:0rPXCbU8QgV6vrs6kskIgr2JK6sOSnIy/bCP2/mozUE=,tag:4Q7cLsRtyYH2Xa4wyGj94g==,type:str]",
-	"client_x509_cert_url": "ENC[AES256_GCM,data:o6ODhYhut1Nh8O/eI1GlwHlysimjizW1CIzfsnbGVz2I3PFtLCbZViOTSB0jOlmQ1AwqVdBzs6kH/gMGccn6NXx+9RuTF84mXgSn9lgKRw+abDT4HmwbTAJVXVDb9qvbO4Go6QfF6tYBIhtw,iv:dKECDm3eo5aRLKMVtJEZ4cMIHTqwly/V7MlRczWjDiM=,tag:3wEVznikXHNNnk3tUbq1AQ==,type:str]",
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2022-03-09T08:56:45Z",
-				"enc": "CiQA4OM7eK7A4GzT8M/tfnYqDC9GZ+j7VdEKn4LtURsydlqx9J0SSQDm5XgWuD5vFgKyh+EmByJxQ1nOakIrA5rYrSHojxF0vgFEtpww0ngHMqecTt6A12Tbt0Crbaz0uIGLCPNZ7NVarrRBD3/S1pI="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2022-03-09T08:56:46Z",
-		"mac": "ENC[AES256_GCM,data:T6BgZYgVH3YUjGFtOT0azXWTDl3oD2w4JowO+y5iYPike8necb71fKUkQljj9AGhCCQf7i6eQkc17I9uqqJ8rOAw9oKoOVualO3H4As33snOCdqqyRXRLPhR82DBRcBhkbpc0ZPTTBs0URGbZ9ED4ACJwvezrs+PUN0UBhdj47o=,iv:W4yAYt5cnNBeOqyiA1g+foWx6NyxGIITzLJLmMbmDTI=,tag:3rrlnoiPyT/1Yc8xHb+LnQ==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "type": "ENC[AES256_GCM,data:aRNvFJjtkTPJfckQAK7B,iv:pzD0TlNSO9CpeGkHUQmPfW6hSVM5rs7fNUX/79NdLU4=,tag:6X2G1z4Z4qOHM84yevLm7g==,type:str]",
+    "project_id": "ENC[AES256_GCM,data:PMhJNDDt6khSCkN4R3/V,iv:LkVOJme32KSg9Dpa0St0wx6VznxyHpSimh4O7nVc30c=,tag:UzOWvmiCi7AewadAr/+JiQ==,type:str]",
+    "private_key_id": "ENC[AES256_GCM,data:NYU4beaWy5vn42d4NHeYHxDQJIL5UIDz9aGTerT5I3GLFDaDv3hnhQ==,iv:SKb36z4/R3a1alQMfv2f6ATRn74UdtOdR/eBc7R1OUo=,tag:TCvk1Yg0nRW5H/DiQ1GNxA==,type:str]",
+    "private_key": "ENC[AES256_GCM,data:LF/jo0q5bAW5CttCBNxIs29hOD81K4FcTo593Mr8hc4MnbKsQaHzf9ccXJBz+f6IezNGjrKLhUuALrYf1EnhvlnbWyEnM1hJGUBJuWYTSkgZ71piTBzklXCTJITH4FQeANtaz7oDCtkRUgigtOXJUDhOmzXrGqWupcujs8+aanVVXKvLnKuhh7lL8doHpW/+H6Z5lAL7j/xp6esD3dUqk40sDxNcFrm/KwwhNBhqs1e4jcSHjY6PuOJlE8bJGbN5dmlcp+23mrNEp6gPiW1mM3y09mzl3c/h+WlRpZl9MRwsHFhI+tntmxiVG8F/D6lQa8yQfP+yy8AcdeDpUaUlzQAkHRPO+hUH7vjntPZBjLYneUTALtx8pGjiegi2rlO+1IleH7nb9GP/5gLDIgOo9GNupFIXGcwLEWvR9LCFdQj9PhJDdEteCxugvgZhiwfKI2D4W+Ffv3VjYxy/KHsMu6OacdtKmMwLVmrs+DdAQpI4MMuW8Ec8K35CTPPYqLLobPtvNiZPO+D1GBinU7vHHvnjDp/IcimKE9LWcUsg52K6Y5/1d6OgZHqxteV/vtP/IHMKWbpB1Ydc18S8jk1GRhYU0b887jzBAGyE9LthHoPqp03DBrlNZNfK7ZZ+NcyTD5mZQCsxJlNhtnT/LW5Y779ojSxg6Ri7uXkwUFfQxUpOJ/jwKyExxrqa+qmt6tnCV52rct2iYaFVAntVKECMe/vIsHVSgkEukGkca/CvZ3/qAgc/F9djsXg7P69Wbv9P442rk7Fm3ipNf8hOYMZUKv67pRBMo0oTEhpvZ11FY9UioU+NBxga7dVbh7jz/zee2AJkZ7HvvosndTfBm21+38Shk67NDD7adyXfr9TAurkqbpRDpZvnbmu2hV6Xe16+RRaLvEyJdoFpZ+/RGE0+b7Ps8XcJVgsFwKgLyD2gUMerJVAhl54hcYDYFxUL7226cIbeuSa9zgefbYTc6cmj+TQ1x4LGxmSAprFy9WRp3Q/PaWo6t1Lvekv3d7jA1lRJ/TifZM3J0y8/Eaud4Z2pqT11gsIdoUYSfO9AVlIqYeIXlADgZnov8bwSAdGM9GyLCNqRTXJmI6+uhYbGs01GUoyvKxGs2NIaUnNEUgOVmxiN52wsf+TKcdWqHFXXHmCLaeQ6/vQNWmApXF5uio1WcZFMn05aM6keODSGfg2JUXxPNssvSdij0dOWbHHq83OjWVkOHuyYsYeUTGTnFabAFwAZ8HiaFFTqa1jZdwQKMyfH+iKcnKxsdJPhqJScorVZnhp/t+JmEeN4wydH48U73mmXrP1v/pV6dglDa+J9rr3UiW9clhUYUuaAwBGy4Ry3BEx6kyTHNnzLCAwHIKwxLEJkWUktVHkHG2GRYTw0bqrsTRfwXlAmZOPT+DlKJ0d7exS16sIpYGzrPuDhnNpFZXiOodrkvf+vkZLcnDkN5/3PxkrKGDNIviZYtPP7IRorCFoz3+BYOuuNwEktkpUq8ONI6hH/yoqMmbgDBETM7Qybih5rDGExGhg0E10uWvzPEnhgFaVxb/7EheXqMyJIiiAD/LM6/u+b4jJsZLxKgWNoNAJmQXFHWKbFGG3BKIE4fzy5frEKo4kOqRXboZLG21EL9VlEwDWd56b6OEszSn990nslr59fbhoHG9ex1g/kM5QArD3W0Yguoo6aHtg1afaAqXaaTAfIScBCgcoAGjbtkOVCIao5Jt/UpoKSRRv2L6uxu+FtvA87Lj7XRGDQ/Fss/xTAABByeWHt1YbxjCZNZorZZnPpLxJ1yAQMFlwYUaKYs2+rwwIicxXqyy20SSy5ulBh4I5oYZGIIZEAOqHZO0Kuhg5Jo1Nejq1s+Oo/mcY9upBDcuvyIadKv7IFGzb5h0IUm/Xxito67G/b5+ylRYWTsMLlWOgTuPxlhh+7usW5OEBq+O3pcV+eUtiqrRy3QKmmbnTyff78btPEdGLFObtqqvvfLkJH1mvJwUaLWXKmmnLRO5r+QZz1JeaLz8zyPhK/CXVPBIHuXyl7vqPZ9HLYeObyoqQesbeS2M2B/im1q8ODLKxzruQJs/0xr9c2gjFhI+DS91G7mO8v0digHDF6uGPwpB7pBxW2Hr5uPIuKbzPgTA9VYQKP8ZCAotcVwwo5IhNfT3om/P7iEluyTzJ8ax4lTFa4dBObsg64NI+Ku8RK1UOh0SvoJa1vexej/17iUTsjEzy940HufUMjNy6RFl3Lh/bMVQJ7afV0nzLKEHwmeyCkkUJn59cswS8NiQQhdJkQ,iv:7tMN1x38NISqyPBaETn8rjIOmW/Wn8jrBLC3xPEPwNs=,tag:AcdHVyBoqimgSdZ2tlwMug==,type:str]",
+    "client_email": "ENC[AES256_GCM,data:EbzbyF+ky6ojmwHZ2Y1a+SMrR6BKqBKwuoUm+xd0uEo0G4ZTPT1PpBjORqxMf/fji91uBRNWksw=,iv:ibdWeIHFKSBYVwrCUnu6ncxF7Z2ohst8Ok/I46YMM/I=,tag:yP7SjDAU4ycg/biuDtRyzQ==,type:str]",
+    "client_id": "ENC[AES256_GCM,data:61CbUgkIBiS3h+Kmq22CZU3p5j1p,iv:d+5T3JinjdS/qFeSi/IqJcViIPa+AJmas7cDgAeNlgU=,tag:yS8mIHWynu0K+iKiEy+jfw==,type:str]",
+    "auth_uri": "ENC[AES256_GCM,data:T2Ee2AB4jo3iIEYvTXDo9PElyv8sFJ9RORXT3q65hQC2hGGVYjLKuJQ=,iv:PCbnb/kWs/z39jxiCudDzcRZYheR7DlmOKAq77E4hZA=,tag:7AmmLigR8ncGTpUQje0lag==,type:str]",
+    "token_uri": "ENC[AES256_GCM,data:iFJBZMBPYJD9U5WHftHgi5vIASW2ZVJQ4Gde8YYqveeeA6w=,iv:Q1NNGMqExCt3PhDoBPiEVqbhFAaYVJHXDJIbT4EhRok=,tag:l24lacVBF0L5+wAKV8B+fw==,type:str]",
+    "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:XFZx+XGiTsoeKRkh++BOyr1VipS8HRGgCnbIx4krRqUMYKKeKI02PrX0,iv:0rPXCbU8QgV6vrs6kskIgr2JK6sOSnIy/bCP2/mozUE=,tag:4Q7cLsRtyYH2Xa4wyGj94g==,type:str]",
+    "client_x509_cert_url": "ENC[AES256_GCM,data:o6ODhYhut1Nh8O/eI1GlwHlysimjizW1CIzfsnbGVz2I3PFtLCbZViOTSB0jOlmQ1AwqVdBzs6kH/gMGccn6NXx+9RuTF84mXgSn9lgKRw+abDT4HmwbTAJVXVDb9qvbO4Go6QfF6tYBIhtw,iv:dKECDm3eo5aRLKMVtJEZ4cMIHTqwly/V7MlRczWjDiM=,tag:3wEVznikXHNNnk3tUbq1AQ==,type:str]",
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2022-03-09T08:56:45Z",
+                "enc": "CiQA4OM7eK7A4GzT8M/tfnYqDC9GZ+j7VdEKn4LtURsydlqx9J0SSQDm5XgWuD5vFgKyh+EmByJxQ1nOakIrA5rYrSHojxF0vgFEtpww0ngHMqecTt6A12Tbt0Crbaz0uIGLCPNZ7NVarrRBD3/S1pI="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2022-03-09T08:56:46Z",
+        "mac": "ENC[AES256_GCM,data:T6BgZYgVH3YUjGFtOT0azXWTDl3oD2w4JowO+y5iYPike8necb71fKUkQljj9AGhCCQf7i6eQkc17I9uqqJ8rOAw9oKoOVualO3H4As33snOCdqqyRXRLPhR82DBRcBhkbpc0ZPTTBs0URGbZ9ED4ACJwvezrs+PUN0UBhdj47o=,iv:W4yAYt5cnNBeOqyiA1g+foWx6NyxGIITzLJLmMbmDTI=,tag:3rrlnoiPyT/1Yc8xHb+LnQ==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/carbonplan/enc-deployer-credentials.secret.json
+++ b/config/clusters/carbonplan/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
-	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:al0s8YCkle85pguzIGCzFFOiS28=,iv:/KifdsAttkhV0GYNsYsNNMlCaJTNyqoNpVuZ4DDrTsE=,tag:WRBj1WZmrrm10vCMv6+Z0Q==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:sdJC4HrDKoPwFwycESdoLl/IYNdY1hX+cp6QPDJheAxMM70OrmW7EQ==,iv:D8ihv0tO91q/2FS9I8Ruy9xG/J+1FkHypCDQNmqTosQ=,tag:NISFPYlrBs9HMjWCzXm5aw==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:0FObrzV9PIGBED65pw61//FuOjJicck=,iv:UXMhO5XGVXcJGZTQMtLNOJdG7WZh+EbS2VNcWoef6A4=,tag:Qoq4z5eSHBZAEHek+pHT3Q==,type:str]"
-	},
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-12-15T13:46:57Z",
-				"enc": "CiQA4OM7eFuB8u3cx5iw89KqzlzdyNXWBhwxBi4h43agspUXpgcSSQAZvYDZ/ltRKEi0dhuvDnmvvT2B5axUG1JQa6icIFO+XvApmbii2psG3cmyTEsZ2bJj7aP37qQHSSZedD8tOsSSGbFWJEnFXzE="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-12-15T13:46:58Z",
-		"mac": "ENC[AES256_GCM,data:HAmrHlFs7ptLEQQYpWNp+Dynw7SEXa3fMu8dBQqzm2/N7cgMPfH6P8ATsJ48FpVZ+mgkpxh/ynsmT7n+XTozTgliV4+GqvQ6dVNGx9V7B2ojqefJeQfQixRN3aLcVWQzkCx0stxBUTtj31JHxIrqyZCsvMmsB2Nh5FkHMiOSHbI=,iv:surqqycx42e/zv3ykYPzJ0XyO83/1jBY5nAGOTWvglk=,tag:K+CAfTxTHq4qcKlBDHqZVA==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "AccessKey": {
+        "AccessKeyId": "ENC[AES256_GCM,data:al0s8YCkle85pguzIGCzFFOiS28=,iv:/KifdsAttkhV0GYNsYsNNMlCaJTNyqoNpVuZ4DDrTsE=,tag:WRBj1WZmrrm10vCMv6+Z0Q==,type:str]",
+        "SecretAccessKey": "ENC[AES256_GCM,data:sdJC4HrDKoPwFwycESdoLl/IYNdY1hX+cp6QPDJheAxMM70OrmW7EQ==,iv:D8ihv0tO91q/2FS9I8Ruy9xG/J+1FkHypCDQNmqTosQ=,tag:NISFPYlrBs9HMjWCzXm5aw==,type:str]",
+        "UserName": "ENC[AES256_GCM,data:0FObrzV9PIGBED65pw61//FuOjJicck=,iv:UXMhO5XGVXcJGZTQMtLNOJdG7WZh+EbS2VNcWoef6A4=,tag:Qoq4z5eSHBZAEHek+pHT3Q==,type:str]"
+    },
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-12-15T13:46:57Z",
+                "enc": "CiQA4OM7eFuB8u3cx5iw89KqzlzdyNXWBhwxBi4h43agspUXpgcSSQAZvYDZ/ltRKEi0dhuvDnmvvT2B5axUG1JQa6icIFO+XvApmbii2psG3cmyTEsZ2bJj7aP37qQHSSZedD8tOsSSGbFWJEnFXzE="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-12-15T13:46:58Z",
+        "mac": "ENC[AES256_GCM,data:HAmrHlFs7ptLEQQYpWNp+Dynw7SEXa3fMu8dBQqzm2/N7cgMPfH6P8ATsJ48FpVZ+mgkpxh/ynsmT7n+XTozTgliV4+GqvQ6dVNGx9V7B2ojqefJeQfQixRN3aLcVWQzkCx0stxBUTtj31JHxIrqyZCsvMmsB2Nh5FkHMiOSHbI=,iv:surqqycx42e/zv3ykYPzJ0XyO83/1jBY5nAGOTWvglk=,tag:K+CAfTxTHq4qcKlBDHqZVA==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/cloudbank/enc-deployer-credentials.secret.json
+++ b/config/clusters/cloudbank/enc-deployer-credentials.secret.json
@@ -1,30 +1,30 @@
 {
-	"type": "ENC[AES256_GCM,data:rsmceDwWEe0TfXXOJ8wv,iv:1/KehoEFfMGqfC5zKTrXFXhDW4N/ecp97QNXHi/nIss=,tag:k1FFJ0zqSZkCh9XL1etCmQ==,type:str]",
-	"project_id": "ENC[AES256_GCM,data:8Y82EMW7hJ/l+bcW,iv:2UZqoZFuTD3ohnUOI72Up1ZEYXU2Kkvjxdq2/SJBJE8=,tag:n4JVzjsRssv4U9EvJBO3SA==,type:str]",
-	"private_key_id": "ENC[AES256_GCM,data:NR6BiEgSm9HQUV+BcQ+KeVO5GS5amwwUbU9nFuvroH9K3UPoWlETpg==,iv:ujOs9CnHvmyVbMqHu69lLzNIc87iJRosUOoMjXaZ9Yg=,tag:nWOdlSWmLPon6pGyzbGY4A==,type:str]",
-	"private_key": "ENC[AES256_GCM,data:ZNIlIUvUJi1RN7ikCk8QvBV2wTvkb2QwuQh3q6wF7cUyD6KulZmSceanxvY5ziT/r7KIvJsYTMfP0Xi1MBfpiapn+S5YKenpbz6DOf4lIU10/0tCG/6qaOxiviI/ggCKsVWrKHa4EfDVFEfMYJGw5lH1ft0mMEDpIZkPRGgY1NaCP3/izGVaxZ1QeR0kPP8WVBAgZIVBgdi5tlkqP9LStXZ58R6b+CAU2rGlrg1lkGeSUMOJj6vzLIULLq4U9ykqU+CcO3PL3Evxr5OV5mPixPDN4mQrRTSkzXpvKvwxh21hR/CMKuY2M9bSfx08APkQk9ivvwoZrhXTJyZQV0FKZNeU1F1d0w1znEXCfODpoTLSv980Zblvfu63P/Pkj7MBaqJ7w9YmtRc9wcdJuuOSPgacmXDyIrl7jzAQqBh7CwT9bPN0Ti6iJrM6RdjyB1QKkBReOFL8HAS2rmQ4LYHxSh1+DMUdhkRIfqVuKjOO5qgYMQeJM5Nh2t8S6veQhwoOag4LFD83j0EbANQJbgVSkWvsi32S9kRuhDOu9ltwRfxn/6Rbvr3+h/Wlm6XY8hkKA7R3F0P1PkByWULYz7adX+fe4N6Juhw6oeTtfOn6xMf66ZP0HS6hk8X+b03RuJxlEFDKzBDo/g1eDbpy5xeeFQO5AL7VRGTglvVfogwgJDwhMnfiKCO91mBe9AtwRrBz1WD92E8Ey/Nw19iOdj1G+Gqvz2hWgj5ZbTLqff0ydSpY5TPchMbEJiGMkNZLwNUJSoNo/bVPADhCza2HuHsV1Qmh+m80ftF+SilYqOfkqkwj3PVs04S3fApKu8v3wGNxqSPoiw4fi05OuSsZ7/sEALEUXdPmQWBTTWn3XMKuDGbp7GYG5bvbFZoeXn1yUCENIjktuYIziyeDqsXBDsbZvQXONYvC2cE2rikYYz5Qw6TyYeM93BlOX4GBw/gAPjbc9pnDOmDTVwyk0m3txHZuWrG85eACzO7b1kEb0LFyqUZOdSLtu0loCvlKWRUWMB665EKWLGntx9xcHyZQYHPvww0LucNK4BHHKN7CLGfcc22gsvGgJtn8QBIrWCipkvIDYPzQKROklSn/xr8qDu7Vx0ZDII1epU/OGBuTJDvNffLmBoKJ7yty8ZxRDl/zl22tbhyFN6pt5ziBnVWks1vVELAKKCO/SoaWhvY52zYKrFf8aFcGxR74vQBpmyR9Mgi5tA7fdJKY+dNf7zmVuPnirkkUHlHanjbMUB4H11a4tWJlax4W0tD1lCiUKUu8krZM2Lrxf9erOeuh633weNDP7y29RrHEKJmH3nw9BfNpw9S2/jl3Bn7Kxrp/qJuLnjqokoh+uvmo7+3P5U5ELRSO4x4Rf15EtARAQXWAZpBPInkNnjsqZX9nh8/nKedcDnvHCAmcE9/NhSRLLjJeaqgcpiaJo1boZZpJG6lqV4nBbW+eF99G8NzraotKM4ZD2pWkPy0pw0f03SJWeuWHvpWVsfydRnxqiPqS2uoQtd4mMb8+b3fzRvjJovb0LDwb0+kZer92cVlINbt3rc5D6BOibwBUEjmQZGZN/60JrcyYyIVOO6RpKgEEKvyrpSqbQ1BvkkzEuEEq7DAMRbbCqEjZgNEOfdafERt8xaRI0SjH+LrUIGiQ3wyLw+/ubW6OCrqFRb/EwX72QtXpgGUezwPPs3X8Yju7JILJjPBKjtpcc/vvL/gkWOXI/Ki8Tvg2ToK2aLtd9J1ZOR5ao/BCwVYynV8GRvMUhZrWtWHBzngyYapyk36Smsd1rA7CYt9LLKghqgbySxfBsBGUlfkVlAWP7vYJT01A74sVrEkvMFOPKZNntLWM0r4nMKBSgrJg/IA7+iuKM5IG1yO1kIMTBPyE554uGQO8zzZhjrsQYxGvzk2/67jiR5pB/4sUyIDLN6ZBtFBr10niVBMoN1j44gK8XvVYfXhN1N89l/t31E1EJAuVd6cdLIY8Jtw1VnA/6qw8vGYFPzZHxwmhcc1h6QK8RwhVDZd6vuqDnS7NSqMncc5sYRg3MgwIw6PbXTGyubFj4AgcDlTVJdKwKUMZ+gbR3PS49XFzYR2edhkfVQD1duOtAt98DEvQfpQUL7pSfYq3+rUMqLiV9i0rxOmA/Zl154nvlyyOXg+A/lgxfJYYX7OeqIgGLeFqRbSFzjPSnjOjHYwp5EOwNMV4kxFp2+2sE95J2ZCal06iizm/bT/6THWiQzaNZkXSGMp0ykNY1vh4cViv0cZQ16OtI0zBeUSHl0cE/3EP8RD0,iv:H9QOyUZgqGMwLBQLiX08urWWyL8Spf/NVjY5vTFXx5I=,tag:TEe0Rkv3876z0AQD2Mh+jA==,type:str]",
-	"client_email": "ENC[AES256_GCM,data:28kMoVYLhnvaM8GY3vF8y1vXO7Qs+/2FuOmRzFZJSFtdxJoTufDuPEjIITPJ,iv:lm2o0iF6gbQ772/lij+RK1JoJAj/wQJsDtaAfNTtAV0=,tag:ogJVdlSRzyrA1J2T9eIGhA==,type:str]",
-	"client_id": "ENC[AES256_GCM,data:B2yR571jaBlFb2CWs5wi+vfFBEgC,iv:xHbGXDA90O4R8ZdWwA22jo4MwVTIt+oVmVu+Gomwla0=,tag:WCxra8qSqN77BgT6yov/IA==,type:str]",
-	"auth_uri": "ENC[AES256_GCM,data:JmXbFHRvE4bhQJlAlQjNitOhyPhS39+fIKafdjns26DC5OpApn2s9x4=,iv:/cYZq7C5HC2kFnjF7S53Q+McNZmdxQjfBknIbUh4/5U=,tag:GUAXCapNHzFJB8HS/iE/Qw==,type:str]",
-	"token_uri": "ENC[AES256_GCM,data:XMZCr1ENtDUUUGvIHf7R5Ldn1NOdUZ1/Hb+F+BGoWoPc3iM=,iv:09RU3VxFpMRzdjtGdTzGIzDGpfBEZu7rEDCnB76RU4g=,tag:M2G1+VwuzMdWufce6QN0fw==,type:str]",
-	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:krsSXzhwlkF+HKQQWYf8srkEwHZsBsBuOmUXXpIh5y4UddFFa2QmdMSW,iv:9orBxV8d1UIIMaxGs47tknCYmd3zuqL0yG1GNG/xmAk=,tag:c+AzpSVwMg93N2C3zc8ERQ==,type:str]",
-	"client_x509_cert_url": "ENC[AES256_GCM,data:yqrvLpwqWxdYHIzx10I/qyTuARK1g8egy6cuh0FMmqLVutjYchMvmK6Ogh4LJZ0ZLVqn8bfZ+bQlAboVn4ADTvsdSJBvIENaaMrEDBZNVMw8VEYoMQNp8mxavLMO1ciy8Q==,iv:RKaQAxWe2jeObYNHCkeqDGq/mB5jgh+aNJsukFAqsSM=,tag:boh3jdQE7MYtE/q6mtQKRw==,type:str]",
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-06-10T09:49:01Z",
-				"enc": "CiQA4OM7eHDda/5n/sRqbZOv5xsiossNK1HcAJBjKWTRxeDF4VASSQB6TpsYO0+m/K6nOnf1v5Y8/paAsN5wfeYzWM50jXN0M0gJM1DE2wkHVFaTEYO/LFdt36MM2op8fHEpqM5n1+5iUsiyHnXQCeA="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-06-10T09:49:02Z",
-		"mac": "ENC[AES256_GCM,data:aqUrkms7LQTsZzHM3v9uEES2LnhtF7CZclAd1x+zaXMzmCGVNPV8GvcZ1kGYFP1ARSAHvxb+j210BfZLemUbFIRO4rr3tbskH16Z9rsKJI0EQkdFgQtv6ThHd55dt3mcmit/JaY2O9ckXVPitCPkMVjUnjOe67HNIOhiXVC0EwE=,iv:1oy5oOyQ0oGuWHw6K8vq1cQt44zoa3QIp+H1BRgf7lY=,tag:NYvxPB/A30aeF3z4YDN6ig==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "type": "ENC[AES256_GCM,data:rsmceDwWEe0TfXXOJ8wv,iv:1/KehoEFfMGqfC5zKTrXFXhDW4N/ecp97QNXHi/nIss=,tag:k1FFJ0zqSZkCh9XL1etCmQ==,type:str]",
+    "project_id": "ENC[AES256_GCM,data:8Y82EMW7hJ/l+bcW,iv:2UZqoZFuTD3ohnUOI72Up1ZEYXU2Kkvjxdq2/SJBJE8=,tag:n4JVzjsRssv4U9EvJBO3SA==,type:str]",
+    "private_key_id": "ENC[AES256_GCM,data:NR6BiEgSm9HQUV+BcQ+KeVO5GS5amwwUbU9nFuvroH9K3UPoWlETpg==,iv:ujOs9CnHvmyVbMqHu69lLzNIc87iJRosUOoMjXaZ9Yg=,tag:nWOdlSWmLPon6pGyzbGY4A==,type:str]",
+    "private_key": "ENC[AES256_GCM,data:ZNIlIUvUJi1RN7ikCk8QvBV2wTvkb2QwuQh3q6wF7cUyD6KulZmSceanxvY5ziT/r7KIvJsYTMfP0Xi1MBfpiapn+S5YKenpbz6DOf4lIU10/0tCG/6qaOxiviI/ggCKsVWrKHa4EfDVFEfMYJGw5lH1ft0mMEDpIZkPRGgY1NaCP3/izGVaxZ1QeR0kPP8WVBAgZIVBgdi5tlkqP9LStXZ58R6b+CAU2rGlrg1lkGeSUMOJj6vzLIULLq4U9ykqU+CcO3PL3Evxr5OV5mPixPDN4mQrRTSkzXpvKvwxh21hR/CMKuY2M9bSfx08APkQk9ivvwoZrhXTJyZQV0FKZNeU1F1d0w1znEXCfODpoTLSv980Zblvfu63P/Pkj7MBaqJ7w9YmtRc9wcdJuuOSPgacmXDyIrl7jzAQqBh7CwT9bPN0Ti6iJrM6RdjyB1QKkBReOFL8HAS2rmQ4LYHxSh1+DMUdhkRIfqVuKjOO5qgYMQeJM5Nh2t8S6veQhwoOag4LFD83j0EbANQJbgVSkWvsi32S9kRuhDOu9ltwRfxn/6Rbvr3+h/Wlm6XY8hkKA7R3F0P1PkByWULYz7adX+fe4N6Juhw6oeTtfOn6xMf66ZP0HS6hk8X+b03RuJxlEFDKzBDo/g1eDbpy5xeeFQO5AL7VRGTglvVfogwgJDwhMnfiKCO91mBe9AtwRrBz1WD92E8Ey/Nw19iOdj1G+Gqvz2hWgj5ZbTLqff0ydSpY5TPchMbEJiGMkNZLwNUJSoNo/bVPADhCza2HuHsV1Qmh+m80ftF+SilYqOfkqkwj3PVs04S3fApKu8v3wGNxqSPoiw4fi05OuSsZ7/sEALEUXdPmQWBTTWn3XMKuDGbp7GYG5bvbFZoeXn1yUCENIjktuYIziyeDqsXBDsbZvQXONYvC2cE2rikYYz5Qw6TyYeM93BlOX4GBw/gAPjbc9pnDOmDTVwyk0m3txHZuWrG85eACzO7b1kEb0LFyqUZOdSLtu0loCvlKWRUWMB665EKWLGntx9xcHyZQYHPvww0LucNK4BHHKN7CLGfcc22gsvGgJtn8QBIrWCipkvIDYPzQKROklSn/xr8qDu7Vx0ZDII1epU/OGBuTJDvNffLmBoKJ7yty8ZxRDl/zl22tbhyFN6pt5ziBnVWks1vVELAKKCO/SoaWhvY52zYKrFf8aFcGxR74vQBpmyR9Mgi5tA7fdJKY+dNf7zmVuPnirkkUHlHanjbMUB4H11a4tWJlax4W0tD1lCiUKUu8krZM2Lrxf9erOeuh633weNDP7y29RrHEKJmH3nw9BfNpw9S2/jl3Bn7Kxrp/qJuLnjqokoh+uvmo7+3P5U5ELRSO4x4Rf15EtARAQXWAZpBPInkNnjsqZX9nh8/nKedcDnvHCAmcE9/NhSRLLjJeaqgcpiaJo1boZZpJG6lqV4nBbW+eF99G8NzraotKM4ZD2pWkPy0pw0f03SJWeuWHvpWVsfydRnxqiPqS2uoQtd4mMb8+b3fzRvjJovb0LDwb0+kZer92cVlINbt3rc5D6BOibwBUEjmQZGZN/60JrcyYyIVOO6RpKgEEKvyrpSqbQ1BvkkzEuEEq7DAMRbbCqEjZgNEOfdafERt8xaRI0SjH+LrUIGiQ3wyLw+/ubW6OCrqFRb/EwX72QtXpgGUezwPPs3X8Yju7JILJjPBKjtpcc/vvL/gkWOXI/Ki8Tvg2ToK2aLtd9J1ZOR5ao/BCwVYynV8GRvMUhZrWtWHBzngyYapyk36Smsd1rA7CYt9LLKghqgbySxfBsBGUlfkVlAWP7vYJT01A74sVrEkvMFOPKZNntLWM0r4nMKBSgrJg/IA7+iuKM5IG1yO1kIMTBPyE554uGQO8zzZhjrsQYxGvzk2/67jiR5pB/4sUyIDLN6ZBtFBr10niVBMoN1j44gK8XvVYfXhN1N89l/t31E1EJAuVd6cdLIY8Jtw1VnA/6qw8vGYFPzZHxwmhcc1h6QK8RwhVDZd6vuqDnS7NSqMncc5sYRg3MgwIw6PbXTGyubFj4AgcDlTVJdKwKUMZ+gbR3PS49XFzYR2edhkfVQD1duOtAt98DEvQfpQUL7pSfYq3+rUMqLiV9i0rxOmA/Zl154nvlyyOXg+A/lgxfJYYX7OeqIgGLeFqRbSFzjPSnjOjHYwp5EOwNMV4kxFp2+2sE95J2ZCal06iizm/bT/6THWiQzaNZkXSGMp0ykNY1vh4cViv0cZQ16OtI0zBeUSHl0cE/3EP8RD0,iv:H9QOyUZgqGMwLBQLiX08urWWyL8Spf/NVjY5vTFXx5I=,tag:TEe0Rkv3876z0AQD2Mh+jA==,type:str]",
+    "client_email": "ENC[AES256_GCM,data:28kMoVYLhnvaM8GY3vF8y1vXO7Qs+/2FuOmRzFZJSFtdxJoTufDuPEjIITPJ,iv:lm2o0iF6gbQ772/lij+RK1JoJAj/wQJsDtaAfNTtAV0=,tag:ogJVdlSRzyrA1J2T9eIGhA==,type:str]",
+    "client_id": "ENC[AES256_GCM,data:B2yR571jaBlFb2CWs5wi+vfFBEgC,iv:xHbGXDA90O4R8ZdWwA22jo4MwVTIt+oVmVu+Gomwla0=,tag:WCxra8qSqN77BgT6yov/IA==,type:str]",
+    "auth_uri": "ENC[AES256_GCM,data:JmXbFHRvE4bhQJlAlQjNitOhyPhS39+fIKafdjns26DC5OpApn2s9x4=,iv:/cYZq7C5HC2kFnjF7S53Q+McNZmdxQjfBknIbUh4/5U=,tag:GUAXCapNHzFJB8HS/iE/Qw==,type:str]",
+    "token_uri": "ENC[AES256_GCM,data:XMZCr1ENtDUUUGvIHf7R5Ldn1NOdUZ1/Hb+F+BGoWoPc3iM=,iv:09RU3VxFpMRzdjtGdTzGIzDGpfBEZu7rEDCnB76RU4g=,tag:M2G1+VwuzMdWufce6QN0fw==,type:str]",
+    "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:krsSXzhwlkF+HKQQWYf8srkEwHZsBsBuOmUXXpIh5y4UddFFa2QmdMSW,iv:9orBxV8d1UIIMaxGs47tknCYmd3zuqL0yG1GNG/xmAk=,tag:c+AzpSVwMg93N2C3zc8ERQ==,type:str]",
+    "client_x509_cert_url": "ENC[AES256_GCM,data:yqrvLpwqWxdYHIzx10I/qyTuARK1g8egy6cuh0FMmqLVutjYchMvmK6Ogh4LJZ0ZLVqn8bfZ+bQlAboVn4ADTvsdSJBvIENaaMrEDBZNVMw8VEYoMQNp8mxavLMO1ciy8Q==,iv:RKaQAxWe2jeObYNHCkeqDGq/mB5jgh+aNJsukFAqsSM=,tag:boh3jdQE7MYtE/q6mtQKRw==,type:str]",
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-06-10T09:49:01Z",
+                "enc": "CiQA4OM7eHDda/5n/sRqbZOv5xsiossNK1HcAJBjKWTRxeDF4VASSQB6TpsYO0+m/K6nOnf1v5Y8/paAsN5wfeYzWM50jXN0M0gJM1DE2wkHVFaTEYO/LFdt36MM2op8fHEpqM5n1+5iUsiyHnXQCeA="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-06-10T09:49:02Z",
+        "mac": "ENC[AES256_GCM,data:aqUrkms7LQTsZzHM3v9uEES2LnhtF7CZclAd1x+zaXMzmCGVNPV8GvcZ1kGYFP1ARSAHvxb+j210BfZLemUbFIRO4rr3tbskH16Z9rsKJI0EQkdFgQtv6ThHd55dt3mcmit/JaY2O9ckXVPitCPkMVjUnjOe67HNIOhiXVC0EwE=,iv:1oy5oOyQ0oGuWHw6K8vq1cQt44zoa3QIp+H1BRgf7lY=,tag:NYvxPB/A30aeF3z4YDN6ig==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/farallon/enc-deployer-credentials.secret.json
+++ b/config/clusters/farallon/enc-deployer-credentials.secret.json
@@ -1,27 +1,27 @@
 {
-	"AccessKey": {
-		"UserName": "ENC[AES256_GCM,data:xzejx3ekJ3o=,iv:6pkDM1SlOUZam95khZZsRkszGpf8rzE87ZZFTYfPuNA=,tag:TYF7ctbZ3szuY88kA8MyCg==,type:str]",
-		"AccessKeyId": "ENC[AES256_GCM,data:baIaSl6LkHTPI6VlIDFU/vhLjHI=,iv:lS1kSvvyB0BCnJ2ROt5ZYqKwRHD5+8PGttyrJRrfNt4=,tag:aATT82STHnqA0gJ18Z6h1w==,type:str]",
-		"Status": "ENC[AES256_GCM,data:dITKVJJU,iv:zNPAZiM9WlBGFcqTtgYZMCIUYFLGJeIkgnolyL70paU=,tag:y5dsK27jgopRA4YTjFeBTw==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:dv1lLpX+oNckM99jq9XyNDtmvatshvw0vG1R7um3eSWAAK5mhR8lPQ==,iv:vQijh5x9aXKkvwGtC+tz4K7c/2cC+4RS7ZhuR1nH8aE=,tag:DUVVUWjMQVzQ1+COT3gZjQ==,type:str]",
-		"CreateDate": "ENC[AES256_GCM,data:lTRvSgoBvv78lZKaMyo7FFaM1TY=,iv:GCLCdzuNmKebeQ36vFw1j6hLxzBXbauytA+b9rjpXyE=,tag:QQu4b+NFPCbO3VmP8eTo4Q==,type:str]"
-	},
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-09-10T19:47:17Z",
-				"enc": "CiQA4OM7eADZ6//P01khGg4CZO59PqPjFbWve5/BrnloowSkutESSQC9ZQbLAKgNPACzbKGS+Na1TnvxQ5HfjKGuRpe28hjxPRxLdYtjrFAJS9sLzMpMUOS10chi3N6SWLLbngM0mDIpCpx5nAzCjiI="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-09-10T19:47:19Z",
-		"mac": "ENC[AES256_GCM,data:n/hHhm2IdIQOy/s0yyRr9XzRU0sVTLa4VbzqdSWJ91ZtUiGdbBB6sw81lxRFv7x2MXnlGrBVs6QS07urB31QB7ryr1BhRDJeA0tVzceGf6KGmpqih3luWqEEtrtIwQSuqKgNueEQ4zcNmLq7KavfQkijE3MGYnoAudU/FavChFY=,iv:TO/jhfTpM03n71o9Sx/krrCmtuB/qyQg9FFBTdks5ec=,tag:EVg4qv2iP9SFnj0j0q7sIA==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "AccessKey": {
+        "UserName": "ENC[AES256_GCM,data:xzejx3ekJ3o=,iv:6pkDM1SlOUZam95khZZsRkszGpf8rzE87ZZFTYfPuNA=,tag:TYF7ctbZ3szuY88kA8MyCg==,type:str]",
+        "AccessKeyId": "ENC[AES256_GCM,data:baIaSl6LkHTPI6VlIDFU/vhLjHI=,iv:lS1kSvvyB0BCnJ2ROt5ZYqKwRHD5+8PGttyrJRrfNt4=,tag:aATT82STHnqA0gJ18Z6h1w==,type:str]",
+        "Status": "ENC[AES256_GCM,data:dITKVJJU,iv:zNPAZiM9WlBGFcqTtgYZMCIUYFLGJeIkgnolyL70paU=,tag:y5dsK27jgopRA4YTjFeBTw==,type:str]",
+        "SecretAccessKey": "ENC[AES256_GCM,data:dv1lLpX+oNckM99jq9XyNDtmvatshvw0vG1R7um3eSWAAK5mhR8lPQ==,iv:vQijh5x9aXKkvwGtC+tz4K7c/2cC+4RS7ZhuR1nH8aE=,tag:DUVVUWjMQVzQ1+COT3gZjQ==,type:str]",
+        "CreateDate": "ENC[AES256_GCM,data:lTRvSgoBvv78lZKaMyo7FFaM1TY=,iv:GCLCdzuNmKebeQ36vFw1j6hLxzBXbauytA+b9rjpXyE=,tag:QQu4b+NFPCbO3VmP8eTo4Q==,type:str]"
+    },
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-09-10T19:47:17Z",
+                "enc": "CiQA4OM7eADZ6//P01khGg4CZO59PqPjFbWve5/BrnloowSkutESSQC9ZQbLAKgNPACzbKGS+Na1TnvxQ5HfjKGuRpe28hjxPRxLdYtjrFAJS9sLzMpMUOS10chi3N6SWLLbngM0mDIpCpx5nAzCjiI="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-09-10T19:47:19Z",
+        "mac": "ENC[AES256_GCM,data:n/hHhm2IdIQOy/s0yyRr9XzRU0sVTLa4VbzqdSWJ91ZtUiGdbBB6sw81lxRFv7x2MXnlGrBVs6QS07urB31QB7ryr1BhRDJeA0tVzceGf6KGmpqih3luWqEEtrtIwQSuqKgNueEQ4zcNmLq7KavfQkijE3MGYnoAudU/FavChFY=,iv:TO/jhfTpM03n71o9Sx/krrCmtuB/qyQg9FFBTdks5ec=,tag:EVg4qv2iP9SFnj0j0q7sIA==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/meom-ige/enc-deployer-credentials.secret.json
+++ b/config/clusters/meom-ige/enc-deployer-credentials.secret.json
@@ -1,30 +1,30 @@
 {
-	"type": "ENC[AES256_GCM,data:jNwbQW9dcvm3b+SOcHkn,iv:ihTmC8qpzvhggLVvE01p3QXKyTqrEtbsLb6ol0DqaJ8=,tag:HQwH0NpGK+3QFRmoUdlGtg==,type:str]",
-	"project_id": "ENC[AES256_GCM,data:EdLC95xgY/rChVG7Gw==,iv:5fJnvs7OeDMJYAHpR8eR0oWw2JjrCeJQ7IA3+XRbuC0=,tag:1ySiocy9ArzlBPqoT2BF+g==,type:str]",
-	"private_key_id": "ENC[AES256_GCM,data:IFeOBQp8S8PIrCzBCH4y9N5G86Ui+qa7sY4D6VCR2p2Oj5uuDinipw==,iv:c0qBGg9knPKSHgemQsqtR/nXlKAqy4xlgqnU6St1VmY=,tag:TiVEauSFDjnsJ4HmgIZyqw==,type:str]",
-	"private_key": "ENC[AES256_GCM,data:hd1dgtHGhi+ivlRFlirglLwR8+aZBuqa9+E6bVR82TNzC71wyb66U/rz/pO5ZCN/X3tHbThS3Ca7fQP6ejCOhbYaPZmLDoQQE5I16l5YHZ5BW3hABkiFrjwmEB6vi/zRoYBSq6ozNugySzL99Jt+gZAALPcZ+C3jOV1Sn/s0u8Wc+QyfYhxnQB/YWERttslY9iC2qb9my3hCuxGfesAUsHZGVUrG4VeFZYCdKYjX1z6by8RrOTbGr/RtAK6xa8IpJxtguWaBVkA3K0bAL34qDExUzqdBwtLXvFL2rX0G0VALYfdG16M8HRyLLAk7UindTezlPSrEiB1p3cHsu8IAyMRtX2gn0m/tGGDOT9UbTu4rQZfegw5A0bbbHjJBl0agyeprtiBZkLkDI+ahCibFWpDgAoeD5FHj++6Jl/2F4A+tHjKNQAzbRIl86TSESCA8o2rVGlUp4zrMjPUGOCE02G0oSL02FRWdJAsKckAdS1DtXDF9xSbL2CVqy1dRUCT1zZOg5VtvbbmHypBSZFgFT+j3SN8VwiP7O/Nr/sGTdmeXc6Bzj4I1wC6t5vmiXTpTBsNfsQeYBhCUgULxQduArLJh5i+WNWeEI9OVUo59aOat3DDtk+BHzCqn6iz+Dubg6dZ8w9ThbEVPuceGT+QscwkXspRMx+udaCKCYzdA21i3QwIif9ayVWs8Pdu++Ja6Fj+FAces/J+30t41WBW6ezz8c+MRpR+nzhWIxeJ21t4JVx39wWSBe6DjNhvd66Y/l7TAGsV63CDVg5FG4vAMiz+Yc+nj5/KuM0KLkep20wTVGhXLkw3Bqv2GWyQpwrwuYk2JiBUmlnqogX2FYLNNU+BWNRV77FNGUVgnfs6j+TgNnpG3I0k8FXSF0AiS7wPO5IDkvznBXswDIOjl7kZyBlfuHuZANshzAqJqOdNDycjgUh2v8rfnlYwgEFJRa/iK4WFzmtOT9OtQ9Q3YT71iPqQ5b0cYyZNAA9iUzeQB8xs7OUkLYPxB9E4FeYIQwSyU/floyIAupsVgJD4sTuxa/mb4DM32LydF4JOWJhuUiWexjrVQGibDCfLOsCaq5kSvuob6j2pFZSbXg6LbC2c/G+4cz+S2ReAKUNfQWkc13/lYDPq+H4nCTFo0KaZh1H54dZZ8MjmCobxUEhrsVrF25eNxSp9S5g3F5NW9cw10KMtsWaglWszaiffXm3qmycwIx5jjV03rftz/BXvyVcMygBYqYZ28cTTwhMGdRK8QHjtPgjfumqzisPiCs8zwNZC2wqNWRcgf/a4257sKSraJjGxCxVS/JPp7QEmfNWSBU5agWK5oUXztNaBkY8uYAk4EP3oEVC3hf0+33gyDuHyOdR2mKzdlmgnDuCD10BrSL49IYbFW93LFHZfbqMvPa4ssO64gZ8K1ve4qF1Ff0a24EVojc8tHoFmu3O+hER/FbHbjbP7NV7rXDTivc0ceD1vOVHLqauYelJ1yD+8mkR+MUx1nT2eNMna8U9xkFG4L2Bcf6JDIRnsulEIfUkkbxDrHAZXselfHFFJm6PXk+tPK1RFMI/wOiH0BF1aWbBj8NPPzWIyV1DvhMaEQpS/jde79h2R9zkk0EIL/2TgAT83ajhcpA50xQUT5U+c0qKhCxZZylSwA4EELf5ZsjtnZEkbGFwjw6vA8ozalKO8ip4qSXa6BUWTXHPWQ34AZyycvucQR0r8spf5LKyMd4kQoPXMz3bl2qe3RU4cupa6H5C/OvWsFDm1roDpCZLoQ+N+o/KYtPyWUPnYiQvfkez4dLeNrAifyzZgWkQfnM6xsw0KQ4sOBwc1OKuI42/bf9YZD76Acgbh7llgkzo2t+M+NFrzTUZfYu6vyoTz+0apXNvW8n2myeILDJixwdWsrQUgb9sXSGODPq7L3Bx2Rly+//G90Of7MFOG+vk1c8aotYCIdJUH4Rk78MsvTPJ5nQEIqfp8ksfULD0fbqLkcMoy3iVptf4azIu+0Tjy2qJduEQUVGg/FmMebb5C7azC+SK0sBtyvJ2YUklv7r6v0WxE7ZbPOpt3GE4Dea8fpkwmdXDrLBq/1WN7J7OQYBH8BpLCAe9pRhZo4NkdFEtjrqmafWUC64QwR3Lz0I+UtjERxfeRsTdX9hzY0LizGtg2cL5lb3MZXpIKZP1SxdtVDW7ItRJvuO3Kk4A4n7SopyjxgL+/5lJRyZxVlScoqrT+A+gkSeq1rIRinQv/tPX/+lEeXgexTseeUuEpU3vy2gcba/WejQ90K+GwQSRxL,iv:+fyhLY+e2F05MlJZxvlXWObrkzyGLSeFStmyZAwTRbY=,tag:Rwh7a6ZLGXmsJKJwbu/5rg==,type:str]",
-	"client_email": "ENC[AES256_GCM,data:6/C0GazMYHKOy9y51zx92hqm6Lx0OhU3kItIZc+FT6VFsfjM+yvHck7lX66KElatZesdzQ==,iv:jJFwmT4EW5O/OiOcuklNFQsXdg1L3hHbFQCH+oZSXdM=,tag:rlnp2I1HFxR4IYITj0MJJQ==,type:str]",
-	"client_id": "ENC[AES256_GCM,data:tSYokW7CkSM11YqwZY7HieCp1RyY,iv:0Fet0g3N/pfbXzB5hNxww6aiao3pXj9h/22wZg/3Zvc=,tag:r+YwjdQbqzlCwtYPXCZA+g==,type:str]",
-	"auth_uri": "ENC[AES256_GCM,data:jQaZHHW4rOX+ifzkyI/6zo1AFAbVpD+MhtwGJGLnQNfvi8BwVkcoa1w=,iv:mG8XXGKF5YPtGMzgXY3syqZkgDJqToKRddcmdBZmlx0=,tag:rJE8GYHaKvd5TNc2Z0BFng==,type:str]",
-	"token_uri": "ENC[AES256_GCM,data:r6XjwVYWD38zNjVRKIuYXAM2UHJuM9YC2iejTHkUyc7qmBI=,iv:p+w7xi+AZAt+pAglfSZ0I5PKROCN6mCk1C6+I5x90ik=,tag:nUh5btDpEEFORA2yzz/PhQ==,type:str]",
-	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:M4AHJXdIf26OScO5mKEpN1vv+yI5fVbxV+ALGJxbwNWrThl604wOCoa9,iv:Cey/Yunb53zs/pE5fasm/4gtg4XNxF47+aPj8AdSFxQ=,tag:Fy1HtbGu+wH0rRah0LZOGA==,type:str]",
-	"client_x509_cert_url": "ENC[AES256_GCM,data:Xq9BuSgjDZNM6fIgrG8FKGBwrCiIebISotOZ5rWqxtuFA4hkDJt6BzwcFhnIlPyqpDQVaJubGaY2Jksqf4fZ3+D9dULsCPxa9OXTdKKbfyWGw8EShsfWHcz7LUh1yVgSWGdFF3U2dUw=,iv:OoKx5528MCvZQyjVjmXDWstyYu0wbeK3BiffhocaKCY=,tag:C+M8e7YqpJ6M7qvya1rpIQ==,type:str]",
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-08-06T08:51:13Z",
-				"enc": "CiQA4OM7eNHpo0/b6OyG3GTiAdjaNi1tdID/JfwPuQRVxt0g2s0SSQB6TpsYnNEWtwzANLqqHlzxE8c0T0Z/Y35P81QtDHnwjNRpPtqieXkWhMDT3xOXi8SHXNmiWjncqbXUW0hoHQIX79syoBgqfQA="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-08-06T08:51:14Z",
-		"mac": "ENC[AES256_GCM,data:eQs6ABB0Tl3nVzWtt36Bd4eZPVnHnjcInFCXsiML7wqojhXF3Cp00Fjo+oIPYYcyu6MeVNsOs2ICw8wNxzhUw5YtYSgTaL31PhuQ0be4CcHySTOnAsozpPowuUe2LbBCanQeNioNbwLug+NJcZU3Z7wlVDqTB+ggKdgw9WaiffM=,iv:pP/JEkNIJKwiwa7HRLWhuT+ONrvv4yZd0B3duuUV9mU=,tag:sJs9zmuZPy3/0KizVougZQ==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "type": "ENC[AES256_GCM,data:jNwbQW9dcvm3b+SOcHkn,iv:ihTmC8qpzvhggLVvE01p3QXKyTqrEtbsLb6ol0DqaJ8=,tag:HQwH0NpGK+3QFRmoUdlGtg==,type:str]",
+    "project_id": "ENC[AES256_GCM,data:EdLC95xgY/rChVG7Gw==,iv:5fJnvs7OeDMJYAHpR8eR0oWw2JjrCeJQ7IA3+XRbuC0=,tag:1ySiocy9ArzlBPqoT2BF+g==,type:str]",
+    "private_key_id": "ENC[AES256_GCM,data:IFeOBQp8S8PIrCzBCH4y9N5G86Ui+qa7sY4D6VCR2p2Oj5uuDinipw==,iv:c0qBGg9knPKSHgemQsqtR/nXlKAqy4xlgqnU6St1VmY=,tag:TiVEauSFDjnsJ4HmgIZyqw==,type:str]",
+    "private_key": "ENC[AES256_GCM,data:hd1dgtHGhi+ivlRFlirglLwR8+aZBuqa9+E6bVR82TNzC71wyb66U/rz/pO5ZCN/X3tHbThS3Ca7fQP6ejCOhbYaPZmLDoQQE5I16l5YHZ5BW3hABkiFrjwmEB6vi/zRoYBSq6ozNugySzL99Jt+gZAALPcZ+C3jOV1Sn/s0u8Wc+QyfYhxnQB/YWERttslY9iC2qb9my3hCuxGfesAUsHZGVUrG4VeFZYCdKYjX1z6by8RrOTbGr/RtAK6xa8IpJxtguWaBVkA3K0bAL34qDExUzqdBwtLXvFL2rX0G0VALYfdG16M8HRyLLAk7UindTezlPSrEiB1p3cHsu8IAyMRtX2gn0m/tGGDOT9UbTu4rQZfegw5A0bbbHjJBl0agyeprtiBZkLkDI+ahCibFWpDgAoeD5FHj++6Jl/2F4A+tHjKNQAzbRIl86TSESCA8o2rVGlUp4zrMjPUGOCE02G0oSL02FRWdJAsKckAdS1DtXDF9xSbL2CVqy1dRUCT1zZOg5VtvbbmHypBSZFgFT+j3SN8VwiP7O/Nr/sGTdmeXc6Bzj4I1wC6t5vmiXTpTBsNfsQeYBhCUgULxQduArLJh5i+WNWeEI9OVUo59aOat3DDtk+BHzCqn6iz+Dubg6dZ8w9ThbEVPuceGT+QscwkXspRMx+udaCKCYzdA21i3QwIif9ayVWs8Pdu++Ja6Fj+FAces/J+30t41WBW6ezz8c+MRpR+nzhWIxeJ21t4JVx39wWSBe6DjNhvd66Y/l7TAGsV63CDVg5FG4vAMiz+Yc+nj5/KuM0KLkep20wTVGhXLkw3Bqv2GWyQpwrwuYk2JiBUmlnqogX2FYLNNU+BWNRV77FNGUVgnfs6j+TgNnpG3I0k8FXSF0AiS7wPO5IDkvznBXswDIOjl7kZyBlfuHuZANshzAqJqOdNDycjgUh2v8rfnlYwgEFJRa/iK4WFzmtOT9OtQ9Q3YT71iPqQ5b0cYyZNAA9iUzeQB8xs7OUkLYPxB9E4FeYIQwSyU/floyIAupsVgJD4sTuxa/mb4DM32LydF4JOWJhuUiWexjrVQGibDCfLOsCaq5kSvuob6j2pFZSbXg6LbC2c/G+4cz+S2ReAKUNfQWkc13/lYDPq+H4nCTFo0KaZh1H54dZZ8MjmCobxUEhrsVrF25eNxSp9S5g3F5NW9cw10KMtsWaglWszaiffXm3qmycwIx5jjV03rftz/BXvyVcMygBYqYZ28cTTwhMGdRK8QHjtPgjfumqzisPiCs8zwNZC2wqNWRcgf/a4257sKSraJjGxCxVS/JPp7QEmfNWSBU5agWK5oUXztNaBkY8uYAk4EP3oEVC3hf0+33gyDuHyOdR2mKzdlmgnDuCD10BrSL49IYbFW93LFHZfbqMvPa4ssO64gZ8K1ve4qF1Ff0a24EVojc8tHoFmu3O+hER/FbHbjbP7NV7rXDTivc0ceD1vOVHLqauYelJ1yD+8mkR+MUx1nT2eNMna8U9xkFG4L2Bcf6JDIRnsulEIfUkkbxDrHAZXselfHFFJm6PXk+tPK1RFMI/wOiH0BF1aWbBj8NPPzWIyV1DvhMaEQpS/jde79h2R9zkk0EIL/2TgAT83ajhcpA50xQUT5U+c0qKhCxZZylSwA4EELf5ZsjtnZEkbGFwjw6vA8ozalKO8ip4qSXa6BUWTXHPWQ34AZyycvucQR0r8spf5LKyMd4kQoPXMz3bl2qe3RU4cupa6H5C/OvWsFDm1roDpCZLoQ+N+o/KYtPyWUPnYiQvfkez4dLeNrAifyzZgWkQfnM6xsw0KQ4sOBwc1OKuI42/bf9YZD76Acgbh7llgkzo2t+M+NFrzTUZfYu6vyoTz+0apXNvW8n2myeILDJixwdWsrQUgb9sXSGODPq7L3Bx2Rly+//G90Of7MFOG+vk1c8aotYCIdJUH4Rk78MsvTPJ5nQEIqfp8ksfULD0fbqLkcMoy3iVptf4azIu+0Tjy2qJduEQUVGg/FmMebb5C7azC+SK0sBtyvJ2YUklv7r6v0WxE7ZbPOpt3GE4Dea8fpkwmdXDrLBq/1WN7J7OQYBH8BpLCAe9pRhZo4NkdFEtjrqmafWUC64QwR3Lz0I+UtjERxfeRsTdX9hzY0LizGtg2cL5lb3MZXpIKZP1SxdtVDW7ItRJvuO3Kk4A4n7SopyjxgL+/5lJRyZxVlScoqrT+A+gkSeq1rIRinQv/tPX/+lEeXgexTseeUuEpU3vy2gcba/WejQ90K+GwQSRxL,iv:+fyhLY+e2F05MlJZxvlXWObrkzyGLSeFStmyZAwTRbY=,tag:Rwh7a6ZLGXmsJKJwbu/5rg==,type:str]",
+    "client_email": "ENC[AES256_GCM,data:6/C0GazMYHKOy9y51zx92hqm6Lx0OhU3kItIZc+FT6VFsfjM+yvHck7lX66KElatZesdzQ==,iv:jJFwmT4EW5O/OiOcuklNFQsXdg1L3hHbFQCH+oZSXdM=,tag:rlnp2I1HFxR4IYITj0MJJQ==,type:str]",
+    "client_id": "ENC[AES256_GCM,data:tSYokW7CkSM11YqwZY7HieCp1RyY,iv:0Fet0g3N/pfbXzB5hNxww6aiao3pXj9h/22wZg/3Zvc=,tag:r+YwjdQbqzlCwtYPXCZA+g==,type:str]",
+    "auth_uri": "ENC[AES256_GCM,data:jQaZHHW4rOX+ifzkyI/6zo1AFAbVpD+MhtwGJGLnQNfvi8BwVkcoa1w=,iv:mG8XXGKF5YPtGMzgXY3syqZkgDJqToKRddcmdBZmlx0=,tag:rJE8GYHaKvd5TNc2Z0BFng==,type:str]",
+    "token_uri": "ENC[AES256_GCM,data:r6XjwVYWD38zNjVRKIuYXAM2UHJuM9YC2iejTHkUyc7qmBI=,iv:p+w7xi+AZAt+pAglfSZ0I5PKROCN6mCk1C6+I5x90ik=,tag:nUh5btDpEEFORA2yzz/PhQ==,type:str]",
+    "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:M4AHJXdIf26OScO5mKEpN1vv+yI5fVbxV+ALGJxbwNWrThl604wOCoa9,iv:Cey/Yunb53zs/pE5fasm/4gtg4XNxF47+aPj8AdSFxQ=,tag:Fy1HtbGu+wH0rRah0LZOGA==,type:str]",
+    "client_x509_cert_url": "ENC[AES256_GCM,data:Xq9BuSgjDZNM6fIgrG8FKGBwrCiIebISotOZ5rWqxtuFA4hkDJt6BzwcFhnIlPyqpDQVaJubGaY2Jksqf4fZ3+D9dULsCPxa9OXTdKKbfyWGw8EShsfWHcz7LUh1yVgSWGdFF3U2dUw=,iv:OoKx5528MCvZQyjVjmXDWstyYu0wbeK3BiffhocaKCY=,tag:C+M8e7YqpJ6M7qvya1rpIQ==,type:str]",
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-08-06T08:51:13Z",
+                "enc": "CiQA4OM7eNHpo0/b6OyG3GTiAdjaNi1tdID/JfwPuQRVxt0g2s0SSQB6TpsYnNEWtwzANLqqHlzxE8c0T0Z/Y35P81QtDHnwjNRpPtqieXkWhMDT3xOXi8SHXNmiWjncqbXUW0hoHQIX79syoBgqfQA="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-08-06T08:51:14Z",
+        "mac": "ENC[AES256_GCM,data:eQs6ABB0Tl3nVzWtt36Bd4eZPVnHnjcInFCXsiML7wqojhXF3Cp00Fjo+oIPYYcyu6MeVNsOs2ICw8wNxzhUw5YtYSgTaL31PhuQ0be4CcHySTOnAsozpPowuUe2LbBCanQeNioNbwLug+NJcZU3Z7wlVDqTB+ggKdgw9WaiffM=,iv:pP/JEkNIJKwiwa7HRLWhuT+ONrvv4yZd0B3duuUV9mU=,tag:sJs9zmuZPy3/0KizVougZQ==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/openscapes/enc-deployer-credentials.secret.json
+++ b/config/clusters/openscapes/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
-	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:tcbUKHauMIqSOGQShrqytVWj1ZU=,iv:yEVehMVmVtXr/UJ5JKTBd45THoO4vWG+vrJ/Uzzi8qc=,tag:3uF0Xsfz5DrS/teyXbuvog==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:oHT/Fpq0G6arV0zeaPYGP59wAmUMFNgFvH9Me+5sQhhQ4MekMWkUcQ==,iv:RRer24FQm6RRvxfGBUqi30Jc9HnmmqsU9OpLlys4SSs=,tag:KRc9iHN6ATUmR2IhSF4MDA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:QKA1nFgKPlRaR68K9gYLPdb/cNt1VQM=,iv:5jrH03moJzsRRmgn3oyadcxobXJCMeO7f0j2MwScvws=,tag:HpSeW60gYOb9YnJx6BScug==,type:str]"
-	},
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-12-15T11:13:08Z",
-				"enc": "CiQA4OM7eAatL2sC4XWJjCIeuE43fR4/Z130cV1GvpnrhJb5BKkSSQAZvYDZvrVv7eug28hblZw/W3QScZaYwh1l9ohShGw412wYWdN3JVjWIIxyww4YdIiAsbLZVIpQAo82yIy8feoDKTi3NLHrhJ0="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-12-15T11:13:09Z",
-		"mac": "ENC[AES256_GCM,data:B68hcazns/o1EEjJmkZRGpVW8nxZmtb11d66cadJ2qWPKRMcNVLbU4Mst6QS3KKJSKeMWCAk9AhpeFM3Y62JU4+dakGAZQTxGn0pefp0tgqlAAitiy8tl6Y0PDn9fcpBVOb/2i9nVqVNDXJqsk7320lDu1U0RpGDmr9YpW/S3Ps=,iv:N4x28DBvqDDBHvuDvjKuoC7IzBIqJAiK3/d22Ok4PgQ=,tag:T4v4L3LiG/zRvPOPBvsEtw==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "AccessKey": {
+        "AccessKeyId": "ENC[AES256_GCM,data:tcbUKHauMIqSOGQShrqytVWj1ZU=,iv:yEVehMVmVtXr/UJ5JKTBd45THoO4vWG+vrJ/Uzzi8qc=,tag:3uF0Xsfz5DrS/teyXbuvog==,type:str]",
+        "SecretAccessKey": "ENC[AES256_GCM,data:oHT/Fpq0G6arV0zeaPYGP59wAmUMFNgFvH9Me+5sQhhQ4MekMWkUcQ==,iv:RRer24FQm6RRvxfGBUqi30Jc9HnmmqsU9OpLlys4SSs=,tag:KRc9iHN6ATUmR2IhSF4MDA==,type:str]",
+        "UserName": "ENC[AES256_GCM,data:QKA1nFgKPlRaR68K9gYLPdb/cNt1VQM=,iv:5jrH03moJzsRRmgn3oyadcxobXJCMeO7f0j2MwScvws=,tag:HpSeW60gYOb9YnJx6BScug==,type:str]"
+    },
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-12-15T11:13:08Z",
+                "enc": "CiQA4OM7eAatL2sC4XWJjCIeuE43fR4/Z130cV1GvpnrhJb5BKkSSQAZvYDZvrVv7eug28hblZw/W3QScZaYwh1l9ohShGw412wYWdN3JVjWIIxyww4YdIiAsbLZVIpQAo82yIy8feoDKTi3NLHrhJ0="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-12-15T11:13:09Z",
+        "mac": "ENC[AES256_GCM,data:B68hcazns/o1EEjJmkZRGpVW8nxZmtb11d66cadJ2qWPKRMcNVLbU4Mst6QS3KKJSKeMWCAk9AhpeFM3Y62JU4+dakGAZQTxGn0pefp0tgqlAAitiy8tl6Y0PDn9fcpBVOb/2i9nVqVNDXJqsk7320lDu1U0RpGDmr9YpW/S3Ps=,iv:N4x28DBvqDDBHvuDvjKuoC7IzBIqJAiK3/d22Ok4PgQ=,tag:T4v4L3LiG/zRvPOPBvsEtw==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/pangeo-hubs/enc-deployer-credentials.secret.json
+++ b/config/clusters/pangeo-hubs/enc-deployer-credentials.secret.json
@@ -1,30 +1,30 @@
 {
-	"type": "ENC[AES256_GCM,data:BpYDstdNbfuh34obJRgg,iv:a9D8sCXijikpiA1TL0MEmWKNPTtVMCkUuHJAE3JY6Ug=,tag:tPOkdB9EJDHcuNnVwd9Lfg==,type:str]",
-	"project_id": "ENC[AES256_GCM,data:cwRsXyoRgCWsIt6ZLwXMaP+nPlGKymND3KM=,iv:iOwixFUlZq1DJy9fsX2NjiEFCTzDNbGLu9SaxFLSqyU=,tag:CSbC3Te/veHLVRCf4ngUdg==,type:str]",
-	"private_key_id": "ENC[AES256_GCM,data:b+YoQld80IpLUrSEMwV2WUWk1ExXffirUnH9YoC1HRnXEY0d9PqAPw==,iv:fdSA1sC1PqYGpVUedjr/ZYNbCpE0dx1zC3c7wBpZowc=,tag:350iE7A9HGlEajSTDXw07w==,type:str]",
-	"private_key": "ENC[AES256_GCM,data:d6HpRHUHsaRTz8cxfdGBOhgl5vrB2APTa5P6L+i9bE3Y9RDsAJpLiZJY4mLrkg26txiuZCLOOeOkgT+FOaNb9TOckwNrJfOV0IR8xcyBDT/WZVXuHthdTEhW6xwd8G5wV4EvH7/61I8hp3GQbPgRKjTgHiuI4Sjbc880R8hft59meJ35ewSWQ/1iS1Q6rinMvj11IZkZtdXIIVWiWVvF7oHBcwQn6uacDhkYx/KvS/mpvUiYWIy2233Jv3s8J4zjiurt7Zjpos+4ETdBUROV+5gA1c44Rtfz/NP7yj4rwtPp0WAD4fUdvqwlfC8atVbnfVVSQvefu5KCmUQhuMwsNQYfHxN/chBn8chSH2KMyWaU5s8xUBegDK1qw7fkt3DZ0Ci8eHZtCt+gWzzDEDDIuDTEpe/SfGdrhaP8o/f/J686yfIxIVtG0CwWmmTV42ujcrr3GatRpQ7U52LHIpG092iYELKPapTylVotGrHSDtlldetmNKuZbq2L2KusygUGB4AkFTJPlY68U+ysw/SWVRyc16whSKc5HcozoyyYayHrqzh1xd+tLLmwXiyccFEY+EXK7Gc3WRO7s03zgozCiFfXcAvQNB8B2H8SkiofJREvavHIBqDOOSqDYjFJJfOCr6KMhNxb152Bqa6ntkjPiTQ9dThZJ87z7Ep3p1cL3YzlELE8qSOzj6S8ERBTqZCgH9oeIO+oIPkNVw5T2C5QeFvEAtKD/jvlKYBL8+iFCtled7wj++BKNdQccNyg7I5u8iwlJ9GIFUMq+e+uX0f8uL8PDcNGVDEUJZtd4dJmawNm2ZDN8l8PQ7KJHH0G0Ty1+SYYjqv3LaOEf4VTpT+G5uBVXFtbAgo0ATgvRjs56tXSAxZfyqXjStG5O2KTqWk6gXSOd7f1kUr87FXORNjse2kmvx0iWgJ0NKe4MkSUP1Tcc7fp+E00yEdeIApmWxeZ+HrOVFiTLbVrTQZFE4j1Md+Htsp1p1Xr7H18ZV4of6s1xErDrdhY4s39VDx4fA8Sc77CDZ+Urw3NSLhD4/Ltxr5FX9wRJVRUdl0mL/7zc4V9aUd5QevhYR8r+miIw+EIWsifnV7D1+zDg4xu//66jW4pxUJOC9W9IyNWQnpzjJXOVGwmNt9K9MDEH34/uHL0h89jiD8MESMFhA75y5dnwjtKpyff0bDIeogyIHDMyF7FAdtWD7vIZe9XcYaSzqJF2cytt9xpFd67a210oaydBflrAowvUFsroxNbEUENQZ/2pM99TPKcd2bKiilCY/9EioFZbAU9zvLhgnlnDmOc9/4HVPUsk598cmhbr5i2WxuDGCT9hvXVjqLihvmvnUPtW+vhxKFzYuHazKn9cQ60NR1bK/Khwo5dcJBl7FqIt3eP80697oCma6pBBe+026rLVyT/wc6DkyXPcLwqYAnAgDiIQ2ubYfsohLordSUJ1OeUfHsPV+ByRO9SwKofGLq0KeKDLXsCqbSHoalvwqV+pADY5jW2FGuPOxOVW13LYYyF0huLC8gMy0dyIGlhCM8tk2QoPI0JX6AlJBAeapdjLKCA6lQj0oFOZT9RFwSVe7VK2ZXFXb5VU2QbN521m2idpz16dDjAWcHkhiDtCuT7fNxvjmpRTFL7Yc2anoluVGpLEuHRqiRzNnOCUXS87pY5BcfQOJQrCWXAH9YFuLihipib/Dyd4LRs5fOY6M9G8aTrhqmvfuIXa8+amxUcYrymmRJ2NACniLrbpO3PKGUk+YSCvTUsSdvcub7FKoHinlmRIXZ3IK3JDfOS54Pje+4GpxtGZwstkoExMPVA0FgHRpxQqFXnNfy9DopSI3/q3Y5FIAaRxFchnj/ImHUyd0AE1KsxVt/wLBaQK6UFRKsKBSJXY1RxAb0SRFbBkHKxvCdFnoP+zc5tXvdKx7Q1TQB1wW/lUIiSZeHZmkRbGlA2REzBxAFypaaX/eqHXE0Tj9nE2S7b5U3AcC1NJ8MOQT1KDQpAXfd3XE8yytCuyzJM5U2Uq6I0KPTovTfXt/mUiw10AphhcSK8Gakcvoa/7GBkNC5Uno5vF74sGRK3IBPZrq6CkbADv3vpAkwG+MFUdYivs4R9t4hHgfeRUTtslpX+u4Orp490djU+OeLywLA3FDP3jzoiS8ICiqFuUoObXwGCLU4dko1DiqceTOjlsJn4vjBDrMwBOtZd/ycEk7RfNNksz6L+fuF4N6ADlhcupbKiNtvVBnhw2Ym8J0DV5CUvinWApQSUmzMRWAhCeiHgl+9bqJ2SxpPt,iv:Tp8Dy8l26JpJyedw/mVeQKOr+PMm8aXg0oGnozmRS9k=,tag:Inw+hO/rRqVUdlC4s5Q5sg==,type:str]",
-	"client_email": "ENC[AES256_GCM,data:yqtWM20izp3xgNJN8VJIQZtbjV4JdD6JkmJq8A0x/MOB0TVtd8shAvbAMTwzEXN3641dXUohGXiVura/xgKGT7ydHmI=,iv:iGdMJ6gi0SOT25+jL3NAEYbgW/p5ASX336fxVxmnByw=,tag:o4AOBk2mGI3om8cBMGda3w==,type:str]",
-	"client_id": "ENC[AES256_GCM,data:ZFV8xCAnmcWVbg2BGkq0fPMDOCpw,iv:ADlvc7wuy/g8zqHtoDFS3QaDrcWxb8EMt9v7GtaMr68=,tag:Eo9vjMRj62XFngv2ehJVmA==,type:str]",
-	"auth_uri": "ENC[AES256_GCM,data:dkdzkT+x002mNF5GnyRE+B5yAX9hbpcn+pltt+L/Oy3m/v/y+MFt8/k=,iv:UHfEkTEIi7xkMzojknpd4n9ue/7woYE4j0tVK3B8LI0=,tag:ZDuMvTw8GH1R951QQY4sKg==,type:str]",
-	"token_uri": "ENC[AES256_GCM,data:jKl7rvk0fzAV7agx6e9BP6KMYNZuOXLqqvaEoAR0g93qBQw=,iv:wNzjWQx1KHMei0xgohS9FiatcGgRlJQkKxdrB80FTDY=,tag:Hb3BHQTweORaq7T8t5RTSg==,type:str]",
-	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:wdcXZMEJbcLO9E+KZQBYggj5vpXqvWa4ksTRIHgp4s0i4khH1PTKW8FV,iv:rNauzaC3Xt0bD6l6dCvePJqBc8AcEquWmnt7HErkz1M=,tag:e9+silsJAenBYNn0IBvq6Q==,type:str]",
-	"client_x509_cert_url": "ENC[AES256_GCM,data:VhQd72oZDQHwbWVdCBHaZ+DsKozdHtNPmK2vv6wtzICsvmFUHp0+YufSIRAVNYSePvO1+RKH8GT0M2WZF9rUqXGCdCIEcInkoTfQJFkTf/9eNeP8BiOTnj9ob+80en6EhBaVIkSonKtxBZI5J7L3JocsUEQO52wo,iv:3J3hH9TNzwtPmgLqHaEni8wmqU3bNpEZmQAEqoyOGNA=,tag:SbT34VjJUFgMkHi0TaoMxw==,type:str]",
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2021-08-23T14:45:15Z",
-				"enc": "CiQA4OM7eFa/9wYyRK80/kfn8b3mvJH1XOEuqeh3Yyq3g9k8/RgSSQB6TpsYPWrXiJDxyO9pJ1dH1AyZ632RMC5ldi/ZSEwPQiJeMABiePdgh3zMKJoQ0Gp3ZcyZL/biFKF21dgGrFyimGzNOk6CCXU="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2021-08-23T14:45:15Z",
-		"mac": "ENC[AES256_GCM,data:F5ULgkpVjuFgc1D3BdWMHMpfYn10c5pvok751WwYd6N3RePa4XsjgbUokmSmPvhi++lKNM6WSofMHAjPK72umFZrxe10ry6ynxP/76Dp6wQss6UrEVMzf+0FAkvw40BJi2AW8ikLsj5RDdKABKkKzZgxmReYcbaGVu5UmFDaJ3Q=,iv:bcavb+FIQbe0Ym4gGD4VKcqRzverxxFbVq+61vyTR6c=,tag:USyM7nVPDm7SiIbUXtNaxQ==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "type": "ENC[AES256_GCM,data:BpYDstdNbfuh34obJRgg,iv:a9D8sCXijikpiA1TL0MEmWKNPTtVMCkUuHJAE3JY6Ug=,tag:tPOkdB9EJDHcuNnVwd9Lfg==,type:str]",
+    "project_id": "ENC[AES256_GCM,data:cwRsXyoRgCWsIt6ZLwXMaP+nPlGKymND3KM=,iv:iOwixFUlZq1DJy9fsX2NjiEFCTzDNbGLu9SaxFLSqyU=,tag:CSbC3Te/veHLVRCf4ngUdg==,type:str]",
+    "private_key_id": "ENC[AES256_GCM,data:b+YoQld80IpLUrSEMwV2WUWk1ExXffirUnH9YoC1HRnXEY0d9PqAPw==,iv:fdSA1sC1PqYGpVUedjr/ZYNbCpE0dx1zC3c7wBpZowc=,tag:350iE7A9HGlEajSTDXw07w==,type:str]",
+    "private_key": "ENC[AES256_GCM,data:d6HpRHUHsaRTz8cxfdGBOhgl5vrB2APTa5P6L+i9bE3Y9RDsAJpLiZJY4mLrkg26txiuZCLOOeOkgT+FOaNb9TOckwNrJfOV0IR8xcyBDT/WZVXuHthdTEhW6xwd8G5wV4EvH7/61I8hp3GQbPgRKjTgHiuI4Sjbc880R8hft59meJ35ewSWQ/1iS1Q6rinMvj11IZkZtdXIIVWiWVvF7oHBcwQn6uacDhkYx/KvS/mpvUiYWIy2233Jv3s8J4zjiurt7Zjpos+4ETdBUROV+5gA1c44Rtfz/NP7yj4rwtPp0WAD4fUdvqwlfC8atVbnfVVSQvefu5KCmUQhuMwsNQYfHxN/chBn8chSH2KMyWaU5s8xUBegDK1qw7fkt3DZ0Ci8eHZtCt+gWzzDEDDIuDTEpe/SfGdrhaP8o/f/J686yfIxIVtG0CwWmmTV42ujcrr3GatRpQ7U52LHIpG092iYELKPapTylVotGrHSDtlldetmNKuZbq2L2KusygUGB4AkFTJPlY68U+ysw/SWVRyc16whSKc5HcozoyyYayHrqzh1xd+tLLmwXiyccFEY+EXK7Gc3WRO7s03zgozCiFfXcAvQNB8B2H8SkiofJREvavHIBqDOOSqDYjFJJfOCr6KMhNxb152Bqa6ntkjPiTQ9dThZJ87z7Ep3p1cL3YzlELE8qSOzj6S8ERBTqZCgH9oeIO+oIPkNVw5T2C5QeFvEAtKD/jvlKYBL8+iFCtled7wj++BKNdQccNyg7I5u8iwlJ9GIFUMq+e+uX0f8uL8PDcNGVDEUJZtd4dJmawNm2ZDN8l8PQ7KJHH0G0Ty1+SYYjqv3LaOEf4VTpT+G5uBVXFtbAgo0ATgvRjs56tXSAxZfyqXjStG5O2KTqWk6gXSOd7f1kUr87FXORNjse2kmvx0iWgJ0NKe4MkSUP1Tcc7fp+E00yEdeIApmWxeZ+HrOVFiTLbVrTQZFE4j1Md+Htsp1p1Xr7H18ZV4of6s1xErDrdhY4s39VDx4fA8Sc77CDZ+Urw3NSLhD4/Ltxr5FX9wRJVRUdl0mL/7zc4V9aUd5QevhYR8r+miIw+EIWsifnV7D1+zDg4xu//66jW4pxUJOC9W9IyNWQnpzjJXOVGwmNt9K9MDEH34/uHL0h89jiD8MESMFhA75y5dnwjtKpyff0bDIeogyIHDMyF7FAdtWD7vIZe9XcYaSzqJF2cytt9xpFd67a210oaydBflrAowvUFsroxNbEUENQZ/2pM99TPKcd2bKiilCY/9EioFZbAU9zvLhgnlnDmOc9/4HVPUsk598cmhbr5i2WxuDGCT9hvXVjqLihvmvnUPtW+vhxKFzYuHazKn9cQ60NR1bK/Khwo5dcJBl7FqIt3eP80697oCma6pBBe+026rLVyT/wc6DkyXPcLwqYAnAgDiIQ2ubYfsohLordSUJ1OeUfHsPV+ByRO9SwKofGLq0KeKDLXsCqbSHoalvwqV+pADY5jW2FGuPOxOVW13LYYyF0huLC8gMy0dyIGlhCM8tk2QoPI0JX6AlJBAeapdjLKCA6lQj0oFOZT9RFwSVe7VK2ZXFXb5VU2QbN521m2idpz16dDjAWcHkhiDtCuT7fNxvjmpRTFL7Yc2anoluVGpLEuHRqiRzNnOCUXS87pY5BcfQOJQrCWXAH9YFuLihipib/Dyd4LRs5fOY6M9G8aTrhqmvfuIXa8+amxUcYrymmRJ2NACniLrbpO3PKGUk+YSCvTUsSdvcub7FKoHinlmRIXZ3IK3JDfOS54Pje+4GpxtGZwstkoExMPVA0FgHRpxQqFXnNfy9DopSI3/q3Y5FIAaRxFchnj/ImHUyd0AE1KsxVt/wLBaQK6UFRKsKBSJXY1RxAb0SRFbBkHKxvCdFnoP+zc5tXvdKx7Q1TQB1wW/lUIiSZeHZmkRbGlA2REzBxAFypaaX/eqHXE0Tj9nE2S7b5U3AcC1NJ8MOQT1KDQpAXfd3XE8yytCuyzJM5U2Uq6I0KPTovTfXt/mUiw10AphhcSK8Gakcvoa/7GBkNC5Uno5vF74sGRK3IBPZrq6CkbADv3vpAkwG+MFUdYivs4R9t4hHgfeRUTtslpX+u4Orp490djU+OeLywLA3FDP3jzoiS8ICiqFuUoObXwGCLU4dko1DiqceTOjlsJn4vjBDrMwBOtZd/ycEk7RfNNksz6L+fuF4N6ADlhcupbKiNtvVBnhw2Ym8J0DV5CUvinWApQSUmzMRWAhCeiHgl+9bqJ2SxpPt,iv:Tp8Dy8l26JpJyedw/mVeQKOr+PMm8aXg0oGnozmRS9k=,tag:Inw+hO/rRqVUdlC4s5Q5sg==,type:str]",
+    "client_email": "ENC[AES256_GCM,data:yqtWM20izp3xgNJN8VJIQZtbjV4JdD6JkmJq8A0x/MOB0TVtd8shAvbAMTwzEXN3641dXUohGXiVura/xgKGT7ydHmI=,iv:iGdMJ6gi0SOT25+jL3NAEYbgW/p5ASX336fxVxmnByw=,tag:o4AOBk2mGI3om8cBMGda3w==,type:str]",
+    "client_id": "ENC[AES256_GCM,data:ZFV8xCAnmcWVbg2BGkq0fPMDOCpw,iv:ADlvc7wuy/g8zqHtoDFS3QaDrcWxb8EMt9v7GtaMr68=,tag:Eo9vjMRj62XFngv2ehJVmA==,type:str]",
+    "auth_uri": "ENC[AES256_GCM,data:dkdzkT+x002mNF5GnyRE+B5yAX9hbpcn+pltt+L/Oy3m/v/y+MFt8/k=,iv:UHfEkTEIi7xkMzojknpd4n9ue/7woYE4j0tVK3B8LI0=,tag:ZDuMvTw8GH1R951QQY4sKg==,type:str]",
+    "token_uri": "ENC[AES256_GCM,data:jKl7rvk0fzAV7agx6e9BP6KMYNZuOXLqqvaEoAR0g93qBQw=,iv:wNzjWQx1KHMei0xgohS9FiatcGgRlJQkKxdrB80FTDY=,tag:Hb3BHQTweORaq7T8t5RTSg==,type:str]",
+    "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:wdcXZMEJbcLO9E+KZQBYggj5vpXqvWa4ksTRIHgp4s0i4khH1PTKW8FV,iv:rNauzaC3Xt0bD6l6dCvePJqBc8AcEquWmnt7HErkz1M=,tag:e9+silsJAenBYNn0IBvq6Q==,type:str]",
+    "client_x509_cert_url": "ENC[AES256_GCM,data:VhQd72oZDQHwbWVdCBHaZ+DsKozdHtNPmK2vv6wtzICsvmFUHp0+YufSIRAVNYSePvO1+RKH8GT0M2WZF9rUqXGCdCIEcInkoTfQJFkTf/9eNeP8BiOTnj9ob+80en6EhBaVIkSonKtxBZI5J7L3JocsUEQO52wo,iv:3J3hH9TNzwtPmgLqHaEni8wmqU3bNpEZmQAEqoyOGNA=,tag:SbT34VjJUFgMkHi0TaoMxw==,type:str]",
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2021-08-23T14:45:15Z",
+                "enc": "CiQA4OM7eFa/9wYyRK80/kfn8b3mvJH1XOEuqeh3Yyq3g9k8/RgSSQB6TpsYPWrXiJDxyO9pJ1dH1AyZ632RMC5ldi/ZSEwPQiJeMABiePdgh3zMKJoQ0Gp3ZcyZL/biFKF21dgGrFyimGzNOk6CCXU="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2021-08-23T14:45:15Z",
+        "mac": "ENC[AES256_GCM,data:F5ULgkpVjuFgc1D3BdWMHMpfYn10c5pvok751WwYd6N3RePa4XsjgbUokmSmPvhi++lKNM6WSofMHAjPK72umFZrxe10ry6ynxP/76Dp6wQss6UrEVMzf+0FAkvw40BJi2AW8ikLsj5RDdKABKkKzZgxmReYcbaGVu5UmFDaJ3Q=,iv:bcavb+FIQbe0Ym4gGD4VKcqRzverxxFbVq+61vyTR6c=,tag:USyM7nVPDm7SiIbUXtNaxQ==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }

--- a/config/clusters/uwhackweeks/enc-deployer-credentials.secret.json
+++ b/config/clusters/uwhackweeks/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
-	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:9UBAO1fDSYD36SxW9PomPpDY2A4=,iv:sU7B/EU2y/Ry0lg10mMek4Couvir2s8c5gHZg6nPA3U=,tag:as9XDHt6Bt5vQn3G8cxknQ==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:tRvI8+XoNSeEdKmNre7uH6lgYl5MD9t0Bk8wKxUrcljvWiJTVCiqzg==,iv:9iPOkaz6YfTpl/Z5HvtXQdYImXHRCu7PVmkf1vJqKjM=,tag:gW4N+Q5dsgIfOkKFU8B6+A==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:xf4XtiLA/Y0MT2NUo3mMT7+R33l5mwg=,iv:xUHUhOwK5G25K9KlskjFzgy3mOFX97Ney4LLuNwwVc8=,tag:QfsDLWb/NJU6j9Oq93KQWg==,type:str]"
-	},
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2022-02-07T07:50:33Z",
-				"enc": "CiQA4OM7eAg164kMkSY9t4XbAjkDZdJdHVpzWSoi2bIsAu8WuQoSSQAZvYDZMNEt7aygAA5RnBkgL7SPOpGC9yNooL+RPWpu7AGwBIex9Q0L+coh5jduzVxVgUQUBruZVkxatxmuuWIZTCejGIqIelo="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2022-02-07T07:50:33Z",
-		"mac": "ENC[AES256_GCM,data:T7MVLqCPtP+p8MAvwVFLHnjmQhLk0ia7TC8kuFpQtWgAck5Sd6W8kTMtNlL1644k0X3gTxpKzqFpaFG0QAgmWwppYWAMxTAHcXgf0KUa4WHpHpcwedoYBDPTZFhwycCS0BzLm8e8zOlbtKIlPw9v3N7ENree5ppi8GHk5OH4cgc=,iv:wJFVot2aJO96OtLnwuw6/hWKJC9/WLcDLneoG3j02TU=,tag:Aj+Kg/QKJ8jdtVotXlEf6w==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.1"
-	}
+    "AccessKey": {
+        "AccessKeyId": "ENC[AES256_GCM,data:9UBAO1fDSYD36SxW9PomPpDY2A4=,iv:sU7B/EU2y/Ry0lg10mMek4Couvir2s8c5gHZg6nPA3U=,tag:as9XDHt6Bt5vQn3G8cxknQ==,type:str]",
+        "SecretAccessKey": "ENC[AES256_GCM,data:tRvI8+XoNSeEdKmNre7uH6lgYl5MD9t0Bk8wKxUrcljvWiJTVCiqzg==,iv:9iPOkaz6YfTpl/Z5HvtXQdYImXHRCu7PVmkf1vJqKjM=,tag:gW4N+Q5dsgIfOkKFU8B6+A==,type:str]",
+        "UserName": "ENC[AES256_GCM,data:xf4XtiLA/Y0MT2NUo3mMT7+R33l5mwg=,iv:xUHUhOwK5G25K9KlskjFzgy3mOFX97Ney4LLuNwwVc8=,tag:QfsDLWb/NJU6j9Oq93KQWg==,type:str]"
+    },
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2022-02-07T07:50:33Z",
+                "enc": "CiQA4OM7eAg164kMkSY9t4XbAjkDZdJdHVpzWSoi2bIsAu8WuQoSSQAZvYDZMNEt7aygAA5RnBkgL7SPOpGC9yNooL+RPWpu7AGwBIex9Q0L+coh5jduzVxVgUQUBruZVkxatxmuuWIZTCejGIqIelo="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2022-02-07T07:50:33Z",
+        "mac": "ENC[AES256_GCM,data:T7MVLqCPtP+p8MAvwVFLHnjmQhLk0ia7TC8kuFpQtWgAck5Sd6W8kTMtNlL1644k0X3gTxpKzqFpaFG0QAgmWwppYWAMxTAHcXgf0KUa4WHpHpcwedoYBDPTZFhwycCS0BzLm8e8zOlbtKIlPw9v3N7ENree5ppi8GHk5OH4cgc=,iv:wJFVot2aJO96OtLnwuw6/hWKJC9/WLcDLneoG3j02TU=,tag:Aj+Kg/QKJ8jdtVotXlEf6w==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
 }


### PR DESCRIPTION
#1108 broke our CI because we had some hard tabs in our encrypted JSON files, instead of whitespace, and apparently this is the only case where valid JSON `!=` valid YAML?!?!

This PR replaced all the tabs found in JSON files with four whitespaces, generated by running the following command (modified for mac's FreeBSD version of `sed`):

```
find . -type f -name "*.json" -exec sed -i '' "s/\t/    /g" {} +
```