### PR TITLE
Explicitly allow two admin email addresses for tuskegee

### DIFF
--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -33,4 +33,4 @@ jupyterhub:
           - deborah_nolan@berkeley.edu
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@eecs\.berkeley\.edu|.+@tuskegee\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -33,4 +33,4 @@ jupyterhub:
           - deborah_nolan@berkeley.edu
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@eecs\.berkeley\.edu|.+@tuskegee\.edu|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|yanlisa@eecs\.berkeley\.edu|ericvd@gmail\.com|deployment-service-check)$'


### PR DESCRIPTION
Hub at https://tuskegee.cloudbank.2i2c.cloud was not available because two admin users were not matching the `username_pattern`.

This PR explicitly allows those usernames, but without allowing all usernames from that domain (`@eecs.berkeley.edu`, `@gmail.com`) since for `gmail` at least I believe it's too broad.

We shouldn't need an `username_pattern` if we transition to using latest `oauthenticator` with https://github.com/jupyterhub/oauthenticator/issues/515 and decide to allow pairs of domains and identity providers.

@sean-morris, if you believe others with `@eecs.berkeley.edu`, `@gmail.com` should be allowed to login, please add those to the pattern, or allow the entire domain (whichever seems more appropriate).