### PR TITLE
Tweak some of the neurohackademy hub resources

### DIFF
--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -41,6 +41,12 @@ jupyterhub:
       tag: "3d441bdb82f6"
     nodeSelector:
       2i2c.org/community: neurohackademy
+    cpu:
+      guarantee: 0.1
+      limit: 2
+    memory:
+      guarantee: 6G
+      limit: 8G
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -39,6 +39,8 @@ jupyterhub:
     image:
       name: quay.io/arokem/nh-jhub-2022
       tag: "3d441bdb82f6"
+    nodeSelector:
+      2i2c.org/community: neurohackademy
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -42,10 +42,11 @@ jupyterhub:
     nodeSelector:
       2i2c.org/community: neurohackademy
     cpu:
-      guarantee: 0.1
-      limit: 2
+      guarantee: 0.5
+      # We're on n1-highmem-16 machines
+      limit: 14
     memory:
-      guarantee: 6G
+      guarantee: 4G
       limit: 8G
   hub:
     config:

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -25,11 +25,16 @@ notebook_nodes = {
   },
   "neurohackademy": {
     # We expect around 120 users
-    min: 2,
-    max: 10,
-    machine_type: "n1-highmem-4",
+    min: 1,
+    max: 100,
+    machine_type: "n1-highmem-16",
     labels: {
       "2i2c.org/community": "neurohackademy"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
     }
   }
 }

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -22,6 +22,15 @@ notebook_nodes = {
       type: "",
       count: 0
     }
+  },
+  "neurohackademy": {
+    # We expect around 120 users
+    min: 2,
+    max: 10,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "neurohackademy"
+    }
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/2i2c-org/infrastructure/issues/1532

- According to [some notes](https://github.com/neurohackademy/nh2020-jupyterhub/blob/32ab7bc2d24717a8d732da7e442c2ab6a1bc2daa/deployments/hub-neurohackademy-org/config/prod.yaml#L81-L87) from past events (thanks for those @consideRatio) 6GBof mem should be enough, so I'm setting the guarantee to be 6G
- Not sure about CPU though. Is a limit of 2 too little?