### PR TITLE
Add the hub username to the list of allowed pod labels

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -66,7 +66,7 @@ prometheus:
   # make sure we collect metrics on pods by app/component at least
   kube-state-metrics:
     metricLabelsAllowlist:
-      - pods=[app,component]
+      - pods=[app,component,hub.jupyter.org/username]
       - nodes=[*]
 
 grafana:


### PR DESCRIPTION
We need one more label to be tracked for compatibility with latest prometheus and our grafana dashboards.