### PR TITLE
Use minSize property for scaling eksctl nodes

### DIFF
--- a/docs/howto/operate/new-cluster/aws.md
+++ b/docs/howto/operate/new-cluster/aws.md
@@ -204,11 +204,11 @@ minimum and maximum number of nodes. In certain cases, it might be helpful to 's
 a nodegroup in a cluster before an event, to test cloud provider quotas or to make user
 server startup faster.
 
-1. Open the appropriate `.jsonnet` file for the cluster in question, and set the
-   `minNodes` property of `notebookNodes` to the appropriate number you want.
+1. Open the appropriate `.jsonnet` file for the cluster in question, and set a
+   `minSize` property of `notebookNodes` to the appropriate number you want.
 
    ```{warning}
-   It is currently unclear if *lowering* the `minNodes` property just allows
+   It is currently unclear if *lowering* the `minSize` property just allows
    the autoscaler to reclaim nodes, or if it actively destroys nodes at time
    of application! If it actively destroys nodes, it is unclear if it does
    so regardless of user pods running in these nodes! Until this can be

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -16,12 +16,12 @@ local namespaces = ['staging', 'prod'];
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.large", minNodes: 0 },
-    { instanceType: "r5.xlarge", minNodes: 0 },
-    { instanceType: "r5.2xlarge", minNodes: 0 },
-    { instanceType: "r5.8xlarge", minNodes: 0 },
-    { instanceType: "x1.16xlarge", minNodes: 0 },
-    { instanceType: "x1.32xlarge", minNodes: 0 }
+    { instanceType: "r5.large" },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.2xlarge" },
+    { instanceType: "r5.8xlarge" },
+    { instanceType: "x1.16xlarge" },
+    { instanceType: "x1.32xlarge" }
 ];
 
 // Node definitions for dask worker nodes. Config here is merged
@@ -80,7 +80,7 @@ local daskNodes = [
             // instanceTypes always have a .
             name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
-            minSize: n.minNodes,
+            minSize: 0,
             maxSize: 500,
             instanceType: n.instanceType,
             ssh: {

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -16,10 +16,10 @@ local namespaces = ['staging', 'prod'];
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "m5.large", minNodes: 0 },
-    { instanceType: "m5.xlarge", minNodes: 0 },
-    { instanceType: "m5.2xlarge", minNodes: 0 },
-    { instanceType: "m5.8xlarge", minNodes: 0 },
+    { instanceType: "m5.large" },
+    { instanceType: "m5.xlarge" },
+    { instanceType: "m5.2xlarge" },
+    { instanceType: "m5.8xlarge" },
 ];
 
 // Node definitions for dask worker nodes. Config here is merged
@@ -83,7 +83,7 @@ local daskNodes = [
             // instanceTypes always have a .
             name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
-            minSize: n.minNodes,
+            minSize: 0,
             maxSize: 500,
             instanceType: n.instanceType,
             ssh: {


### PR DESCRIPTION
We were unnecessarily introducing a new minNodes property
when we could just use the eksctl native minSize property