### PR TITLE
Post hub deployment plan as a comment on PRs

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -46,12 +46,14 @@ jobs:
   # hub upgraded; and the second set of jobs describe which production hubs require
   # upgrading. These two lists are set as job outputs using ::set-output to be consumed
   # by the later jobs. They are also pretty-printed in a human-readable format to the
-  # logs.
+  # logs, and converted into Markdown tables for posting into GitHub comments.
   generate-jobs:
     runs-on: ubuntu-latest
     outputs:
       support-and-staging-matrix-jobs: ${{ steps.generate-jobs.outputs.support-and-staging-matrix-jobs }}
       prod-hub-matrix-jobs: ${{ steps.generate-jobs.outputs.prod-hub-matrix-jobs }}
+      md-table-support-staging: ${{ steps.generate-jobs.outputs.md-table-support-staging }}
+      md-table-prod: ${{ steps.generate-jobs.outputs.md-table-prod }}
 
     steps:
       - name: Checkout repo
@@ -91,9 +93,6 @@ jobs:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: Post the pretty print output of this step as a comment on the Pull Request.
-      # Do this in a Netlify-style way where if a comment already exists, it is updated
-      # instead of generating a new comment.
       - name: Generate matrix jobs
         id: generate-jobs
         run: |
@@ -288,3 +287,108 @@ jobs:
           max_attempts: 3
           command: |
             python deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
+
+  # This job posts the matrix jobs defined in generate-jobs to a comment on a Pull
+  # Request in Markdown table format. This means that no-one has to go searching through
+  # GitHub Actions logs to see if the hubs they intended to be upgraded, are being
+  # upgraded. The job posts the comment in a 'Netlify style', i.e., if a comment has
+  # already been posted (identified as having the 'github-actions[bot]' author and
+  # '<!-- deployment-plan -->' string in the body), the existing comment will be
+  # updated rather than posting a new one.
+  #
+  # This job requires the generate-jobs job to have completed successfully and assigned
+  # the Markdown formatted tables to the md-table-support-staging and md-table-prod
+  # variables.
+  post-deployment-plan:
+    # Only run this job on Pull Requests
+    if: github.event_name == 'pull_request'
+    # Grant GITHUB_TOKEN just enough permissions to comment on pull requests
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: [generate-jobs]
+    steps:
+      - name: Install ghapi to interact with the GitHub API via Python
+        run: |
+          pip install ghapi
+
+      # As far as GitHub's API is concerned regarding comments, Pull Requests are the
+      # same objects as issues so we use "issue" terminology here
+      - name: Ascertain if a comment already exists on the Pull Request
+        id: comment-exists
+        shell: python
+        run: |
+          from ghapi.all import GhApi, paged
+
+          # Setup variables
+          api = GhApi(token=r"""${{ secrets.GITHUB_TOKEN }}""")
+          owner, repo = r"""${{ github.repository }}""".split("/")
+          issue_number = r"""${{ github.event.number }}"""
+
+          # List all comments on current issue
+          issue_comments = paged(
+              api.issues.list_comments,
+              owner=onwer,
+              repo=repo,
+              issue_number=issue_number,
+              per_page=100,
+          )
+
+          # Find if a deployment-plan comment has been previously posted
+          comment = next(
+              (
+                  comment[0]
+                  for comment in issue_comments
+                  if comment[0].user.login == "github-actions[bot]"
+                  and "<!-- deployment-plan -->" in comment[0].body
+              ),
+              False,
+          )
+
+          # Set outputs
+          if comment:
+              print("::set-output name=comment-exists::true")
+              print(f"::set-output name=comment-id::{comment.id}")
+          else:
+              print("::set-output name=comment-exists::false")
+              print(f"::set-output name=comment-id::null")
+
+      - name: Post deployment plan as a comment
+        if: steps.comment-exists.outputs.comment-exists == 'false'
+        uses: actions/github-script@v6.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var MD_TABLE_SUPPORT_STAGING = process.env.MD_TABLE_SUPPORT_STAGING;
+            var MD_TABLE_PROD = process.env.MD_TABLE_PROD;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `<!-- deployment-plan -->\n\nMerging this Pull Request will trigger the following deployments:\n\n**Support and Staging deployments**\n\n ${MD_TABLE_SUPPORT_STAGING}\n\n**Production deployments**\n\n${MD_TABLE_PROD}`
+            })
+        env:
+          MD_TABLE_SUPPORT_STAGING: ${{ needs.generate-jobs.outputs.md-table-support-staging }}
+          MD_TABLE_PROD: ${{ needs.generate-jobs.outputs.md-table-prod }}
+
+      - name: Update a comment containing a deployment plan
+        if: steps.comment-exists.outputs.comment-exists == 'true'
+        uses: actions/github-script@v6.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var MD_TABLE_SUPPORT_STAGING = process.env.MD_TABLE_SUPPORT_STAGING;
+            var MD_TABLE_PROD = process.env.MD_TABLE_PROD;
+            var COMMENT_ID = process.env.COMMENT_ID
+
+            github.rest.issues.updateComment({
+              comment_id: `${COMMENT_ID}`,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `<!-- deployment-plan -->\n\nMerging this Pull Request will trigger the following deployments:\n\n**Support and Staging deployments**\n\n ${MD_TABLE_SUPPORT_STAGING}\n\n**Production deployments**\n\n${MD_TABLE_PROD}`
+            })
+        env:
+          MD_TABLE_SUPPORT_STAGING: ${{ needs.generate-jobs.outputs.md-table-support-staging }}
+          MD_TABLE_PROD: ${{ needs.generate-jobs.outputs.md-table-prod }}
+          COMMENT_ID: ${{ steps.comment-exists.outputs.comment-id }}

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -301,8 +301,10 @@ jobs:
   # the Markdown formatted tables to the md-table-support-staging and md-table-prod
   # variables.
   post-deployment-plan:
-    # Only run this job on Pull Requests
-    if: github.event_name == 'pull_request'
+    # Only run this job on Pull Requests and when the job matrices are not empty
+    if: github.event_name == 'pull_request' &&
+      needs.generate-jobs.outputs.support-and-staging-matrix-jobs != '[]' &&
+      needs.generate-jobs.outputs.prod-hub-matrix-jobs != '[]'
     # Grant GITHUB_TOKEN just enough permissions to comment on pull requests
     permissions:
       pull-requests: write

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -21,7 +21,8 @@ on:
       - deployer/**
       - requirements.txt
       - .github/actions/setup-deploy/**
-      - "**.yaml"
+      - helm-charts/**
+      - config/clusters/**
       # We no longer trigger on this file since it does not contain any logic
       # concerning setting up the clusters for deploy. This now all lives in the
       # setup-deploy local action

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -263,8 +263,9 @@ def generate_helm_upgrade_jobs(changed_filepaths):
 
         # Generate template dictionary for all jobs associated with this cluster
         cluster_info = {
-            "cluster_name": cluster_name,
             "provider": provider,
+            "cluster_name": cluster_name,
+            "hub_name": "",
             "reason_for_redeploy": "",
         }
 

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -22,6 +22,7 @@ from config_validation import (
 from file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
 from helm_upgrade_decision import (
     assign_staging_jobs_for_missing_clusters,
+    convert_to_markdown_table,
     discover_modified_common_files,
     ensure_support_staging_jobs_have_correct_keys,
     generate_hub_matrix_jobs,
@@ -338,6 +339,13 @@ def generate_helm_upgrade_jobs(changed_filepaths):
         print(
             f"::set-output name=support-and-staging-matrix-jobs::{json.dumps(support_and_staging_matrix_jobs)}"
         )
+
+        # Generate Markdown tables from the job matrices and set them as outputs for use
+        # in another job
+        convert_to_markdown_table(
+            support_and_staging_matrix_jobs, suffix="support-staging"
+        )
+        convert_to_markdown_table(prod_hub_matrix_jobs, suffix="prod")
 
 
 def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -586,4 +586,4 @@ def convert_to_markdown_table(data, suffix=None):
     md_table = md_table.replace("\n", "%0A")
 
     # Set the Markdown table string as an output variable
-    print(f"::set-output {name}::{md_table}")
+    print(f"::set-output name={name}::{md_table}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,10 @@ auth0-python
 # jsonschema is used for validating cluster.yaml configurations
 jsonschema
 
-# rich is used for pretty printing outputs that would otherwise be difficult to
-# parse by a human
+# rich and py-markdown-table are used for pretty printing outputs that would otherwise
+# be difficult to parse by a human
 rich
+py-markdown-table
 
 # jhub_client, pytest, and pytest-asyncio are used for our health checks
 jhub-client==0.1.6


### PR DESCRIPTION
fixes #1269 

This PR adds a workflow job that will post a table of the hub deployment plan (which clusters will have their support chart and/or staging hub upgraded, and which prod hubs will be upgraded) as a comment to a Pull Request that triggers the deploy-hubs.yaml workflow file. This will make it obvious which hubs, if any, will be upgraded when the PR is merged, without having to go through the GitHub Actions logs.

* The comment is posted in a "Netlify way", i.e., update an existing comment rather than posting a new one, and doesn't post a comment at all if no matrix jobs are generated
* Unfortunately, rich didn't have a nice way to get a Markdown table from what is rendered by rich (see https://github.com/Textualize/rich/discussions/1254). I first experimented with the [text](https://github.com/sgibson91/testing-gh-actions/pull/19#issuecomment-1154342947) and html output, but they weren't formatted very nicely. So I ended up using a new package called py-markdown-table to get something that will render nicely in comments.
* There are some changes to how the dictionaries are constructed in the Python file. This is a noop change, but ensures that when the dictionaries are rendered as tables, the order of the columns (or dictionary keys) makes sense to a human reading the table.