### PR TITLE
Bump up kubespawner version

### DIFF
--- a/docs/howto/customize/custom-image.md
+++ b/docs/howto/customize/custom-image.md
@@ -1,5 +1,5 @@
 (customize/custom-image)=
-# Use a custom hub image
+# Use a custom user image
 
 Community hubs use an image we curate as the default. This can be replaced with your
 own custom image fairly easily. However, custom images should be maintained

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -288,7 +288,7 @@ jupyterhub:
           - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n2453.h7734a80"
+      tag: "0.0.1-n2546.ha1b6098"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,6 +12,12 @@ ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}
 
+
+# Install newer version of jupyterhub-kubespawner, to bring in https://github.com/jupyterhub/kubespawner/pull/525
+# https://github.com/2i2c-org/infrastructure/issues/1103 is happening frequently enough
+# z2jh 1.2.x ships with kubespawner 1.1.0, so we just do a little bump
+RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
+
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/issues/1103 is happening
more frequently now, and it's a hard fail - many users just can
not start up their servers. The z2jh upgrade will involve more
work (https://github.com/2i2c-org/infrastructure/issues/1055),
so let's just bump up kubespawner in our custom hub image until then.
    
Fixes https://github.com/2i2c-org/infrastructure/issues/1103