### PR TITLE
Actually upgrade the binder-staging hub on the 2i2c cluster

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -201,7 +201,7 @@ jobs:
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} dask-staging
 
-      - name: Upgrade dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
+      - name: Upgrade binder-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
         if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} binder-staging

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -201,6 +201,11 @@ jobs:
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} dask-staging
 
+      - name: Upgrade dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
+        if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
+        run: |
+          python deployer deploy ${{ matrix.jobs.cluster_name }} binder-staging
+
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
         if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'

--- a/docs/reference/ci-cd/hub-deploy.md
+++ b/docs/reference/ci-cd/hub-deploy.md
@@ -44,8 +44,8 @@ A matrix job is set up that parallelises over all the clusters defined in the JS
 For each cluster, the support chart is first upgraded (if required) followed by the staging hub (if required).
 
 ```{note}
-The 2i2c cluster is a special case here as it has two staging hubs: one running the `basehub` Helm chart, and the other running the `daskhub` Helm chart.
-We therefore run an extra step for the 2i2c cluster to upgrade the `dask-staging` hub (if required).
+The 2i2c cluster is a special case here as it has three staging hubs: one running the `basehub` Helm chart, another running the `daskhub` Helm chart, and another running the `binderhub` helm chart.
+We therefore run extra steps for the 2i2c cluster to upgrade these hubs (if required).
 ```
 
 We use staging hubs as [canary deployments](https://sre.google/workbook/canarying-releases/) and prevent deploying production hubs if a staging deployment fails.


### PR DESCRIPTION
Since it has `staging` in it's name, the binder-staging hub was not being upgraded since we don't generate explicit jobs for multiple staging hubs on the same cluster because the 2i2c cluster is the only one with multiple staging hubs running on it.

We add a step so that binder-staging is upgraded and update the docs to reflect this.