### PR TITLE
Increase memory for meom-ige prometheus

### DIFF
--- a/config/clusters/meom-ige/support.values.yaml
+++ b/config/clusters/meom-ige/support.values.yaml
@@ -17,7 +17,7 @@ prometheus:
         memory: 512Mi
       limits:
         cpu: 500m
-        memory: 1G
+        memory: 2G
 grafana:
   ingress:
     hosts:


### PR DESCRIPTION
The upgrade fails with the following message, but the prometheus server is now running again, so this PR or the k8s objects themselves may need a little tweaking to fix the error 🤷🏻‍♀️ 

```
Error: UPGRADE FAILED: cannot patch "support-prometheus-server" with kind Ingress: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://support-ingress-nginx-controller-admission.support.svc:443/networking/v1beta1/ingresses?timeout=10s": x509: certificate signed by unknown authority
```

relevant #1404 