### PR TITLE
Enable cryptnono on all our clusters

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -35,3 +35,10 @@ dependencies:
     version: 1.3.1
     repository: https://kvaps.github.io/charts
     condition: nfs-server-provisioner.enabled
+
+  # cryptnono, counters crypto mining
+  # Source code: https://github.com/yuvipanda/cryptnono/
+  - name: cryptnono
+    version: "0.0.1-n025.h28f473f"
+    repository: https://yuvipanda.github.io/cryptnono/
+    condition: cryptnono.enabled

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -18,6 +18,7 @@ required:
   - nfs-server-provisioner
   - nvidiaDevicePlugin
   - prometheusIngressAuthSecret
+  - cryptnono
   - global
 properties:
   # cluster-autoscaler is a dependent helm chart, we rely on its schema
@@ -48,6 +49,10 @@ properties:
   # validation for values passed to it and are not imposing restrictions on them
   # in this helm chart.
   nfs-server-provisioner:
+    type: object
+    additionalProperties: true
+  # Enables  https://github.com/yuvipanda/cryptnono/ to prevent cryptomining
+  cryptnono:
     type: object
     additionalProperties: true
   # nvidiaDevicePlugin is _not a dependent helm chart_. It is values directly

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -133,6 +133,10 @@ nvidiaDevicePlugin:
   aws:
     enabled: false
 
+# Enables  https://github.com/yuvipanda/cryptnono/ to prevent cryptomining
+cryptnono:
+  enabled: true
+
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or
 # used.


### PR DESCRIPTION
https://github.com/yuvipanda/cryptnono/ is now deployed
on mybinder.org. We've already had a few incidents with
cryptomining (OpenScapes, cloudbank, pangeo binder). This
should help with that.