### PR TITLE
maint: add assertion for docs_service config

### DIFF
--- a/helm-charts/basehub/templates/docs-service-deployment.yaml
+++ b/helm-charts/basehub/templates/docs-service-deployment.yaml
@@ -25,11 +25,10 @@ spec:
           args:
             - clone
             - --depth=1
-            - -b
-            - {{ .Values.jupyterhub.custom.docs_service.branch }}
+            - --branch={{ .Values.jupyterhub.custom.docs_service.branch | required "jupyterhub.custom.docs_service.branch is required with jupyterhub.custom.docs_service.enabled set to true" }}
             - --single-branch
             - --
-            - {{ .Values.jupyterhub.custom.docs_service.repo }}
+            - '{{ .Values.jupyterhub.custom.docs_service.repo | required "jupyterhub.custom.docs_service.repo is required with jupyterhub.custom.docs_service.enabled set to true" }}'
             - /srv/docs
           securityContext:
               runAsUser: 1000


### PR DESCRIPTION
This assertion could probably also be added to the basehub Helm chart's schema, but anything conditional in JSONSchema is quite tricky overall. With this change, calls to `helm template` would still catch errors just like the schema would.

This small change comes from #436 that I have continuously rebased over time but make sense to upstream instead of carry there.