### PR TITLE
refactor: use 4 space indentation in python code consistently

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -361,17 +361,17 @@ jupyterhub:
         c.JupyterHub.authenticate_prometheus = False
       03-no-setuid: |
         c.KubeSpawner.extra_container_config = {
-          'securityContext': {
-            # Explicitly disallow setuid binaries from working inside the container
-            'allowPrivilegeEscalation': False
-          }
+            'securityContext': {
+                # Explicitly disallow setuid binaries from working inside the container
+                'allowPrivilegeEscalation': False
+            }
         }
       04-custom-theme: |
         from z2jh import get_config
         c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/']
 
         c.JupyterHub.template_vars = {
-          'custom': get_config('custom.homepage.templateVars')
+            'custom': get_config('custom.homepage.templateVars')
         }
       05-custom-admin: |
         from z2jh import get_config
@@ -379,16 +379,16 @@ jupyterhub:
         from jupyterhub_configurator.mixins import ConfiguratorSpawnerMixin
 
         class CustomSpawner(ConfiguratorSpawnerMixin, KubeSpawner):
-          def start(self, *args, **kwargs):
-            custom_admin = get_config('custom.singleuserAdmin', {})
-            if custom_admin and self.user.admin:
-                extra_init_containers = custom_admin.get('initContainers', [])
-                extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
+            def start(self, *args, **kwargs):
+                custom_admin = get_config('custom.singleuserAdmin', {})
+                if custom_admin and self.user.admin:
+                    extra_init_containers = custom_admin.get('initContainers', [])
+                    extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
 
-                self.init_containers += [container for container in extra_init_containers if container not in self.init_containers]
-                self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
+                    self.init_containers += [container for container in extra_init_containers if container not in self.init_containers]
+                    self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
 
-            return super().start(*args, **kwargs)
+                return super().start(*args, **kwargs)
 
 
         c.JupyterHub.spawner_class = CustomSpawner
@@ -399,23 +399,23 @@ jupyterhub:
         import os
 
         if scratch_bucket['enabled']:
-          # FIXME: Support other providers too
-          assert cloud_resources['provider'] == 'gcp'
-          project_id = cloud_resources['gcp']['projectId']
+            # FIXME: Support other providers too
+            assert cloud_resources['provider'] == 'gcp'
+            project_id = cloud_resources['gcp']['projectId']
 
-          release = os.environ['HELM_RELEASE_NAME']
-          bucket_protocol = 'gcs'
-          bucket_name = f'{project_id}-{release}-scratch-bucket'
-          env = {
-            'SCRATCH_BUCKET_PROTOCOL': bucket_protocol,
-            # Matches "daskhub.scratchBUcket.name" helm template
-            'SCRATCH_BUCKET_NAME': bucket_name,
-            # Use k8s syntax of $(ENV_VAR) to substitute env vars dynamically in other env vars
-            'SCRATCH_BUCKET': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
-            'PANGEO_SCRATCH': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
-          }
+            release = os.environ['HELM_RELEASE_NAME']
+            bucket_protocol = 'gcs'
+            bucket_name = f'{project_id}-{release}-scratch-bucket'
+            env = {
+                'SCRATCH_BUCKET_PROTOCOL': bucket_protocol,
+                # Matches "daskhub.scratchBUcket.name" helm template
+                'SCRATCH_BUCKET_NAME': bucket_name,
+                # Use k8s syntax of $(ENV_VAR) to substitute env vars dynamically in other env vars
+                'SCRATCH_BUCKET': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
+                'PANGEO_SCRATCH': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
+            }
 
-          c.KubeSpawner.environment.update(env)
+            c.KubeSpawner.environment.update(env)
       07-2i2c-add-staff-user-ids-to-admin-users: |
         from z2jh import get_config
         add_staff_user_ids_to_admin_users = get_config("custom.2i2c.add_staff_user_ids_to_admin_users", False)
@@ -440,4 +440,4 @@ jupyterhub:
         from z2jh import get_config
 
         if get_config("custom.docs_service.enabled"):
-          c.JupyterHub.services.append({"name": "docs", "url": "http://docs-service"})
+            c.JupyterHub.services.append({"name": "docs", "url": "http://docs-service"})


### PR DESCRIPTION
I wanted to trigger a redeploy as I'm still iterating to get things functional in the CI system and a change in the workflow didn't cut it.

So, instead of adding something silly I refactor us to have consistent 4 space indentation within the python code we have nested in YAML.