### PR TITLE
ci: enable support/staging failures to not block other clusters prod deploy

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -87,7 +87,29 @@ jobs:
   # upgrade_staging for each cluster that requires it.
   upgrade-support-and-staging:
     runs-on: ubuntu-latest
-    needs: generate-jobs
+    needs: [generate-jobs]
+
+    # We declare outputs indicating the job failed status of a specific job
+    # variation. We are currently required to do this in a hardcoded fashion,
+    # see this post for feature requests for this to be improved:
+    # https://github.community/t/bug-jobs-output-should-return-a-list-for-a-matrix-job/128626/32?u=consideratio
+    #
+    # IMPORTANT: names can include alphanumerics, '-', and '_', but not '.', so
+    #            we replace '.' for '-' in cluster names.
+    #
+    outputs:
+      failure_2i2c: ${{ steps.declare-failure-status.outputs.failure_2i2c }}
+      failure_azure-carbonplan: ${{ steps.declare-failure-status.outputs.failure_azure-carbonplan }}
+      failure_carbonplan: ${{ steps.declare-failure-status.outputs.failure_carbonplan }}
+      failure_cloudbank: ${{ steps.declare-failure-status.outputs.failure_cloudbank }}
+      failure_farallon: ${{ steps.declare-failure-status.outputs.failure_farallon }}
+      failure_leap: ${{ steps.declare-failure-status.outputs.failure_leap }}
+      failure_meom-ige: ${{ steps.declare-failure-status.outputs.failure_meom-ige }}
+      failure_openscapes: ${{ steps.declare-failure-status.outputs.failure_openscapes }}
+      failure_pangeo-hubs: ${{ steps.declare-failure-status.outputs.failure_pangeo-hubs }}
+      failure_utoronto: ${{ steps.declare-failure-status.outputs.failure_utoronto }}
+      failure_uwhackweeks: ${{ steps.declare-failure-status.outputs.failure_uwhackweeks }}
+
     # Only run this job on pushes to the default branch and when the job output is not
     # an empty list
     if: |
@@ -144,28 +166,74 @@ jobs:
           command: |
             python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} dask-staging
 
-  # TODO: Add in "job 3a" where the matrix for prod jobs is edited to exclude any clusters
-  # that failed the preceding upgrade-support-and-staging job. See discussion in:
-  # https://github.com/2i2c-org/infrastructure/issues/1131
+      - name: Declare failure status
+        id: declare-failure-status
+        if: always()
+        run: |
+          echo ::set-output name=failure_${{ matrix.jobs.cluster_name }}::${{ failure() }}
 
-  # This job upgrades production hubs on clusters in parallel, if required. This job
-  # needs both the `generate-jobs` and `upgrade-support-and-staging` jobs to have
-  # completed and set an output to the `prob-hub-matrix-jobs` variable name. It's inputs
-  # are a list of dictionaries with the keys cluster_name, provider, and hub+name for
-  # each production hub that requires an upgrade.
-  upgrade-prod-hubs:
+  # This jobs reduces the initially planned prod-hub-matrix-jobs deployments by
+  # filtering out any deployment to a cluster with a failed support-and-staging
+  # job.
+  filter-generate-jobs:
     runs-on: ubuntu-latest
     needs: [generate-jobs, upgrade-support-and-staging]
+    # Only run this job on pushes to the default branch and when the job output is not
+    # an empty list
+    if: |
+      (github.event_name == 'push' && contains(github.ref, 'master')) &&
+      needs.generate-jobs.outputs.support-and-staging-matrix-jobs != '[]' &&
+      needs.generate-jobs.outputs.prod-hub-matrix-jobs != '[]'
+
+    outputs:
+      filtered-prob-hub-matrix-jobs: ${{ steps.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs }}
+
+    steps:
+      - name: Filter prod deploy jobs to run based on failures in support/staging
+        id: filter-generate-jobs
+        shell: python
+        run: |
+          import json
+
+          prod_hub_matrix_jobs = json.loads(
+              r"""
+              ${{ fromJson(needs.generate-jobs.outputs.prod-hub-matrix-jobs) }}
+              """
+          )
+          outputs = json.loads(
+              r"""
+              ${{ fromJson(needs.upgrade-support-and-staging.outputs) }}
+              """
+          )
+
+          # Filter any prod job that had a support/staging job run and fail
+          filtered_prod_hub_matrix_jobs = [
+              prod_job
+              for prod_job in prod_hub_matrix_jobs
+              if outputs[f"failure_{prod_job['cluster_name']}"] != "true"
+          ]
+
+          print(f"::set-output name=filtered-prod-hub-matrix-jobs::{json.dumps(filtered_prod_hub_matrix_jobs)}")
+
+  # This job upgrades production hubs on clusters in parallel, if required. This
+  # job needs both the `filter-generate-jobs` to have completed to provide its
+  # output `filtered-prob-hub-matrix-jobs`. It is a list of dictionaries with
+  # the keys cluster_name, provider, and hub+name for each production hub that
+  # requires an upgrade and didn't have a failed support-and-staging-upgrade job
+  # run as part of this workflow.
+  upgrade-prod-hubs:
+    runs-on: ubuntu-latest
+    needs: [filter-generate-jobs]
     # Only run this job on pushes to the default branch and when the `generate-jobs` job output is not
     # an empty list
     if: |
       (github.event_name == 'push' && contains(github.ref, 'master')) &&
-      needs.generate-jobs.outputs.prob-hub-matrix-jobs != '[]'
+      needs.filter-generate-jobs.outputs.filtered-prob-hub-matrix-jobs != '[]'
     strategy:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
-        jobs: ${{ fromJson(needs.generate-jobs.outputs.prob-hub-matrix-jobs) }}
+        jobs: ${{ fromJson(needs.filter-generate-jobs.outputs.filtered-prob-hub-matrix-jobs) }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -218,7 +218,7 @@ jobs:
   # This job upgrades production hubs on clusters in parallel, if required. This
   # job needs both the `filter-generate-jobs` to have completed to provide its
   # output `filtered-prob-hub-matrix-jobs`. It is a list of dictionaries with
-  # the keys cluster_name, provider, and hub+name for each production hub that
+  # the keys cluster_name, provider, and hub_name for each production hub that
   # requires an upgrade and didn't have a failed support-and-staging-upgrade job
   # run as part of this workflow.
   upgrade-prod-hubs:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -170,7 +170,7 @@ jobs:
         id: declare-failure-status
         if: always()
         run: |
-          echo ::set-output name=failure_${{ matrix.jobs.cluster_name }}::${{ failure() }}
+          echo ::set-output name=failure_${{ matrix.jobs.cluster_name }}::${{ job.status == 'failure' }}
 
   # This jobs reduces the initially planned prod-hub-matrix-jobs deployments by
   # filtering out any deployment to a cluster with a failed support-and-staging

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -224,7 +224,19 @@ def generate_support_matrix_jobs(
             cluster, the cloud provider that cluster runs on, a Boolean indicating if
             the support chart should be upgraded, and a reason why the support chart
             needs upgrading.
+
+            Example:
+
+            [
+                {
+                    "cluster_name": 2i2c,
+                    "provider": "gcp",
+                    "reason_for_support_redeploy": "Support helm chart has been modified",
+                    "upgrade_support": True,
+                },
+            ]
     """
+    # Rename dictionary key
     cluster_info["reason_for_support_redeploy"] = cluster_info.pop(
         "reason_for_redeploy"
     )


### PR DESCRIPTION
This makes us skip deploying prod hubs after a staging fails. Note that i think it also fixes a bug where prod deployment would continue even if staging failed as we had an if conditional that disregarded that.

This implementation is the job3a from https://github.com/2i2c-org/infrastructure/issues/1131#issuecomment-1072573736. Constraints that led to the hardcoding you see of cluster names is reported already to https://github.community/t/bug-jobs-output-should-return-a-list-for-a-matrix-job/128626/32?u=consideratio.

Closes #1131.

---

This code is not tested in this context, so there are very possibly small tweaks needed following merge.