### PR TITLE
Add ability to grant hub users extra IAM permissions

### DIFF
--- a/docs/howto/features/cloud-access.md
+++ b/docs/howto/features/cloud-access.md
@@ -200,3 +200,20 @@ on why users want this!
 
 4. Get this change deployed, and users should now be able to use the buckets!
    Currently running users might have to restart their pods for the change to take effect.
+
+
+## Granting access to cloud buckets in other accounts
+
+Sometimes, users on a hub we manage need access to a storage bucket
+managed by an external third party - often a different research
+group. This can help with access to raw data, collaboration, etc.
+
+This section outlines how to grant this access. Currently, this
+functionality is implemented only on AWS - but we can add it for
+other cloud providers when needed.
+
+### AWS
+
+1. Get ARN of the IAM role we'll use
+2. Get 3rd party to give it appropriate rights on the bucket
+3. Add it to hub_cloud_permissions for the hub we care about

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -1,18 +1,18 @@
 resource "aws_s3_bucket" "user_buckets" {
   for_each = var.user_buckets
-  bucket     = "${var.cluster_name}-${each.key}"
+  bucket   = "${var.cluster_name}-${each.key}"
 
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "user_bucket_expiry" {
   for_each = var.user_buckets
-  bucket     = "${var.cluster_name}-${each.key}"
+  bucket   = "${var.cluster_name}-${each.key}"
 
   dynamic "rule" {
     for_each = each.value.delete_after != null ? [1] : []
 
     content {
-      id = "delete-after-expiry"
+      id     = "delete-after-expiry"
       status = "Enabled"
 
       expiration {
@@ -34,11 +34,10 @@ locals {
   ]))
 }
 
-
 data "aws_iam_policy_document" "bucket_access" {
   for_each = { for bp in local.bucket_permissions : "${bp.hub_name}.${bp.bucket_name}" => bp }
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["s3:*"]
     principals {
       type = "AWS"
@@ -57,6 +56,6 @@ data "aws_iam_policy_document" "bucket_access" {
 resource "aws_s3_bucket_policy" "user_bucket_access" {
 
   for_each = { for bp in local.bucket_permissions : "${bp.hub_name}.${bp.bucket_name}" => bp }
-  bucket = aws_s3_bucket.user_buckets[each.value.bucket_name].id
-  policy = data.aws_iam_policy_document.bucket_access[each.key].json
+  bucket   = aws_s3_bucket.user_buckets[each.value.bucket_name].id
+  policy   = data.aws_iam_policy_document.bucket_access[each.key].json
 }

--- a/terraform/aws/irsa.tf
+++ b/terraform/aws/irsa.tf
@@ -4,7 +4,7 @@ data "aws_partition" "current" {}
 
 resource "aws_iam_role" "irsa_role" {
   for_each = var.hub_cloud_permissions
-  name = "${var.cluster_name}-${each.key}"
+  name     = "${var.cluster_name}-${each.key}"
 
   assume_role_policy = data.aws_iam_policy_document.irsa_role_assume[each.key].json
 }
@@ -13,29 +13,42 @@ data "aws_iam_policy_document" "irsa_role_assume" {
   for_each = var.hub_cloud_permissions
   statement {
 
-  effect = "Allow"
+    effect = "Allow"
 
-  actions = ["sts:AssumeRoleWithWebIdentity"]
+    actions = ["sts:AssumeRoleWithWebIdentity"]
 
-  principals {
-    type = "Federated"
+    principals {
+      type = "Federated"
 
-    identifiers = [
-          "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}"
-    ]
-  }
+      identifiers = [
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}"
+      ]
+    }
     condition {
       test     = "StringEquals"
       variable = "${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}:sub"
-      values   = [
+      values = [
         "system:serviceaccount:${each.key}:user-sa"
       ]
     }
   }
 }
 
+resource "aws_iam_policy" "extra_user_policy" {
+  for_each    = { for hub_name, value in var.hub_cloud_permissions : hub_name => value if value.extra_iam_policy != "" }
+  name        = "${var.cluster_name}-${each.key}-extra-user-policy"
+  description = "Extra permissions granted to users on hub ${each.key} on ${var.cluster_name}"
+  policy      = each.value.extra_iam_policy
+}
+
+resource "aws_iam_role_policy_attachment" "extra_user_policy" {
+  for_each   = { for hub_name, value in var.hub_cloud_permissions : hub_name => value if value.extra_iam_policy != "" }
+  role       = aws_iam_role.irsa_role[each.key].name
+  policy_arn = aws_iam_policy.extra_user_policy[each.key].arn
+}
+
 output "kubernetes_sa_annotations" {
-  value       = {
+  value = {
     for k, v in var.hub_cloud_permissions :
     k => "eks.amazonaws.com/role-arn: ${aws_iam_role.irsa_role[k].arn}"
   }

--- a/terraform/aws/projects/uwhackweeks.tfvars
+++ b/terraform/aws/projects/uwhackweeks.tfvars
@@ -21,13 +21,44 @@ hub_cloud_permissions = {
   "staging" : {
     requestor_pays: true,
     bucket_admin_access: ["scratch-staging"],
+    extra_iam_policy: ""
   },
   "prod" : {
     requestor_pays: true,
     bucket_admin_access: ["scratch"],
+    extra_iam_policy: ""
   },
   "snowex" : {
     requestor_pays: true,
     bucket_admin_access: ["snowex-scratch"],
+    # Grant S3 access to S3 buckets in other accounts
+    # See https://github.com/2i2c-org/infrastructure/issues/1455
+    extra_iam_policy: <<-EOT
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::dinosar",
+                  "arn:aws:s3:::eis-dh-hydro"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::dinosar/*",
+                  "arn:aws:s3:::eis-dh-hydro/*"
+                ]
+            }
+        ]
+      }
+  EOT
   }
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -23,7 +23,7 @@ variable "user_buckets" {
   type        = map(object({ delete_after : number }))
   default     = {}
   description = <<-EOT
-  GCS Buckets to be created.
+  S3 Buckets to be created.
 
   The key for each entry will be prefixed with {var.prefix}- to form
   the name of the bucket.
@@ -35,7 +35,7 @@ variable "user_buckets" {
 }
 
 variable "hub_cloud_permissions" {
-  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string) }))
+  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string), extra_iam_policy : string }))
   default     = {}
   description = <<-EOT
   Map of cloud permissions given to a particular hub
@@ -46,7 +46,19 @@ variable "hub_cloud_permissions" {
   1. requestor_pays: Identify as coming from the google cloud project when accessing
      storage buckets marked as  https://cloud.google.com/storage/docs/requester-pays.
      This *potentially* incurs cost for us, the originating project, so opt-in.
-  2. bucket_admin_access: List of GCS storage buckets that users on this hub should have read
+  2. bucket_admin_access: List of S3 storage buckets that users on this hub should have read
      and write permissions for.
+  3. extra_iam_policy: An AWS IAM Policy document that grants additional rights to the users
+     on this hub when talking to AWS services.
+  EOT
+}
+
+variable "extra_user_iam_policy" {
+  default     = {}
+  description = <<-EOT
+  Policy JSON to attach to the IAM role assumed by users of the hub.
+
+  Used to grant additional permissions to the IAM role that is assumed by
+  user pods when making requests to AWS services (such as S3)
   EOT
 }


### PR DESCRIPTION
- Helpful to grant users on a given hub extra IAM permissions,
  such as S3 access, db access, etc.
- Grant access to two S3 buckets for the SnowEx hackathon based
  on request

Ref https://github.com/2i2c-org/infrastructure/issues/1455