### PR TITLE
[linked-earth] Change GitHub OAuth scope to read:org

### DIFF
--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -47,7 +47,7 @@ basehub:
             - 2i2c-org
             - LinkedEarth
           scope:
-            - read:user
+            - read:org
     singleuser:
       image:
         # User image repo: https://quay.io/repository/linkedearth/pyleoclim


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/1418#issuecomment-1183787928 it was noted that other members of the LinkedEarth GitHub org could not log into the hub. I suspect this is due to the `read:user` scope being set which requires all members of the org to have their membership set to public for the authentication to work, as stipulated in the docs [here](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html?highlight=allowed_organizations#github).

This PR changes the scope from `read:user` to `read:org` which will allow members of an org whose membership is not public to access the hub.