### PR TITLE
Set PANGEO_SCRATCH for leap and m2lines hubs

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -56,9 +56,6 @@ basehub:
         name: pangeo/pangeo-notebook
         tag: 2022.04.20
       extraEnv:
-        # This bucket is created by terraform
-        SCRATCH_BUCKET: "gs://leap-pangeo-scratch/$(JUPYTERHUB_USER)"
-        PANGEO_SCRATCH: "gs://leap-pangeo-scratch/$(JUPYTERHUB_USER)"
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
       profileList:

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -6,6 +6,7 @@ basehub:
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gcs://leap-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://leap-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -6,6 +6,7 @@ basehub:
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gcs://leap-scratch-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://leap-scratch-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -6,6 +6,7 @@ basehub:
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gcs://m2lines-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://m2lines-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/staging.values.yaml
+++ b/config/clusters/m2lines/staging.values.yaml
@@ -6,6 +6,7 @@ basehub:
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gcs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:


### PR DESCRIPTION
While we consider PANGEO_SCRATCH deprecated, it's still
set in the upstream Pangeo images
(https://github.com/pangeo-data/pangeo-docker-images/blob/1939869ce8e3b3accb65a0fdf40ec7eedc7f7235/pytorch-notebook/start#L6
and similar), so let's keep it for now.

This commit removes the setup in common.yaml for leap, as
staging and prod have separate scratch buckets

Fixes https://github.com/2i2c-org/infrastructure/issues/1295