### PR TITLE
Create multiple repositories in GAR with Service Accounts

### DIFF
--- a/terraform/gcp/registry.tf
+++ b/terraform/gcp/registry.tf
@@ -6,11 +6,49 @@
 resource "google_artifact_registry_repository" "registry" {
   provider = google-beta
 
+  for_each      = toset(var.container_repos)
+
   location      = var.region
-  repository_id = "${var.prefix}-registry"
+  repository_id = "${each.key}-registry"
   format        = "DOCKER"
   project       = var.project_id
 
   // Set these values explicitly so they don't "change outside terraform"
   labels = {}
+}
+
+// Create a service account for the hub to authenticate push/pulls to the GAR with
+resource "google_service_account" "registry_sa" {
+  for_each     = toset(var.container_repos)
+
+  account_id   = "${each.key}-registry-sa"
+  display_name = "Service account to manage images in GAR repo ${each.key}"
+  project      = var.project_id
+}
+
+// Assign the artifactregistry.writer role to the service account so that new images
+// can be created and pushed
+resource "google_project_iam_member" "registry_sa_roles" {
+  for_each = google_service_account.registry_sa
+
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${each.value.email}"
+}
+
+// Generate a key for each service account
+resource "google_service_account_key" "registry_sa_keys" {
+  for_each = google_service_account.registry_sa
+
+  service_account_id = each.value.name
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}
+
+// Output the service account key for use in the hub config to authenticate image push/pulls
+output "registry_sa_keys" {
+  value     = { for n, k in var.container_repos : k => base64decode(google_service_account_key.registry_sa_keys[n].private_key) }
+  sensitive = true
+
+  description = <<-EOT
+  EOT
 }

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -297,3 +297,14 @@ variable "hub_cloud_permissions" {
      and write permissions for.
   EOT
 }
+
+variable "container_repos" {
+  type        = list
+  default     = []
+  description = <<-EOT
+  A list of container repositories to create in Google Artifact Registry to store Docker
+  images. Each entry is the name of the hub namespace in the cluster. If deploying a
+  BiderHub, definitely add the namespace here so that there is somewhere to push the
+  repo2docker-built images to.
+  EOT
+}


### PR DESCRIPTION
Create one repository per provided hub namespace in a Google Artifact
Registry. Also create a Service Account Key with artifactregistry.writer
role to push/pull images (for BinderHub).