### PR TITLE
Update CI triggers to be more robust than **.yaml

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -7,8 +7,9 @@ on:
     paths:
       - deployer/**
       - requirements.txt
+      - helm-charts/**
+      - config/clusters/**
       - .github/actions/setup-deploy/**
-      - "**.yaml"
 
 jobs:
   # In order to comment on a Pull Request, we need its number. But because we do not

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -8,7 +8,8 @@ on:
       - deployer/**
       - requirements.txt
       - .github/actions/setup-deploy/**
-      - "**.yaml"
+      - helm-charts/**
+      - config/clusters/**
       # We no longer trigger on this file since it does not contain any logic
       # concerning setting up the clusters for deploy. This now all lives in the
       # setup-deploy local action


### PR DESCRIPTION
We wanted to exclude full scale redeployments if Our GitHub Actions workflows files changed, but the `**.yaml` path actually included these. I've updated the path triggers to only include `config/clusters/**` and `helm-charts/**` since changes on these paths should trigger large scale redeployments.