### PR TITLE
ci: dummy bump of sops patch version to trigger re-deploy

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -63,7 +63,7 @@ runs:
     - name: Setup sops
       uses: mdgreenwald/mozilla-sops-action@v1
       with:
-        version: v3.7.1
+        version: v3.7.2
 
     - name: Setup kops
       if: inputs.provider == 'aws'

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -12,11 +12,7 @@ on:
       # We no longer trigger on this file since it does not contain any logic
       # concerning setting up the clusters for deploy. This now all lives in the
       # setup-deploy local action
-      #
-      # FIXME: Disable trigger on changes to workflow, temporary enabled to get
-      #        things right.
-      #
-      - .github/workflows/deploy-hubs.yaml
+      # - .github/workflows/deploy-hubs.yaml
   pull_request:
     branches:
       - master


### PR DESCRIPTION
I'm self-merging small changes to fix the broken ci system.

#1207 was the previous attempt.