### PR TITLE
Move a few hubs off *.pilot.2i2c.cloud

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -12,7 +12,7 @@ support:
 hubs:
   - name: staging
     display_name: "2i2c staging"
-    domain: staging.pilot.2i2c.cloud
+    domain: staging.2i2c.cloud
     helm_chart: basehub
     auth0:
       # connection update? Also ensure the basehub Helm chart is provided a
@@ -25,7 +25,7 @@ hubs:
       - staging.values.yaml
   - name: dask-staging
     display_name: "2i2c dask staging"
-    domain: dask-staging.pilot.2i2c.cloud
+    domain: dask-staging.2i2c.cloud
     helm_chart: daskhub
     auth0:
       # connection update? Also ensure the basehub Helm chart is provided a
@@ -38,7 +38,7 @@ hubs:
       - dask-staging.values.yaml
   - name: demo
     display_name: "2i2c demo"
-    domain: demo.pilot.2i2c.cloud
+    domain: demo.2i2c.cloud
     helm_chart: basehub
     auth0:
       # connection update? Also ensure the basehub Helm chart is provided a


### PR DESCRIPTION
To signal that this is reasonably stable infrastructure,
we're removing 'pilot' from a few domain names. I've setup
a wildcard domain *.2i2c.cloud to point to the pilot-hubs
cluster's nginx-ingress service IP, so merging this would
just switch out these 3 hubs to get rid of the .pilot
part of their domain.

This does mean our 'primary' cluster becomes a bit more
important, so we should make it a little more resilient.
See https://github.com/2i2c-org/infrastructure/issues/1105
and https://github.com/2i2c-org/infrastructure/issues/1102

Ref https://github.com/2i2c-org/infrastructure/issues/989