### PR TITLE
Add jackeddy hub

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -166,3 +166,12 @@ hubs:
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
       - utexas.values.yaml
+  - name: jackeddy
+    display_name: "Jack Eddy Symposium"
+    domain: jackeddy.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - jackeddy.values.yaml
+      - enc-jackeddy.secret.values.yaml

--- a/config/clusters/2i2c/enc-jackeddy.secret.values.yaml
+++ b/config/clusters/2i2c/enc-jackeddy.secret.values.yaml
@@ -1,0 +1,21 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:pKbFnP/2j9bmxIWDbD4XMNN1Cpo=,iv:P4YgHP1WS0a+XW7WFbHQyTYSVGPKDaPaYHwKRmID2cc=,tag:chrE50gZEijmqEeuLajU0g==,type:str]
+                    client_secret: ENC[AES256_GCM,data:GAd2q3+beAdijK8i46h71G+ZpIxxJuSZ/NlRKi6hqgwBWwwbb6MNJg==,iv:XeMzu/XES1dxZ9BI3dPAk5nSL+JlBAhTzN/2OrVfMh4=,tag:AhQRDCZzkKmYiUTsOU4mVA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-03-15T18:22:39Z"
+          enc: CiQA4OM7eDjl5gKH7+wzLKDVoI5KcuJ7gVfLlnQ05U9ztKRtBXISSQDm5XgWoRzJjQSuC+PEMk6t4P2YMxDK6dvnpVlojQkI4X3tlQcSPvq1m0JRKXOhcCT3EjvQiM2ZiU2hRB0u2ZbK8nRfw9cW4l8=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-05-26T16:36:36Z"
+    mac: ENC[AES256_GCM,data:+cnN/SCe71LXhFQWMZrNLFRrRik0fgKkhy6iH3fe9CZTPioChPuyalx/l1WElMFx3ni9xEBul+eR6zsH2l+GKFForkAQZ85gUUl7FDZITwbtIqSFXM5idrhYKkN+yB/ky0WxflKO+6mhNRnuu9nTJ7F4/fPsniyJK/6MWO9sODs=,iv:1ACC55neHqNuhjENiNIZGnjFTSppMxYF+aE8uKZWGRY=,tag:sDUiw4Svh9B1R2z6AJKTzw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -23,14 +23,42 @@ basehub:
             name: 2i2c
             url: https://2i2c.org
     singleuser:
-      # Resources of a single n1-highmem-4
-      memory:
-        guarantee: 21G
-        limit: 24G
-      cpu:
-        guarantee: 3
-        limit: 4
+      profileList:
+        # The mem-guarantees are here so k8s doesn't schedule other pods
+        # on these nodes. They need to be just under total allocatable
+        # RAM on a node, not total node capacity. Values calculated using
+        # https://learnk8s.io/kubernetes-instance-calculator
+        - display_name: "Small"
+          description: 5GB RAM, 2 CPUs
+          default: true
+          kubespawner_override:
+            mem_limit: 7G
+            mem_guarantee: 4.5G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-2
+        - display_name: Medium
+          description: 11GB RAM, 4 CPUs
+          kubespawner_override:
+            mem_limit: 15G
+            mem_guarantee: 11G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-4
+        - display_name: Large
+          description: 24GB RAM, 8 CPUs
+          kubespawner_override:
+            mem_limit: 30G
+            mem_guarantee: 24G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-8
+        - display_name: Huge
+          description: 52GB RAM, 16 CPUs
+          kubespawner_override:
+            mem_limit: 60G
+            mem_guarantee: 52G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-16
       nodeSelector:
+        # Applied to all profile options
         2i2c.org/community: jackeddy
       defaultUrl: /lab
       initContainers:

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -23,12 +23,15 @@ basehub:
             name: 2i2c
             url: https://2i2c.org
     singleuser:
+      # Resources of a single n1-highmem-4
       memory:
-        guarantee: 8G
-        limit: 8G
+        guarantee: 21G
+        limit: 24G
       cpu:
-        guarantee: 1
-        limit: 2
+        guarantee: 3
+        limit: 4
+      nodeSelector:
+        2i2c.org/community: jackeddy
       defaultUrl: /lab
       initContainers:
         # Need to explicitly fix ownership here, since EFS doesn't do anonuid

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -1,0 +1,96 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: pilot-hubs-jackeddy@two-eye-two-see.iam.gserviceaccount.com
+  jupyterhub:
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: true
+        add_staff_user_ids_of_type: "github"
+      homepage:
+        templateVars:
+          org:
+            name: Jack Eddy Symposium JupyterHub
+            logo_url: https://cpaess.ucar.edu/sites/default/files/meetings/2022/nasa-jack-eddy-symposium-2022-860.jpg
+            url: https://cpaess.ucar.edu/meetings/eddy-symposium-2022
+          designed_by:
+            name: 2i2c
+            url: https://2i2c.org
+          operated_by:
+            name: 2i2c
+            url: https://2i2c.org
+          funded_by:
+            name: 2i2c
+            url: https://2i2c.org
+    singleuser:
+      defaultUrl: /lab
+      initContainers:
+        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
+        - name: volume-mount-ownership-fix
+          image: busybox
+          command:
+            [
+              "sh",
+              "-c",
+              "id && chown 1000:1000 /home/jovyan /home/jovyan/shared && ls -lhd /home/jovyan",
+            ]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: home
+              mountPath: /home/jovyan
+              subPath: "{username}"
+            - name: home
+              mountPath: /home/jovyan/shared
+              subPath: _shared
+      extraEnv:
+        SCRATCH_BUCKET: gcs://pilot-hubs-jackeddy-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://pilot-hubs-jackeddy-scratch/$(JUPYTERHUB_USER)
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.37646d01f3f58a80"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/jack-eddy-jupyterhub-push-access
+      image:
+        name: pangeo/pangeo-notebook
+        tag: 2022.05.10
+      storage:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/shared
+            subPath: _shared
+            readOnly: true
+    scheduling:
+      userPlaceholder:
+        enabled: false
+        replicas: 0
+      userScheduler:
+        enabled: false
+    hub:
+      allowNamedServers: true
+      networkPolicy:
+        # FIXME: For dask gateway
+        enabled: false
+      readinessProbe:
+        enabled: false
+      config:
+        JupyterHub:
+          authenticator_class: github
+        GitHubOAuthenticator:
+          oauth_callback_url: https://jackeddy.2i2c.cloud/hub/oauth_callback
+          allowed_organizations:
+            - 2i2c-org:tech-team
+            - jack-eddy-symposium
+          scope:
+            - read:org
+        Authenticator:
+          # This hub uses GitHub Orgs/Teams auth and so we do not set
+          # allowed_users in order to not deny access to valid members of
+          # the listed Orgs/Teams. The following people should have admin
+          # access though.
+          admin_users:
+            - colliand
+            - dan800
+dask-gateway:
+  gateway:
+    extraConfig:
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -23,6 +23,12 @@ basehub:
             name: 2i2c
             url: https://2i2c.org
     singleuser:
+      memory:
+        guarantee: 1G
+        limit: 1G
+      cpu:
+        guarantee: 1
+        limit: 2
       defaultUrl: /lab
       initContainers:
         # Need to explicitly fix ownership here, since EFS doesn't do anonuid

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -24,8 +24,8 @@ basehub:
             url: https://2i2c.org
     singleuser:
       memory:
-        guarantee: 1G
-        limit: 1G
+        guarantee: 8G
+        limit: 8G
       cpu:
         guarantee: 1
         limit: 2

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -39,7 +39,11 @@ dask_nodes = {
   }
 }
 
-user_buckets = {}
+user_buckets = {
+  "jackeddy-scratch": {
+    "delete_after": 7
+  }
+}
 
 
 hub_cloud_permissions = {
@@ -58,5 +62,11 @@ hub_cloud_permissions = {
     requestor_pays : true,
     bucket_admin_access: [],
     hub_namespace: "catalyst-cooperative"
+  },
+  "jackeddy": {
+    requestor_pays: true,
+    bucket_admin_access: ["jackeddy-scratch"],
+    hub_namespace: "jackeddy"
   }
+
 }

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,6 +23,19 @@ notebook_nodes = {
       count: 0
     }
   },
+  "jackeddy" : {
+    min : 0,
+    max : 150,
+    machine_type : "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "jackeddy"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
 }
 
 dask_nodes = {

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,10 +23,49 @@ notebook_nodes = {
       count: 0
     }
   },
-  "jackeddy" : {
+  "jackeddy-small" : {
     min : 0,
-    max : 150,
-    machine_type : "n1-highmem-4",
+    max : 100,
+    machine_type : "n1-standard-2",
+    labels: {
+      "2i2c.org/community": "jackeddy"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+  "jackeddy-medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-4",
+    labels: {
+      "2i2c.org/community": "jackeddy"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+  "jackeddy-large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {
+      "2i2c.org/community": "jackeddy"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+  "jackeddy-huge" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-16",
     labels: {
       "2i2c.org/community": "jackeddy"
     },


### PR DESCRIPTION
- Put in GCP as the CMIP6 data desired is on GCP as well.
  However, I thin GCP's CMIP6 dataset is more limited than AWS' -
  we cna move this to AWS if needed.
- SCRATCH_BUCKET is setup
- Secure push to GitHub via gh-scoped-creds is setup
- GitHub teams is used for auth
- Default memory limits are 1Gi Limit + 256Mi Guarantee. I *think*
  this won't be enough - let's customize this as needed.
- I tried to use https://gallery.ecr.aws/q3h7b4o8/helio-notebook-py
  built from https://git.mysmce.com/heliocloud/heliocloud-docker-images,
  but it doesn't work - primarily because it has JupyterHub 2.0 in
  there, and we're still at 1.5.  Need to debug that. In the meantime,
  just using the default pangeo image.

Ref https://github.com/2i2c-org/infrastructure/issues/1329