### PR TITLE
Fix links in docs

### DIFF
--- a/docs/howto/k8s/index.md
+++ b/docs/howto/k8s/index.md
@@ -12,7 +12,7 @@ See the following section for instructions on how to do so.
 ```{toctree}
 :maxdepth: 2
 
-cmd-access.md
+/topic/cloud-auth
 ```
 
 ## Common operations with Kubernetes

--- a/docs/howto/operate/index.md
+++ b/docs/howto/operate/index.md
@@ -1,0 +1,11 @@
+# Setup cloud Kubernetes infrastructure
+
+These guides go through the steps to create a new Kubernetes cluster on any of our supported cloud providers and make the cluster ready to host a hub by installing our periphery infrastructre.
+
+```{toctree}
+:maxdepth: 2
+new-cluster/index.md
+grafana.md
+manual-nfs-setup.md
+override-domain.md
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ How-To guides answer the question 'How do I...?' for a lot of topics.
 ```{toctree}
 :maxdepth: 2
 :caption: How-to guides
+howto/operate/index.md
 howto/hubs/index.md
 howto/features/index
 howto/k8s/index.md


### PR DESCRIPTION
This PR fixes a few failures in our linkcheck test relating to references to docs that don't exist anymore or docs that are not referenced in any toctree.