### PR TITLE
Separate hub health check into it's own function/cli subcommand

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -114,10 +114,20 @@ jobs:
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} staging
 
+      - name: Run health check for staging hub on cluster ${{ matrix.jobs.cluster_name }}
+        if: matrix.jobs.upgrade_staging == 'true'
+        run: |
+          python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} staging
+
       - name: Upgrade dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
         if: matrix.jobs.upgrade_staging == 'true' && matrix.jobs.cluster_name == '2i2c'
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} dask-staging
+
+      - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
+        if: matrix.jobs.upgrade_staging == 'true' && matrix.jobs.cluster_name == '2i2c'
+        run: |
+          python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} dask-staging
 
   # TODO: Add in "job 3a" where the matrix for prod jobs is edited to exclude any clusters
   # that failed the preceding upgrade-support-and-staging job. See discussion in:
@@ -146,12 +156,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup deploy for ${{ matrix.jobs.cluster_name }}
+      - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
         uses: ./.github/actions/setup-deploy
         with:
           provider: ${{ matrix.jobs.provider }}
           GCP_KMS_DECRYPTOR_KEY: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
 
-      - name: Upgrade and test ${{ matrix.jobs.hub_name }} on cluster ${{ matrix.jobs.cluster_name }}
+      - name: Upgrade ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name }}
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
+
+      - name: Run health check against ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name}}
+        run: |
+          python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -142,7 +142,6 @@ def main():
         deploy(
             args.cluster_name,
             args.hub_name,
-            args.skip_hub_health_test,
             args.config_path,
         )
     elif args.action == "validate":

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -9,6 +9,7 @@ from deploy_actions import (
     deploy_grafana_dashboards,
     use_cluster_credentials,
     generate_helm_upgrade_jobs,
+    run_hub_health_check,
 )
 from config_validation import (
     validate_cluster_config,
@@ -117,6 +118,22 @@ def main():
         type=_converted_string_to_list,
         help="A singular or space-delimited list of added or modified filepaths in the repo",
     )
+
+    # run-hub-health-check subcommand
+    run_hub_health_check_parser = subparsers.add_parser(
+        "run-hub-health-check",
+        parents=[base_parser],
+        help="",
+    )
+    run_hub_health_check_parser.add_argument(
+        "hub_name",
+        help="The hub to run health checks against.",
+    )
+    run_hub_health_check_parser.add_argument(
+        "--check-dask-scaling",
+        action="store_true",
+        help="",
+    )
     # === End section ===#
 
     args = argparser.parse_args()
@@ -140,3 +157,9 @@ def main():
         use_cluster_credentials(args.cluster_name)
     elif args.action == "generate-helm-upgrade-jobs":
         generate_helm_upgrade_jobs(args.filepaths)
+    elif args.action == "run-hub-health-check":
+        run_hub_health_check(
+            args.cluster_name,
+            args.hub_name,
+            check_dask_scaling=args.check_dask_scaling,
+        )

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -123,7 +123,7 @@ def main():
     run_hub_health_check_parser = subparsers.add_parser(
         "run-hub-health-check",
         parents=[base_parser],
-        help="",
+        help="Run a health check against a given hub deployed on a given cluster",
     )
     run_hub_health_check_parser.add_argument(
         "hub_name",
@@ -132,7 +132,7 @@ def main():
     run_hub_health_check_parser.add_argument(
         "--check-dask-scaling",
         action="store_true",
-        help="",
+        help="For daskhubs, optionally check that dask workers can be scaled",
     )
     # === End section ===#
 

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -354,6 +354,18 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
 
     print_colour(f"Running hub health check for {hub.spec['name']}...")
 
+    # Check if this hub has a domain override file. If yes, apply override.
+    if "domain_override_file" in hub.spec.keys():
+        domain_override_file = hub.spec["domain_override_file"]
+
+        with get_decrypted_file(
+            hub.cluster.config_path.joinpath(domain_override_file)
+        ) as decrypted_path:
+            with open(decrypted_path) as f:
+                domain_override_config = yaml.load(f)
+
+        hub.spec["domain"] = domain_override_config["domain"]
+
     # Retrieve hub's URL
     hub_url = f'https://{hub.spec["domain"]}'
 

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -334,6 +334,19 @@ def generate_helm_upgrade_jobs(changed_filepaths):
 
 
 def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
+    """Run a health check on a given hub on a given cluster. Optionally check scaling
+    of dask workers if the hub is a daskhub.
+
+    Args:
+        cluster_name (str): The name of the cluster where the hub is deployed
+        hub_name (str): The name of the hub to run a health check for
+        check_dask_scaling (bool, optional): If true, run an additional check that dask
+            workers can scale. Only applies to daskhubs. Defaults to False.
+
+    Returns
+        exit_code (int): The exit code of the pytest process. 0 for pass, any other
+            integer number greater than 0 for failure.
+    """
     # Read in the cluster.yaml file
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
     with open(config_file_path) as f:

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -397,7 +397,7 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
                     "secrets",
                     "hub",
                     f"--namespace={hub.spec['name']}",
-                    r"""--output="jsonpath={.data['hub\.services\.hub-health\.apiToken']}""",
+                    r"--output=jsonpath={.data['hub\.services\.hub-health\.apiToken']}",
                 ],
                 text=True,
             )

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -339,7 +339,9 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
         cluster = Cluster(yaml.load(f), config_file_path.parent)
 
     # Find the hub's config
-    hub_indx = [indx for (indx, h) in enumerate(cluster.hubs) if h.spec["name"] == hub_name]
+    hub_indx = [
+        indx for (indx, h) in enumerate(cluster.hubs) if h.spec["name"] == hub_name
+    ]
     if len(hub_indx) == 1:
         hub = cluster.hubs[hub_indx]
     elif len(hub_indx) > 1:
@@ -347,9 +349,7 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
     elif len(hub_indx) == 0:
         raise ValueError("No hubs with this name found!")
 
-    print_colour(
-        f"Running hub health check for {hub.spec['name']}..."
-    )
+    print_colour(f"Running hub health check for {hub.spec['name']}...")
 
     # Retrieve hub's URL
     hub_url = f'https://{hub.spec["domain"]}'
@@ -357,13 +357,13 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
     # 3. Read in the service api token: https://github.com/2i2c-org/infrastructure/issues/1024#issuecomment-1096862704
     # FIXME: Clean this up
     if hub.spec["helm_chart"] != "basehub":
-        service_api_token = generated_values["basehub"]["jupyterhub"][
-            "hub"
-        ]["services"]["hub-health"]["apiToken"]
-    else:
-        service_api_token = generated_values["jupyterhub"]["hub"][
+        service_api_token = generated_values["basehub"]["jupyterhub"]["hub"][
             "services"
         ]["hub-health"]["apiToken"]
+    else:
+        service_api_token = generated_values["jupyterhub"]["hub"]["services"][
+            "hub-health"
+        ]["apiToken"]
 
     # On failure, pytest prints out params to the test that failed.
     # This can contain sensitive info - so we hide stderr
@@ -383,9 +383,7 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
     ]
     if gh_ci == "true":
         print_colour("Testing on CI, not printing output")
-        with open(os.devnull, "w") as dn, redirect_stderr(
-            dn
-        ), redirect_stdout(dn):
+        with open(os.devnull, "w") as dn, redirect_stderr(dn), redirect_stdout(dn):
             exit_code = pytest.main(pytest_args)
     else:
         print_colour("Testing locally, do not redirect output")

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -346,9 +346,11 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
     if len(hub_indx) == 1:
         hub = cluster.hubs[hub_indx]
     elif len(hub_indx) > 1:
-        raise ValueError("More than one hub with this name found!")
+        print_colour("ERROR: More than one hub with this name found!")
+        sys.exit(1)
     elif len(hub_indx) == 0:
-        raise ValueError("No hubs with this name found!")
+        print_colour("ERROR: No hubs with this name found!")
+        sys.exit(1)
 
     print_colour(f"Running hub health check for {hub.spec['name']}...")
 

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -176,7 +176,7 @@ def deploy_grafana_dashboards(cluster_name):
         shutil.rmtree(dashboards_dir)
 
 
-def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):
+def deploy(cluster_name, hub_name, config_path):
     """
     Deploy one or more hubs in a given cluster
     """
@@ -217,13 +217,13 @@ def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):
         if hub_name:
             hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
             print_colour(f"Deploying hub {hub.spec['name']}...")
-            hub.deploy(k, SECRET_KEY, skip_hub_health_test)
+            hub.deploy(k, SECRET_KEY)
         else:
             for i, hub in enumerate(hubs):
                 print_colour(
                     f"{i+1} / {len(hubs)}: Deploying hub {hub.spec['name']}..."
                 )
-                hub.deploy(k, SECRET_KEY, skip_hub_health_test)
+                hub.deploy(k, SECRET_KEY)
 
 
 def generate_helm_upgrade_jobs(changed_filepaths):

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -357,7 +357,7 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
         indx for (indx, h) in enumerate(cluster.hubs) if h.spec["name"] == hub_name
     ]
     if len(hub_indx) == 1:
-        hub = cluster.hubs[hub_indx]
+        hub = cluster.hubs[hub_indx[0]]
     elif len(hub_indx) > 1:
         print_colour("ERROR: More than one hub with this name found!")
         sys.exit(1)

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -188,7 +188,7 @@ class Hub:
 
         return generated_config
 
-    def deploy(self, auth_provider, secret_key, skip_hub_health_test=False):
+    def deploy(self, auth_provider, secret_key):
         """
         Deploy this hub
         """


### PR DESCRIPTION
### Motivation

Previously, the hub health check ran immediately after a helm upgrade of a hub.

Given that our tests are often flakey since they trigger a spin up of a new node, we would like to retry our tests and give the cluster time to provision the node before the tests fail.

We cannot retry tests in this way easily if we are locked into doing a helm upgrade.

We therefore separate running the hub health check from the deploy function into its own function and subcommand.

### What has changed

A new deployer subcommand called `run-hub-health-check` which takes a cluster name and hub name as arguments and runs our health checks against them.

To retain the previously behaviour, users can run:

```bash
python deployer deploy CLUSTER_NAME HUB_NAME && python deployer run-hub-health-check CLUSTER_NAME HUB_NAME
```

The GitHub Actions workflow file has been updated to run the health check in a new step.

We read the service API token required to interact with the JupyterHub API directly from the Kubernetes secret it is stored in, instead of needing to propagate the state of on-the-fly-generated config across functions. Related discussion to this point in https://github.com/2i2c-org/infrastructure/issues/1024. We have not changed how this API token is generated when we deploy a new/existing hub though.