### PR TITLE
Disable schedule trigger for bump image tags workflow

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -2,8 +2,8 @@ name: Bump Image Tags
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
+  # schedule:
+  #   - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
 
 env:
   team_reviewers: 2i2c-org/tech-team


### PR DESCRIPTION
There is a bug in the action currently that means that comments are not preserved in the way that ruamel promises. I believe this is because I am dumping to an object buffer instead of a file in order to then encode the contents and commit over the API.

It may be easier to checkout the repository and commit the old fashioned way instead.