### PR TITLE
Use OAuthenticator from upstream

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ topic/cloud-auth.md
 topic/features.md
 topic/credits.md
 topic/hub-helm-charts.md
+topic/hub-image.md
 topic/storage-layer.md
 topic/network.md
 topic/terraform.md

--- a/docs/topic/hub-image.md
+++ b/docs/topic/hub-image.md
@@ -1,0 +1,59 @@
+# Hub Image
+
+The 2i2c hubs use a custom hub image that is defined in the [helm-charts directory of the infrastructure repository](https://github.com/2i2c-org/infrastructure/tree/HEAD/helm-charts/images/hub).
+
+This custom hub image is built on top of the [jupyterhub/k8s-hub](https://hub.docker.com/r/jupyterhub/k8s-hub) Docker image and configured based on the needs of 2i2c hubs. This allows adding and configuring other packages like the [jupyterhub-configurator](https://github.com/yuvipanda/jupyterhub-configurator) or using specific versions of the spawner and authenticator. More information about this custom image can be found in the [Dockerfile](https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/images/hub/Dockerfile) itself.
+
+The 2i2c custom hub image is lives at [Quay.io](https://quay.io/repository/2i2c/pilot-hub?tab=tags).
+
+## Updating the hub image
+
+When this hub image needs to be updated, the steps to take are:
+
+1. Update the [Dockerfile]((https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/images/hub/Dockerfile) with any changes wanted
+
+2. Commit the changes
+
+   ```bash
+   git add helm-charts/images/hub/Dockerfile
+   git commit
+   ```
+
+   ```{note}
+   The commit SHA with be used to generate the image tag.
+   ```
+
+3. Rebuild the Docker image and push it to the [Quay.io registry](https://quay.io/repository/2i2c/pilot-hub)
+ 
+   - Your `@2i2c` address should give you access to push to the Quay.io registry where the hub image lives, but make sure you are logged into quay.io container registry with the right credentials and these creds are configured to have access to https://quay.io/repository/2i2c/pilot-hub. Please contact someone at 2i2c for access if this is not the case.
+
+     ```bash
+     docker login quay.io
+     ```
+
+     Checkout the [Getting Started with Quay.io](https://docs.quay.io/solution/getting-started.html) docs for more info.
+
+   - Make sure you have [jupyterhub/chartpress](https://github.com/jupyterhub/chartpress) installed.
+
+     ```bash
+     pip install chartpress
+     ```
+
+     This package is also listed under `dev-requirements.txt`, so it should be present if you've installed the dev dependencies.
+
+   - Run chartpress to build the image, push it to the registry and update the basehub helm chart to use the updated image tag
+
+     ```bash
+     chartpress --push
+     ```
+
+   - Commit the changes made by `chartpress` to `helm-charts/basehub/values.yaml`, but discard the changes made to `helm-charts/basehub/Chart.yaml` as the last may cause problems with the `daskhub` dependency mechanism.
+
+     ```bash
+     git add helm-charts/basehub/values.yaml
+     git commit
+     ```
+
+```{note}
+The image tag of the of the [jupyterhub/k8s-hub](https://hub.docker.com/r/jupyterhub/k8s-hub) [in the Dockerfile](https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/images/hub/Dockerfile#L9) must match the dependent JupyterHub Helm chart's version as declared in [basehub/Chart.yaml](https://github.com/2i2c-org/infrastructure/blob/master/helm-charts/basehub/Chart.yaml#L14).
+```

--- a/docs/topic/hub-image.md
+++ b/docs/topic/hub-image.md
@@ -10,7 +10,7 @@ The 2i2c custom hub image is lives at [Quay.io](https://quay.io/repository/2i2c/
 
 When this hub image needs to be updated, the steps to take are:
 
-1. Update the [Dockerfile]((https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/images/hub/Dockerfile) with any changes wanted
+1. Update the [Dockerfile](https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/images/hub/Dockerfile) with any changes wanted
 
 2. Commit the changes
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -283,7 +283,8 @@ jupyterhub:
                 interfaces:
                   - value: "/tree"
                     title: Classic Notebook
-                    description: The original single-document interface for creating
+                    description:
+                      The original single-document interface for creating
                       Jupyter Notebooks.
                   - value: "/lab"
                     title: JupyterLab

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -283,8 +283,7 @@ jupyterhub:
                 interfaces:
                   - value: "/tree"
                     title: Classic Notebook
-                    description:
-                      The original single-document interface for creating
+                    description: The original single-document interface for creating
                       Jupyter Notebooks.
                   - value: "/lab"
                     title: JupyterLab
@@ -314,7 +313,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3027.h52c5e2a"
+      tag: "0.0.1-n3130.hba64f6a"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configura
 RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
 
 # Brings in https://github.com/jupyterhub/oauthenticator/pull/498
-RUN pip install --no-cache --upgrade git+https://github.com/yuvipanda/oauthenticator@7f3fdc0a14d06f1a081c23b1ceb7060a940d11f8
+RUN pip install --no-cache --upgrade git+https://github.com/jupyterhub/oauthenticator@d189037fe6b57453a3ae733a60740c50f241e713
 
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/1252

https://github.com/jupyterhub/oauthenticator/pull/498 has been merged and although there isn't a new release for `oauthenticator`, until then we can still use the upstream repo.