### PR TITLE
Don't set node_locations for zonal clusters

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -26,7 +26,7 @@ resource "google_container_cluster" "cluster" {
 
   name           = "${var.prefix}-cluster"
   location       = var.regional_cluster ? var.region : var.zone
-  node_locations = [var.zone]
+  node_locations = var.regional_cluster ? [var.zone] : null
   project        = var.project_id
 
   initial_node_count       = 1


### PR DESCRIPTION
Without this, terraform apply fails with:

> for multi-zonal clusters, node_locations should not contain the primary 'zone'