### PR TITLE
Remove unnecessary paths from workflow triggers

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -7,18 +7,24 @@ on:
     paths:
       - deployer/**
       - requirements.txt
-      - .github/workflows/deploy-hubs.yaml
       - .github/actions/setup-deploy/**
       - "**.yaml"
+      # We no longer trigger on this file since it does not contain any logic
+      # concerning setting up the clusters for deploy. This now all lives in the
+      # setup-deploy local action
+      # - .github/workflows/deploy-hubs.yaml
   pull_request:
     branches:
       - master
     paths:
       - deployer/**
       - requirements.txt
-      - .github/workflows/deploy-hubs.yaml
       - .github/actions/setup-deploy/**
       - "**.yaml"
+      # We no longer trigger on this file since it does not contain any logic
+      # concerning setting up the clusters for deploy. This now all lives in the
+      # setup-deploy local action
+      # - .github/workflows/deploy-hubs.yaml
 
 # When multiple PRs triggering this workflow are merged, queue them instead
 # of running them in parallel

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -45,8 +45,7 @@ def discover_modified_common_files(modified_paths):
         # Filepaths related to the deployer infrastructure
         "deployer/*",
         "requirements.txt",
-        # Filepaths related to GitHub Actions infrastructure
-        ".github/workflows/deploy-hubs.yaml",
+        # Filepath to local GitHub Action that sets up clusters for deploy
         ".github/actions/setup-deploy/*",
         # Filepaths related to helm chart infrastructure
         "helm-charts/basehub/*",


### PR DESCRIPTION
Logic to setup clusters for a deploy is no longer contained within `.github/workflows/deploy-hubs.yaml` so I believe it is no longer useful to trigger deploys based on changes to that file