### PR TITLE
Add/update grafana tokens

### DIFF
--- a/config/clusters/azure.carbonplan/enc-grafana-token.secret.yaml
+++ b/config/clusters/azure.carbonplan/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:6qmCts5tIz/hlwW9kFX3cyXumSS9UakBDGVMoX9zYr5sG0jJXSuLYiESPOF7WX6IiULWgrdzIfh1eJiqkFhXIA3oHLcSJlbDw9Lm5Rcupq31WhWXIySTWpMBRmyEuAdg4FKMd+LSGgdAQWQKndspfHVbZFQ=,iv:B0u8VIqPsKxNVvbXyD1pjWJwoJg1QGt8HRye9G74ae8=,tag:X9sgqdKjsFLIVH5OwJWEgA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-06-17T13:55:35Z"
+          enc: CiQA4OM7eKk9kL5KTx7Ibd0yGHau05zAKGO8JidYoqb6EuQFAtMSSQBq6cPrdoU3CQmkXmv9y50TNU3xO9TM8bl+XComLgYqWz0zRcxF0GCH1dFTpKwqR224Bskqy0j/fNZoiAIbwbttvx/sWn8OZSo=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-06-17T13:56:09Z"
+    mac: ENC[AES256_GCM,data:8mju6Dc1ODrWdHumdsXoyIah76q+MICbutK7m07kHVifMDhLwnJupJ6ZNYUdP3WgwZ2ko6MujOyS4XmAaJZzKA8HWWEWrn2BvkZCllXl5+wLTWcJgNj2lIz4iN4RU1Y5USp+k32DTHlk5TmNAAkD74wX9jAzuZ+VvJbHOY7ycY4=,iv:efeq8fdfg/AzoiN2iUiwjZyqm+8BxPDqN6FbJTaRQnU=,tag:zrA4IUrD7oR2xIiE1mjc8g==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/meom-ige/enc-grafana-token.secret.yaml
+++ b/config/clusters/meom-ige/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:8df3/m7243Qq9/qlcbPlLTKvLT7Tbqa5Soy6qRXc+iLNAj1KUifv+oQWATPHjkMNaLeOzEDjHsQQVijlXKL/kdXKa8tMmEjjcv6kouCav03N/+yTh3qjwf52oWpBT3foiNvx2YZ11sRGdQQf1oSshFQ+SF0=,iv:9ICrqrEQ1AUCKjJEecZDLoTsDWNCZe3M8eq5xc78+rA=,tag:Lq27SLrlcDtstcxm9aNQxw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-06-17T14:08:10Z"
+          enc: CiQA4OM7eLgXoTsBOmxU7J6DY/Jt1FuyJGR0aWJzVhzdc0YXgyYSSQBq6cPrJO/xqT8XMx09QLAouwc1M/zC+FFuvr3h5sRSHrs2pRsEe+yc/yz18glzXDvuTCX1K2vFHihn55ik/TmFlz5BqSoHjV0=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-06-17T14:08:49Z"
+    mac: ENC[AES256_GCM,data:/2JZgXdbagk0mGjgAdfLUZcqc0bTwI/hiZSXW8XxdYMZRVHIx2T07E9Yo8yPISdvbxakJCm6bdBTgnyNeXP51zViOcSZbbZmSEZUcnKoxp1DaZTFlJAm+WG1qMeeDTBxuAPN4D3BvgT8wgm5tiYhG7MwbVoA8Bskx7/AORYkzLo=,iv:Y346+SOD3WdJp8hg/Y3BKnDbapknmgg92Ms6YRXwNUQ=,tag:Qu0QgRNIgsA0vhxk7OMv/w==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/openscapes/enc-grafana-token.secret.yaml
+++ b/config/clusters/openscapes/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:a2z2vOY0C17bh9Y6qnYDRqo4kHanAmMRNPE8lR3GgM7Q6v8AvRk7UIw5KKnkeK5a19nN5JbAqneLShwR4r33kkuV5HTx4muMT8y6xlFReRLfsi6lE0PEHVV9EwYlZ59Mx9SiBHgPsVefnrGu5GyXZElK8w0=,iv:FV4kr4X/Dy++7HErkEhEbX1Sz4o1+lGAjvZpGGxNodg=,tag:KV0R0BO21OHXx2vswHlvtg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-06-17T14:11:08Z"
+          enc: CiQA4OM7eGC5PqilEvBdn4ZMfodM+4OmUMnb4Ay1GyEsX4zFU+0SSQBq6cPrCibj3755yvXiEq1fgSa9Z9WTIEkBzQS/vlObSGuWmqB2oGpZ+oBd1Y2s6POXzypgONYrjLecO99jxZHccXfmmYgbLog=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-06-17T14:11:31Z"
+    mac: ENC[AES256_GCM,data:hA893itPTMk8eCsc2wM7nOo0dcSXyZu1iHchZtvCjKNbvCVj1OMrhlos+Xtt8Io6s0mS2hkYNpfz4VKqQsurEQg108O0qeYYj+jnUGc43MgVayLssGpN8SqIOkG/QRvIGCNIKsjD8KhJ7nzLCRe9ZazHmFwiy/RRx8wCQEgGDxc=,iv:/WyI4bl/ZCdRNXdCd6ZV1nc5K2IFw7n8wofmssOSOsU=,tag:NbUB7lYk7SC3/Gi/aYaSPg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/uwhackweeks/enc-grafana-token.secret.yaml
+++ b/config/clusters/uwhackweeks/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:sVHCva7nXXMK7eyGmLG+eA76P3WpfeZRx98ZqThilPZfSRNSIpIVczNBpO+T+N/YdHjmX6ZagKOwLpIkP1K1kF/USYdv+Z3eXFQ8/7hC5k4w4nEi,iv:UxrFAHTwxgV8pjtVUdwMhnmVwAWYgLh5OzGfW8wTmRU=,tag:CIxevt8IQ7sRT2iHDF3UxA==,type:str]
+grafana_token: ENC[AES256_GCM,data:0xyoIywxdi4KU3Gf5dVMreMKtoB5g1v6CLeis694IFK92P0kSRoB6nZD6DMXNFgS7ZbaYqKylM4XKyo6HOMwfefvSjBSyVOQR3zJARbbf80jFJTN0E37xBaoxzbR9dIE5NMX+uPTa4Mc8dvBfwCbZlNWKx0=,iv:iKS2VFvcXFWQ2s8z8+9g/RrL4uRXEtwHDP2mVgwxgxA=,tag:Z4rPUVVibscHuB3JWacq3w==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2022-02-24T18:01:18Z"
-      enc: CiQA4OM7eKIDrkPbN5W79M4cvuReD7UMFZbDto9q/tiCiTLYI9USSADm5XgWZWPHVjmQJC8sFR2OAsvnO5kov/vsN+PtRD1AUbN9F1bt0OhHEkr5DaoW9XrjqoZOhYPFpNdX25U3sKZJjlcqycnZgA==
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: "2022-02-24T18:01:19Z"
-  mac: ENC[AES256_GCM,data:PzY3SfMgkj6SjaJoNaoFrRUnMqj6XY7Vqlwq25dQkv8qMozDgzHvJheoih4i3QfRGM3sJiKFdSJdq6VUZYFscorwxh2BCA6vawDXNM8zi0+Gh2xz+0Js8exz4CCkDHKelDuhpciUycRRzgRrxk4Y1mTr2XdYSl346b5EB20nFSI=,iv:MF/dBFlqz+pGK//uO8NMYAv4RBql65Hnd8WEnBvEna0=,tag:6k7m4HLF1S/Wi2PNMgWLpA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-02-24T18:01:18Z"
+          enc: CiQA4OM7eKIDrkPbN5W79M4cvuReD7UMFZbDto9q/tiCiTLYI9USSADm5XgWZWPHVjmQJC8sFR2OAsvnO5kov/vsN+PtRD1AUbN9F1bt0OhHEkr5DaoW9XrjqoZOhYPFpNdX25U3sKZJjlcqycnZgA==
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-06-17T14:21:34Z"
+    mac: ENC[AES256_GCM,data:9U6kXgYpkU6vbSsM6rrZkQUj1x1/Tb3fX/J0IW5qjKcUi+Szk0GDJNBv4KOQvyeZU2kAlYIHUFLpDltc8DxG8xAw/Lz3TEV95V8c+EnC3WkP6GHhS3UT2Qu8U9PK61BeGBXHhrrO3yHKHSX88l2CtMs8YiCi0AEDZklEZvHIlLs=,iv:DVrk3gu9e3zcxX+/FB8qxCm4PK3di3lkj/e2DA8XCe4=,tag:iTZSGh2piGRZoqn7d0vqrQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3


### PR DESCRIPTION
Manually triggering https://github.com/2i2c-org/infrastructure/actions/runs/2515304896 revealed that some clusters were missing grafana tokens to be used by that action.

This adds those tokens and also updates the token for one cluster (uwhackweeks I believe) that had a token, but didn't have enough permissions (the action might need the token to have `admin` permissions not just `editor`, as a 403 error was returned by the `grafana-dashboards` deployer)?