### PR TITLE
Chown shared-readwrite too so it is actually writeable

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -128,7 +128,7 @@ basehub:
             [
               "sh",
               "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
+              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
             ]
           securityContext:
             runAsUser: 0
@@ -136,6 +136,10 @@ basehub:
             - name: home
               mountPath: /home/jovyan
               subPath: "{username}"
+            # Here so we can chown it appropriately
+            - name: home
+              mountPath: /home/jovyan/shared-readwrite
+              subPath: _shared
 dask-gateway:
   gateway:
     backend:


### PR DESCRIPTION
Otherwise it's just owned by root and unusable

Ref https://github.com/2i2c-org/infrastructure/issues/440