### PR TITLE
Fix related to JSON/YAML/Python-dict-string-representation confusion

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -201,16 +201,8 @@ jobs:
         run: |
           import json
 
-          prod_hub_matrix_jobs = json.loads(
-              r"""
-              ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
-              """
-          )
-          outputs = json.loads(
-              r"""
-              ${{ toJson(needs.upgrade-support-and-staging.outputs) }}
-              """
-          )
+          prod_hub_matrix_jobs = json.loads('${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}')
+          outputs = json.loads('${{ toJson(needs.upgrade-support-and-staging.outputs) }}')
 
           # Filter any prod job that had a support/staging job run and fail
           filtered_prod_hub_matrix_jobs = [

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -125,7 +125,7 @@ jobs:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
-        jobs: ${{ fromJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
+        jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
 
     steps:
       - name: Checkout repo
@@ -239,7 +239,7 @@ jobs:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
-        jobs: ${{ fromJson(needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs) }}
+        jobs: ${{ needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -138,18 +138,18 @@ jobs:
           GCP_KMS_DECRYPTOR_KEY: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
 
       - name: Upgrade support chart on cluster ${{ matrix.jobs.cluster_name }}
-        if: matrix.jobs.upgrade_support == 'true'
+        if: matrix.jobs.upgrade_support
         run: |
           python deployer deploy-support ${{ matrix.jobs.cluster_name }}
 
       - name: Upgrade staging hub on cluster ${{ matrix.jobs.cluster_name }}
-        if: matrix.jobs.upgrade_staging == 'true'
+        if: matrix.jobs.upgrade_staging
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} staging
 
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for staging hub on cluster ${{ matrix.jobs.cluster_name }}
-        if: matrix.jobs.upgrade_staging == 'true'
+        if: matrix.jobs.upgrade_staging
         uses: nick-fields/retry@v2.4.0
         with:
           timeout_minutes: 10
@@ -158,13 +158,13 @@ jobs:
             python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} staging
 
       - name: Upgrade dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
-        if: matrix.jobs.upgrade_staging == 'true' && matrix.jobs.cluster_name == '2i2c'
+        if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} dask-staging
 
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
-        if: matrix.jobs.upgrade_staging == 'true' && matrix.jobs.cluster_name == '2i2c'
+        if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
         uses: nick-fields/retry@v2.4.0
         with:
           timeout_minutes: 10

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -2,6 +2,7 @@
 Actions available when deploying many JupyterHubs to many Kubernetes clusters
 """
 import base64
+import json
 import os
 import sys
 import shutil
@@ -331,9 +332,11 @@ def generate_helm_upgrade_jobs(changed_filepaths):
     if ci_env:
         # Add these matrix jobs as output variables for use in another job
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
-        print(f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}")
         print(
-            f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}"
+            f"::set-output name=prod-hub-matrix-jobs::{json.dumps(prod_hub_matrix_jobs)}"
+        )
+        print(
+            f"::set-output name=support-and-staging-matrix-jobs::{json.dumps(support_and_staging_matrix_jobs)}"
         )
 
 

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -250,7 +250,7 @@ def generate_support_matrix_jobs(
             # We know we're upgrading support on all clusters, so just add the cluster
             # name to the list of matrix jobs and move on
             matrix_job = cluster_info.copy()
-            matrix_job["upgrade_support"] = "true"
+            matrix_job["upgrade_support"] = True
 
             if upgrade_support_on_all_clusters:
                 matrix_job[
@@ -269,7 +269,7 @@ def generate_support_matrix_jobs(
 
             if intersection:
                 matrix_job = cluster_info.copy()
-                matrix_job["upgrade_support"] = "true"
+                matrix_job["upgrade_support"] = True
                 matrix_job[
                     "reason_for_support_redeploy"
                 ] = "Following helm chart values files were modified: " + ", ".join(
@@ -305,9 +305,9 @@ def move_staging_hubs_to_staging_matrix(
     {
         "cluster_name": str,
         "provider": str,
-        "upgrade_support": str(bool),
+        "upgrade_support": bool,
         "reason_for_support_redeploy_: str,
-        "upgrade_staging": str(bool),
+        "upgrade_staging": bool,
         "reason_for_staging_redeploy_: str,
     }
 
@@ -352,7 +352,7 @@ def move_staging_hubs_to_staging_matrix(
         if job_idx is not None:
             # Update the matching job in support_and_staging_matrix_jobs to hold
             # information related to upgrading the staging hub
-            support_and_staging_matrix_jobs[job_idx]["upgrade_staging"] = "true"
+            support_and_staging_matrix_jobs[job_idx]["upgrade_staging"] = True
             support_and_staging_matrix_jobs[job_idx][
                 "reason_for_staging_redeploy"
             ] = staging_job["reason_for_redeploy"]
@@ -364,9 +364,9 @@ def move_staging_hubs_to_staging_matrix(
             new_job = {
                 "cluster_name": staging_job["cluster_name"],
                 "provider": staging_job["provider"],
-                "upgrade_staging": "true",
+                "upgrade_staging": True,
                 "reason_for_staging_redeploy": staging_job["reason_for_redeploy"],
-                "upgrade_support": "false",
+                "upgrade_support": False,
                 "reason_for_support_redeploy": "",
             }
             support_and_staging_matrix_jobs.append(new_job)
@@ -378,7 +378,7 @@ def ensure_support_staging_jobs_have_correct_keys(
     support_and_staging_matrix_jobs, prod_hub_matrix_jobs
 ):
     """This function ensures that all entries in support_and_staging_matrix_jobs have
-    the expected upgrade_staging and eason_for_staging_redeploy keys, even if they are
+    the expected upgrade_staging and reason_for_staging_redeploy keys, even if they are
     set to false/empty.
 
     Args:
@@ -407,7 +407,7 @@ def ensure_support_staging_jobs_have_correct_keys(
             if hubs_on_this_cluster:
                 # There are prod hubs on this cluster that require an upgrade, and so we
                 # also upgrade staging
-                job["upgrade_staging"] = "true"
+                job["upgrade_staging"] = True
                 job[
                     "reason_for_staging_redeploy"
                 ] = "Following prod hubs require redeploy: " + ", ".join(
@@ -416,7 +416,7 @@ def ensure_support_staging_jobs_have_correct_keys(
             else:
                 # There are no prod hubs on this cluster that require an upgrade, so we
                 # do not upgrade staging
-                job["upgrade_staging"] = "false"
+                job["upgrade_staging"] = False
                 job["reason_for_staging_redeploy"] = ""
 
     return support_and_staging_matrix_jobs
@@ -472,9 +472,9 @@ def assign_staging_jobs_for_missing_clusters(
             new_job = {
                 "cluster_name": missing_cluster,
                 "provider": provider,
-                "upgrade_support": "false",
+                "upgrade_support": False,
                 "reason_for_support_redeploy": "",
-                "upgrade_staging": "true",
+                "upgrade_staging": True,
                 "reason_for_staging_redeploy": (
                     "Following prod hubs require redeploy: " + ", ".join(prod_hubs)
                 ),

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -499,9 +499,9 @@ def pretty_print_matrix_jobs(prod_hub_matrix_jobs, support_and_staging_matrix_jo
         support_table.add_row(
             job["provider"],
             job["cluster_name"],
-            job["upgrade_support"],
+            "Yes" if job["upgrade_support"] else "No",
             job["reason_for_support_redeploy"],
-            job["upgrade_staging"],
+            "Yes" if job["upgrade_staging"] else "No",
             job["reason_for_staging_redeploy"],
             end_section=True,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ rich
 # jhub_client, pytest, and pytest-asyncio are used for our health checks
 jhub-client==0.1.6
 pytest
-pytest-asyncio
+pytest-asyncio>=0.17

--- a/tests/test_helm_upgrade_decision.py
+++ b/tests/test_helm_upgrade_decision.py
@@ -193,7 +193,7 @@ def test_generate_support_matrix_jobs_one_cluster():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "true",
+            "upgrade_support": True,
             "reason_for_support_redeploy": "Following helm chart values files were modified: support.values.yaml",
         }
     ]
@@ -232,7 +232,7 @@ def test_generate_support_matrix_jobs_all_clusters():
             {
                 "provider": "gcp",
                 "cluster_name": "cluster1",
-                "upgrade_support": "true",
+                "upgrade_support": True,
                 "reason_for_support_redeploy": reason,
             }
         ]
@@ -300,7 +300,7 @@ def test_move_staging_hubs_to_staging_matrix_job_exists():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "true",
+            "upgrade_support": True,
             "reason_for_support_redeploy": "cluster.yaml file was modified",
         }
     ]
@@ -317,9 +317,9 @@ def test_move_staging_hubs_to_staging_matrix_job_exists():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "true",
+            "upgrade_support": True,
             "reason_for_support_redeploy": "cluster.yaml file was modified",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "cluster.yaml file was modified",
         }
     ]
@@ -366,9 +366,9 @@ def test_move_staging_hubs_to_staging_matrix_job_does_not_exist():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_redeploy": "",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "cluster.yaml file was modified",
         }
     ]
@@ -391,7 +391,7 @@ def test_ensure_support_staging_jobs_have_correct_keys_hubs_exist():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_upgrade": "",
         }
     ]
@@ -409,9 +409,9 @@ def test_ensure_support_staging_jobs_have_correct_keys_hubs_exist():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_upgrade": "",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
         }
     ]
@@ -428,7 +428,7 @@ def test_ensure_support_staging_jobs_have_correct_keys_hubs_dont_exist():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_upgrade": "",
         }
     ]
@@ -437,9 +437,9 @@ def test_ensure_support_staging_jobs_have_correct_keys_hubs_dont_exist():
         {
             "cluster_name": "cluster1",
             "provider": "gcp",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_upgrade": "",
-            "upgrade_staging": "false",
+            "upgrade_staging": False,
             "reason_for_staging_redeploy": "",
         }
     ]
@@ -464,9 +464,9 @@ def test_assign_staging_jobs_for_missing_clusters_is_missing():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_redeploy": "",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
         }
     ]
@@ -491,9 +491,9 @@ def test_assign_staging_jobs_for_missing_clusters_is_present():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_redeploy": "",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
         }
     ]
@@ -502,9 +502,9 @@ def test_assign_staging_jobs_for_missing_clusters_is_present():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "false",
+            "upgrade_support": False,
             "reason_for_support_redeploy": "",
-            "upgrade_staging": "true",
+            "upgrade_staging": True,
             "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
         }
     ]


### PR DESCRIPTION
## Key fix of PR

The key fix in this PR is a84c30a (for https://github.com/2i2c-org/infrastructure/runs/6024029324?check_suite_focus=true) which ensure that the output we set from the deployer is valid JSON, and not a Python string representation of a dictionary.

```python
import json
my_dict = {"a": True}
print(my_dict)
# {'a': True} --- not valid json because of single quotes on the key
print(json.dumps(my_dict))
# {"a": true}
```

I'm somewhat confused why this worked this well so far though. YAML/JSON/Python string representation of objects + GitHub expressions rendering things into YAML etc makes it quite hard to understand overall.

## Extra fluff part of PR

Since I believed this could have been a driver for using strings consistently for output emitted the deployer, I opted to make them true booleans again as well.