### PR TITLE
Add deployer command to open a shell with user homedirs

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -150,6 +150,28 @@ optional arguments:
   -h, --help    show this help message and exit
 ```
 
+### `exec-homes-shell`
+
+This function gives you a shell with the home directories of all the
+users on the given hub in the given cluster mounted under `/home`.
+Very helpful when doing (rare) manual operations on user home directories,
+such as renames.
+
+When you exit the shell, the temporary pod spun up is removed.
+
+**Command line usage:**
+
+```bash
+usage: deployer exec-homes-shell [-h] cluster_name hub_name
+
+positional arguments:
+  cluster_name  The name of the cluster to perform actions on
+  hub_name      The deployed hub whose home directories are to be examined
+
+optional arguments:
+  -h, --help    show this help message and exit
+```
+
 ### `generate-helm-upgrade-jobs`
 
 This function consumes a list of files that have been added or modified, and from that deduces which hubs on which clusters require a helm upgrade, and whether the support chart also needs upgrading.

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -12,6 +12,7 @@ from deploy_actions import (
     deploy,
     deploy_grafana_dashboards,
     deploy_support,
+    exec_homes_shell,
     generate_helm_upgrade_jobs,
     run_hub_health_check,
     use_cluster_credentials,
@@ -134,6 +135,17 @@ def main():
         action="store_true",
         help="For daskhubs, optionally check that dask workers can be scaled",
     )
+
+    # exec-homes subcommand
+    homes_parser = subparsers.add_parser(
+        "exec-homes-shell",
+        parents=[base_parser],
+        help="Pop a shell with home directories of given hub mounted",
+    )
+    homes_parser.add_argument(
+        "hub_name",
+        help="The deployed hub whose home directories are to be examined",
+    )
     # === End section ===#
 
     args = argparser.parse_args()
@@ -144,6 +156,8 @@ def main():
             args.hub_name,
             args.config_path,
         )
+    elif args.action == "exec-homes-shell":
+        exec_homes_shell(args.cluster_name, args.hub_name)
     elif args.action == "validate":
         validate_cluster_config(args.cluster_name)
         validate_support_config(args.cluster_name)

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -439,3 +439,18 @@ def run_hub_health_check(cluster_name, hub_name, check_dask_scaling=False):
         print_colour("Health check succeeded!")
 
     return exit_code
+
+
+def exec_homes_shell(cluster_name, hub_name):
+    """
+    Pop a shell with the home directories of the given hub mounted
+
+    Homes will be mounter under /home
+    """
+    config_file_path = find_absolute_path_to_cluster_file(cluster_name)
+    with open(config_file_path) as f:
+        cluster = Cluster(yaml.load(f), config_file_path.parent)
+    with cluster.auth():
+        hubs = cluster.hubs
+        hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
+        hub.exec_homes_shell()

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -254,6 +254,8 @@ class Hub:
 
         Homes will be mounter under /home
         """
+        # Name pod to include hub name so we don't end up in wrong one
+        pod_name = f'{self.spec["name"]}-shell'
         pod = {
             "apiVersion": "v1",
             "kind": "Pod",
@@ -266,7 +268,7 @@ class Hub:
                 ],
                 "containers": [
                     {
-                        "name": "shell",
+                        "name": pod_name,
                         # Use ubuntu image so we get better gnu rm
                         "image": "ubuntu:jammy",
                         "stdin": True,
@@ -296,7 +298,7 @@ class Hub:
             # Use ubuntu image so we get GNU rm and other tools
             # Should match what we have in our pod definition
             "ubuntu:jammy",
-            "shell",
+            pod_name,
             "--",
             "/bin/bash",
             "-l",


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/1225

Example:

```
❯ python3 deployer exec-homes-shell 2i2c staging                                                                                      2 ↵
Activated service account credentials for: [pilot-hubs-cd-sa@two-eye-two-see.iam.gserviceaccount.com]
Fetching cluster endpoint and auth data.
kubeconfig entry generated for pilot-hubs-cluster.
If you don't see a command prompt, try pressing enter.
root@shell:/# 
root@shell:/# cd home
root@shell:/home# ls
0000-2d0002-2d8055-2d2870  damianavila-402i2c-2eorg           georgianaelena                              yuvipanda-402i2c-2eorg
_shared                    deployment-2dservice-2dcheck       georgianaelena-402i2c-2eorg                 yuvipanda-40gmail-2ecom
blablabla                  dolocansimona-40gmail-2ecom        oauth2-7corcid-7c0000-2d0002-2d8055-2d2870
choldgraf-40gmail-2ecom    georgiana-2edolocan-40gmail-2ecom  sgibson-402i2c-2eorg
root@shell:/home# 
```