### PR TITLE
Switch meom-ige core node to n1-highmem-2

### DIFF
--- a/docs/topic/cluster-design.md
+++ b/docs/topic/cluster-design.md
@@ -35,7 +35,7 @@ or enabling [Network Policy](https://cloud.google.com/kubernetes-engine/docs/how
 requires more resources as well.
 
 With poorly structured experimentation, the current recommendation is to run
-3 `g1-small` instances for a cluster without config connector or network policy,
+3 `n1-highmem-2` instances for a cluster without config connector or network policy,
 or a single `n1-highmem-4` instance for a cluster with either of those options
 turned on. This needs to be better investigated.
 

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -1,16 +1,7 @@
 prefix     = "meom-ige"
 project_id = "meom-ige-cnrs"
 
-# Minimum number of nodes required to fit kube-system is either
-# 2 n1-highcpu-2 nodes, or 3 g1-small nodes. If you don't enable
-# networkpolicy, you can get away with 1 n1-custom-4-3840 node -
-# but with that enable, calico-typha wants 2 replicas that
-# must run on two nodes since they both want the same hostport.
-# 3 g1-small is 13$ a month, wile a single n2-highcpu-2 is
-# already 36$ a month. We want very low base price, and
-# our core nodes will barely see any CPU usage, so g1-small is
-# the way to go
-core_node_machine_type = "g1-small"
+core_node_machine_type = "n1-highmem-2"
 
 # Single-tenant cluster, network policy not needed
 enable_network_policy    = false

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -118,7 +118,7 @@ variable "zone" {
 
 variable "core_node_machine_type" {
   type        = string
-  default     = "g1-small"
+  default     = "n1-highmem-2"
   description = <<-EOT
   Machine type to use for core nodes.
 
@@ -126,7 +126,7 @@ variable "core_node_machine_type" {
   for a cluster. We should try to run with as few of them
   as possible.
 
-  For single-tenant clusters, a single g1-small node seems
+  For single-tenant clusters, a single n1-highmem-2 node seems
   enough - if network policy and config connector are not on.
   For others, please experiment to see what fits.
   EOT


### PR DESCRIPTION
g1-small is too small apparently - CPU usage was too high,
and the nodes kept going into NotReady.

Ref https://github.com/2i2c-org/infrastructure/issues/1423