### PR TITLE
Setup gh-scoped-creds on pangeo hub

### DIFF
--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -58,6 +58,9 @@ basehub:
           scope:
             - read:org
     singleuser:
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.c90ee430400a347f"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/pangeo-gcp-hub-push-access
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook

--- a/docs/howto/features/github.md
+++ b/docs/howto/features/github.md
@@ -1,0 +1,34 @@
+# Allow users to push to GitHub
+
+We use [gh-scoped-creds](https://github.com/yuvipanda/gh-scoped-creds/) to
+allow users to safely push to GitHub from their JupyterHub. This requires
+a little setup on the hub side to make the user experience seamless.
+
+1. [Create a GitHub app](https://github.com/organizations/2i2c-org/settings/apps/new)
+   under the 2i2c organization with the settings
+   [outlined in the gh-scoped-creds docs](https://github.com/yuvipanda/gh-scoped-creds/#github-app-configuration)
+
+2. Set [environment variables](https://github.com/yuvipanda/gh-scoped-creds/#client-configuration)
+   `gh-scoped-creds` needs to figure out which GitHub app to use in the appropriate
+   `.values.yaml` file for the hub in question.
+
+   ```yaml
+    jupyterhub:
+      singleuser:
+         extraEnv:
+            GH_SCOPED_CREDS_CLIENT_ID: <client-id-of-the-github-app>
+            GH_SCOPED_CREDS_APP_URL: <public-url-of-the-github-app>
+   ```
+
+   ```{note}
+   If the hub is a `daskhub`, nest the config under a `basehub` key
+   ```
+
+   Get this change deployed!
+
+3. Make sure the [gh-scoped-creds](https://pypi.org/project/gh-scoped-creds/) python
+   package is available inside the user image.
+
+[This blog post](https://blog.jupyter.org/securely-pushing-to-github-from-a-jupyterhub-3ee42dfdc54f)
+provides more details on how users on the JupyterHub can use `gh-scoped-creds` to
+push changes to GitHub!

--- a/docs/howto/features/index.md
+++ b/docs/howto/features/index.md
@@ -8,6 +8,7 @@ See the sections below for more details:
 :maxdepth: 2
 
 cloud-access
+github
 ../customize/docs-service
 ../customize/configure-login-page
 ../operate/override-domain.md


### PR DESCRIPTION
Also adds docs on how to do this!

https://github.com/pangeo-data/pangeo-docker-images/pull/305 adds
the required package to the pangeo docker image.

See https://github.com/2i2c-org/docs/pull/138#discussion_r848808092
for more discussion