### PR TITLE
Update path trigger for terraform-lint.yaml workflow

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -3,7 +3,7 @@ name: Lint terraform
 on:
   pull_request:
     paths:
-      - terraform/*
+      - "terraform/**"
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed that our terraform lint job hadn't been run in a while. In fact, the last time was on #807. I believe this is because the path trigger "terraform/*" only looked one step below the the terraform directory. This PR changes the path trigger to "terraform/**" which means it should now capture changes in deeper folders under the terraform directory.