### PR TITLE
Use location instead of zone for filestore

### DIFF
--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -1,9 +1,9 @@
 resource "google_filestore_instance" "homedirs" {
 
-  name    = "${var.prefix}-homedirs"
-  zone    = var.zone
-  tier    = var.filestore_tier
-  project = var.project_id
+  name     = "${var.prefix}-homedirs"
+  location = var.zone
+  tier     = var.filestore_tier
+  project  = var.project_id
 
   count = var.enable_filestore ? 1 : 0
 


### PR DESCRIPTION
Removes this deprecation warning:

╷
│ Warning: Argument is deprecated
│
│   with google_filestore_instance.homedirs,
│   on storage.tf line 4, in resource "google_filestore_instance" "homedirs":
│    4:   zone    = var.zone
│
│ Deprecated in favor of location.