### PR TITLE
Move m2lines & LEAP hubs to regional  HA clusters

### DIFF
--- a/config/clusters/leap/cluster.yaml
+++ b/config/clusters/leap/cluster.yaml
@@ -4,7 +4,7 @@ gcp:
   key: enc-deployer-credentials.secret.json
   project: leap-pangeo
   cluster: leap-cluster
-  zone: us-central1-c
+  zone: us-central1
 support:
   helm_chart_values_files:
     - support.values.yaml

--- a/config/clusters/leap/enc-grafana-token.secret.yaml
+++ b/config/clusters/leap/enc-grafana-token.secret.yaml
@@ -1,4 +1,4 @@
-grafana_token: ENC[AES256_GCM,data:PBK+VcnU3cq2cVa7nZwJyVdWWwkcsxslGKiH1nhxBpgFEKC8iylsxhEZb5c89Hy15tFxZ4qNfCOZ4ztwrIVsCQ==,iv:Y+KqfLhpJvgYBw/6IP9Rg3w+qbnS1amvBf2QgFvPx/U=,tag:owkBbmy0W6bUbqtIJepOqg==,type:str]
+grafana_token: ENC[AES256_GCM,data:TdtLCpPMp7DTTSAM8kzztUA3YHMeQnJWi/GgEWjEVmGpQ3gOnC+YwaStRl4YO3Rbw+JZS4R5KZ4sPD5ySV6wH2oR9ofWws6UDgUdKt6WEJHfoMSDQ4tvl01IF9s=,iv:U65xojfHZrRbE7ieWmXE5kmEHbxHJW9sMLsOXisD5Tw=,tag:5kZ85mkKiOnsHqIMKCs1ow==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -8,8 +8,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-09T09:29:33Z"
-    mac: ENC[AES256_GCM,data:ymz/1FyIv7KwvB46+NBBEsDLncBSh1b5NNxRrAxgIq7leOWBjHWkrh7kwWBGc5i2dIHsZ39VhG/AHZLZtXlp0ef9+JZyHUcejCLl2aOSbNB+6CqPLLh1ps63bUQYiKB7D7hec//hRMAu+CyT9UHYJkhj4jHT+hMtRgou800LcWA=,iv:6qzJEV9ktMy7jLoHDeAKFjh2CkGgMq7Go6P7+/3NFOo=,tag:s/xCYa0ttNl4yOJDGTy53g==,type:str]
+    lastmodified: "2022-04-27T03:05:10Z"
+    mac: ENC[AES256_GCM,data:Ms0CQX6EOxTJ7I9O2kn6V6Ammp4ksO9nb9UOzhkQlWMnCvAGXD2daXMFMZRQrJBveWwInYBcYqQ4sWnjQMg+nsrFtoDStJuqGELjnK0NSYCqYyetltszK+90iXV3+qCUtibW5j9WwiCl0AAHm7r1Sv2dmXC8uyiywTp0PqSd1M4=,iv:DBvhzKR9k8WsNDWVNziI2W/4G6WUdq9KoiPF8xEsAY8=,tag:QAvwc6YP2/Ty0yNwvvlWeQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1

--- a/config/clusters/m2lines/cluster.yaml
+++ b/config/clusters/m2lines/cluster.yaml
@@ -4,7 +4,7 @@ gcp:
   key: enc-deployer-credentials.secret.json
   project: m2lines-hub
   cluster: m2lines-cluster
-  zone: us-central1-c
+  zone: us-central1
 support:
   helm_chart_values_files:
     - support.values.yaml

--- a/config/clusters/m2lines/enc-grafana-token.secret.yaml
+++ b/config/clusters/m2lines/enc-grafana-token.secret.yaml
@@ -1,4 +1,4 @@
-grafana_token: ENC[AES256_GCM,data:ZCwk0ThIzasqnKQZse6tHu/RG9uZL0K5KaBDwsfuLlsZN5Re45r3HsOgapJPUxA0AjKeCy6GhTKWH0oTt/Wfg0iZke33zse2e4SQPmxh8+lChDUCmC6R/O2Xp2tJNyx+Qxn8oA==,iv:b55EERUJpliTvXT4J6AN/OxuFzhWSfWZ5jDRMFOXoPI=,tag:IT/kMCJ/tZ3gvVDqOfI6JQ==,type:str]
+grafana_token: ENC[AES256_GCM,data:B+I4E9LVyDCl/zBARp0/Vqo5XjyOyAUGXNvi30BBukzVYMzIjE1+6zn4o9hKF/9caqzlLZkQDqmEGNI/hnYp/IGIichcc9OjD+ucmOXz3a2QJ9GnNAjFD6hcQzU=,iv:NpkxkeYdJuX4jsSRHb8X15iE76YGGMq3cDSLRbSyZFg=,tag:XnQSeCvOb1riP1LsQ6qzGA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -8,8 +8,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-04-26T07:14:27Z"
-    mac: ENC[AES256_GCM,data:w/ccFyx+QBVy9Y8W+GLk5p+Vu8gSqTYBwhoE/dmhzeIkhAut6m6ntS2KFGgxNSlmPvbsOcl5ODPTvWhTxjIRBA0PdGBX3ZIhp5HvnXR4AOOmeM10BYLNje8JurGPqVFPBaOq2EkDtDuON5vyWTfirOwePDRAIQmBkXCzA4n94Tc=,iv:sS99I6UJycqJKoriWTCBTnR3A1GtfTVuyrZ/VIWVnjs=,tag:ymCfO/l599WXGmfsMOOwww==,type:str]
+    lastmodified: "2022-04-27T03:43:54Z"
+    mac: ENC[AES256_GCM,data:/WJ6emgXCBFjqJadi7sXgXJGCUgWv3eBEbnzYss9AM3Aws4gnUJ5Se6XobB8ep+Nt6/KCTYnUaSHFX0HGi1J8lyl1WCYsN0OKBQfSPt5ABJ4qI3A6JifOnlf/7EB3Z6TSGCnJ+4s6bupSejRRi54rsOiDnmD8wt99WFMv/IMnYs=,iv:QedXp+0WKPYfSX0MpHL1QLAF5LTtBEorD9efZlcjheY=,tag:8f3iJm6wH/M+pjlTSc5rGQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1

--- a/docs/howto/operate/new-cluster/new-cluster.md
+++ b/docs/howto/operate/new-cluster/new-cluster.md
@@ -46,8 +46,11 @@ See the [variables file](https://github.com/2i2c-org/infrastructure/tree/HEAD/te
 Example `.tfvars` file:
 
 ```
-prefix     = "my-awesome-project"
-project_id = "my-awesome-project-id
+prefix           = "my-awesome-project"
+project_id       = "my-awesome-project-id
+zone             = "us-central1-c"
+region           = "us-central1"
+regional_cluster = true
 ```
 ````
 

--- a/docs/howto/operate/new-cluster/new-cluster.md
+++ b/docs/howto/operate/new-cluster/new-cluster.md
@@ -30,6 +30,15 @@ The _minimum_ inputs this file requires are:
   Primary identifier to 'group' together resources.
 - `project_id`: GCP Project ID to create resources in.
   Should be the id, rather than display name of the project.
+- `regional_cluster`: Set to true to provision a [GKE Regional
+  Highly Available cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters).
+  Costs ~70$ a month, but worth it for the added reliability for most
+  cases except when cost saving is an absolute requirement.
+- `zone`: Zone where cluster nodes and filestore for home directory
+  are created.
+- `region`: Region where cluster master (if `regional_cluster` is
+  `true`) is run, as well as any storage buckets created with
+  `user_buckets`.
 
 See the [variables file](https://github.com/2i2c-org/infrastructure/tree/HEAD/terraform/gcp/variables.tf) for other inputs this file can take and their descriptions.
 

--- a/docs/howto/operate/new-cluster/new-cluster.md
+++ b/docs/howto/operate/new-cluster/new-cluster.md
@@ -33,7 +33,8 @@ The _minimum_ inputs this file requires are:
 - `regional_cluster`: Set to true to provision a [GKE Regional
   Highly Available cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters).
   Costs ~70$ a month, but worth it for the added reliability for most
-  cases except when cost saving is an absolute requirement.
+  cases except when cost saving is an absolute requirement. Defaults
+  to `true`.
 - `zone`: Zone where cluster nodes and filestore for home directory
   are created.
 - `region`: Region where cluster master (if `regional_cluster` is

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -24,9 +24,10 @@ resource "google_container_cluster" "cluster" {
   # Setting cluster autoscaling profile is in google-beta
   provider = google-beta
 
-  name     = "${var.prefix}-cluster"
-  location = var.zone
-  project  = var.project_id
+  name           = "${var.prefix}-cluster"
+  location       = var.regional_cluster ? var.region : var.zone
+  node_locations = [var.zone]
+  project        = var.project_id
 
   initial_node_count       = 1
   remove_default_node_pool = true

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -6,6 +6,8 @@ core_node_machine_type = "n1-highmem-4"
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy    = true
 
+regional_cluster = false
+
 # No plans to provide storage buckets to users on this hub, so no need to deploy
 # config connector
 config_connector_enabled = false

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -7,6 +7,8 @@ enable_private_cluster = false
 
 # GPUs not available in us-central1-b
 zone = "us-central1-c"
+region = "us-central1"
+regional_cluster = true
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy  = true

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -6,6 +6,8 @@ enable_network_policy  = true
 
 # GPUs not available in us-central1-b
 zone = "us-central1-c"
+region = "us-central1"
+regional_cluster = true
 
 # Setup a filestore for in-cluster NFS
 enable_filestore = true

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -15,6 +15,7 @@ core_node_machine_type = "g1-small"
 # Single-tenant cluster, network policy not needed
 enable_network_policy    = false
 
+regional_cluster = false
 
 notebook_nodes = {
   "small" : {

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -13,6 +13,8 @@ config_connector_enabled = false
 enable_filestore = true
 filestore_capacity_gb = 2048
 
+regional_cluster = false
+
 user_buckets = [
   "scratch",
   "scratch-staging"

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -6,6 +6,8 @@ core_node_machine_type = "n1-highmem-4"
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy    = true
 
+regional_cluster = false
+
 # Some hubs want a storage bucket, so we need to have config connector enabled
 config_connector_enabled = true
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -90,7 +90,7 @@ variable "region" {
 
 variable "regional_cluster" {
   type        = bool
-  default     = false
+  default     = true
   description = <<-EOT
   Enable to have a highly available cluster with multi zonal masters
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -88,6 +88,22 @@ variable "region" {
 
 }
 
+variable "regional_cluster" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable to have a highly available cluster with multi zonal masters
+
+  These are more reliable, as otherwise the k8s API might have small
+  outages now and then - with this set to false, the nodes serving
+  the k8s API can go down periodically for upgrades.
+
+  See https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters
+  for more information
+  EOT
+}
+
+
 variable "zone" {
   type        = string
   default     = "us-central1-b"


### PR DESCRIPTION
These are less prone to k8s API failures, like those reported in https://github.com/2i2c-org/infrastructure/issues/1248

We now default to provisioning regional HA clusters - these cost ~70$ a month,
but I think the added reliability is worth it

Ref https://github.com/2i2c-org/infrastructure/issues/1102