### PR TITLE
Bump oauthenticator

### DIFF
--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -51,4 +51,4 @@ jupyterhub:
         # We only want 2i2c and anu users to sign up
         username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'
         # Delete any prior existing users in the db that don't pass username_pattern
-        # delete_invalid_users: true
+        delete_invalid_users: true

--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -46,7 +46,7 @@ jupyterhub:
               username_claim: "email"
           https://idp2.anu.edu.au/idp/shibboleth:
             username_derivation:
-            username_claim: "email"
+              username_claim: "email"
       Authenticator:
         # We only want 2i2c and anu users to sign up
         username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'

--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -48,7 +48,7 @@ jupyterhub:
             username_derivation:
             username_claim: "email"
       Authenticator:
-        # We only want 2i2c and any users to sign up
+        # We only want 2i2c and anu users to sign up
         username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'
         # Delete any prior existing users in the db that don't pass username_pattern
         # delete_invalid_users: true

--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -44,23 +44,9 @@ jupyterhub:
           http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"
-                action: "strip_idp_domain"
-                # Use a hack here to allow leaving usernames unchanged.
-                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
-                # Since we're only allowing 2i2c.org domains and anu.edu.au, then this will fail
-                # and usernames will be left unchanged.
-                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
-                domain: "gmail.com"
           https://idp2.anu.edu.au/idp/shibboleth:
                 username_derivation:
                 username_claim: "email"
-                action: "strip_idp_domain"
-                # Use a hack here to allow leaving usernames unchanged.
-                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
-                # Since we're only allowing 2i2c.org domains and anu.edu.au, then this will fail
-                # and usernames will be left unchanged.
-                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
-                domain: "gmail.com"
       Authenticator:
         # We only want 2i2c and any users to sign up
         username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'

--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -34,10 +34,35 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://anu.pilot.2i2c.cloud/hub/oauth_callback
-        username_claim: "email"
         admin_users:
           - matthew.mckay@anu.edu.au
-        # We do not define allowed_users here since only usernames matching these domains will be allowed to login into the hub.
+        # Only show the option to login with Google and ANU
+        shown_idps:
+          - https://idp2.anu.edu.au/idp/shibboleth
+          - https://accounts.google.com/o/oauth2/auth
         allowed_idps:
-          - 2i2c.org
-          - anu.edu.au
+          http://google.com/accounts/o8/id:
+              username_derivation:
+                username_claim: "email"
+                action: "strip_idp_domain"
+                # Use a hack here to allow leaving usernames unchanged.
+                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
+                # Since we're only allowing 2i2c.org domains and anu.edu.au, then this will fail
+                # and usernames will be left unchanged.
+                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
+                domain: "gmail.com"
+          https://idp2.anu.edu.au/idp/shibboleth:
+                username_derivation:
+                username_claim: "email"
+                action: "strip_idp_domain"
+                # Use a hack here to allow leaving usernames unchanged.
+                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
+                # Since we're only allowing 2i2c.org domains and anu.edu.au, then this will fail
+                # and usernames will be left unchanged.
+                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
+                domain: "gmail.com"
+      Authenticator:
+        # We only want 2i2c and any users to sign up
+        username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'
+        # Delete any prior existing users in the db that don't pass username_pattern
+        # delete_invalid_users: true

--- a/config/clusters/2i2c/anu.values.yaml
+++ b/config/clusters/2i2c/anu.values.yaml
@@ -42,11 +42,11 @@ jupyterhub:
           - https://accounts.google.com/o/oauth2/auth
         allowed_idps:
           http://google.com/accounts/o8/id:
-              username_derivation:
-                username_claim: "email"
+            username_derivation:
+              username_claim: "email"
           https://idp2.anu.edu.au/idp/shibboleth:
-                username_derivation:
-                username_claim: "email"
+            username_derivation:
+            username_claim: "email"
       Authenticator:
         # We only want 2i2c and any users to sign up
         username_pattern: '^(.+@2i2c\.org|.+@anu\.edu\.au|deployment-service-check)$'

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -37,7 +37,27 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          username_claim: "email"
           oauth_callback_url: "https://dask-staging.2i2c.cloud/hub/oauth_callback"
+          # Only show the option to login with Google
+          shown_idps:
+            - https://accounts.google.com/o/oauth2/auth
           allowed_idps:
-            - "2i2c.org"
+            # CILogon still uses the old google oidc enpoint instead of the new one listed in `shown_idps`.
+            # Should open an issue upstream to fix this.
+            # Docs about new one https://developers.google.com/identity/protocols/oauth2/openid-connect.
+            http://google.com/accounts/o8/id:
+              username_derivation:
+                username_claim: "email"
+                action: "strip_idp_domain"
+                # Use a hack here to allow leaving usernames unchanged.
+                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
+                # Since we're only allowing 2i2c.org domains, then this will fail
+                # and usernames will be left unchanged.
+                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
+                domain: "gmail.com"
+        Authenticator:
+          # We only want 2i2c users to sign up
+          # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
+          username_pattern: '^(.+@2i2c\.org|deployment-service-check)$'
+          # Delete any prior existing users in the db that don't pass username_pattern
+          # delete_invalid_users: true

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -43,8 +43,7 @@ basehub:
             - https://accounts.google.com/o/oauth2/auth
           allowed_idps:
             # CILogon still uses the old google oidc enpoint instead of the new one listed in `shown_idps`.
-            # Should open an issue upstream to fix this.
-            # Docs about new one https://developers.google.com/identity/protocols/oauth2/openid-connect.
+            # Ref https://github.com/ncsa/OA4MP/issues/45
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -53,4 +53,4 @@ basehub:
           # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
           username_pattern: '^(.+@2i2c\.org|deployment-service-check)$'
           # Delete any prior existing users in the db that don't pass username_pattern
-          # delete_invalid_users: true
+          delete_invalid_users: true

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -48,13 +48,6 @@ basehub:
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"
-                action: "strip_idp_domain"
-                # Use a hack here to allow leaving usernames unchanged.
-                # https://github.com/jupyterhub/oauthenticator/blob/42bebe989ec10e8a439bc80a011fbe64cc01669f/oauthenticator/cilogon.py#L341
-                # Since we're only allowing 2i2c.org domains, then this will fail
-                # and usernames will be left unchanged.
-                # FIXME when https://github.com/jupyterhub/oauthenticator/issues/514 lands.
-                domain: "gmail.com"
         Authenticator:
           # We only want 2i2c users to sign up
           # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -288,7 +288,8 @@ jupyterhub:
                 interfaces:
                   - value: "/tree"
                     title: Classic Notebook
-                    description: The original single-document interface for creating
+                    description:
+                      The original single-document interface for creating
                       Jupyter Notebooks.
                   - value: "/lab"
                     title: JupyterLab

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -318,7 +318,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3264.h347b855e"
+      tag: "0.0.1-n3288.h27beafd1"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -288,8 +288,7 @@ jupyterhub:
                 interfaces:
                   - value: "/tree"
                     title: Classic Notebook
-                    description:
-                      The original single-document interface for creating
+                    description: The original single-document interface for creating
                       Jupyter Notebooks.
                   - value: "/lab"
                     title: JupyterLab
@@ -319,7 +318,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3143.h54da806"
+      tag: "0.0.1-n3264.h347b855e"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -18,9 +18,8 @@ RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configura
 # z2jh 1.2.x ships with kubespawner 1.1.0, so we just do a little bump
 RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
 
-# Brings in https://github.com/jupyterhub/oauthenticator/pull/498 and
-# https://github.com/jupyterhub/oauthenticator/pull/504
-RUN pip install --no-cache --upgrade git+https://github.com/jupyterhub/oauthenticator@60ddc4fe3ab06b19c6876992679c1fd2ec1c64dd
+# Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0-0
+RUN pip install --no-cache --upgrade oauthenticator==15.0.0
 
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configura
 RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
 
 # Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0-0
-RUN pip install --no-cache --upgrade oauthenticator==15.0.0
+RUN pip install --no-cache --upgrade oauthenticator==15.0.1
 
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configura
 # z2jh 1.2.x ships with kubespawner 1.1.0, so we just do a little bump
 RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
 
-# Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0-0
+# Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0
 RUN pip install --no-cache --upgrade oauthenticator==15.0.1
 
 USER root


### PR DESCRIPTION
This bumps the oauthenticator version to 15.0.0. However, doing this revealed some shortcomings and this PR contains some workarounds for those.

### OAuthenticator

Some upstream issues that are relevant and provide more info:

- https://github.com/jupyterhub/oauthenticator/issues/514
- https://github.com/jupyterhub/oauthenticator/issues/515

### CILogon

There is a possible issue with CILogon using an old OIDC endpoint for google (and open an issue upstream about this) (Old endpoint is http://google.com/accounts/o8/id, and new endpoint should be https://accounts.google.com/o/oauth2/v2/auth).

Look how for shown idps, the correct url is https://github.com/2i2c-org/infrastructure/blob/6debc6f283276922cc9d69fb40e34ce8694a31b0/config/clusters/2i2c/anu.values.yaml#L42

But the idp field of the `userinfo` response
https://github.com/jupyterhub/oauthenticator/blob/f3af268474ecce4fc2a9eb789c2e06cd692375fa/oauthenticator/cilogon.py#L306

is an old endpoint https://github.com/2i2c-org/infrastructure/blob/6debc6f283276922cc9d69fb40e34ce8694a31b0/config/clusters/2i2c/anu.values.yaml#L44

Opened an issue upstream about this one. https://github.com/ncsa/OA4MP/issues/45

### TODO list
- [x] use oauthenticator 15.0.1 release instead of 15.0.0
Deploy and test these changes on:
- [x] 2i2c-staging
- [x] 2i2c-demo
- [x] leap-staging
- [x] utoronto-staging
Maybe:
- [x] 2i2c-anu
- [x] 2i2c-dask-staging

Closes https://github.com/2i2c-org/infrastructure/issues/1319