### PR TITLE
Modify profiles of pangeo hubs

### DIFF
--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -68,42 +68,58 @@ basehub:
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
-        # RAM on a node, not total node capacity
-        - display_name: "Small (1 GB - 4 GB)"
+        # RAM on a node, not total node capacity. Values calculated using
+        # https://learnk8s.io/kubernetes-instance-calculator
+        - display_name: "Small"
+          description: 5GB RAM, 2 CPUs
           default: true
           kubespawner_override:
-            cpu_limit: 2
-            cpu_guarantee: 0.3
-            mem_limit: 4G
-            mem_guarantee: 1G
+            mem_limit: 7G
+            mem_guarantee: 4.5G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-2
+        - display_name: Medium
+          description: 11GB RAM, 4 CPUs
+          kubespawner_override:
+            mem_limit: 15G
+            mem_guarantee: 11G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-4
-        - display_name: "Medium (4 GB - 8 GB)"
+        - display_name: Large
+          description: 24GB RAM, 8 CPUs
+          allowed_teams:
+            - pangeo-data/cds-lab
+            - 2i2c-org:tech-team
           kubespawner_override:
-            cpu_limit: 2
-            cpu_guarantee: 1
-            mem_limit: 8G
-            mem_guarantee: 4G
+            mem_limit: 30G
+            mem_guarantee: 24G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-8
-        - display_name: "Large (12 GB - 16 GB)"
+        - display_name: Huge
+          description: 52GB RAM, 16 CPUs
+          allowed_teams:
+            - pangeo-data/cds-lab
+            - 2i2c-org:tech-team
           kubespawner_override:
-            cpu_limit: 4
-            cpu_guarantee: 1
-            mem_limit: 16G
-            mem_guarantee: 12G
+            mem_limit: 60G
+            mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-        - display_name: "ML Image - Large (12 GB - 16 GB)"
-          description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
+        - display_name: Large + Nvidia K80 GPU
+          description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU
+          allowed_teams:
+            - pangeo-data/cds-lab
+            - 2i2c-org:tech-team
           kubespawner_override:
             image: "pangeo/ml-notebook:master"
-            cpu_limit: 2
-            cpu_guarantee: 1
-            mem_limit: 16G
-            mem_guarantee: 12G
+            mem_limit: 30G
+            mem_guarantee: 24G
             node_selector:
-              node.kubernetes.io/instance-type: n1-standard-16
+              node.kubernetes.io/instance-type: n1-standard-8
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
+            extra_resource_limits:
+              nvidia.com/gpu: "1"
       initContainers:
         # Need to explicitly fix ownership here, since EFS doesn't do anonuid
         - name: volume-mount-ownership-fix

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -88,7 +88,7 @@ basehub:
         - display_name: Large
           description: 24GB RAM, 8 CPUs
           allowed_teams:
-            - pangeo-data/cds-lab
+            - pangeo-data:cds-lab
             - 2i2c-org:tech-team
           kubespawner_override:
             mem_limit: 30G
@@ -98,7 +98,7 @@ basehub:
         - display_name: Huge
           description: 52GB RAM, 16 CPUs
           allowed_teams:
-            - pangeo-data/cds-lab
+            - pangeo-data:cds-lab
             - 2i2c-org:tech-team
           kubespawner_override:
             mem_limit: 60G
@@ -108,7 +108,7 @@ basehub:
         - display_name: Large + Nvidia K80 GPU
           description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU
           allowed_teams:
-            - pangeo-data/cds-lab
+            - pangeo-data:cds-lab
             - 2i2c-org:tech-team
           kubespawner_override:
             image: "pangeo/ml-notebook:master"

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -105,21 +105,6 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-        - display_name: Large + Nvidia K80 GPU
-          description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU
-          allowed_teams:
-            - pangeo-data:cds-lab
-            - 2i2c-org:tech-team
-          kubespawner_override:
-            image: "pangeo/ml-notebook:master"
-            mem_limit: 30G
-            mem_guarantee: 24G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-8
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
-            extra_resource_limits:
-              nvidia.com/gpu: "1"
       initContainers:
         # Need to explicitly fix ownership here, since EFS doesn't do anonuid
         - name: volume-mount-ownership-fix

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -73,6 +73,9 @@ basehub:
         - display_name: "Small"
           description: 5GB RAM, 2 CPUs
           default: true
+          allowed_teams:
+            - pangeo-data:us-central1-b-gcp
+            - 2i2c-org:tech-team
           kubespawner_override:
             mem_limit: 7G
             mem_guarantee: 4.5G
@@ -80,6 +83,9 @@ basehub:
               node.kubernetes.io/instance-type: n1-standard-2
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
+          allowed_teams:
+            - pangeo-data:us-central1-b-gcp
+            - 2i2c-org:tech-team
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -30,7 +30,7 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-4",
+    machine_type : "n1-standard-2",
     labels: {},
     gpu: {
       enabled: false,
@@ -41,7 +41,7 @@ notebook_nodes = {
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-8",
+    machine_type : "n1-standard-4",
     labels: {},
     gpu: {
       enabled: false,
@@ -52,12 +52,34 @@ notebook_nodes = {
   "large" : {
     min : 0,
     max : 100,
+    machine_type : "n1-standard-8",
+    labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+  "huge" : {
+    min : 0,
+    max : 100,
     machine_type : "n1-standard-16",
     labels: {},
     gpu: {
       enabled: false,
       type: "",
       count: 0
+    }
+  },
+  "gpu-k80" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {},
+    gpu: {
+      enabled: true,
+      type: "nvidia-tesla-k80",
+      count: 1
     }
   },
 }

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -71,17 +71,6 @@ notebook_nodes = {
       count: 0
     }
   },
-  "gpu-k80" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: true,
-      type: "nvidia-tesla-k80",
-      count: 1
-    }
-  },
 }
 
 dask_nodes = {


### PR DESCRIPTION
- Match sizes of the LEAP / m2lines hub, preferring one user
  pod per node
- Add Huge nodepool
- Restrict some profile sizes to specific users
- <s>Add a GPU profile</s> Unfortunately these aren't present in us-central1-b, so no
   GPUs here.

Fixes https://github.com/2i2c-org/infrastructure/issues/1327