### PR TITLE
Allow deleting cilogon oauth apps using just the client id

### DIFF
--- a/deployer/cilogon_app.py
+++ b/deployer/cilogon_app.py
@@ -294,16 +294,20 @@ class CILogonClientProvider:
         )
         print(self.admin_client.get(client_id))
 
-    def delete_client(self, cluster_name, hub_name):
-        config_filename = self._build_config_filename(cluster_name, hub_name)
-
-        client_id = self._load_client_id(config_filename)
-
-        # No client has been found
+    def delete_client(self, cluster_name, hub_name, client_id=None):
         if not client_id:
-            return
+            if not cluster_name or not hub_name:
+                print("Please provide either the client id to delete or or the cluster and hub name.")
+                return
 
-        print(f"Deleting the CILogon client details for {cluster_name}-{hub_name}...")
+            config_filename = self._build_config_filename(cluster_name, hub_name)
+            client_id = self._load_client_id(config_filename)
+
+            # No client has been found
+            if not client_id:
+                return
+
+        print(f"Deleting the CILogon client details for {client_id}...")
         print(self.admin_client.delete(client_id))
 
     def get_all_clients(self):
@@ -396,7 +400,7 @@ def main():
     get_parser.add_argument(
         "hub_name",
         type=str,
-        help="The hub for which we'll retrieve the CILogon client details.",
+        help="The hub for which we'll retrieve the CILogon client details",
     )
 
     # Get all subcommand
@@ -414,13 +418,23 @@ def main():
     delete_parser.add_argument(
         "cluster_name",
         type=str,
-        help="The name of the cluster where the hub lives",
+        help="The name of the cluster where the hub lives or none if --id is present",
+        default="",
+        nargs="?"
     )
 
     delete_parser.add_argument(
         "hub_name",
         type=str,
-        help="The hub for which we'll delete the CILogon client details.",
+        help="The hub for which we'll delete the CILogon client details or none if --id is present",
+        default="",
+        nargs="?"
+    )
+
+    delete_parser.add_argument(
+        "--id",
+        type=str,
+        help="The id of the client to delete of the form cilogon:/client_id/<id>",
     )
 
     args = argparser.parse_args()
@@ -457,6 +471,7 @@ def main():
         cilogon.delete_client(
             args.cluster_name,
             args.hub_name,
+            args.id
         )
     elif args.action == "get-all":
         cilogon.get_all_clients()

--- a/deployer/cilogon_app.py
+++ b/deployer/cilogon_app.py
@@ -297,7 +297,9 @@ class CILogonClientProvider:
     def delete_client(self, cluster_name, hub_name, client_id=None):
         if not client_id:
             if not cluster_name or not hub_name:
-                print("Please provide either the client id to delete or or the cluster and hub name.")
+                print(
+                    "Please provide either the client id to delete or or the cluster and hub name."
+                )
                 return
 
             config_filename = self._build_config_filename(cluster_name, hub_name)
@@ -420,7 +422,7 @@ def main():
         type=str,
         help="The name of the cluster where the hub lives or none if --id is present",
         default="",
-        nargs="?"
+        nargs="?",
     )
 
     delete_parser.add_argument(
@@ -428,7 +430,7 @@ def main():
         type=str,
         help="The hub for which we'll delete the CILogon client details or none if --id is present",
         default="",
-        nargs="?"
+        nargs="?",
     )
 
     delete_parser.add_argument(
@@ -468,11 +470,7 @@ def main():
             args.hub_name,
         )
     elif args.action == "delete":
-        cilogon.delete_client(
-            args.cluster_name,
-            args.hub_name,
-            args.id
-        )
+        cilogon.delete_client(args.cluster_name, args.hub_name, args.id)
     elif args.action == "get-all":
         cilogon.get_all_clients()
 

--- a/deployer/cilogon_app.py
+++ b/deployer/cilogon_app.py
@@ -298,7 +298,7 @@ class CILogonClientProvider:
         if not client_id:
             if not cluster_name or not hub_name:
                 print(
-                    "Please provide either the client id to delete or or the cluster and hub name."
+                    "Please provide either the client id to delete or the cluster and hub name."
                 )
                 return
 


### PR DESCRIPTION
While removing the anu hub, I realized that if you delete the file where the cilogon client credentials are stored, you won't be able to delete the cilogon client with only the cluster and the hub name.

This PR adds the option to delete a cilogon client by its id directly.

In this case you'll need to get all clients with:
```bash
python3 deployer/cilogon_app.py get-all
```
And then identitify the client of the hub and delete based on its id with:
```bash
python3 deployer/cilogon_app.py delete --id cilogon:/client_id/<id>
```
