### PR TITLE
[BUGFIX] Add environment so secrets are accessible

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   bump-helm-versions:
     runs-on: ubuntu-latest
+    environment: github-app-token-generator
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This ensures the bump helm versions workflow runs in the correct environment with access to the required secrets