### PR TITLE
Fix dask daskboard link configuration

### DIFF
--- a/helm-charts/binderhub/values.yaml
+++ b/helm-charts/binderhub/values.yaml
@@ -102,11 +102,11 @@ binderhub:
         DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT:
           '{"SCRATCH_BUCKET": "$(SCRATCH_BUCKET)",
           "PANGEO_SCRATCH": "$(PANGEO_SCRATCH)"}'
-        # DASK_DISTRIBUTED__DASHBOARD_LINK makes the suggested link to the
+        # DASK_DISTRIBUTED__DASHBOARD__LINK makes the suggested link to the
         # dashboard account for the /user/<username> prefix in the path. Note
         # that this still misbehave if you have a named server but now its at
         # least functional for non-named servers.
-        DASK_DISTRIBUTED__DASHBOARD_LINK: "/user/{JUPYTERHUB_USER}/proxy/{port}/status"
+        DASK_DISTRIBUTED__DASHBOARD__LINK: "/user/{JUPYTERHUB_USER}/proxy/{port}/status"
       extraFiles:
         jupyter_notebook_config.json:
           mountPath: /usr/local/etc/jupyter/jupyter_notebook_config.json


### PR DESCRIPTION
We had a bug in our dashboard link configuration it seems, as found by inspecting https://github.com/2i2c-org/infrastructure/issues/1296 and https://discourse.pangeo.io/t/access-dashboard-for-localcluster-on-pangeo-deployments/2171/2?u=consideratio.

## Related
- [Code reading this configuration](https://github.com/dask/distributed/blob/f7f650154fea29978906c65dd0225415da56ed11/distributed/utils.py#L1273-L1281)
- Similar PR: https://github.com/microsoft/planetary-computer-hub/pull/15