### PR TITLE
add rmcgranaghan to list of admin on jackeddy

### DIFF
--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -136,6 +136,7 @@ basehub:
             - colliand
             - dan800
             - fperez
+            - rmcgranaghan
 dask-gateway:
   gateway:
     extraConfig:


### PR DESCRIPTION
Ryan McGranaghan is an organizer of the Jack Eddy Symposium. He needs admin access. I added his username under admin-users inside the jackeddy.values.yaml file.