### PR TITLE
Add notes about authentication with github orgs

### DIFF
--- a/docs/howto/configure/auth-management.md
+++ b/docs/howto/configure/auth-management.md
@@ -1,10 +1,16 @@
 # Manage authentication
 
+This section describes how to set up various authentication providers for the 2i2c JupyterHubs.
+
 ## Auth0
 
 [auth0](https://auth0.com) provides authentication for the majority of 2i2c hubs. It can
 be configured with many different [connections](https://auth0.com/docs/identityproviders)
 that users can authenticate with - such as Google, GitHub, etc.
+
+:::{note}
+If you wish to authenticate users based on their membership in a GitHub organization or team, you'll need to use [the native GitHub OAuthenticator instead](auth:github-orgs).
+:::
 
 So we want to manage authentication by:
 
@@ -53,7 +59,8 @@ So we want to manage authentication by:
 Switching authentication providers (e.g. from GitHub to Google) for a pre-existing hub will simply create new usernames. Any pre-existing users will no longer be able to access their accounts (although administrators will be able to do so). If you have pre-existing users and want to switch the hub authentication, rename the users to the new auth pattern (e.g. convert github handles to emails).
 ```
 
-## Native JupyterHub OAuthenticator for GitHub Orgs and Teams
+(auth:github-orgs)=
+## GitHub Orgs and Teams
 
 ```{note}
 This setup is currently only supported for communities that **require** authentication via a GitHub organisation or team.
@@ -62,7 +69,8 @@ We may update this policy in the future.
 ```
 
 For communities that require authenticating users against [a GitHub organisation or team](https://docs.github.com/en/organizations), we instead use the [native JupyterHub OAuthenticator](https://github.com/jupyterhub/oauthenticator).
-Presently, this involves a few more manual steps than the `auth0` setup described above.
+This involves a few more manual steps than the `auth0` setup described above.
+There are also some steps that a Community Representative will need to take to set up authentication, described below.
 
 1. **Create a GitHub OAuth App.**
    This can be achieved by following [GitHub's documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app).
@@ -171,6 +179,17 @@ Presently, this involves a few more manual steps than the `auth0` setup describe
     ```
 
 6. Run the deployer as normal to apply the config.
+
+### Follow-up: GitHub organization administrators must grant access
+
+Once the OAuth callbacks have been set up following the steps above, somebody with administrator permissions for the GitHub organization needs to grant access to the OAuth app that we have created.
+
+The first time that somebody tries to log on to the hub with this authentication set up, they should be presented with a page that asks them to grant access to various GitHub organizations.
+**They must grant access to the organization that is being used to authenticate**.
+
+If administrators report a `403 forbidden` error when they try to log in to the hub, there is a good chance that they did _not grant access_ to the right GitHub organization.
+In this case, they should go to the configuration page for this app within their GitHub organization and explicitly grant it access.
+See [the GitHub apps for organizations docs](https://docs.github.com/en/organizations/managing-access-to-your-organizations-apps) for more information.
 
 ## CILogon
 


### PR DESCRIPTION
As a follow up to https://github.com/2i2c-org/infrastructure/pull/1113 and https://2i2c.freshdesk.com/a/tickets/104 we discovered that a confusing situation can arise where an organization administrator has not granted our GitHub Org/Teams authenticator app the proper permissions. In this case, they'll get an unauthorized `403` error, and the solution is to grant the auth app access. This adds docs to describe this situation so it's more debuggable later.