### PR TITLE
Tweak dask-gateway on LEAP hub

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -145,8 +145,8 @@ dask-gateway:
     backend:
       scheduler:
         cores:
-          request: 0.8
-          limit: 1
+          request: 1
+          limit: 2
         memory:
-          request: 1G
-          limit: 2G
+          request: 4G
+          limit: 4G

--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -16,9 +16,12 @@ prometheus:
           hosts:
             - prometheus.leap.2i2c.cloud
     resources:
+      requests:
+        cpu: 3
+        memory: 20Gi
       limits:
-        cpu: 2
-        memory: 12Gi
+        cpu: 3.9
+        memory: 22Gi
 
 grafana:
   ingress:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -66,7 +66,7 @@ prometheus:
   # make sure we collect metrics on pods by app/component at least
   kube-state-metrics:
     metricLabelsAllowlist:
-      - pods=[app,component,hub.jupyter.org/username]
+      - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
       - nodes=[*]
 
 grafana:

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -102,7 +102,7 @@ dask_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
+    machine_type : "n1-highmem-2",
     labels: {},
     gpu: {
       enabled: false,
@@ -113,7 +113,7 @@ dask_nodes = {
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-4",
+    machine_type : "n1-highmem-4",
     labels: {},
     gpu: {
       enabled: false,
@@ -124,7 +124,7 @@ dask_nodes = {
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-8",
+    machine_type : "n1-highmem-8",
     labels: {},
     gpu: {
       enabled: false,
@@ -135,7 +135,7 @@ dask_nodes = {
   "huge" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-16",
+    machine_type : "n1-highmem-16",
     labels: {},
     gpu: {
       enabled: false,


### PR DESCRIPTION
- Provide more memory & cpu for the dask-scheduler pod. When
  we were running a larger cluster, the scheduler kept dying
  and providing strange errors. Increasing resources helps us
  get bigger clusters.
- Tweak the size of nodes for dask. Dask, at least as used in
  LEAP, is primarily memory bound and not cpu-bound. This helps
  us use resources more efficiently.
- Bump up the prometheus resource requests so it stops crashing
- Add another label to record from pods, required for reporting on
  dask-gateway

Worked with @TomNicholas and @rabernat for bringing up a big cluster
to crunch through some compute for Tom's talk today.

The other thing we discovered is that by default, dask-gateway
sets number of *threads* to number of CPUs, which actually causes
a lot of GIL contention in our workflows. Need to carefully tune
and investigate that.