### PR TITLE
[neurohackademy] Set defaultUrl to be a nbgitpuller link instead

### DIFF
--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -35,8 +35,7 @@ jupyterhub:
           name: The National Institutes of Health grant 2R25MH112480-06
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
-    # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
-    defaultUrl: https://neurohackademy.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
+    defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
     image:
       name: quay.io/arokem/nh-jhub-2022
@@ -57,6 +56,33 @@ jupyterhub:
           http://github.com/login/oauth/authorize:
             username_derivation:
               username_claim: "preferred_username"
+     extraFiles:
+      configurator-schema-default:
+        data:
+          properties:
+            Spawner.default_url:
+              type: string
+              title: Default User Interface
+              enum:
+                - "/tree"
+                - "/lab"
+                - "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+              default: "/lab"
+              enumMetadata:
+                interfaces:
+                  - value: "/tree"
+                    title: Classic Notebook
+                    description:
+                      The original single-document interface for creating
+                      Jupyter Notebooks.
+                  - value: "/lab"
+                    title: JupyterLab
+                    description: A Powerful next generation notebook interface
+                  - value: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+                    title: Pull curriculum repo and redirect to /lab
+                    description: Use ngbitpuller to pull https://github.com/neurohackademy/nh2022-curriculum and redirect to /lab afterwards
+
+
     services:
       dex:
         url: http://dex:5556

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -36,6 +36,8 @@ jupyterhub:
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
     # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
+    # This configuration needs to be paired with not setting a defaultURL again in the schema configuration of jupyterhub-configurator, see the
+    # hub.extraFiles.configurator-schema-default entry below!
     defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
     image:
@@ -58,6 +60,11 @@ jupyterhub:
             username_derivation:
               username_claim: "preferred_username"
     extraFiles:
+      # We disable the defaultUrl set by the jupyterhub-configurator schema,
+      # otherwise it would override the singleuser.defaultUrl set above.
+      # This is because the jupyterhub-configurator schema gets loaded after the hub
+      # yaml config and overrides any config set before.
+      # Ref: https://infrastructure.2i2c.org/en/latest/topic/config.html#inheritance-of-configuration
       configurator-schema-default:
         data:
           properties:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -56,7 +56,7 @@ jupyterhub:
           http://github.com/login/oauth/authorize:
             username_derivation:
               username_claim: "preferred_username"
-     extraFiles:
+    extraFiles:
       configurator-schema-default:
         data:
           properties:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -35,6 +35,7 @@ jupyterhub:
           name: The National Institutes of Health grant 2R25MH112480-06
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
+    # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
     defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
     image:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -61,27 +61,7 @@ jupyterhub:
         data:
           properties:
             Spawner.default_url:
-              type: string
-              title: Default User Interface
-              enum:
-                - "/tree"
-                - "/lab"
-                - "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
-              default: "/lab"
-              enumMetadata:
-                interfaces:
-                  - value: "/tree"
-                    title: Classic Notebook
-                    description:
-                      The original single-document interface for creating
-                      Jupyter Notebooks.
-                  - value: "/lab"
-                    title: JupyterLab
-                    description: A Powerful next generation notebook interface
-                  - value: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
-                    title: Pull curriculum repo and redirect to /lab
-                    description: Use ngbitpuller to pull https://github.com/neurohackademy/nh2022-curriculum and redirect to /lab afterwards
-
+              default: null
     services:
       dex:
         url: http://dex:5556

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -82,7 +82,6 @@ jupyterhub:
                     title: Pull curriculum repo and redirect to /lab
                     description: Use ngbitpuller to pull https://github.com/neurohackademy/nh2022-curriculum and redirect to /lab afterwards
 
-
     services:
       dex:
         url: http://dex:5556

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -35,8 +35,9 @@ jupyterhub:
           name: The National Institutes of Health grant 2R25MH112480-06
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
+    # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
+    defaultUrl: https://neurohackademy.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
-    defaultUrl: /lab
     image:
       name: quay.io/arokem/nh-jhub-2022
       tag: "3d441bdb82f6"


### PR DESCRIPTION
Addresses https://2i2c.freshdesk.com/a/tickets/155, 

Reference: https://github.com/2i2c-org/infrastructure/issues/1536

**Todo:** 
- [x] make sure nbgitpuller is installed in the user image