### PR TITLE
Fix env var name

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -28,7 +28,7 @@ concurrency: deploy
 # This environment variable triggers the deployer to colourise print statments in the
 # GitHug Actions logs for easy reading
 env:
-  term: XTERM
+  TERM: XTERM
 
 jobs:
   # This job runs in Pull Requests and on pushes to the default branch. It identifies

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -28,7 +28,7 @@ concurrency: deploy
 # This environment variable triggers the deployer to colourise print statments in the
 # GitHug Actions logs for easy reading
 env:
-  TERM: XTERM
+  TERM: xterm
 
 jobs:
   # This job runs in Pull Requests and on pushes to the default branch. It identifies


### PR DESCRIPTION
We look for capitalised TERM in utils.print_colour, so update env var to match. `xterm` also needs to be lower case in order to be recognised by the shell in the runner.