### PR TITLE
Add config for 2i2c grafana github auth

### DIFF
--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -2,9 +2,10 @@ prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:JvYLxEOsbjfFCn+ZUwLQZ9KzrUFsUxxrHh/+66cWnD7H8ThGPtEPGwtZBDQXPZWiLkiI6Xp3tLTu/WGjMUnstw==,iv:eaElI1PK3Qnzd7/msM/14ws6a0WgAX69fQhyC/gMqdg=,tag:9TVlhr+4M3a2lZgFG9l12g==,type:str]
     password: ENC[AES256_GCM,data:MelDCxj31MKwzYQazMFWOPaE8xF9dlesW1r7zl4njPftKLGyqjfvLSzrjoqc+3O1mZBH0a97L3eBb6S+NLBxzA==,iv:4mo8AhPHz5DQNs/w9fpoWmP1WA/HPj0u/T5IpR68x3o=,tag:gs4V+Db9g3uf/DKsCkIRjQ==,type:str]
 grafana:
-    auth.github:
-        client_id: ENC[AES256_GCM,data:hhwWCQS9fVW4IO1BZu1ObooqTRY=,iv:79qx37jX6xUfjtyjyVfhBGtM0maUjIbtqs9WgT+qYWs=,tag:lHMKgs9JCFEZyOp33oApSA==,type:str]
-        client_secret: ENC[AES256_GCM,data:rTViEWKoVPnm2Ti2euxxpvgdKWop2uvSsmg0zeeOQAmzaYJ6clzqnw==,iv:lvwofj/L62ez8NMa5DZmtOlcbe0eQbJnJcmojGAFvAI=,tag:+zuzkSY76LPwE5zL32e4mw==,type:str]
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:8h2NTnOgi69C9r2rPhAsovA9j5w=,iv:ChibKvAdzbI3F8ew21Fy2TqAIdCgpf0J0A1wICsAuIo=,tag:6JAlaJ8H/6MvJwXS8gDAzQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:/bm7OcoLM8f8kUbP/bSAi8iFO6mETEydjiqwqXd2qGzwl6D213Okdw==,iv:syKMxz6GIfH2CeN+pSekebcS2mQgrEizt56eJz1rZJs=,tag:9jzXPcnBbNL6SLNHJ859zg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -14,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-22T15:22:04Z"
-    mac: ENC[AES256_GCM,data:MtEZ4n1byobWNKgHZ9QGOZow+OB42uYAYsoQqSuXsIq6ZHiXoft/fic2KYFSswRlC1vbfpBLNaqoc84oUdJFv3SH9yO/PfmuJYqOrO5GBdaI4aLo5y0WqZGZ2jpROsmjTIJks7w1w0iXSiZg/lk76IIccfQBIFlP7AauicTPaT8=,iv:hJa7Rti+M1MyuIlzWeIGNPrniGD5+eb4ijAZLAYeTUA=,tag:bSiw3tMAvnrjn/IfX6dqoA==,type:str]
+    lastmodified: "2022-06-23T10:29:01Z"
+    mac: ENC[AES256_GCM,data:tnc2+Gdu/vuQvBA5LtsapIaIgHX1FrmsS2+mrz5FSqhpG5VRKEGG/zNjO0q3tJl55jLNHA1M5630xW9U5XqZOGcp8p+k9HRgwf2V3BxH2NTckbQpARmrRiZWE/TOGdxhEwNeNaRT0OF7g/GNMILBoZpeQZ+WnAxEafTPPxuXmAU=,iv:2m/mQ8Rb0wAV16TM3QCGc2mOE8UvkkCvwiAXsY/LCz0=,tag:bIU1IA1ubfJr8WPvER3/ZA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -1,6 +1,10 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:JvYLxEOsbjfFCn+ZUwLQZ9KzrUFsUxxrHh/+66cWnD7H8ThGPtEPGwtZBDQXPZWiLkiI6Xp3tLTu/WGjMUnstw==,iv:eaElI1PK3Qnzd7/msM/14ws6a0WgAX69fQhyC/gMqdg=,tag:9TVlhr+4M3a2lZgFG9l12g==,type:str]
     password: ENC[AES256_GCM,data:MelDCxj31MKwzYQazMFWOPaE8xF9dlesW1r7zl4njPftKLGyqjfvLSzrjoqc+3O1mZBH0a97L3eBb6S+NLBxzA==,iv:4mo8AhPHz5DQNs/w9fpoWmP1WA/HPj0u/T5IpR68x3o=,tag:gs4V+Db9g3uf/DKsCkIRjQ==,type:str]
+grafana:
+    auth.github:
+        client_id: ENC[AES256_GCM,data:hhwWCQS9fVW4IO1BZu1ObooqTRY=,iv:79qx37jX6xUfjtyjyVfhBGtM0maUjIbtqs9WgT+qYWs=,tag:lHMKgs9JCFEZyOp33oApSA==,type:str]
+        client_secret: ENC[AES256_GCM,data:rTViEWKoVPnm2Ti2euxxpvgdKWop2uvSsmg0zeeOQAmzaYJ6clzqnw==,iv:lvwofj/L62ez8NMa5DZmtOlcbe0eQbJnJcmojGAFvAI=,tag:+zuzkSY76LPwE5zL32e4mw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +14,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:46Z"
-    mac: ENC[AES256_GCM,data:NlUJ2RJ04eIPsE144Xc6UcMdsrHfvE9cmwDWc366EVpKKSyPteo3H1xiIvWqJalwI+4NGfEirSI7kPDPeyuihrUZCAWf6BqIH8eDL/8NqdaAPklZAaWTvr3GzdFUSq4J0kRjMruwRQ5cGSmWNevqPIKtbcgjatsdFw1ytVLNidA=,iv:uISK61stVoknaSvjGoJ0KRAvhdtHI+eTFfyDIhboRIc=,tag:ow/vnvib7lcjv59TEwvF0A==,type:str]
+    lastmodified: "2022-06-22T15:22:04Z"
+    mac: ENC[AES256_GCM,data:MtEZ4n1byobWNKgHZ9QGOZow+OB42uYAYsoQqSuXsIq6ZHiXoft/fic2KYFSswRlC1vbfpBLNaqoc84oUdJFv3SH9yO/PfmuJYqOrO5GBdaI4aLo5y0WqZGZ2jpROsmjTIJks7w1w0iXSiZg/lk76IIccfQBIFlP7AauicTPaT8=,iv:hJa7Rti+M1MyuIlzWeIGNPrniGD5+eb4ijAZLAYeTUA=,tag:bSiw3tMAvnrjn/IfX6dqoA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.3

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -36,4 +36,4 @@ grafana:
     token_url:  https://github.com/login/oauth/access_token
     api_url: https://api.github.com/user
     allowed_organizations:
-      - 2i2c
+      - 2i2c-org

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -33,7 +33,7 @@ grafana:
       - user:email
       - read:org
     auth_url: https://github.com/login/oauth/authorize
-    token_url:  https://github.com/login/oauth/access_token
+    token_url: https://github.com/login/oauth/access_token
     api_url: https://api.github.com/user
     allowed_organizations:
       - 2i2c-org

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -26,14 +26,14 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.pilot.2i2c.cloud
-  auth.github:
-    enabled: true
-    # allow_sign_up: true
-    scopes:
-      - user:email
-      - read:org
-    auth_url: https://github.com/login/oauth/authorize
-    token_url: https://github.com/login/oauth/access_token
-    api_url: https://api.github.com/user
-    allowed_organizations:
-      - 2i2c-org
+  grafana.ini:
+    server:
+      root_url: https://grafana.pilot.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allow_sign_up: false
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      allowed_organizations: 2i2c-org

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -26,3 +26,14 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.pilot.2i2c.cloud
+  auth.github:
+    enabled: true
+    # allow_sign_up: true
+    scopes:
+      - user:email
+      - read:org
+    auth_url: https://github.com/login/oauth/authorize
+    token_url:  https://github.com/login/oauth/access_token
+    api_url: https://api.github.com/user
+    allowed_organizations:
+      - 2i2c


### PR DESCRIPTION
- [x] created a GitHub OAuth app and stored the secretes
- [x] added some initial config that should allow 2i2c org team member to sign in with GitHub in the 2i2c central grafana
- [x] deploy and test if this works

Closes https://github.com/2i2c-org/infrastructure/issues/1437