### PR TITLE
Increase prometheus server limits for the 2i2c cluster

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -11,7 +11,13 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.pilot.2i2c.cloud
-
+    resources:
+      requests:
+        cpu: 1
+        memory: 2Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
 grafana:
   ingress:
     hosts:


### PR DESCRIPTION
The `prometheus-server` pod gets `OOMKilled` currently so we don't have dashboards for the 2i2c cluster.

Currently, the sizes are:

```
Limits:
      cpu:     1
      memory:  2Gi
    Requests:
      cpu:        200m
      memory:     512Mi
```

@damianavila, please feel free to merge this is you think it's LGTM to use the grafana dashbords today
