### PR TITLE
Bugfixing the bump image tags workflow

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -54,5 +54,5 @@ jobs:
           config_path: ${{ matrix.config_path }}
           images_info: ${{ matrix.images_info }}
           github_token: ${{ steps.generate_token.outputs.token }}
-          team_reviewers: ${{ env.team_reviewers }}
+          # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"


### PR DESCRIPTION
- An extra quotation mark caused a json.load failure
- Assigning team reviewers is currently broken, so disable that for now