### PR TITLE
Cache pip's install cache between jobs in a workflow run, stop re-install of gcloud, pin helm's version

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -75,7 +75,20 @@ runs:
       with:
         python-version: "3.9"
 
-    - name: Setup deployer script Python dependencies
+    - name: Attempt to restore cached Python dependencies
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        # key determines if we define or re-use an existing cache or not, and we
+        # define a string composed of parts to ensure we only cache within a
+        # workflow run attempt, not between workflow runs or separate attempts
+        # of the runs.
+        key: "${{ github.run_id }}-${{ github.run_attempt }}"
+
+    - name: Install deployer script's Python dependencies
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
-        python -m pip install -r requirements.txt
+        pip install -r requirements.txt
+        pip list
       shell: bash

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -17,9 +17,10 @@
 #
 name: "Setup the deployer script for use to deploy"
 description: >-
-  Setups the deployer script by loading credentials and installing relevant tools
-  needed to interact with encrypted files, kubernetes clusters, and container
-  registries.
+  Setups the deployer script by loading credentials and installing library
+  dependencies and relevant tools needed to interact with encrypted files,
+  kubernetes clusters, and container registries. Tools already available in the
+  github virtual environments are not re-installed (gcloud, helm).
 
 # inputs configuration reference:
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
@@ -48,12 +49,6 @@ runs:
       uses: google-github-actions/auth@v0
       with:
         credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"
-
-    - name: Install gcloud
-      uses: google-github-actions/setup-gcloud@v0
-
-    - name: Setup helm
-      uses: azure/setup-helm@v2.0
 
     - name: Setup sops
       uses: mdgreenwald/mozilla-sops-action@v1

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -45,28 +45,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup credentials for sops to decrypt files with Google Cloud KMS
-      uses: google-github-actions/auth@v0
-      with:
-        credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"
-
-    - name: Setup sops
-      uses: mdgreenwald/mozilla-sops-action@v1
-      with:
-        version: v3.7.2
-
-    - name: Setup kops
-      if: inputs.provider == 'aws'
-      run: |
-        curl -Lo /tmp/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
-        chmod +x /tmp/kops
-        sudo mv /tmp/kops /usr/local/bin/kops
-      env:
-        KOPS_VERSION: "v1.21.1"
-      shell: bash
-
-    - name: Setup Python 3.9
-      uses: actions/setup-python@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: "3.9"
 
@@ -87,3 +66,23 @@ runs:
         pip install -r requirements.txt
         pip list
       shell: bash
+
+    - name: Install kops
+      if: inputs.provider == 'aws'
+      run: |
+        curl -Lo /tmp/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
+        chmod +x /tmp/kops
+        sudo mv /tmp/kops /usr/local/bin/kops
+      env:
+        KOPS_VERSION: "v1.21.1"
+      shell: bash
+
+    - name: Install sops
+      uses: mdgreenwald/mozilla-sops-action@v1
+      with:
+        version: v3.7.2
+
+    - name: Setup sops credentials to decrypt repo secrets
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -49,16 +49,18 @@ runs:
       with:
         python-version: "3.9"
 
-    - name: Attempt to restore cached Python dependencies
+    # There should always be a cache hit because from the "generate-jobs" job
+    # that is needed by any job calling this composite action. The installation
+    # step below is a precaution.
+    - name: Restore cached Python dependencies
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        # key determines if we define or re-use an existing cache or not, and we
-        # define a string composed of parts to ensure we only cache within a
-        # workflow run attempt, not between workflow runs or separate attempts
-        # of the runs.
-        key: "${{ github.run_id }}-${{ github.run_attempt }}"
+        # key determines if we define or re-use an existing cache or not. Our
+        # key ensure we cache within a workflow run and its attempts, but not
+        # between workflow runs.
+        key: "${{ github.run_id }}"
 
     - name: Install deployer script's Python dependencies
       if: steps.cache-pip.outputs.cache-hit != 'true'
@@ -67,6 +69,8 @@ runs:
         pip list
       shell: bash
 
+    # This step could be cached, but we only do it for a few jobs in the
+    # workflow where this action is used
     - name: Install kops
       if: inputs.provider == 'aws'
       run: |
@@ -77,6 +81,7 @@ runs:
         KOPS_VERSION: "v1.21.1"
       shell: bash
 
+    # This action use the github official cache mechanism so we don't need to
     - name: Install sops
       uses: mdgreenwald/mozilla-sops-action@v1
       with:

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -68,6 +68,14 @@ runs:
         pip list
       shell: bash
 
+    # This action use the github official cache mechanism internally
+    - uses: azure/setup-helm@v2.0
+      with:
+        # version is pinned for helm to avoid an automatic update of its version
+        # which would cause something unexpected without an action on our
+        # behalf.
+        version: v3.8.2
+
     # This step could be cached, but we only do it for a few jobs in the
     # workflow where this action is used
     - name: Install kops
@@ -80,7 +88,7 @@ runs:
         KOPS_VERSION: "v1.21.1"
       shell: bash
 
-    # This action use the github official cache mechanism so we don't need to
+    # This action use the github official cache mechanism internally
     - name: Install sops
       uses: mdgreenwald/mozilla-sops-action@v1
       with:

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -19,8 +19,9 @@ name: "Setup the deployer script for use to deploy"
 description: >-
   Setups the deployer script by loading credentials and installing library
   dependencies and relevant tools needed to interact with encrypted files,
-  kubernetes clusters, and container registries. Tools already available in the
-  github virtual environments are not re-installed (gcloud, helm).
+  kubernetes clusters, and container registries. `gcloud` already available in
+  the github virtual environment is not re-installed but `helm` is pinned to
+  avoid issues of a changing version.
 
 # inputs configuration reference:
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
@@ -49,12 +50,11 @@ runs:
       with:
         python-version: "3.9"
 
-    # There should always be a cache hit because from the "generate-jobs" job
-    # that is needed by any job calling this composite action. The installation
-    # step below is a precaution.
-    - name: Restore cached Python dependencies
+    # There will always be a cache hit on the cache key when this composite
+    # action is run, as its only done after the "generate-jobs" job has been run
+    # which will save a cache.
+    - name: Restore pip's install cache
       uses: actions/cache@v3
-      id: cache-pip
       with:
         path: ~/.cache/pip
         # key determines if we define or re-use an existing cache or not. Our
@@ -63,7 +63,6 @@ runs:
         key: "${{ github.run_id }}"
 
     - name: Install deployer script's Python dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         pip install -r requirements.txt
         pip list

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -65,9 +65,12 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Save cache of Python dependencies on job completion
+      # There will almost never be a cache hit on the cache key when this job is
+      # run, as it is the first of all jobs in this workflow. An exception is if
+      # this job is re-attempted as part of the same workflow run after
+      # succeeding previously.
+      - name: Save pip's install cache on job completion
         uses: actions/cache@v3
-        id: cache-pip
         with:
           path: ~/.cache/pip
           # key determines if we define or re-use an existing cache or not. Our
@@ -76,7 +79,6 @@ jobs:
           key: "${{ github.run_id }}"
 
       - name: Install deployer script's Python dependencies
-        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
           pip install -r requirements.txt
           pip list

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -65,10 +65,22 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install deployer script dependencies
+      - name: Save cache of Python dependencies on job completion
+        uses: actions/cache@v3
+        id: cache-pip
+        with:
+          path: ~/.cache/pip
+          # key determines if we define or re-use an existing cache or not. Our
+          # key ensure we cache within a workflow run and its attempts, but not
+          # between workflow runs.
+          key: "${{ github.run_id }}"
+
+      - name: Install deployer script's Python dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip list
 
       - name: Identify files that have been added or modified
         uses: jitterbit/get-changed-files@v1

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -78,7 +78,6 @@ jobs:
       - name: Install deployer script's Python dependencies
         if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
-          pip install --upgrade pip
           pip install -r requirements.txt
           pip list
 


### PR DESCRIPTION
We run an [action run ~50 times on each deploy workflow execution](https://github.com/2i2c-org/infrastructure/actions/runs/2170081750), so the value of optimizing this is can avoid wasting compute/energy and our time waiting for it.

Closes #1203

## How does actions/cache action work?

- Actions can have a "post job" hook. I think an action that failed to restore cache already saved from another job will use the "post job" hook to upload files instead for others to use. This means, that saving of cache isn't done when the action is called during a step in a job, but at job completion - but restoring of cache will be done when the cache action is called if a cache is found.
- I assume the cache is stored someplace with GitHub's object storage.
- The configured `key` helps decide if a cache should be used, and if so, what version of the cache. If a key is the same all the time, it will re-use a cache forever unless cleared for other reasons. But, we don't want to re-use a cache nonstop, so we specify a key that is unique for the workflow "run" - meaning for each time it is originally triggered (but a cache is reused between re-attempts of the same workflow).

## What did I do and why?

- EDIT: I had written that python dependencies were cached, but it's really only the pip's install cache that is itself cached. This will still speed up execution as installing from pip's install cache is faster than re-building wheels from source, but it's not as good performance improvement as I originally thought we could accomplish.

  I setup caching of python dependencies installed for the deployer script, which is relevant in two locations: .github/workflows/deploy-hubs.yaml and .github/actions/setup-deploy/action.yaml
- I've reordered steps in .github/actions/setup-deploy/action.yaml to delay exposing credentials more directly
- EDIT: I've added back `helm` (re-)install with the efficient `azure/setup-helm` action using a github cache mechanism internally and pinned the `helm` version.

  I've removed the (re-)install of `gcloud` and `helm`, which shouldn't affect us as its already [available from the GitHub's virtual environment](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md). I motivate this with two pro-points and a con-point:
  - con: we can't pin `gcloud` / `helm` any more, but I'm not sure its a net positive to do that. We had `gcloud` pinned, but doesn't have it pinned any more with this PR.
  - pro: we reduce risk of issues with a github action being malicious in these workflows
  - pro: we maybe save up to a few seconds by removing this per job execution
  
## Further optimizations

- We could have a) setup-python b) cache deps c) install deps run in a dedicated action, like that we could avoid duplicating some code in both generate-jobs job in the deploy workflow and in our setup-deploy/action.yaml action used by the other deploy workflow jobs.
- We could cache kops, but its not needed for `generate-jobs` job and only used in a few situations, therefore its a bit trickier to cache its installation. Also, the impact is lower as we only use `kops` once or twice or so anyhow. Further we move away from it, so I suggest we don't do this.