### PR TITLE
Bump prometheus memory limit for pangeo-hubs

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -29,4 +29,4 @@ prometheus:
     resources:
       limits:
         cpu: 2
-        memory: 12Gi
+        memory: 16Gi


### PR DESCRIPTION
Prometheus is now back up on the pangeo-hubs cluster

relevant https://github.com/2i2c-org/infrastructure/issues/1422