### PR TITLE
Add m2lines hub

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -14,6 +14,7 @@ jobs:
           - cluster_name: cloudbank
           - cluster_name: carbonplan
           - cluster_name: pangeo-hubs
+          - cluster_name: m2lines
           - cluster_name: utoronto
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -116,6 +116,7 @@ jobs:
     # IMPORTANT: names can include alphanumerics, '-', and '_', but not '.', so
     #            we replace '.' for '-' in cluster names.
     #
+    # If you are adding a new cluster, please remember to list it here!
     outputs:
       failure_2i2c: "${{ steps.declare-failure-status.outputs.failure_2i2c }}"
       failure_azure-carbonplan: "${{ steps.declare-failure-status.outputs.failure_azure-carbonplan }}"
@@ -128,6 +129,7 @@ jobs:
       failure_pangeo-hubs: "${{ steps.declare-failure-status.outputs.failure_pangeo-hubs }}"
       failure_utoronto: "${{ steps.declare-failure-status.outputs.failure_utoronto }}"
       failure_uwhackweeks: "${{ steps.declare-failure-status.outputs.failure_uwhackweeks }}"
+      failure_m2lines: "${{ steps.declare-failure-status.outputs.failure_m2lines }}"
 
     # Only run this job on pushes to the default branch and when the job output is not
     # an empty list

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -49,6 +49,7 @@ jobs:
           - cluster_name: meom-ige
           - cluster_name: openscapes
           - cluster_name: pangeo-hubs
+          - cluster_name: m2lines
           - cluster_name: utoronto
           - cluster_name: uwhackweeks
 

--- a/config/clusters/m2lines/cluster.yaml
+++ b/config/clusters/m2lines/cluster.yaml
@@ -1,0 +1,32 @@
+name: pangeo-hubs
+provider: gcp
+gcp:
+  key: enc-deployer-credentials.secret.json
+  project: m2lines-hub
+  cluster: m2lines-cluster
+  zone: us-central1-b
+support:
+  helm_chart_values_files:
+    - support.values.yaml
+    - enc-support.secret.values.yaml
+hubs:
+  - name: staging
+    display_name: "M2LInES (staging)"
+    domain: staging.m2lines.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - common.values.yaml
+      - staging.values.yaml
+      - enc-staging.secret.values.yaml
+  - name: prod
+    display_name: "M2LInES (prod)"
+    domain: m2lines.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - common.values.yaml
+      - prod.values.yaml
+      - enc-prod.secret.values.yaml

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -1,0 +1,119 @@
+basehub:
+  nfs:
+    enabled: true
+    pv:
+      mountOptions:
+        - soft
+        - noatime
+      # Google FileStore IP
+      serverIP: 10.19.162.106
+      # Name of Google Filestore share
+      baseShareName: /homes/
+  jupyterhub:
+    proxy:
+      https:
+        enabled: false
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: true
+        add_staff_user_ids_of_type: "github"
+      homepage:
+        templateVars:
+          org:
+            name: M²LInES
+            url: https://m2lines.github.io/
+            logo_url: https://m2lines.github.io/images/newlogo.png
+          designed_by:
+            name: 2i2c
+            url: https://2i2c.org
+          operated_by:
+            name: 2i2c
+            url: https://2i2c.org
+          funded_by:
+            name: M²LInES
+            url: https://m2lines.github.io/
+    hub:
+      config:
+        Authenticator:
+          # This hub uses GitHub Teams auth and so we don't set
+          # allowed_users in order to not deny access to valid members of
+          # the listed teams. These people should have admin access though.
+          admin_users:
+            - rabernat
+            - johannag126
+        JupyterHub:
+          authenticator_class: github
+        GitHubOAuthenticator:
+          allowed_organizations:
+            - m2lines
+            - 2i2c-org:tech-team
+          scope:
+            - read:org
+    singleuser:
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.1c4d967ffc205f98"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/m2lines-pangeo-hub-push-access
+      # User image repo: https://github.com/pangeo-data/pangeo-docker-images
+      image:
+        name: pangeo/pangeo-notebook
+        tag: 2022.04.20
+      profileList:
+        # The mem-guarantees are here so k8s doesn't schedule other pods
+        # on these nodes. They need to be just under total allocatable
+        # RAM on a node, not total node capacity. Values calculated using
+        # https://learnk8s.io/kubernetes-instance-calculator
+        - display_name: "Small"
+          description: 5GB RAM, 2 CPUs
+          default: true
+          kubespawner_override:
+            mem_limit: 7G
+            mem_guarantee: 4.5G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-2
+        - display_name: Medium
+          description: 11GB RAM, 4 CPUs
+          kubespawner_override:
+            mem_limit: 15G
+            mem_guarantee: 11G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-4
+        - display_name: Large
+          description: 24GB RAM, 8 CPUs
+          kubespawner_override:
+            mem_limit: 30G
+            mem_guarantee: 24G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-8
+        - display_name: Huge
+          description: 52GB RAM, 16 CPUs
+          kubespawner_override:
+            mem_limit: 60G
+            mem_guarantee: 52G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-16
+      initContainers:
+        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
+        - name: volume-mount-ownership-fix
+          image: busybox
+          command:
+            [
+              "sh",
+              "-c",
+              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
+            ]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: home
+              mountPath: /home/jovyan
+              subPath: "{username}"
+dask-gateway:
+  gateway:
+    backend:
+      scheduler:
+        cores:
+          request: 0.8
+          limit: 1
+        memory:
+          request: 1G
+          limit: 2G

--- a/config/clusters/m2lines/enc-deployer-credentials.secret.json
+++ b/config/clusters/m2lines/enc-deployer-credentials.secret.json
@@ -1,0 +1,30 @@
+{
+    "type": "ENC[AES256_GCM,data:o5iQdCSx6He25YK21ns7,iv:E0ZhnliaqqUshq9opf5P64aZ2gleVh8GXvKDDonNujk=,tag:9OJtJ07C+wEQZd7fm0ST0Q==,type:str]",
+    "project_id": "ENC[AES256_GCM,data:TczySIGqSVzfBe8=,iv:WInieCMP4tNc+gQaC6ix9iLsoQsA84wYXZohP9nexHI=,tag:J1XqaqvV10AhNCUCFYDyFA==,type:str]",
+    "private_key_id": "ENC[AES256_GCM,data:6oXJKMXb2H67NL8lpROe8Vp2rjnRDlBSPuez5Co8GgxP1VLYCwgwlQ==,iv:THRIMoHw1nqnVAtsuMIOQmDYDgFLjkzj6E6sajHKEgI=,tag:4ps0IKMObNRYq5HwvbItUQ==,type:str]",
+    "private_key": "ENC[AES256_GCM,data:5uuZCAzX8yA0s+mOcKl261KVASzOJo2ivnmhFHJJv1jKRdf6JLBRnYRAYkVAfhMyF3+SAZdWUl8hEQKGdPZATl1PBF148hrJ9rHNEeVoi5vZJadGxzRVp2Kdu568OhTNdynb2feEc2GoXawtP6QeXn8t0yNhxGDbNckbZDZriHpv+nYTxN7ntL2HUjz15v99PN2gBvCgspWjVCk+tF6hAZfVlplKk6o6KO+UHJGO86B733LyzA+RRBm298Jsu3/71ZHmNB4nCD1CG3TVSVhx67Nel2tXWXSl2mu9E7yyhQl/JceSaikWzrxl/4a+9YyqqIhSJOdl37za7MCcJb0z7iydR3OAUr6DsjizxZfnXl/+3NXo9rbdg3ODbImFphhNXYbrzBwAtx8EFyZ+7Kv51SWgr0ImDpVY9DCjj0wUUjVVMN+PAJL94baAXQeY7YbS8dKmRcRwkFUNN0KQcSFLvtgyvP9rwzMumZ9Z/KVMHSJRIgBGWdsC+MJmr57uHU8yjId5A9hlq16M3eYjj5CThGasKx33+4YraRE98zlCbfBwqO1xS/TFcOxWtAsT5/phIrwb2H6gcD/CVme+5Rjra8RmFAV7fUeFKtVe36VYqVneUV7+3vIS67f7dnAKvMAoSyr0M752TEEy7KMIAIg87+vH+NPHBDjsWfFiOlVt0hhUTUc3oYoruUIQe2eHIsgOTyILleq7yoR2Z1Nhb3CHKMLRJAIOKLubjd4EtwSUoHxaPsil0/bAcOOKbj7yozxORb3n2H7J98wzvngfnJQqaNvsztQeOWcYOCQs2DChWJl7T2M5QXrJWx5OwVKb1EHvDfZPvziJ730F+3Hvirqe/X7NGgbts0QEMMAJyFPBDls2Gz191tUHs3Jbj5JXSk3nEAOtzQeHhLFGAJt8g5uE7iW0pE63J+w9WSJ6oFokUSks3X6lMd81rR5uG6RBvK9II5a0ReH9AbFRO58DW5htkFqKNaI0+Sfiw8NrKODIVP2lhkjnmf4lEc9sq+gAyPW0hzOHzCa6WDYqaqCAoVEa2+j1eKG1b/sXJEQpycwAoUXc2TJN01q3Noh4niMQvT/Zye3N6lKAA1h9hK+v+G8Z/fSgEj3YPzIaQsNjY78sJWqM/qQGNCZO6kLUm68jCRphxTlMKpvsQ2YUtvWPBYi0IFdkwPTi7p4c4vMigwwdBFtKFxpRkk3Yr++eE15s0dy/CIfn0x6XQHFIE5YTJ9YmNX1uz0/hEDzm02EYqWyrG3rjRffEm5duoXU+SDm3TaUU6lBFFa07QonQYCWVnll8HC0E8C93MS+KxwllH6ikYR8zoAOH7uVztZSpN7m+prgMqX1ZJLj55Qjr70mHczIVomTGRhq2zWyFCI0m+RD5oBRjwl0FQIQQ6BTlRqMDOMXgcRMnEiD91Am0sv6NArMMy/wlknc3FVgg6n9DMzyLUzSBQJEamK+ikOCA+DdJqbCojLynG5y5GbCs2YOyhRIUMRk8eAFiTe3Orp5/5xdFzCMps5/nlJp/qOYaUY5VjseAYBU3BKjmIL9N/UjSNhf4XAiQdlM5JMmBif+UdE5N3ueTdMITHt1I+RLGbtza0v0TN+YDt+Po/AwiiOQ3tUF14mLdhHDUJ1IbuUstdS64YSFmoc4rsimrpvMw35H/6dmLWbXSIF0zZ6fQF1jgrDOXjcvGBgi/jNbKGtyymDb+BgIy0TCL00cgFjpDeOPpdy9t6KT6LIpBpnaVAShyL9rtiFDo9Supb16tPjU9XEeWFLBu8yioKjw17Bztmtc4FUdAxvR3eEyPRJm4ALlaAUSg3OReyWoxk+F7771YH7Vw7xAfsyHusMp7qfuZNVDgMzf+4xzfQiQ/I2zYxjTtooOdqCBHqyXEKxgpSgsuJ1y18QpekMELS+FCf0JDm9xfz6Jnwb6KIJ9mf/4KJ21DY1nxVRJTny7yoUgcd9KY93UHpqVj3ZubiYqruCWonq/vjCcEC9IJvJZ7w5iQ9jcBbkTHmKS9hTrHmfrQ9+pdkO6F8rJjFhN5k2nOAb8jm900U/+5AVUdz8xbNBKmF0z9dRDmDHaQZJgDPuUkh7uRDMKQSiUj+87i8zhJL6eoUvCKhrGdmdfsOepTz/VC8p7xptTb3VRW+NWiioIlK2LmIos5I+T8TgBUTHzNy1SnYUxNpXuShFr4Ufh0rs4iGZ/r4XH23L6M3BTd0/0xi7hI8GYVhgGXS/sl7eiI/6yDuSSIEMF54oqHdN8A0S6oP0dMGuMpcumNRPBS9K8+,iv:rmRCtU6RXiGmIbzRKdWbR8VlvywMTWUOUOYeUVoVMf0=,tag:yKjot8ngY1zCks8wwvOLBA==,type:str]",
+    "client_email": "ENC[AES256_GCM,data:rNZeWQ9TZJNQrN+HvtAri0yStO4psHyugfY4Udj2RApHvbsJYdag6s1EneRhpfgevQ==,iv:M41Vif6C4LULpcnwV/mUIH3wglR4hn1WqSPq9JOFDSU=,tag:NBocOLmd/zCtSMfCXZa7qw==,type:str]",
+    "client_id": "ENC[AES256_GCM,data:ZLpz7dCUXyPYAqplnE4TsDsYFvsQ,iv:vWbNrO5NJmFpF/cQwBqSNabD+fXQ9GlC1tVTUr0DY48=,tag:nbJAs42l1lsbt7G0zGsNHg==,type:str]",
+    "auth_uri": "ENC[AES256_GCM,data:QUsRaNY7OI/nfX40y9E8RQwUP4rstYs5S5aa1Ww8At0PuZvq6+/yHX4=,iv:hd2taUTzkqFFwFGHmctKCzhiSWEOufk5h7j8BYOiM1I=,tag:5jHHLnLLMInfXVyTX0tqAA==,type:str]",
+    "token_uri": "ENC[AES256_GCM,data:v38JzbW8pcdCJin7x9AiBPJe9VIbmTAKBxcV4X6ynQQM2Eo=,iv:9unHaTCUTKomQ/mHUbPxsGBCbnRITTKcE+kGoirocOo=,tag:MOaF/MiAs7stD/SvKH5sKw==,type:str]",
+    "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:xJY3gpJ5Do8he83jdD1XEEw5NCFKuYwoowqxHAQhjK1HCeqPFsMGSMfZ,iv:DIt76K55ZJSuLg9ah6W5rgqPH69lnWOFSDGL71O0l+M=,tag:O5xZrZ+ikbQj3tGjUIMZZQ==,type:str]",
+    "client_x509_cert_url": "ENC[AES256_GCM,data:sTMP/Tf2VmfniajBjGoBvT2SMzeWc2tUw4QQ8Y2Bc8UMUBdrVokk6IeauPBot5ga/jY0fWBR3irM6lXYbT06r+qfVqk5L4drsRAxGCJEv6LzHH3S6dV1JR0uRT5Cq0gcfRzCKNI=,iv:iMy/S9w1kj1yF83xHcFVEQTMVWdPepDlwMfk67gV1Ak=,tag:iqHoN5vwQmLoj1Xg81jiYQ==,type:str]",
+    "sops": {
+        "kms": null,
+        "gcp_kms": [
+            {
+                "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+                "created_at": "2022-04-21T23:16:11Z",
+                "enc": "CiQA4OM7eIRc+FYllfAK9jLSSQVMq5i9FxVuaER+uYrLn2SpZZwSSQDm5XgWvHyssjFagiw6STl22unhlmm+R3PRWR3adhTZ2j83XmxQWXhrrqo0eaqiSoY/zEWYJWELzxbel6cyeK447XjHfvx61no="
+            }
+        ],
+        "azure_kv": null,
+        "hc_vault": null,
+        "age": null,
+        "lastmodified": "2022-04-21T23:16:11Z",
+        "mac": "ENC[AES256_GCM,data:hStmvkfpirqn+pTEeLRGAA9ssw1urXKLugDE3bfgVu7+TKl4VUm8XUlJer/khK3XmTxx6o464YFu7dGSr+ffEaGvsmq3n//gFpLV6lS/Pq49wNFXD6gWAaL3iDlAdKiaBgkl2a0KZ6TUji6aJgEWmV11k81vYsRMJHEjjC7PYvs=,iv:Ad8C9bTFdCcVkTI9yS3327+ZYWHaxC9fVC1v6a4YoYI=,tag:i1Vp3fw7r4sz95xkC3dNxw==,type:str]",
+        "pgp": null,
+        "unencrypted_suffix": "_unencrypted",
+        "version": "3.7.1"
+    }
+}

--- a/config/clusters/m2lines/enc-grafana-token.secret.yaml
+++ b/config/clusters/m2lines/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:bgcHk/eIfq4LebvAQu/OGKr9Rx19S5J/Bd2/6vtm0AitJ6scP4+xSAFgfnVk2FbXsMkwlikNHsx7ku8twSY8KIKccK9Uz/CthCDkx4595Q+poJ3sBMsVMbSu+AOUoH8eiiVtKQ==,iv:pja9XHxq/tVFTKfcpGIsjX1+oi1VzyGxUdTshPACN0E=,tag:4ttlyJTXbEI/JAB74WP6wQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-02-24T17:56:52Z"
+          enc: CiQA4OM7eA1jS3a2zwDnUXuczQfvJW5u9Zp3QHRgCZjXk1ha/P4SSQDm5XgWif8sOYLkjo9k+hTKISv4PddEGATlvRChHeNZREfg2nreeDYujK6tOdiXplp8Yzv+uWxnxxUvlYPbhvReCDgmuEKLGI0=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-22T00:29:20Z"
+    mac: ENC[AES256_GCM,data:Km6/OgHij/J346w5C+tTJrU0EQp28RFa6rV7E+pjxQ9wWW41Yk7KM508OUM4JMqrK0WUIvMuzqftJnweCBFZcgkp9TnqQpX9SMXQPxg+/1Iy1lC/5Xq9Vaym4r/u7E4BdIfR1EygHmdwu8qDO7ojgE72EU42ZZsdcJb5bKa3KVM=,iv:ZztTDiY7/fwySHjdEXBNwosUJVrr0GP4H1lifOBPleI=,tag:6sF6pYwZnvNUlups7k7H1w==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/m2lines/enc-prod.secret.values.yaml
+++ b/config/clusters/m2lines/enc-prod.secret.values.yaml
@@ -1,0 +1,21 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:9Ck6xNrjH6YXQibljjwV+Pl90QA=,iv:mqf/qY0uOJ1A640AIhetv8ztEQLMboD4nUz2ta7xia4=,tag:JgSJwIzbNIPoA93/mCwxdw==,type:str]
+                    client_secret: ENC[AES256_GCM,data:kjzpWRgVsXdt/KemCh4ZCnuo/4k342URs4T6CPoCVNh1pD3siiG69A==,iv:vjq3j9kXKY8WkdQ8flmcM687Qdwln3VioKMphwDAMHw=,tag:PMNXUkgjjBtbroketamPiQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-02-24T18:31:21Z"
+          enc: CiQA4OM7eNU4/NC1GSyOypie5mku2r/szfsjQHdxf5CkEib8PWISSQDm5XgWPd3+MJEgP6vyMdkr+5xZCc0MbF1aoNtwLVU/Z9PKOZsw2UgcoYIAHxpoMCm9aC2mS+qZJyq7N5GnR0xxIc3cGMNybVo=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-21T23:43:03Z"
+    mac: ENC[AES256_GCM,data:o5+2PJDg7QXH0BkoTfA5Wp/DSp9eEqL1od922Eo0zlzU0CEJiixC8Zk7UJa4U3crrJh8PgsuMFcitSgKrLk2neNz0TzT0R5e4Xnh+/KVn4VCf9gfn/nqRKEqou3mRyuECOSad9oeRBv5uLxJb065Vk4lV8VoonhYATCkT3GnpdE=,iv:eb43lzrERBGakB4gJycc+bINdoM/Pw5ndt0MnbyjfHA=,tag:4ovUvHdIlUS/oeATqpkHtQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/m2lines/enc-staging.secret.values.yaml
+++ b/config/clusters/m2lines/enc-staging.secret.values.yaml
@@ -1,0 +1,21 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:Zq5gIGURTn520LKB2or6ms9wEYc=,iv:Mj3a6EeQm0KM0/9/sfIB9LiNf40sIR+kteT37LowVGk=,tag:GSjAGvtj8as6Ho+mlElfZg==,type:str]
+                    client_secret: ENC[AES256_GCM,data:N8ffgXc1JuEnPGdP8tL5iYW2RYclgrLyPmf+ndvm2eNTGK16MUpwKQ==,iv://0l/GqTLZ+wxHyltwb+a66eumTfFveSUJHwSF+g05Y=,tag:n1y/ZHKTrJRRmaD8RW1S8A==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-02-24T18:04:17Z"
+          enc: CiQA4OM7eP6diuWK5cq1WJfLBHrUaMLetApVQYdQJjlOFUKSsHASSQDm5XgW8L7w2ZN+LPLHBMIcfpO6YIBeajtpkKFnTdpRgbhgR7+fb9p4HHT8z3H1U7nwKuOaQPtsXj2e8ZPjWr/2tqy6ramzlhU=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-21T23:29:26Z"
+    mac: ENC[AES256_GCM,data:IJK1wZfjVSgOrcOYC88vSN1lxc/zgQZwzJc/1p5kQyU8HamzOzX76SCFTgA6dv+uNQWZC6rfekrRHIh9fZGBf5X5+gaFnlQREFj0UDJOLSxUtZQo/a1sJezkzI9nB4gv4WJylGbjKBo7p0QLN67vXeJQwBspFGaP2n3y+BGXlaE=,iv:Jtl42eYBWDmeSLCDMTx3Ml03pLTYnlGGS6wYVXate0A=,tag:7UbZe/23JrqhoiMdBgmizw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/m2lines/enc-support.secret.values.yaml
+++ b/config/clusters/m2lines/enc-support.secret.values.yaml
@@ -1,0 +1,17 @@
+prometheusIngressAuthSecret:
+    username: ENC[AES256_GCM,data:Gs9mrGaLFU6hsYF8/wwpODWAt8xpcEu/heuDkneWhqiL47KISnLGBVOL6BsuljKKREJxuXOSwU8YTI/DPzUQ2w==,iv:0MVlwiPlxxRW4FLobzwaclFASLIfhuAolyjWkT6ytcs=,tag:xhC0iH+Gf+3E/ISk1D88aA==,type:str]
+    password: ENC[AES256_GCM,data:xQPRntL+XM1w6s41zFu3QKvrPGUV+egeJfqdHiqV8Ps18ebvWEYevUyt8fuujtmlEt9EJOqKoy7UrbaptmF2jA==,iv:HJLjntlpEGUiHKXsbfPPd42GJ/FBOnaO7nI3Ac1PnDs=,tag:2dveWGpIs0u9cfGp/at+Iw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-03-14T20:52:45Z"
+          enc: CiQA4OM7eJtxMekwe8M2xF3+DD4ZunAeBVpTJD9wg1PKaJEy7kASSQDm5XgWsVdfRQVoQaTbAptAhyIRxdJKiLlAOxNTfUwsLXxRC30PYheM5d5nBv5Ah5e0xtxAdMrYEnJvwtUy7d6Ugek02bncmfg=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-21T23:32:50Z"
+    mac: ENC[AES256_GCM,data:s96EB617sgeDleLEQeCMTttKe06aMsE3IrvCYJAhf4hMGW4fdAovnZOSdSZ2p1oAQWnU8byblkhcRotPCd30GNZvtzIf6thYb2ZoH4o5Pnt9dEsVmgpVQvMLgZMrDO8Z8QCOalnw1nyUfWQIyta9GMbFEy71+op7tq0D9CgVmJ4=,iv:7+DHiE/smIR6aPCgnpsNsxSNFBaDjPQJ9EQA6xqagdA=,tag:EHfY6OE9itzpqdF0goNfVg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -1,0 +1,12 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: m2lines-prod@m2lines-hub.iam.gserviceaccount.com
+  jupyterhub:
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: gcs://m2lines-scratch/$(JUPYTERHUB_USER)
+    hub:
+      config:
+        GitHubOAuthenticator:
+          oauth_callback_url: https://m2lines.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/m2lines/staging.values.yaml
+++ b/config/clusters/m2lines/staging.values.yaml
@@ -1,0 +1,12 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: m2lines-staging@m2lines-hub.iam.gserviceaccount.com
+  jupyterhub:
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: gcs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
+    hub:
+      config:
+        GitHubOAuthenticator:
+          oauth_callback_url: https://staging.m2lines.2i2c.cloud

--- a/config/clusters/m2lines/support.values.yaml
+++ b/config/clusters/m2lines/support.values.yaml
@@ -1,0 +1,26 @@
+grafana:
+  ingress:
+    hosts:
+      - grafana.m2lines.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.m2lines.2i2c.cloud
+
+prometheusIngressAuthSecret:
+  enabled: true
+
+prometheus:
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - prometheus.m2lines.2i2c.cloud
+      tls:
+        - secretName: prometheus-tls
+          hosts:
+            - prometheus.m2lines.2i2c.cloud
+    resources:
+      limits:
+        cpu: 2
+        memory: 12Gi

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -1,0 +1,83 @@
+prefix                 = "m2lines"
+project_id             = "m2lines-hub"
+core_node_machine_type = "n1-highmem-4"
+
+enable_network_policy  = true
+
+
+# Setup a filestore for in-cluster NFS
+enable_filestore = true
+filestore_capacity_gb = 2048
+
+user_buckets = [
+  "scratch",
+  "scratch-staging"
+]
+
+# Setup notebook node pools
+notebook_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-2",
+    labels: {}
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-4",
+    labels: {}
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {}
+  },
+  "huge" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+}
+
+dask_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-2",
+    labels: {}
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-4",
+    labels: {}
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {}
+  },
+  "huge" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+}
+
+hub_cloud_permissions = {
+  "staging" : {
+    requestor_pays : true,
+    bucket_admin_access: ["scratch-staging"],
+    hub_namespace: "staging"
+  },
+  "prod" : {
+    requestor_pays : true,
+    bucket_admin_access: ["scratch"],
+    hub_namespace: "prod"
+  },
+}


### PR DESCRIPTION
Features enabled:
- GitHub Auth, anyone part of https://github.com/m2lines org can
  log in
- Dask-gateway is enabled
- gh-scoped-creds (https://github.com/yuvipanda/gh-scoped-creds/) is
  enabled for secure pushing to GitHub
- Scratch GCS storage bucket is available, accessed via the
  SCRATCH_BUCKET environment variable

Ref https://github.com/2i2c-org/infrastructure/issues/1168