### PR TITLE
Resize utexas postgres volumes to be 10G

### DIFF
--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -47,6 +47,8 @@ jupyterhub:
             )
 
         # 1Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
+        # This size can be increased, and users will get the newer sized disk when they start
+        # their servers next - https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims
         make_db_pvc = partial(make_extra_pvc, 'postgres-storage', 'postgres-{username}', 'standard-rwo', '10Gi')
 
         async def ensure_db_pvc(spawner):

--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -46,8 +46,8 @@ jupyterhub:
                 annotations=annotations
             )
 
-        # 1Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
-        make_db_pvc = partial(make_extra_pvc, 'postgres-storage', 'postgres-{username}', 'standard-rwo', '1Gi')
+        # 10Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
+        make_db_pvc = partial(make_extra_pvc, 'postgres-storage', 'postgres-{username}', 'standard-rwo', '10Gi')
 
         async def ensure_db_pvc(spawner):
             """"

--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -46,7 +46,7 @@ jupyterhub:
                 annotations=annotations
             )
 
-        # 10Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
+        # 1Gi seems the smallest PVC you can make - anything smaller than that is rounded up to 1Gi
         make_db_pvc = partial(make_extra_pvc, 'postgres-storage', 'postgres-{username}', 'standard-rwo', '10Gi')
 
         async def ensure_db_pvc(spawner):


### PR DESCRIPTION
k8s should dynamically resize the volumes the next time
the user starts their server

Fixes https://github.com/2i2c-org/infrastructure/issues/1261