### PR TITLE
pre-commit: add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,14 @@ repos:
           - --py36-plus
 
   # Autoformat: Python code
+  - repo: https://github.com/pycqa/isort
+    rev: "5.10.1"
+    hooks:
+      - id: isort
+
+  # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: "22.3.0"
     hooks:
       - id: black
 

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -3,6 +3,5 @@ Main entrypoint for deployer
 """
 import cli
 
-
 if __name__ == "__main__":
     cli.main()

--- a/deployer/cilogon_app.py
+++ b/deployer/cilogon_app.py
@@ -25,14 +25,13 @@ by executing the script with `--help` flag, from the root of the repository:
 
 import argparse
 import base64
-import requests
 import subprocess
-
 from pathlib import Path
+
+import requests
+from file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
 from ruamel.yaml import YAML
 from yarl import URL
-
-from file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
 
 yaml = YAML(typ="safe")
 

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -3,18 +3,18 @@ Command line interface for deployer
 """
 import argparse
 
-from deploy_actions import (
-    deploy,
-    deploy_support,
-    deploy_grafana_dashboards,
-    use_cluster_credentials,
-    generate_helm_upgrade_jobs,
-    run_hub_health_check,
-)
 from config_validation import (
     validate_cluster_config,
-    validate_support_config,
     validate_hub_config,
+    validate_support_config,
+)
+from deploy_actions import (
+    deploy,
+    deploy_grafana_dashboards,
+    deploy_support,
+    generate_helm_upgrade_jobs,
+    run_hub_health_check,
+    use_cluster_credentials,
 )
 
 

--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -1,14 +1,13 @@
-import os
 import json
+import os
 import subprocess
 import tempfile
-
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
 
+from file_acquisition import get_decrypted_file, get_decrypted_files
 from hub import Hub
 from utils import print_colour
-from file_acquisition import get_decrypted_file, get_decrypted_files
 
 
 class Cluster:

--- a/deployer/config_validation.py
+++ b/deployer/config_validation.py
@@ -3,18 +3,17 @@ Functions related to validating configuration files such as helm chart values an
 cluster.yaml files
 """
 import functools
-import os
-import sys
 import json
+import os
 import subprocess
-import jsonschema
-
+import sys
 from pathlib import Path
-from ruamel.yaml import YAML
 
+import jsonschema
 from cluster import Cluster
-from utils import print_colour
 from file_acquisition import find_absolute_path_to_cluster_file
+from ruamel.yaml import YAML
+from utils import print_colour
 
 yaml = YAML(typ="safe", pure=True)
 helm_charts_dir = Path(__file__).parent.parent.joinpath("helm-charts")

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -4,35 +4,34 @@ Actions available when deploying many JupyterHubs to many Kubernetes clusters
 import base64
 import json
 import os
-import sys
 import shutil
 import subprocess
+import sys
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 import pytest
-from ruamel.yaml import YAML
-from contextlib import redirect_stderr, redirect_stdout
-
 from auth import KeyProvider
 from cluster import Cluster
-from utils import print_colour
-from file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
 from config_validation import (
+    assert_single_auth_method_enabled,
     validate_cluster_config,
     validate_hub_config,
     validate_support_config,
-    assert_single_auth_method_enabled,
 )
+from file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
 from helm_upgrade_decision import (
     assign_staging_jobs_for_missing_clusters,
     discover_modified_common_files,
     ensure_support_staging_jobs_have_correct_keys,
-    get_all_cluster_yaml_files,
     generate_hub_matrix_jobs,
     generate_support_matrix_jobs,
+    get_all_cluster_yaml_files,
     move_staging_hubs_to_staging_matrix,
     pretty_print_matrix_jobs,
 )
+from ruamel.yaml import YAML
+from utils import print_colour
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)

--- a/deployer/file_acquisition.py
+++ b/deployer/file_acquisition.py
@@ -3,12 +3,11 @@ Functions related to finding and reading files. Checking files exist, finding th
 absolute paths, decrypting and reading encrypted files when needed.
 """
 import os
-import warnings
 import subprocess
 import tempfile
-
+import warnings
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from contextlib import contextmanager, ExitStack
 
 from ruamel.yaml import YAML
 from ruamel.yaml.scanner import ScannerError

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -3,14 +3,13 @@ import hmac
 import json
 import subprocess
 import tempfile
-
 from pathlib import Path
 from textwrap import dedent
-from ruamel.yaml import YAML
 
 from auth import KeyProvider
-from utils import print_colour
 from file_acquisition import get_decrypted_file, get_decrypted_files
+from ruamel.yaml import YAML
+from utils import print_colour
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -1,7 +1,8 @@
-from pathlib import Path
 import os
+from pathlib import Path
+
 import pytest
-from jhub_client.execute import execute_notebook, JupyterHubAPI
+from jhub_client.execute import JupyterHubAPI, execute_notebook
 
 
 @pytest.fixture

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,12 +73,14 @@ def setup(app):
     app.add_css_file("custom.css")
 
 
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
 # -- Custom scripts -----------------------------------------
 # Pull latest list of communities served by infrastructure/
 from yaml import safe_load
-import pandas as pd
-from pathlib import Path
-import subprocess
 
 
 def render_hubs():

--- a/extra_scripts/approved_prs_reminder.py
+++ b/extra_scripts/approved_prs_reminder.py
@@ -6,9 +6,10 @@ This script helps remind our team when it's time to merge a PR. It does these th
 - If the approval was longer than 24 hours ago, add it to a list of PRs we should merge
 - Ping our #hub-development channel with a list of the PRs that are ready to merge
 """
-from ghapi.all import GhApi
-import pandas as pd
 from datetime import datetime
+
+import pandas as pd
+from ghapi.all import GhApi
 
 api = GhApi()
 

--- a/extra_scripts/rsync-active-users.py
+++ b/extra_scripts/rsync-active-users.py
@@ -9,20 +9,21 @@ home directories.
 An environment variable 'JUPYTERHUB_ADMIN' must be set with an admin token,
 obtainable from {hub_url}/hub/token by an admin user.
 """
-import os
-import requests
-from dateutil.parser import parse
-from datetime import datetime, timedelta, timezone
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import argparse
-import time
+import os
+import string
 import subprocess
+import sys
+import time
 
 # Copied from https://github.com/minrk/escapism/blob/d1d406c69b9ab0b14aa562d98a9e198adf9c047a/escapism.py
 # this is the library JuptyerHub uses to escape usernames into a form that works for filesystem paths
 import warnings
-import string
-import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+
+import requests
+from dateutil.parser import parse
 
 SAFE = set(string.ascii_letters + string.digits)
 ESCAPE_CHAR = "_"

--- a/helm-charts/images/hub/jupyterhub_configurator_config.py
+++ b/helm-charts/images/hub/jupyterhub_configurator_config.py
@@ -1,7 +1,6 @@
+import json
 import os
 from glob import glob
-import json
-
 
 CONFIGURATOR_BASE_PATH = "/usr/local/etc/jupyterhub-configurator"
 

--- a/kops/setup-efs.py
+++ b/kops/setup-efs.py
@@ -10,10 +10,11 @@ Should be terraform that runs after kops cluster is created and
 fetches VPC / SG / Subnets with data sources instead.
 """
 
-import sys
-import boto3
 import secrets
+import sys
 import time
+
+import boto3
 
 
 def find_subnets(cluster_name, region):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[tool.black]
+# target-version should be all supported versions
+target-version = ['py37', 'py38', 'py39', 'py310']
+
+[tool.isort]
+profile = "black"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = [

--- a/terraform/azure/proxycommand.py
+++ b/terraform/azure/proxycommand.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-import sys
 import subprocess
+import sys
 import time
-
 
 POD_NAME = "ssh-proxycommand-pod"
 POD_IMAGE = "alpine/socat"


### PR DESCRIPTION
After isort was configured to have a "black" profile, I've only seen people be happy about it so far in the JupyterHub team. It is now adopted in the jupyterhub/jupyterhub project and some other jupyterhub projects.

I appreciate:
- how it groups imports in a way that helps me say if something is a python standard lib module or third party module
- how it autoformats something more to help us conform to some style whatever style it now is