### PR TITLE
cert-manager setup: remove installCRDs=true

### DIFF
--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -91,7 +91,6 @@ class Cluster:
                 "--create-namespace",
                 "--namespace=cert-manager",
                 f"--version={cert_manager_version}",
-                "--set=installCRDs=true",
             ]
         )
         print_colour("Done!")


### PR DESCRIPTION
We no longer need this since we install CRDS ourselves

follow up to #1479 