### PR TITLE
Create support link that will appear on new issue page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Looking for Support?
+    url: https://docs.2i2c.org/en/latest/support.html
+    about: Ask for help through our support process


### PR DESCRIPTION
We get a few questions opened as issues on this repo instead of being sent to our support email. This PR adds a config file under ISSUE_TEMPLATE which will add a new option to our "New Issues" page that redirects to our support docs. Inspired by the work @GeorgianaElena did here: https://github.com/jupyterhub/.github/blob/master/.github/ISSUE_TEMPLATE/config.yml 💖 Thank you!