### PR TITLE
[BUGFIX] Fix team name for review requests

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * 1" # Run every Monday at 00:00 UTC
 
 env:
-  team_reviewers: 2i2c-org/tech-team
+  team_reviewers: tech-team
 
 jobs:
   bump-helm-versions:

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -6,7 +6,7 @@ on:
   #   - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
 
 env:
-  team_reviewers: 2i2c-org/tech-team
+  team_reviewers: tech-team
 
 jobs:
   bump-image-tags:


### PR DESCRIPTION
This fixes a bug where a review from `2i2c-org/tech-team` was not being requested. This is because the API expects only the `team_slug` which (after a lot of unhelpful documentation and defaulting to experimentation) is apparently _just_ `tech-team`, not `2i2c-org/tech-team`.