### PR TITLE
Add all clusters to the deploy grafana workflow

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -10,12 +10,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The grafana for 2i2c cluster holds also info about all other clusters
           - cluster_name: 2i2c
-          - cluster_name: cloudbank
+          - cluster_name: azure.carbonplan
           - cluster_name: carbonplan
-          - cluster_name: pangeo-hubs
+          - cluster_name: cloudbank
+          - cluster_name: leap
           - cluster_name: m2lines
+          - cluster_name: meom-ige
+          - cluster_name: openscapes
+          - cluster_name: pangeo-hubs
           - cluster_name: utoronto
+          - cluster_name: uwhackweeks
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds missing clusters that have the support chart deployed to the  deploy jupyterhub dashboards workflow job matrix.

The value of this workflow is that each time https://github.com/jupyterhub/grafana-dashboards gets updated, we can manually trigger this workflow and the dashboards in each of the grafanas of the clusters here will get the updates.