### PR TITLE
Restrict cloudbank demo hub to edu & 2i2c users

### DIFF
--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -95,16 +95,13 @@ hubs:
     domain: demo.cloudbank.2i2c.cloud
     helm_chart: basehub
     auth0:
-      # connection update? Also ensure the basehub Helm chart is provided a
-      # matching value for jupyterhub.custom.2i2c.add_staff_user_ids_of_type!
-      connection: password
-      password:
-        database_name: database-demo
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
       - demo.values.yaml
+      - enc-demo.secret.values.yaml
   - name: lassen
     display_name: "Lassen College"
     domain: lassen.cloudbank.2i2c.cloud

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -29,12 +29,21 @@ jupyterhub:
           url: http://cloudbank.org/
   hub:
     config:
+      JupyterHub:
+        authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
+        username_claim: email
       Authenticator:
-        # Everyone should be able to sign up, so we don't set allowed_users
         # These folks should still have admin tho
         admin_users:
-          - ericvd@gmail.com
+          - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
+        # We only want 2i2c users and users with .edu emails to sign up
+        # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
+        # FIXME: This doesn't account for educational institutions that have emails that don't end in .edu,
+        # as is the case for some non-euroamerican universities.
+        username_pattern: '^(.+@2i2c\.org|.+\.edu|deployment-service-check)$'
   cull:
     # Cull after 30min of inactivity
     every: 300

--- a/config/clusters/cloudbank/enc-demo.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-demo.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:1zP3Usi95CAOxE95TTGFFZcxoyFuQ2qisIQ2XQDTZiZ41TBv184QHCKRymgYudLJWNpm,iv:OmBRfhDkfbVikm8e9So6gkvLeTAV8q7kG+3URfOXdTU=,tag:f3//VxZiWz7bvLZoRha58g==,type:str]
+                client_secret: ENC[AES256_GCM,data:dkEE5BMzAX9GS9aN/JU6wwNxNn0C/a/Va+pa/oilPUbNgtUIGT8Mo+cdjBDom8cexnx/SP05zFSHSEcvAt8KomlkceohXNkjZFRrVqdMIFUYPJABJIA=,iv:HT1P+/j+eEjYzdkahoZYWG0ECPQqg7R6sjUsuwk1b/U=,tag:EbneGkcgNdAqmUVyCUjEUw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-04-19T18:11:15Z"
+          enc: CiQA4OM7eEcSp9nO1NvQ0AUpKnF3o/twKjxoJmd3j1L6zBazFGYSSQDm5XgWqfTahn7RCiABotkCKvdGwhTeiWYogzF4MXjkY4dEJrcsIR/ILYstXDmF70GhjkMdB+975XzwXQ8xNIhHhZJVJ3Kijbs=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-19T18:11:15Z"
+    mac: ENC[AES256_GCM,data:DhuZODN2vqrwlyjOSkA/Q3PHqzM4cPGJIr77oSGX0qqVarS9PEZmk6ueX/QaAEVLF5ZsjfhAfunlbXad1anGRRaW9lmugNcGdUB2/kpo/ZJwcjYGvKC0F/9iV0A5gBk75GSxGrthXWjnCj5FYoxHdxBBKIF58jn+QUBlW0XpOxw=,iv:QvbmRCcNWbMycJHeyLwxC6zYckC/pCMDQ+g7xU59sBo=,tag:h/xtYTImDMibJEH6xB7FUw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1


### PR DESCRIPTION
- Move cloudbank hub from username / password auth0 auth to
  CILogon
- Restrcit login to folks with emails either of 2i2c.org or any
  email ending in .edu. This doesn't catch *all* educational users,
  but I think it should catch everyone that cloudbank tries to reach.
- Switches @ericvd-ucb's admin email to use his berkeley.edu email,
  as gmail.com emails are no longer allowed

Fixes https://github.com/2i2c-org/infrastructure/issues/1216