### PR TITLE
Set GPU config for all terraform workspaces

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -18,6 +18,11 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-highmem-4",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 }
 
@@ -27,6 +32,11 @@ dask_nodes = {
     max : 100,
     machine_type : "n1-highmem-4",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 }
 

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -23,30 +23,55 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-standard-2",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "medium" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-8",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-16",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "very-large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-32",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "huge" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-64",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 
 }
@@ -57,30 +82,55 @@ dask_nodes = {
     max : 20,
     machine_type : "n1-standard-2",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "medium" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-8",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-16",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "very-large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-32",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "huge" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-64",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 
 }

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -27,18 +27,33 @@ notebook_nodes = {
     max : 100,
     machine_type : "n1-standard-4",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 }
 
@@ -48,18 +63,33 @@ dask_nodes = {
     max : 100,
     machine_type : "n1-standard-4",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
     labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 }
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -17,6 +17,11 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-highmem-4",
     labels: { },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   },
 }
 
@@ -25,7 +30,12 @@ dask_nodes = {
     min : 0,
     max : 100,
     machine_type : "n1-highmem-4",
-    labels: { }
+    labels: { },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   }
 }
 


### PR DESCRIPTION
- Since we don't use terraform nested defaults, we have to explicitly say
   'no gpu' for all nodes that don't have a GPU - otherwise terraform apply won't work
- Explicitly set GPU taint for GPU nodes, as terraform otherwise sets this implicitly, freaks
  out on each `apply` and wants to recreate the entire nodepool