### PR TITLE
Bump dask gateway

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -118,7 +118,8 @@ basehub:
       readinessProbe:
         enabled: false
 dask-gateway:
-  extraConfig:
-    idle: |
-      # timeout after 30 minutes of inactivity
-      c.KubeClusterConfig.idle_timeout = 1800
+  gateway:
+    extraConfig:
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -120,7 +120,8 @@ basehub:
           # Without this, any GitHub user can authenticate
           allowed_users: *users
 dask-gateway:
-  extraConfig:
-    idle: |
-      # timeout after 30 minutes of inactivity
-      c.KubeClusterConfig.idle_timeout = 1800
+  gateway:
+    extraConfig:
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/uwhackweeks/common.values.yaml
+++ b/config/clusters/uwhackweeks/common.values.yaml
@@ -126,7 +126,8 @@ basehub:
           admin_users:
             - scottyhq
 dask-gateway:
-  extraConfig:
-    idle: |
-      # timeout after 30 minutes of inactivity
-      c.KubeClusterConfig.idle_timeout = 1800
+  gateway:
+    extraConfig:
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800

--- a/helm-charts/daskhub/Chart.yaml
+++ b/helm-charts/daskhub/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: "0.1.0"
     repository: file://../basehub
   - name: dask-gateway
-    version: "0.9.0"
-    repository: "https://dask.org/dask-gateway-helm-repo/"
+    version: "2022.4.0"
+    repository: "https://helm.dask.org/"


### PR DESCRIPTION
This bumps the version of `dask-gateway` to `2022.4.0` and updates the config of a few hubs, thanks to dask-gateway schema validator that caught some misconfigurations we had.

- [ ] Still need to do the manual steps described in https://gateway.dask.org/changelog.html before merging

Closes https://github.com/2i2c-org/infrastructure/issues/1224