### PR TITLE
Update dask-gateway helm chart location link

### DIFF
--- a/docs/topic/hub-helm-charts.md
+++ b/docs/topic/hub-helm-charts.md
@@ -33,7 +33,7 @@ the hub domain, how the JupyterHub landing page will look like and authenticatio
 
 The helm charts are structured in a **hierarchical** model.
 The [jupyterhub helm chart](https://jupyterhub.github.io/helm-chart/) is a subchart of the basehub chart and
-the basehub chart along with the [dask-gateway](https://dask.org/dask-gateway-helm-repo/) one are
+the basehub chart along with the [dask-gateway](https://helm.dask.org) one are
 subcharts of the daskhub.
 
 **Visual of the helm-chart hierarchy:**


### PR DESCRIPTION
Otherwise, linkcheck fails. For example: https://github.com/2i2c-org/infrastructure/runs/6928234701?check_suite_focus=true