### PR TITLE
Simplify incident response template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_incident-report.md
+++ b/.github/ISSUE_TEMPLATE/3_incident-report.md
@@ -6,19 +6,39 @@ labels: ["type: Hub Incident", "support"]
 assignees: ""
 ---
 
-# Summary
+# Context
 
-<!-- 
-Quick summary of the problem. Update this section as we learn more, answering:
+## Summary
 
-- what user impact was
-- how long it was
-- what went wrong and how we fixed it.
--->
+<!-- Quick summary of the problem and resolution. Update as we learn more -->
 
-## Hub information
+## Impact on users
+
+<!-- How this impacts users on the hub. Help us understand how urgent this is. -->
+
+## Important information
+
+<!-- Any links that could help people debug or learn more.  -->
 
 - Hub URL: {{ INSERT HUB URL HERE }}
+- Support ticket ref: {{ INSERT SUPPORT REF HERE }}
+
+## Tasks and updates
+
+- [ ] Incident has been dealt with or is over
+- [ ] Copy/paste the after-action report below and fill in relevant sections
+- [ ] Incident title and after-action report is cleaned up
+- [ ] All actionable items above have linked GitHub Issues
+
+<!-- A copy/paste-able after-action report to help with follow-up -->
+<details>
+<summary>After-action report template</summary>
+
+```
+# After-action report
+
+These sections should be filled out once we've resolved the incident and know what happened.
+They should focus on the knowledge we've gained and any improvements we should take.
 
 ## Timeline (if relevant)
 
@@ -37,13 +57,6 @@ Investigation starts.
 ### {{ hh:mm }}
 
 More details.
-
----
-
-# After-action report
-
-These sections should be filled out once we've resolved the incident and know what happened.
-They should focus on the knowledge we've gained and any improvements we should take.
 
 ## What went wrong
 
@@ -74,10 +87,6 @@ These are only sample subheadings. Every action item should have a GitHub issue
 
 1. {{ summary }} [link to github issue]
 2. {{ summary }} [link to github issue]
+```
 
-# Actions
-
-- [ ] Incident has been dealt with or is over
-- [ ] Sections above are filled out
-- [ ] Incident title and after-action report is cleaned up
-- [ ] All actionable items above have linked GitHub Issues
+</details>

--- a/.github/ISSUE_TEMPLATE/3_incident-report.md
+++ b/.github/ISSUE_TEMPLATE/3_incident-report.md
@@ -6,29 +6,28 @@ labels: ["type: Hub Incident", "support"]
 assignees: ""
 ---
 
-# Context
-
-## Summary
+### Summary
 
 <!-- Quick summary of the problem and resolution. Update as we learn more -->
 
-## Impact on users
+### Impact on users
 
 <!-- How this impacts users on the hub. Help us understand how urgent this is. -->
 
-## Important information
+### Important information
 
 <!-- Any links that could help people debug or learn more.  -->
 
 - Hub URL: {{ INSERT HUB URL HERE }}
 - Support ticket ref: {{ INSERT SUPPORT REF HERE }}
 
-## Tasks and updates
+### Tasks and updates
 
+- [ ] Discuss and address incident, leaving comments below with updates
 - [ ] Incident has been dealt with or is over
 - [ ] Copy/paste the after-action report below and fill in relevant sections
-- [ ] Incident title and after-action report is cleaned up
-- [ ] All actionable items above have linked GitHub Issues
+- [ ] Incident title is discoverable and accurate
+- [ ] All actionable items in report have linked GitHub Issues
 
 <!-- A copy/paste-able after-action report to help with follow-up -->
 <details>

--- a/.github/ISSUE_TEMPLATE/3_incident-report.md
+++ b/.github/ISSUE_TEMPLATE/3_incident-report.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F4DD Hub Incident"
+name: "🚨 Hub Incident"
 about: "Report an incident on our running hub infrastructure."
 title: "[Incident] {{ TITLE }}"
 labels: ["type: Hub Incident", "support"]

--- a/.github/ISSUE_TEMPLATE/3_incident-report.md
+++ b/.github/ISSUE_TEMPLATE/3_incident-report.md
@@ -39,38 +39,36 @@ assignees: ""
 These sections should be filled out once we've resolved the incident and know what happened.
 They should focus on the knowledge we've gained and any improvements we should take.
 
-## Timeline (if relevant)
+## Timeline
 
-If it makes sense to include a timeline for this incident, then do so below.
+_A short list of dates / times and major updates, with links to relevant comments in the issue for more context._
 
 All times in {{ most convenient timezone}}.
 
-### {{ yyyy-mm-dd hh:mm }}
+- {{ yyyy-mm-dd }} - [Summary of first update](link to comment)
+- {{ yyyy-mm-dd }} - [Summary of another update](link to comment)
+- {{ yyyy-mm-dd }} - [Summary of final update](link to comment)
 
-Start of incident. First symptoms, possibly how they were identified.
-
-### {{ hh:mm }}
-
-Investigation starts.
-
-### {{ hh:mm }}
-
-More details.
 
 ## What went wrong
 
-Things that could have gone better. Ideally these should result in concrete
+_Things that could have gone better. Ideally these should result in concrete
 action items that have GitHub issues created for them and linked to under
-Action items. 
+Action items._
+
+- Thing one
+- Thing two
 
 ## Where we got lucky
 
-These are good things that happened to us but not because we had planned for them.
+_These are good things that happened to us but not because we had planned for them._
 
-## Action items
+- Thing one
+- Thing two
 
-These are only sample subheadings. Every action item should have a GitHub issue
-(even a small skeleton of one) attached to it, so these do not get forgotten. These issues don't have to be in `infrastructure/`, they can be in other repositories.
+## Follow-up actions
+
+_Every action item should have a GitHub issue (even a small skeleton of one) attached to it, so these do not get forgotten. These issues don't have to be in `infrastructure/`, they can be in other repositories._
 
 ### Process improvements
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ Chart.lock
 docs/tmp
 docs/reference/terraform.md
 
+# Common editor config
+.vscode
 
 
 # Python.gitignore below - Add exceptions above for easier maintenance


### PR DESCRIPTION
We've had some recent incidents, and I found that it was quite noisy to have a huge incident report with "empty" fields waiting to be filled in. During the incident itself, you want to focus effort on fixing the problem itself, and having all the extra "after action report" stuff was making it difficult to focus on this.

So, this PR rearranges our incident template to try and boost the signal-to-noise a little bit. Here are the major changes:

- The after-action report is now hidden under a `details` tab, and is meant to by copy/pasted into the issue after the incident is resolved, so that we can focus on it at the right time.
- Moved the "timeline" into the after action report, with the idea that we link to comments in the issue w/ timestamps, rather than manually noting when various things happened. Also simplified it a bit.

[Here's what the new template will look like when rendered](https://github.com/2i2c-org/infrastructure/blob/f49db9ffbb0548b7c4127cd45468a17ea0ab9ffe/.github/ISSUE_TEMPLATE/3_incident-report.md)