### PR TITLE
Add config for a dummy hub with GitHub Teams auth

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -166,3 +166,11 @@ hubs:
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
       - utexas.values.yaml
+  - name: dummy
+    domain: dummy.2i2c.cloud
+    helm_chart: basehub
+    auth0:
+      connection: false
+    helm_chart_values_files:
+      - dummy.values.yaml
+      - enc-dummy.secret.values.yaml

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -167,7 +167,7 @@ hubs:
       # that you intend for these files to be applied in this order.
       - utexas.values.yaml
   - name: dummy
-    domain: dummy.2i2c.cloud
+    domain: dummy.hub.2i2c.cloud
     helm_chart: basehub
     auth0:
       enabled: false

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -170,7 +170,7 @@ hubs:
     domain: dummy.2i2c.cloud
     helm_chart: basehub
     auth0:
-      connection: false
+      enabled: false
     helm_chart_values_files:
       - dummy.values.yaml
       - enc-dummy.secret.values.yaml

--- a/config/clusters/2i2c/dummy.values.yaml
+++ b/config/clusters/2i2c/dummy.values.yaml
@@ -11,3 +11,19 @@ jupyterhub:
           - 2i2c-org:test-team
         scope:
           - read:org
+  custom:
+    homepage:
+      templateVars:
+        org:
+          name: Dummy
+          url: https://2i2c.org
+          logo_url: "https://raw.githubusercontent.com/pangeo-data/pangeo/master/docs/_static/pangeo_simple_logo.svg"
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: NSF EarthCube Program (Award ICER-2026932)
+          url: "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2026932"

--- a/config/clusters/2i2c/dummy.values.yaml
+++ b/config/clusters/2i2c/dummy.values.yaml
@@ -1,0 +1,13 @@
+jupyterhub:
+  hub:
+    config:
+      Authenticator:
+        admin_users:
+          - sgibson91
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        allowed_organizations:
+          - 2i2c-org:test-team
+        scope:
+          - read:org

--- a/config/clusters/2i2c/enc-dummy.secret.values.yaml
+++ b/config/clusters/2i2c/enc-dummy.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:NUw23dD+x1qjm3oPdSIUevgTKCo=,iv:KJvGqYVLc/9Ph3BAR54DqMX60cE6vPPGyvfquhGl/rs=,tag:a/4gKYVgzEhGmaWaAjkigg==,type:str]
+                client_secret: ENC[AES256_GCM,data:acqV0bkokVcxaowiqvh7fDf9neoXuUwkO9nJPcZwTmv1ham9a+7cdg==,iv:sN4A8eGPe5SrLU3qVrarKp0SdhDirS7nj6pHf7wFiew=,tag:/whKttpBJulA9P915+qjww==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-04-28T09:25:54Z"
+          enc: CiQA4OM7eAEnZ9aAf4+zU5sCCHM6S/KGORYW7Qb+NGQzqZWOokYSSQDm5XgWLK/8UqrXmqHNsvrFkCUfuFOVt4bJGGbaBL6ZvdenO9Ju9rB2elok8FWsF9QK5LPoVJ3R1QRd9KnVC1rwABubzkS8d3A=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-28T09:25:58Z"
+    mac: ENC[AES256_GCM,data:ZojGmFFeT5178mRUFWya8QrqzIH0BxPrK1qV/ZPFwwre6YBcaJgDwi4afl9jgkSDfIrVvaLPVIqMMdalVUsTWH7hKRMaYH73OIMd0SFElOAuRWIWYGvEPZzuJDJ73cns9CzaMq1xwrjOIR9Ibt+o3tzbrGp0YvIyCPW5Zl6tBTY=,iv:9KkNoTVeCMz37jOyTAdXgmcfADMcZyTXDTxKRhqGz10=,tag:2xPzbfKT4ZiLKlk9SG8tSg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1


### PR DESCRIPTION
This PR is adding a dummy hub for me to test GitHub Teams auth against as requested in https://github.com/2i2c-org/infrastructure/issues/1222

This PR shouldn't be merged, it's just here to provide a quick reference to the config that I am using for debugging.