### PR TITLE
Tuskegee: modified username_pattern

### DIFF
--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -29,8 +29,8 @@ jupyterhub:
         admin_users:
           - mndoye@tuskegee.edu
           - yrawajfih@tuskegee.edu
-          - yanlisa@eecs.berkeley.edu
+          - yanlisa@berkeley.edu
           - deborah_nolan@berkeley.edu
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|yanlisa@eecs\.berkeley\.edu|.+@gmail\.com|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|.+@gmail\.com|deployment-service-check)$'

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -31,6 +31,6 @@ jupyterhub:
           - yrawajfih@tuskegee.edu
           - yanlisa@eecs.berkeley.edu
           - deborah_nolan@berkeley.edu
-          - ericvd@gmail.com
+          - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|yanlisa@eecs\.berkeley\.edu|ericvd@gmail\.com|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@tuskegee\.edu|yanlisa@eecs\.berkeley\.edu|.+@gmail\.com|deployment-service-check)$'


### PR DESCRIPTION
- I change the ercvd from gmail to berkeley so could remove the specific
username_pattern entry
- I temporarily added @gmail.com to
username_pattern so Tuskegee users could use the hub
while we work out the cilogon issues