### PR TITLE
ci: attempt fix filter jobs python snippet

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -197,12 +197,12 @@ jobs:
 
           prod_hub_matrix_jobs = json.loads(
               r"""
-              ${{ fromJson(needs.generate-jobs.outputs.prod-hub-matrix-jobs) }}
+              ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
               """
           )
           outputs = json.loads(
               r"""
-              ${{ fromJson(needs.upgrade-support-and-staging.outputs) }}
+              ${{ toJson(needs.upgrade-support-and-staging.outputs) }}
               """
           )
 

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -182,9 +182,9 @@ class Hub:
             generated_config["dask-gateway"] = {
                 "gateway": {"auth": {"jupyterhub": {"apiToken": gateway_token}}}
             }
-            generated_config["basehub"]["jupyterhub"]["hub"]["services"][
-                "dask-gateway"
-            ] = {"apiToken": gateway_token}
+            generated_config.setdefault("jupyterhub", {}).setdefault(
+                "hub", {}
+            ).setdefault("services", {})["dask-gateway"] = {"apiToken": gateway_token}
 
         return generated_config
 

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -167,7 +167,7 @@ class Hub:
         if hub_helm_chart != "basehub":
             generated_config = {"basehub": generated_config}
 
-        # FIXME: This section can be removed upon resolution of, where we would
+        # FIXME: This section can be removed upon resolution of the below linked issue, where we would
         #        instead just define a JupyterHub service under hub.services and
         #        rely on the JupyterHub Helm chart to generate an api token if
         #        needed.

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -159,22 +159,22 @@ class Hub:
         """
         hub_helm_chart = self.spec["helm_chart"]
 
-        # Generate a token for the hub health service
-        hub_health_token = hmac.new(
-            secret_key, b"health-" + self.spec["name"].encode(), hashlib.sha256
-        ).hexdigest()
-        # Describe the hub health service
-        generated_config.setdefault("jupyterhub", {}).setdefault("hub", {}).setdefault(
-            "services", {}
-        )["hub-health"] = {"apiToken": hub_health_token, "admin": True}
-
-        # FIXME: Have a templates config somewhere? Maybe in Chart.yaml
-        # FIXME: This is a hack. Fix it.
+        # FIXME: This section is only relevant if we generate any config in this
+        #        function. Currently we only generate a JupyterHub API token for
+        #        dask-gateway to use, but as that is resolved we can cleanup
+        #        this entire function.
+        #
         if hub_helm_chart != "basehub":
             generated_config = {"basehub": generated_config}
 
-        # FIXME: This section can be fixed upon resolution of:
-        # https://github.com/dask/dask-gateway/issues/473
+        # FIXME: This section can be removed upon resolution of, where we would
+        #        instead just define a JupyterHub service under hub.services and
+        #        rely on the JupyterHub Helm chart to generate an api token if
+        #        needed.
+        #
+        #        Blocked by https://github.com/dask/dask-gateway/issues/473 and a
+        #        release including it.
+        #
         if hub_helm_chart == "daskhub":
             gateway_token = hmac.new(
                 secret_key, b"gateway-" + self.spec["name"].encode(), hashlib.sha256

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -293,6 +293,17 @@ jupyterhub:
           - -m
           - jupyterhub_configurator.app
           - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
+      # hub-health service helps us run health checks from the deployer script.
+      # The JupyterHub Helm chart will automatically generate an API token for
+      # services and expose it in a k8s Secret named `hub`. When we run health
+      # tests against a hub, we read this token from the k8s Secret to acquire
+      # the credentials needed to interacting with the JupyterHub API.
+      #
+      hub-health:
+        # FIXME: With JupyterHub 2 we can define a role for this service with
+        #        more tightly scoped permissions based on our needs.
+        #
+        admin: true
     image:
       name: quay.io/2i2c/pilot-hub
       tag: "0.0.1-n2546.ha1b6098"


### PR DESCRIPTION
`fromJson` expects a string, not an object. If we have an object, we should instead transform it to a json string. If we already have a json string, no action is needed.