### PR TITLE
Update utoronto user image to accomodate latest fixes

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -77,7 +77,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: 18b55a7bcb96
+      tag: a716955d6147
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -77,7 +77,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: a716955d6147
+      tag: 3aa146dc095f
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -77,7 +77,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: 3aa146dc095f
+      tag: d422076c3695
   hub:
     db:
       pvc:


### PR DESCRIPTION
Particularly this one https://github.com/2i2c-org/utoronto-image/pull/17.

- Reference https://2i2c.freshdesk.com/a/tickets/65
- Available image tags https://quay.io/repository/2i2c/utoronto-image?tab=tags

cc @damianavila 