### PR TITLE
Automate installation of CRDs for cert-manager

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -103,13 +103,15 @@ This command only needs to be run once per cluster, not once per hub.
 **Command line usage:**
 
 ```bash
-usage: python deployer deploy-support [-h] cluster_name
+usage: python deployer deploy-support [-h] [--cert-manager-version CERT_MANAGER_VERSION] cluster_name
 
 positional arguments:
-  cluster_name  The name of the cluster to perform actions on
+  cluster_name          The name of the cluster to perform actions on
 
 optional arguments:
-  -h, --help    show this help message and exit
+  -h, --help            show this help message and exit
+  --cert-manager-version CERT_MANAGER_VERSION
+                        The version of cert-manager to deploy in the form vX.Y.Z. Defaults to v1.3.1
 ```
 
 ### `deploy-grafana-dashboards`

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -92,6 +92,13 @@ def main():
         parents=[base_parser],
         help="Install/upgrade the support helm release on a given cluster",
     )
+    deploy_support_parser.add_argument(
+        "--cert-manager-version",
+        type=str,
+        default="v1.3.1",
+        help="The version of cert-manager to deploy in the form vX.Y.Z. Defaults to v1.3.1",
+    )
+
 
     # deploy-grafana-dashboards subcommand
     deploy_grafana_dashboards_parser = subparsers.add_parser(
@@ -163,7 +170,7 @@ def main():
         validate_support_config(args.cluster_name)
         validate_hub_config(args.cluster_name, args.hub_name)
     elif args.action == "deploy-support":
-        deploy_support(args.cluster_name)
+        deploy_support(args.cluster_name, cert_manager_version=args.cert_manager_version)
     elif args.action == "deploy-grafana-dashboards":
         deploy_grafana_dashboards(args.cluster_name)
     elif args.action == "use-cluster-credentials":

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -99,7 +99,6 @@ def main():
         help="The version of cert-manager to deploy in the form vX.Y.Z. Defaults to v1.3.1",
     )
 
-
     # deploy-grafana-dashboards subcommand
     deploy_grafana_dashboards_parser = subparsers.add_parser(
         "deploy-grafana-dashboards",
@@ -170,7 +169,9 @@ def main():
         validate_support_config(args.cluster_name)
         validate_hub_config(args.cluster_name, args.hub_name)
     elif args.action == "deploy-support":
-        deploy_support(args.cluster_name, cert_manager_version=args.cert_manager_version)
+        deploy_support(
+            args.cluster_name, cert_manager_version=args.cert_manager_version
+        )
     elif args.action == "deploy-grafana-dashboards":
         deploy_grafana_dashboards(args.cluster_name)
     elif args.action == "use-cluster-credentials":

--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -68,11 +68,18 @@ class Cluster:
                 with open(dockercfg_path, "w") as f:
                     json.dump(config, f, indent=4)
 
-    def deploy_support(self):
+    def deploy_support(self, cert_manager_version):
         cert_manager_url = "https://charts.jetstack.io"
-        cert_manager_version = "v1.3.1"
 
         print_colour("Provisioning cert-manager...")
+        subprocess.check_call(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                f"https://github.com/cert-manager/cert-manager/releases/download/{cert_manager_version}/cert-manager.crds.yaml",
+            ]
+        )
         subprocess.check_call(
             [
                 "helm",

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -66,9 +66,13 @@ def use_cluster_credentials(cluster_name):
         subprocess.check_call([os.environ["SHELL"], "-l"])
 
 
-def deploy_support(cluster_name):
-    """
-    Deploy support components to a cluster
+def deploy_support(cluster_name, cert_manager_version):
+    """Deploy support components to a cluster
+
+    Args:
+        cluster_name (str): The name of the cluster to deploy support components to
+        cert_manager_version (str): The version of cert-manager to deploy to the
+            cluster, in the form vX.Y.Z. where X.Y.Z is valid SemVer.
     """
     validate_cluster_config(cluster_name)
     validate_support_config(cluster_name)
@@ -79,7 +83,7 @@ def deploy_support(cluster_name):
 
     if cluster.support:
         with cluster.auth():
-            cluster.deploy_support()
+            cluster.deploy_support(cert_manager_version=cert_manager_version)
 
 
 def deploy_grafana_dashboards(cluster_name):


### PR DESCRIPTION
- Adds a CLI flag to deploy-support to set which version of cert-manager to install (this was previously hard-coded into the deployer)
- Add a subprocess.check_call command to install cert-managers CRDs before installing/upgrading the chart

related https://github.com/2i2c-org/infrastructure/issues/1381