### PR TITLE
[neurohackademy] Replace RStudio defaultURL option to an nbgitpuller link

### DIFF
--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -36,8 +36,6 @@ jupyterhub:
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
     # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
-    # This configuration needs to be paired with not setting a defaultURL again in the schema configuration of jupyterhub-configurator, see the
-    # hub.extraFiles.configurator-schema-default entry below!
     defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
     image:
@@ -60,16 +58,30 @@ jupyterhub:
             username_derivation:
               username_claim: "preferred_username"
     extraFiles:
-      # We disable the defaultUrl set by the jupyterhub-configurator schema,
-      # otherwise it would override the singleuser.defaultUrl set above.
-      # This is because the jupyterhub-configurator schema gets loaded after the hub
-      # yaml config and overrides any config set before.
-      # Ref: https://infrastructure.2i2c.org/en/latest/topic/config.html#inheritance-of-configuration
       configurator-schema-default:
         data:
           properties:
             Spawner.default_url:
-              default: null
+              type: string
+              title: Default User Interface
+              enum:
+                - "/tree"
+                - "/lab"
+                - "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+              default: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+              enumMetadata:
+                interfaces:
+                  - value: "/tree"
+                    title: Classic Notebook
+                    description:
+                      The original single-document interface for creating
+                      Jupyter Notebooks.
+                  - value: "/lab"
+                    title: JupyterLab
+                    description: A Powerful next generation notebook interface
+                  - value: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+                    title: Pull curriculum repo and redirect to /lab
+                    description: Use ngbitpuller to pull https://github.com/neurohackademy/nh2022-curriculum and redirect to /lab afterwards
     services:
       dex:
         url: http://dex:5556

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -35,8 +35,6 @@ jupyterhub:
           name: The National Institutes of Health grant 2R25MH112480-06
           url: https://reporter.nih.gov/search/ydTvTwXxk0yd6eGdRznbLQ/project-details/10409452
   singleuser:
-    # Pulls content from https://github.com/neurohackademy/nh2022-curriculum using nbgitpuller then opens up /lab
-    defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main
     # User image: https://quay.io/repository/arokem/nh-jhub-2022?tab=tags
     image:
       name: quay.io/arokem/nh-jhub-2022

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -67,8 +67,8 @@ jupyterhub:
               enum:
                 - "/tree"
                 - "/lab"
-                - "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
-              default: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+                - "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab&branch=main"
+              default: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab&branch=main"
               enumMetadata:
                 interfaces:
                   - value: "/tree"
@@ -79,7 +79,7 @@ jupyterhub:
                   - value: "/lab"
                     title: JupyterLab
                     description: A Powerful next generation notebook interface
-                  - value: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab%2Ftree%2Fnh2022-curriculum%2F&branch=main"
+                  - value: "/git-pull?repo=https%3A%2F%2Fgithub.com%2Fneurohackademy%2Fnh2022-curriculum&urlpath=lab&branch=main"
                     title: Pull curriculum repo and redirect to /lab
                     description: Use ngbitpuller to pull https://github.com/neurohackademy/nh2022-curriculum and redirect to /lab afterwards
     services:


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/1552

For some reason this doesn't work although same config worked ok on staging.

This one is changing the RStudio option to the nbgitpuller link.
Anyway, this should do the trick until we figure out the "why"s.