### PR TITLE
Point linked-earth hubs to new filestore

### DIFF
--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -6,7 +6,7 @@ basehub:
         - soft
         - noatime
       # Google FileStore IP
-      serverIP: 10.58.206.114
+      serverIP: 10.155.150.2
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/1513