### PR TITLE
update image to 2022.05.10

### DIFF
--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -56,7 +56,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: 2022.04.20
+        tag: 2022.05.10
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable


### PR DESCRIPTION
Images are published roughly every two weeks. Ideally manually updating will eventually become unnecessary once #1253 is resolved.