### PR TITLE
Collect additional pod and nodes labels

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -63,6 +63,11 @@ prometheus:
     retention: 90d
     service:
       type: ClusterIP
+  # make sure we collect metrics on pods by app/component at least
+  kube-state-metrics:
+    metricLabelsAllowlist:
+      - pods=[app,component]
+      - nodes=[*]
 
 grafana:
   persistence:


### PR DESCRIPTION
We're now running `kube-state-metrics` v2.0 that came with the recent prometheus chart bump and the existent grafana dashboards use some pod and node labels that aren't added by default anymore.

Copied from https://github.com/jupyterhub/mybinder.org-deploy/pull/2284

Checkout for additional info:
- https://github.com/jupyterhub/grafana-dashboards/issues/30
- https://github.com/jupyterhub/grafana-dashboards/pull/42