### PR TITLE
Add troubleshooting entry on failed webhook

### DIFF
--- a/docs/topic/troubleshooting.md
+++ b/docs/topic/troubleshooting.md
@@ -74,6 +74,6 @@ where the `-A` flag will apply this command across all namespaces.
 Find the webhooks running on a cluster by running:
 
 ```bash
-kubectl get ValidatingWebhooksConfigurations
+kubectl -A get ValidatingWebhooksConfigurations
 ```
 ````

--- a/docs/topic/troubleshooting.md
+++ b/docs/topic/troubleshooting.md
@@ -1,7 +1,9 @@
+(troubleshooting)=
 # Troubleshooting and debugging
 
 These sections describe a few common and useful tips for troubleshooting our infrastructure.
 
+(troubleshooting/rollback)=
 ## Roll back (revert) a helm deploy
 
 Sometimes it is useful to simply **revert** a Kubernetes deployment with Helm.
@@ -30,6 +32,7 @@ If you'd simply like to revert back to the state of the Kubernetes infrastructur
 
 This should revert the Helm deployment to the previous revision (the one just before you ran `helm upgrade`).
 
+(troubleshooting/prometheus-oom)=
 ## Prometheus Server is Out Of Memory (OOM)
 
 Prometheus collects Kubernetes metrics for our grafana charts and often requires a lot of memory during startup.
@@ -49,3 +52,28 @@ prometheus:
 The [default for this value is 2GB](https://github.com/2i2c-org/infrastructure/tree/HEAD/helm-charts/support/values.yaml#L38).
 Try increasing this value in small increments and deploying using `python deployer deploy-support {{CLUSTER_NAME}}` until the server successfully starts up.
 Then make a Pull Request with your updated config.
+
+(troubleshooting/validation-webhook)=
+## Failure calling validation webhook for `support` components
+
+After addressing [](troubleshooting/prometheus-oom), you may see the following error when redeploying the support chart:
+
+```bash
+Error: UPGRADE FAILED: cannot patch "support-prometheus-server" with kind Ingress: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://support-ingress-nginx-controller-admission.support.svc:443/networking/v1beta1/ingresses?timeout=10s": x509: certificate signed by unknown authority
+```
+
+You can resolve this by deleting the webhook and redeploying - helm will simply recreate the webhook.
+
+```bash
+kubectl -A delete ValidatingWebhookConfiguration support-ingress-nginx-admission
+```
+
+where the `-A` flag will apply this command across all namespaces.
+
+````{tip}
+Find the webhooks running on a cluster by running:
+
+```bash
+kubectl get ValidatingWebhooksConfigurations
+```
+````


### PR DESCRIPTION
This adds the debugging steps taken in https://github.com/2i2c-org/infrastructure/pull/1448 to our troubleshooting guide