### PR TITLE
Automate bumping of repo2docker image in BinderHub helm chart

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -22,7 +22,7 @@ jobs:
             config_path: "helm-charts/binderhub/values.yaml"
             images_info: '{"values_path": ".binderhub.config.BinderHub.build_image"}'
 
-          # Turn of bumping of Pangeo images as per https://github.com/2i2c-org/infrastructure/issues/1240#issuecomment-1151212986
+          # Turn off bumping of Pangeo images as per https://github.com/2i2c-org/infrastructure/issues/1240#issuecomment-1151212986
           # - name: "pangeo-hubs common singleuser image"
           #   config_path: "config/clusters/pangeo-hubs/common.values.yaml"
           #   # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -2,8 +2,8 @@ name: Bump Image Tags
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
+  schedule:
+    - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
 
 env:
   team_reviewers: tech-team
@@ -18,6 +18,9 @@ jobs:
         include:
           # For each new config_path to monitor, add a new item in this matrix.
           # The Action can read multiple paths to images, but not multiple config files.
+          - name: "BinderHub/repo2docker bump"
+            config_path: "helm-charts/binderhub/values.yaml"
+            images_info: '{"values_path": ".binderhub.config.BinderHub.build_image"}'
 
           # Turn of bumping of Pangeo images as per https://github.com/2i2c-org/infrastructure/issues/1240#issuecomment-1151212986
           # - name: "pangeo-hubs common singleuser image"

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -18,20 +18,22 @@ jobs:
         include:
           # For each new config_path to monitor, add a new item in this matrix.
           # The Action can read multiple paths to images, but not multiple config files.
-          - name: "pangeo-hubs common singleuser image"
-            config_path: "config/clusters/pangeo-hubs/common.values.yaml"
-            # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
-            images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
-          - name: "m2lines common singleuser/PyTorch/Tensorflow"
-            config_path: "config/clusters/m2lines/common.values.yaml"
-            # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
-            # If the ordering of profileList changes, update the index in this expression
-            images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[4].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[5].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
-          - name: "leap common singleuser/pangeo-ml-notebook"
-            config_path: "config/clusters/leap/common.values.yaml"
-            # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
-            # If the ordering of profileList changes, update the index in this expression
-            images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[4].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
+
+          # Turn of bumping of Pangeo images as per https://github.com/2i2c-org/infrastructure/issues/1240#issuecomment-1151212986
+          # - name: "pangeo-hubs common singleuser image"
+          #   config_path: "config/clusters/pangeo-hubs/common.values.yaml"
+          #   # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
+          #   images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
+          # - name: "m2lines common singleuser/PyTorch/Tensorflow"
+          #   config_path: "config/clusters/m2lines/common.values.yaml"
+          #   # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
+          #   # If the ordering of profileList changes, update the index in this expression
+          #   images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[4].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[5].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
+          # - name: "leap common singleuser/pangeo-ml-notebook"
+          #   config_path: "config/clusters/leap/common.values.yaml"
+          #   # The regexpr attribute will ensure we only bump tags in the form YYYY.MM.DD
+          #   # If the ordering of profileList changes, update the index in this expression
+          #   images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[4].kubespawner_override.image", "regexpr": "[0-9]{4}.[0-9]{2}.[0-9]{2}"}]'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,


### PR DESCRIPTION
This PR enables automatic bumping of the repo2docker image listed in the BinderHub helm chart values file.

It also disables bumping of Pangeo images as per: https://github.com/2i2c-org/infrastructure/issues/1240#issuecomment-1151212986