### PR TITLE
Enable 0 user placeholders when using continuous prePuller

### DIFF
--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -110,7 +110,8 @@ basehub:
             readOnly: true
     scheduling:
       userPlaceholder:
-        enabled: false
+        # Needed for continuous prePuller to work
+        enabled: true
         replicas: 0
       userScheduler:
         enabled: false


### PR DESCRIPTION
Without this, looks like prePuller tries to use the priority
set for placeholder and the daemonset fails.

Daemonset fails with:

> Error creating: pods "continuous-image-puller-" is forbidden: no PriorityClass with name jackeddy-user-placeholder-priority was found