### PR TITLE
Add snowex hub to uwhackweeks cluster

### DIFF
--- a/config/clusters/uwhackweeks/cluster.yaml
+++ b/config/clusters/uwhackweeks/cluster.yaml
@@ -11,7 +11,7 @@ support:
     - enc-support.secret.values.yaml
 hubs:
   - name: staging
-    display_name: "ICESat Hackweek (staging)"
+    display_name: "Staging"
     domain: staging.uwhackweeks.2i2c.cloud
     helm_chart: daskhub
     auth0:
@@ -24,7 +24,7 @@ hubs:
       - staging.values.yaml
       - enc-staging.secret.values.yaml
   - name: prod
-    display_name: "ICESat Hackweek (prod)"
+    display_name: "ICESat Hackweek"
     domain: uwhackweeks.2i2c.cloud
     helm_chart: daskhub
     auth0:
@@ -36,3 +36,13 @@ hubs:
       - common.values.yaml
       - prod.values.yaml
       - enc-prod.secret.values.yaml
+  - name: snowex
+    display_name: "SnowEx Hackweek"
+    domain: snowex.uwhackweeks.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - common.values.yaml
+      - snowex.values.yaml
+      - enc-snowex.secret.values.yaml

--- a/config/clusters/uwhackweeks/common.values.yaml
+++ b/config/clusters/uwhackweeks/common.values.yaml
@@ -18,10 +18,6 @@ basehub:
         add_staff_user_ids_of_type: "github"
       homepage:
         templateVars:
-          org:
-            name: ICESat Hackweek
-            logo_url: https://github.com/ICESAT-2HackWeek/icesat-2hackweek.github.io/raw/2022.03.01/assets/images/ICESat2.png
-            url: https://icesat-2hackweek.github.io
           designed_by:
             name: 2i2c
             url: https://2i2c.org
@@ -124,9 +120,6 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
-          allowed_organizations:
-            - 2i2c-org:tech-team
-            - ICESAT-2HackWeek:jupyterhub-2022
           scope:
             - read:org
         Authenticator:

--- a/config/clusters/uwhackweeks/enc-snowex.secret.values.yaml
+++ b/config/clusters/uwhackweeks/enc-snowex.secret.values.yaml
@@ -1,0 +1,21 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:3ZbjsnK53bBmkDo4I/iJt5LgXH8=,iv:82COPiuem1h1ADErZlXgKyVdKEiG9NfDYTOfJc+Z+Ic=,tag:HCZDuDtW+hXJ3zTNyXy32g==,type:str]
+                    client_secret: ENC[AES256_GCM,data:dtlgCPp6Zs8txD6FYFoHcsWFCH4MAbvHm0sll41uvN0dAuol5qQJyA==,iv:jrsP5GHwaxUXF6AvsaKmGGwEDSXYgK2yemtvt6JTzjM=,tag:5Ly2E1+mgALoW7YDKrDddw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-02-24T18:12:40Z"
+          enc: CiQA4OM7eM986pwcfywav/lIXoxXqO3E3vw8LN5WukiUiVYa6JYSSQDm5XgWeV8iHxE8DEGG09q53mwD3ebl580QIapA5J7LK9lvr5miJ6HlFLJqucnCW1Di2oiSM9lrIf9IbDnkopHRNGmZucbnnxU=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-05-26T08:06:48Z"
+    mac: ENC[AES256_GCM,data:ZnJ8L+Zq84HDZWUU95Cpn64KnfQdVWGFVliWPbZLtZhygKwJs14IRYa5fHNcIPwLA83C3IzZRyLePzb0qrXmhY/5sdVBJMXk13Y8xFK1umv9Gq4CRkeLWKkJiESJfPZdpc3H4dIj5zMekFjBO++Q5BaetjecE3OlJ4pYw+jwCIs=,iv:L9QdyobINoVelyiS3OHFQYeflz595L3zf0rcErRgOEk=,tag:8pDkIB/dA7VoAIzprYYPIA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/uwhackweeks/prod.values.yaml
+++ b/config/clusters/uwhackweeks/prod.values.yaml
@@ -3,6 +3,13 @@ basehub:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::740010314650:role/uwhackweeks-prod
   jupyterhub:
+    custom:
+      homepage:
+        templateVars:
+          org:
+            name: ICESat Hackweek
+            logo_url: https://github.com/ICESAT-2HackWeek/icesat-2hackweek.github.io/raw/2022.03.01/assets/images/ICESat2.png
+            url: https://icesat-2hackweek.github.io
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: s3://uwhackweeks-scratch/$(JUPYTERHUB_USER)
@@ -10,4 +17,7 @@ basehub:
     hub:
       config:
         GitHubOAuthenticator:
+          allowed_organizations:
+            - 2i2c-org:tech-team
+            - ICESAT-2HackWeek:jupyterhub-2022
           oauth_callback_url: https://uwhackweeks.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/uwhackweeks/snowex.values.yaml
+++ b/config/clusters/uwhackweeks/snowex.values.yaml
@@ -1,0 +1,29 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::740010314650:role/uwhackweeks-snowex
+  jupyterhub:
+    custom:
+      homepage:
+        templateVars:
+          org:
+            name: SnowEx Hackweek
+            logo_url: https://snowex-hackweek.github.io/website/_static/logo.png
+            url: https://snowex-hackweek.github.io/website/intro.html
+    singleuser:
+      # User image: https://quay.io/repository/uwhackweek/snowex?tab=tags
+      image:
+        name: quay.io/uwhackweek/snowex
+        tag: "2021.07.07"
+      extraEnv:
+        SCRATCH_BUCKET: s3://uwhackweeks-snowex-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: s3://uwhackweeks-snowex-scratch/$(JUPYTERHUB_USER)
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/snowex-jupyterhub-push-access
+        GH_SCOPED_CREDS_CLIENT_ID: Iv1.0d0934b2905d0b6c
+    hub:
+      config:
+        GitHubOAuthenticator:
+          allowed_organizations:
+            - 2i2c-org:tech-team
+            - snowex-hackweek:participants-2022
+          oauth_callback_url: https://snowex.uwhackweeks.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -3,6 +3,13 @@ basehub:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::740010314650:role/uwhackweeks-staging
   jupyterhub:
+    custom:
+      homepage:
+        templateVars:
+          org:
+            name: ICESat Hackweek
+            logo_url: https://github.com/ICESAT-2HackWeek/icesat-2hackweek.github.io/raw/2022.03.01/assets/images/ICESat2.png
+            url: https://icesat-2hackweek.github.io
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: s3://uwhackweeks-scratch-staging/$(JUPYTERHUB_USER)
@@ -10,4 +17,7 @@ basehub:
     hub:
       config:
         GitHubOAuthenticator:
+          allowed_organizations:
+            - 2i2c-org:tech-team
+            - ICESAT-2HackWeek:jupyterhub-2022
           oauth_callback_url: https://staging.uwhackweeks.2i2c.cloud/hub/oauth_callback

--- a/terraform/aws/projects/uwhackweeks.tfvars
+++ b/terraform/aws/projects/uwhackweeks.tfvars
@@ -10,6 +10,9 @@ user_buckets = {
     },
     "scratch": {
         "delete_after": 7
+    },
+    "snowex-scratch": {
+        "delete_after": 7
     }
 }
 
@@ -22,5 +25,9 @@ hub_cloud_permissions = {
   "prod" : {
     requestor_pays: true,
     bucket_admin_access: ["scratch"],
+  },
+  "snowex" : {
+    requestor_pays: true,
+    bucket_admin_access: ["snowex-scratch"],
   }
 }


### PR DESCRIPTION
- Moves current hackweeks hub (which is really icesat hackweek hub)
  config out of common and into staging / prod.yaml
- Add new config for snowex hackweek
- Add scratch bucket for snowex hackweek

Ref https://github.com/2i2c-org/infrastructure/issues/1309