### PR TITLE
Deploy the support chart to meom-ige

### DIFF
--- a/config/clusters/meom-ige/cluster.yaml
+++ b/config/clusters/meom-ige/cluster.yaml
@@ -5,6 +5,10 @@ gcp:
   project: meom-ige-cnrs
   cluster: meom-ige-cluster
   zone: us-central1-b
+support:
+  helm_chart_values_files:
+    - support.values.yaml
+    - enc-support.secret.values.yaml
 hubs:
   - name: staging
     display_name: "SWOT Ocean Pangeo Team (staging)"

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -85,12 +85,6 @@ basehub:
       userScheduler:
         enabled: false
     proxy:
-      service:
-        type: LoadBalancer
-      https:
-        enabled: true
-        letsencrypt:
-          contactEmail: yuvipanda@gmail.com
       chp:
         resources:
           requests:

--- a/config/clusters/meom-ige/enc-support.secret.values.yaml
+++ b/config/clusters/meom-ige/enc-support.secret.values.yaml
@@ -1,0 +1,17 @@
+prometheusIngressAuthSecret:
+    username: ENC[AES256_GCM,data:UgQfeU/OUU3z+8ylT3OQTvWh6R7QevM5lPd/XkJ+AltY7Po6INJxSluH/esJLC2V8q7jZF2mCejGNKy7dt8Xjw==,iv:rh1VPMfvXlqgrVgLzqj8eL+PA+lqZ0Esa+Aklswn24Y=,tag:uTIm1HBAQjTLJDQBfyJKjg==,type:str]
+    password: ENC[AES256_GCM,data:caUmNT2gG5MFm2PpLjazqHLWZkI7GXRdqdeK7wxhI15FMO+8led5dW3Bd8pm0aLkIhgs0v4wCxL69oBw80qaKw==,iv:A/26GE1/R9S4mCBvknNvFtWyxI+PCBoXUVRbYZLAmzU=,tag:3ajE+3UUKKaev87P+afcOA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-05-19T11:58:53Z"
+          enc: CiQA4OM7eGGu80FXgtHsK4nuZSwYtn/Qzy171PiSkeG2F+S1nK8SSQDm5XgWAoqJCnpY6wg5IK+Fw5m4DmogftHNB1BBpZCNOH2XX+dXOdT+IlmWWyAV3LM4WsbpyN4whzgTpKgSoUxBRl6OeNE+G8Y=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-05-19T11:58:54Z"
+    mac: ENC[AES256_GCM,data:tRu30bx2qkFQ2T+QOtR3pFa4dhrgXhdaFuKfFOvuPQkUzCyW+aSRolPkgiBcmON6rWOvVHf2EpyMZbTEqE5JAdZV2mz0z+yIBnqlhxh0Vsorl1cP7fjSguHdjYYI5uzxj96OSt4GW4gdXr8nPSzzmByLTswPdsIBa1Q4hIF6JLg=,iv:6phRu509nLWPuVVXiBc/zHq1ZQ13vZDKd0NKUZopAho=,tag:1uOZzo7p79dKxhxH/i2IVw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/meom-ige/support.values.yaml
+++ b/config/clusters/meom-ige/support.values.yaml
@@ -1,6 +1,6 @@
 prometheusIngressAuthSecret:
-    enabled: true
-  
+  enabled: true
+
 prometheus:
   server:
     ingress:

--- a/config/clusters/meom-ige/support.values.yaml
+++ b/config/clusters/meom-ige/support.values.yaml
@@ -17,7 +17,7 @@ prometheus:
         memory: 512Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1G
 grafana:
   ingress:
     hosts:

--- a/config/clusters/meom-ige/support.values.yaml
+++ b/config/clusters/meom-ige/support.values.yaml
@@ -1,0 +1,28 @@
+prometheusIngressAuthSecret:
+    enabled: true
+  
+prometheus:
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - prometheus.meom-ige.2i2c.cloud
+      tls:
+        - secretName: prometheus-tls
+          hosts:
+            - prometheus.meom-ige.2i2c.cloud
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+grafana:
+  ingress:
+    hosts:
+      - grafana.meom-ige.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.meom-ige.2i2c.cloud


### PR DESCRIPTION
- This adds config for deploying the support chart for meom-ige
- Enables prometheus authentication
- Removes the LoadBalancer + autohttps config since we'll be using nginx-ingress

### The following manual steps are required:
- [x] deploy the support chart with:
    `python3 deployer deploy-support meom-ige`
- [x] retrieve the external IP address for the nginx-ingress load balancer.
    `kubectl --namespace support get svc support-ingress-nginx-controller`
- [x] point the dns record to this ip instead of proxy-public
- [x] delete the `proxy-public` service
- [x] do a deploy of the cluster
    `python3 deployer deploy meom-ige`
- [ ] merge this PR

@2i2c-org/tech-team, can you please confirm if the manual steps mentioned above ⬆️ are ok please?

Ref: https://github.com/2i2c-org/infrastructure/issues/1278 and https://github.com/2i2c-org/infrastructure/issues/594