### PR TITLE
Migrate the ANU hub to use the JupyterHub CILogonOAuthenticator

### DIFF
--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -30,9 +30,14 @@ jupyterhub:
       tag: b7937f446fe6
   hub:
     config:
-      Authenticator:
+      JupyterHub:
+        authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://anu.pilot.2i2c.cloud/hub/oauth_callback
+        username_claim: "email"
         admin_users:
           - matthew.mckay@anu.edu.au
-        # We do not define allowed_users here since only usernames matching this regex will be allowed to login into the hub.
-        # Ref: https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.username_pattern
-        username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'
+        # We do not define allowed_users here since only usernames matching these domains will be allowed to login into the hub.
+        allowed_idps:
+          - 2i2c.org
+          - anu.edu.au

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -146,12 +146,13 @@ hubs:
     domain: anu.pilot.2i2c.cloud
     helm_chart: basehub
     auth0:
-      connection: CILogon
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
       - anu.values.yaml
+      - enc-anu.secret.values.yaml
   - name: utexas
     display_name: "University of Texas"
     domain: utexas.pilot.2i2c.cloud

--- a/config/clusters/2i2c/enc-anu.secret.values.yaml
+++ b/config/clusters/2i2c/enc-anu.secret.values.yaml
@@ -1,0 +1,19 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:SqOiSEzDVQymO3Y0l9fQEAlVKaX7mmvWNapxWUnik8zpC1k2tFvq0q0SJnPlpo0a/YOB,iv:5VqcadjVnaUG1fX5yUUXfOsNa1f2G8JiH3cdGGhKcxI=,tag:sCgFM+ZFRaiSC4QlgYBXUw==,type:str]
+                client_secret: ENC[AES256_GCM,data:wbEkC3lJ42TfBiDKHy7shdRh0WVk32qCdwQ312iQTe8NLGJS7LfX7nJ7ZDr9WS/ccqBB0d6MkjBBxD5EfG0xPlmCmUVqY88JLVazMi4sv+byKV+bl2A=,iv:8p3cHnIfwiQLObyv9Xk5pGnCwF/3wg0r9+Pkj//JvsI=,tag:vTWpqfN+gu8TrVFGOiehFg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+    -   resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+        created_at: '2022-04-07T15:51:59Z'
+        enc: CiQA4OM7eJqy/DyO+7N/K1H64MsZktTQETd3tSP2d0pg1EsAfVISSQDm5XgW8Q6lw120cxZ14rHh6d32nyYWff45u2goBfP1I6t9q32vJsBeNZKNegOA8jnVq9AJWcfJfu2Q5QPp3SQxyBDdWP8SBd0=
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-04-07T15:52:00Z'
+    mac: ENC[AES256_GCM,data:20t4XjZpBavEzuinRRbiEhSCQTMGMEkRvwQfB+p6qnWkO5j8trxUCe30acQaPzNu3A9RjNpE1dNBv3p3Udq7+0NTH+KW0xz3BxBAIb9YGqm8zQDU3pyqnxaD9t3QwAFaH63FemPGX7dVeY7Pyti6ubLDz66DQ4jbNEhO1f7LN3s=,iv:u0oNPVg6H2QCOY+wpcbhxsHqQJahCapm96V9h37zUjs=,tag:3fuWPYHBEscAG5sNpkuuVg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1


### PR DESCRIPTION
Part of https://github.com/2i2c-org/infrastructure/issues/967.
Hopefully, this shouldn't disrupt the current users too much, and usernames should be preserved.