### PR TITLE
Add actions:read permission for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -25,9 +25,10 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
-    # Give GITHUB_TOKEN enough permissions to read issue comments and post/update
-    # comments on Pull Requests
+    # Give GITHUB_TOKEN enough permissions to read actions artifacts, issue comments and
+    # post/update comments on Pull Requests
     permissions:
+      actions: read
       issues: read
       pull-requests: write
     steps:


### PR DESCRIPTION
The new comment-deployment-plan-pr workflow was failing because GITHUB_TOKEN did not have sufficient permissions to read/get workflow artifacts