### PR TITLE
Reduce linkedearth homedir capacity

### DIFF
--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -7,7 +7,7 @@ enable_network_policy  = true
 
 # Setup a filestore for in-cluster NFS
 enable_filestore = true
-filestore_capacity_gb = 2048
+filestore_capacity_gb = 1024
 
 user_buckets = {
   "scratch-staging": {


### PR DESCRIPTION
We can increase this later if necessary, as otherwise it is
unnecessary expense. 1TB is a lot!