### PR TITLE
[BUGFIX] Set base branch of repo to master in bump image tags workflow

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -52,3 +52,4 @@ jobs:
           values_paths: ${{ matrix.values_paths }}
           github_token: ${{ steps.generate_token.outputs.token }}
           team_reviewers: ${{ env.team_reviewers }}
+          base_branch: "master"


### PR DESCRIPTION
Configure `bump-jhub-image-action` to set `base_branch` to `master`. The action assumes `main`.