### PR TITLE
Cleanup base values.yaml files a little

### DIFF
--- a/config/clusters/farallon/common.values.yaml
+++ b/config/clusters/farallon/common.values.yaml
@@ -90,6 +90,8 @@ basehub:
         type: LoadBalancer
       https:
         enabled: true
+        letsencrypt:
+          contactEmail: yuvipanda@gmail.com
       chp:
         nodeSelector: {}
         tolerations:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -89,6 +89,8 @@ basehub:
         type: LoadBalancer
       https:
         enabled: true
+        letsencrypt:
+          contactEmail: yuvipanda@gmail.com
       chp:
         resources:
           requests:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -134,10 +134,6 @@ jupyterhub:
           memory: 64Mi
         limits:
           memory: 1Gi
-    https:
-      enabled: false
-      letsencrypt:
-        contactEmail: yuvipanda@gmail.com
   singleuser:
     extraEnv:
       # notebook writes secure files that don't need to survive a
@@ -252,6 +248,17 @@ jupyterhub:
                   app.kubernetes.io/component: traefik
   hub:
     config:
+      JupyterHub:
+        # Allow unauthenticated prometheus requests
+        # Otherwise our prometheus server can't get hub metrics
+        authenticate_prometheus: false
+      KubeSpawner:
+        # Make sure working directory is ${HOME}
+        working_dir: /home/jovyan
+        extra_container_config:
+          securityContext:
+            # Explicitly disallow setuid binaries from working inside the container
+            allowPrivilegeEscalation: false
       Authenticator:
         # Don't allow test username to login into the hub
         # The test service will still be able to create this hub username
@@ -359,29 +366,14 @@ jupyterhub:
       limits:
         memory: 2Gi
     extraConfig:
-      01-working-dir: |
-        # Make sure working directory is ${HOME}
-        # hubploy has a bug where it unconditionally puts workingdir to be /srv/repo
-        c.KubeSpawner.working_dir = '/home/jovyan'
-      02-prometheus: |
-        # Allow unauthenticated prometheus requests
-        # Otherwise our prometheus server can't get to these
-        c.JupyterHub.authenticate_prometheus = False
-      03-no-setuid: |
-        c.KubeSpawner.extra_container_config = {
-            'securityContext': {
-                # Explicitly disallow setuid binaries from working inside the container
-                'allowPrivilegeEscalation': False
-            }
-        }
-      04-custom-theme: |
+      01-custom-theme: |
         from z2jh import get_config
         c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/']
 
         c.JupyterHub.template_vars = {
             'custom': get_config('custom.homepage.templateVars')
         }
-      05-custom-admin: |
+      02-custom-admin: |
         from z2jh import get_config
         from kubespawner import KubeSpawner
         from jupyterhub_configurator.mixins import ConfiguratorSpawnerMixin
@@ -400,7 +392,7 @@ jupyterhub:
 
 
         c.JupyterHub.spawner_class = CustomSpawner
-      06-cloud-storage-bucket: |
+      03-cloud-storage-bucket: |
         from z2jh import get_config
         cloud_resources = get_config('custom.cloudResources')
         scratch_bucket = cloud_resources['scratchBucket']
@@ -424,7 +416,7 @@ jupyterhub:
             }
 
             c.KubeSpawner.environment.update(env)
-      07-2i2c-add-staff-user-ids-to-admin-users: |
+      04-2i2c-add-staff-user-ids-to-admin-users: |
         from z2jh import get_config
         add_staff_user_ids_to_admin_users = get_config("custom.2i2c.add_staff_user_ids_to_admin_users", False)
 
@@ -444,12 +436,12 @@ jupyterhub:
             if authenticator_class == "github" and c.Authenticator.allowed_users:
                 print("WARNING: hub.config.JupyterHub.authenticator_class was set to github and c.Authenticator.allowed_users was set, custom 2i2c jupyterhub config is now resetting allowed_users to an empty set.")
                 c.Authenticator.allowed_users = set()
-      08-add-docs-service-if-enabled: |
+      05-add-docs-service-if-enabled: |
         from z2jh import get_config
 
         if get_config("custom.docs_service.enabled"):
             c.JupyterHub.services.append({"name": "docs", "url": "http://docs-service"})
-      09-gh-teams: |
+      06-gh-teams: |
         from textwrap import dedent
         from tornado import gen, web
         from oauthenticator.github import GitHubOAuthenticator

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -2,9 +2,6 @@ basehub:
   # Copied from https://github.com/dask/helm-chart/blob/master/daskhub/values.yaml
   # FIXME: Properly use the upstream chart.
   jupyterhub:
-    prePuller:
-      hook:
-        enabled: false
     singleuser:
       # Almost everyone using dask by default wants JupyterLab
       defaultUrl: /lab


### PR DESCRIPTION
- Use hub.config instead of extraConfig for some simple config
  settings.
- Remove proxy.https in the base, as it is disabled by default. We
  only use it in farallon and meom-ige, and so the config is shifted
  there.
- Remove a config override on daskhub that was config as basehub