### PR TITLE
maint: remove traefik pin, ensure image tags are strings, ensure `latest` tags are fresh

### DIFF
--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
       limit: 2
     image:
       name: quay.io/mmcky/anu-emet2007
-      tag: b7937f446fe6
+      tag: "b7937f446fe6"
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c/catalyst-cooperative.values.yaml
+++ b/config/clusters/2i2c/catalyst-cooperative.values.yaml
@@ -7,7 +7,7 @@ basehub:
     singleuser:
       image:
         name: catalystcoop/pudl-jupyter
-        tag: 2021.11.11
+        tag: "2021.11.11"
       memory:
         limit: 6G
         guarantee: 4G

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -31,7 +31,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: 2021.02.19
+        tag: "2021.02.19"
     hub:
       config:
         JupyterHub:

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -32,7 +32,7 @@ basehub:
                 protocol: TCP
       image:
         name: ghcr.io/oceanhackweek/jupyer-image
-        tag: 9efd4fb
+        tag: "9efd4fb"
       memory:
         # Increase memory alloted during the workshop
         #  https://github.com/2i2c-org/infrastructure/issues/549#issuecomment-891264570

--- a/config/clusters/2i2c/paleohack2021.values.yaml
+++ b/config/clusters/2i2c/paleohack2021.values.yaml
@@ -34,7 +34,7 @@ jupyterhub:
       limit: 2
     image:
       name: quay.io/2i2c/paleohack-2021
-      tag: 9d557294938e
+      tag: "9d557294938e"
   hub:
     config:
       Authenticator:

--- a/config/clusters/azure.carbonplan/common.values.yaml
+++ b/config/clusters/azure.carbonplan/common.values.yaml
@@ -51,7 +51,10 @@ basehub:
               subPath: "{username}"
       image:
         name: carbonplan/cmip6-downscaling-single-user
-        tag: latest
+        # pullPolicy set to "Always" because we use the changing over time tag
+        # "latest".
+        pullPolicy: Always
+        tag: "latest"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes.

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -51,7 +51,10 @@ basehub:
               subPath: "{username}"
       image:
         name: carbonplan/trace-python-notebook
-        tag: latest
+        # pullPolicy set to "Always" because we use the changing over time tag
+        # "latest".
+        pullPolicy: Always
+        tag: "latest"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes.

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -54,7 +54,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: 2022.04.20
+        tag: "2022.04.20"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -56,7 +56,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: 2022.05.10
+        tag: "2022.05.10"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -77,7 +77,7 @@ basehub:
       defaultUrl: /lab
       image:
         name: pangeo/pangeo-notebook
-        tag: 2021.07.17
+        tag: "2021.07.17"
     scheduling:
       userPlaceholder:
         enabled: false

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -64,7 +64,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: 2022.04.20
+        tag: "2022.04.20"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -83,7 +83,7 @@ jupyterhub:
             subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: d422076c3695
+      tag: "d422076c3695"
   hub:
     db:
       pvc:

--- a/docs/howto/configure/update-env.md
+++ b/docs/howto/configure/update-env.md
@@ -73,7 +73,7 @@ jupyterhub:
   singleuser:
     image:
       name: pangeo/pangeo-notebook
-      tag: 2020.12.08
+      tag: "2020.12.08"
 ```
 
 This can be any image name & tag available in a public container regsitry.

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -167,7 +167,7 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     image:
       name: quay.io/2i2c/2i2c-hubs-image
-      tag: 532c5eab47a1
+      tag: "532c5eab47a1"
     storage:
       type: static
       static:


### PR DESCRIPTION
Ensures we avoid a few issues long term:
1. images with `latest` tags declare `imagePullPolicy: Always` to avoid issues with images getting out of sync and remain updated. They could otherwise experience hard-to-understand issues caused by a node restart that led to a clearing of image cache and suddenly a new version of the image is used.
2. tags are quoted in our YAML config systematically, this helps us avoid issues when a pure hash is used as a tag - they can be numerical, and then, you get an issue with the helm chart schema validation.
3. traefik was pinned to 2.4.8, but z2jh 1.2.0 points to 2.4.11. Bumping it historically was perhaps relevant, but it isn't any more it seems.