### PR TITLE
Disable user scheduler almost everywhere

### DIFF
--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -10,6 +10,9 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
+    scheduler:
+      userScheduler:
+        enabled: true
     proxy:
       https:
         enabled: false

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -10,9 +10,6 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    scheduling:
-      userScheduler:
-        enabled: true
     proxy:
       https:
         enabled: false

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -10,7 +10,7 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    scheduler:
+    scheduling:
       userScheduler:
         enabled: true
     proxy:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -10,7 +10,7 @@ nfs:
     # Trailing slash is important!
     baseShareName: /2i2cutorontohubstorage/homes/
 jupyterhub:
-  scheduler:
+  scheduling:
     userScheduler:
       enabled: true
   # pre-puller is necessary as the image is pretty big, and

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -10,6 +10,9 @@ nfs:
     # Trailing slash is important!
     baseShareName: /2i2cutorontohubstorage/homes/
 jupyterhub:
+  scheduler:
+    userScheduler:
+      enabled: true
   # pre-puller is necessary as the image is pretty big, and
   # pulling during first user spawn might cause timeouts.
   # Only required on staging hub though, as they share the same

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -88,7 +88,7 @@ jupyterhub:
       defaultPriority: 0
       userPlaceholderPriority: -10
     userScheduler:
-      enabled: true
+      enabled: false
       nodeSelector:
         hub.jupyter.org/node-purpose: core
       resources:


### PR DESCRIPTION
After https://github.com/2i2c-org/infrastructure/pull/1026,
all our GCP hubs use the 'Optimize Utilization' scheduler.
It functions pretty similar to the z2jh custom user scheduler,
and is generally faster & has less overhead. So we want to use
that wherever possible.

In other cloud providers, most of the hubs we have operate on
a one node per user model - a user gets all the resources on a
single node. The only hub that falls outside this is UToronto. this PR
disables user scheduler by default, but enables it on just on UToronto.

utoronto should be explicitly enabled when both these conditions are met:

1. The Cloud provider is *not* GKE
2. The user profiles available pack multiple pods into the same node, rather than
    providing one dedicated node per user.
