### PR TITLE
Remove fudging of worker_cores

### DIFF
--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -177,7 +177,7 @@ dask-gateway:
                 }
                 return {
                     "worker_cores_limit": options.worker_cores,
-                    "worker_cores": min(options.worker_cores / 2, 1),
+                    "worker_cores": options.worker_cores,
                     "worker_memory": "%fG" % options.worker_memory,
                     "image": options.image,
                     "scheduler_extra_pod_annotations": extra_annotations,


### PR DESCRIPTION
min(worker_cores / 2, 1) is always going to be 1 for worker_cores > 2!

Not sure why this was here, but let's just pass through worker_cores
directly to the pod definition

Fixes https://github.com/2i2c-org/infrastructure/issues/1305