### PR TITLE
Switch the order of target date and required date in new hub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_new-hub.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub.yml
@@ -47,8 +47,8 @@ body:
       description: |
         Any important dates that we should consider for this hub. For example, if it will be used for a class, the starting day of class and any days with tests.
       value: |
-        - **Required start date**: <!-- the hub MUST by running as-needed by this date -->
         - **Target start date**: <!-- choose a target date ~1 week earlier than the required date -->
+        - **Required start date**: <!-- the hub MUST by running as-needed by this date -->
         - **Any important dates for usage**: <!-- For example - exams, periods of heavy usage, etc. -->
     validations:
       required: true
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Hub user image
       description: |
-        It is possible to customize the user image for the hub, as long as the image is in a public registry. 
+        It is possible to customize the user image for the hub, as long as the image is in a public registry.
         For example, a [quay.io registry image](https://quay.io/). See [the Infrastructure documentation on custom images](https://infrastructure.2i2c.org/en/latest/howto/customize/custom-image.html) for more information.
         Use this section to fill in relevant information:
       value: |


### PR DESCRIPTION
To me this makes more sense to have these the other way around:

- Target date is first, it's the ideal date to have the hub running by
- Required date is second, it's a hard deadline to have the hub up and functional