### PR TITLE
Pin setup-gcloud action to @v0

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install jsonnet
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: "290.0.1"
           # This is used for KMS only

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -79,7 +79,7 @@ jobs:
         if: |
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: "290.0.1"
           # This is used for KMS only


### PR DESCRIPTION
@master is broken, and they explicitly ask you to switch
to using @v0: https://github.com/2i2c-org/infrastructure/runs/5668729514?check_suite_focus=true

https://github.com/google-github-actions/setup-gcloud#-notices
has migration info