### PR TITLE
Bump z2jh closer to v2.0

### DIFF
--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -31,7 +31,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2021.02.19"
+        tag: "2022.06.02"
     hub:
       config:
         JupyterHub:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -77,7 +77,7 @@ basehub:
       defaultUrl: /lab
       image:
         name: pangeo/pangeo-notebook
-        tag: "2021.07.17"
+        tag: "2022.06.13"
     scheduling:
       userPlaceholder:
         enabled: false

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 1.2.0
+    version: 1.1.3-n648.hab95aa08
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -140,6 +140,9 @@ jupyterhub:
       # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
       - jupyterhub-singleuser
     extraEnv:
+      # until https://github.com/jupyterhub/jupyterhub/pull/3918 or equivalent lands,
+      # and we upgrade to jupyterhub >= 2.3.1 on all images.
+      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
       # notebook writes secure files that don't need to survive a
       # restart here. Writing 'secure' files on some file systems (like
       # Azure Files with SMB) seems buggy, so we just put runtime dir on

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -337,7 +337,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3429.h31787df0"
+      tag: "0.0.1-n3521.hb54fb723"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -321,7 +321,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3288.h27beafd1"
+      tag: "0.0.1-n3429.h31787df0"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -176,7 +176,7 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     image:
       name: quay.io/2i2c/2i2c-hubs-image
-      tag: "532c5eab47a1"
+      tag: 69b1f9dff7c7
     storage:
       type: static
       static:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -254,6 +254,15 @@ jupyterhub:
                 matchLabels:
                   app.kubernetes.io/component: traefik
   hub:
+    loadRoles:
+      # Should use this, not hub.config.JupyterHub.load_roles - that will
+      # override any existing load_roles set by z2jh
+      service-use:
+        name: user
+        scopes:
+          # Allow all users access to 'services', which includes dask-gateway & configurator
+          - access:services
+          - self
     config:
       JupyterHub:
         # Allow unauthenticated prometheus requests

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -135,6 +135,10 @@ jupyterhub:
         limits:
           memory: 1Gi
   singleuser:
+    cmd:
+      # Explicitly define this, as it's no longer set by z2jh
+      # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
+      - jupyterhub-singleuser
     extraEnv:
       # notebook writes secure files that don't need to survive a
       # restart here. Writing 'secure' files on some file systems (like

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -6,17 +6,11 @@
 # quay.io container registry credentials configured to have access to
 # https://quay.io/repository/2i2c/pilot-hub.
 #
-FROM jupyterhub/k8s-hub:1.2.0
+FROM jupyterhub/k8s-hub:1.1.3-n644.h35436cda
 
 ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}
-
-
-# Install newer version of jupyterhub-kubespawner, to bring in https://github.com/jupyterhub/kubespawner/pull/525
-# https://github.com/2i2c-org/infrastructure/issues/1103 is happening frequently enough
-# z2jh 1.2.x ships with kubespawner 1.1.0, so we just do a little bump
-RUN pip install --no-cache --upgrade jupyterhub-kubespawner==1.1.2
 
 # Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0
 RUN pip install --no-cache --upgrade oauthenticator==15.0.1


### PR DESCRIPTION
I've been running z2jh close to master at Berkeley for a few weeks without issue
(see https://github.com/berkeley-dsep-infra/datahub/issues/3418). This PR bumps 
us to latest master of z2jh 2.0. 

This will help with:

- https://github.com/2i2c-org/infrastructure/issues/1253
- https://github.com/2i2c-org/infrastructure/issues/1004

# Upgrading jupyterhub package in our user images

The pangeo images already use jupyterhub >= 2.3.x in their images,
and it's working on with our current version of z2jh. This PR will help match
those. 

Testing across our other hubs, everything seems to work fine with older
versions of jupyterhub in the image too - at least with jupyterhub 1.5.x.
With 1.3.x, the default URL doesn't take effect. I'll open separate PRs to 
bump up versions of jupyterhub:

- https://github.com/2i2c-org/2i2c-hubs-image/pull/1
- https://github.com/2i2c-org/utoronto-image/pull/31

Refs
* https://github.com/2i2c-org/infrastructure/issues/233
* https://github.com/2i2c-org/infrastructure/issues/1055