### PR TITLE
Check filter-generate-jobs job completed successfully before trying to run upgrade-prod-hubs job

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -248,7 +248,11 @@ jobs:
     # Only run this job on pushes to the default branch and when the `generate-jobs` job output is not
     # an empty list
     #
+    # always() is added as it seems to be a magic function to ensure a job can
+    # run at all without being skipped if a previous job has had any failures.
+    #
     if: |
+      always() &&
       (github.event_name == 'push' && contains(github.ref, 'master')) &&
       needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs != '[]'
     strategy:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -248,11 +248,7 @@ jobs:
     # Only run this job on pushes to the default branch and when the `generate-jobs` job output is not
     # an empty list
     #
-    # always() is added as it seems to be a magic function to ensure a job can
-    # run at all without being skipped if a previous job has had any failures.
-    #
     if: |
-      always() &&
       (github.event_name == 'push' && contains(github.ref, 'master')) &&
       needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs != '[]'
     strategy:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -205,7 +205,7 @@ jobs:
     #
     # always() is added as it seems to be a magic function to ensure a job can
     # run at all without being skipped if a previous job has had any failures.
-    #
+    # https://docs.github.com/en/actions/learn-github-actions/expressions#always
     if: |
       always() &&
       (github.event_name == 'push' && contains(github.ref, 'master')) &&
@@ -249,10 +249,12 @@ jobs:
     # an empty list
     #
     # always() is added as it seems to be a magic function to ensure a job can
-    # run at all without being skipped if a previous job has had any failures.
-    #
+    # run at all without being skipped if a previous job has had any failures. By
+    # using always() we need to ensure filter-generate-jobs wasn't skipped or
+    # failed explicitly now though.
+    # https://docs.github.com/en/actions/learn-github-actions/expressions#always
     if: |
-      always() &&
+      always() && needs.filter-generate-jobs.result == 'success' &&
       (github.event_name == 'push' && contains(github.ref, 'master')) &&
       needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs != '[]'
     strategy:


### PR DESCRIPTION
Adds a statement to check that the `filter-generate-jobs` job completed successfully before trying to execute `upgrade-prod-hubs` job. This should prevent the job always trying to run, even with invalid input.

fixes https://github.com/2i2c-org/infrastructure/issues/1233