### PR TITLE
Block auth for test user

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -251,6 +251,10 @@ jupyterhub:
                 matchLabels:
                   app.kubernetes.io/component: traefik
   hub:
+    config:
+      Authenticator:
+        blocked_users:
+          - deployment-service-check
     extraFiles:
       configurator-schema-default:
         mountPath: /usr/local/etc/jupyterhub-configurator/00-default.schema.json

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -253,6 +253,10 @@ jupyterhub:
   hub:
     config:
       Authenticator:
+        # Don't allow test username to login into the hub
+        # The test service will still be able to create this hub username
+        # and start their server.
+        # Ref: https://github.com/2i2c-org/meta/issues/321
         blocked_users:
           - deployment-service-check
     extraFiles:


### PR DESCRIPTION
- fixes https://github.com/2i2c-org/meta/issues/321
- adds the test username to the list of users that are not allowed to login using the authentication flow
- the test hub service can still create this user, and start a server for it
- I have checked how this will behave for `username_pattern` and `blocked_users` takes priority over `username_pattern` in the auth flow, and it works as expected
- we're blocking this username for all hubs, no matter the authenticator used, since it doesn't hurt, simplifies the implementation, and it will be useful if we ever want to do domain stripping for the hubs using the email claim

