### PR TITLE
Update ohw hub for this year's event

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -76,13 +76,12 @@ hubs:
     domain: ohw.pilot.2i2c.cloud
     helm_chart: daskhub
     auth0:
-      # connection update? Also ensure the basehub Helm chart is provided a
-      # matching value for jupyterhub.custom.2i2c.add_staff_user_ids_of_type!
-      connection: github
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
+      - enc-ohw.secret.values.yaml
       - ohw.values.yaml
   - name: pfw
     display_name: "Purdue Fort Wayne"

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -36,16 +36,16 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            # todo: find out the correct image
-            # image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            # todo: change this with the community image
+            image: quay.io/2i2c/2i2c-hubs-image:69b1f9dff7c7
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            # todo: find out the correct image
-            # image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            # todo: change this with the community image
+            image: quay.io/2i2c/2i2c-hubs-image:69b1f9dff7c7
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -37,15 +37,16 @@ basehub:
           default: true
           kubespawner_override:
             # todo: find out the correct image
-            image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            # image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
-          default: true
           kubespawner_override:
             # todo: find out the correct image
-            image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            # image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G
     custom:
@@ -86,6 +87,5 @@ basehub:
           scope:
             - read:org
         Authenticator:
-          allowed_users: &ohw_users
+          admin_users:
             - ocefpaf
-          admin_users: *ohw_users

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -75,6 +75,16 @@ basehub:
             url: https://2i2c.org
     hub:
       config:
+        JupyterHub:
+          authenticator_class: github
+        GitHubOAuthenticator:
+          oauth_callback_url: https://ohw.pilot.2i2c.cloud/hub/oauth_callback
+          allowed_organizations:
+            - 2i2c-org:tech-team
+            - oceanhackweek/participants_2022
+            - oceanhackweek/ohw22-organizers
+          scope:
+            - read:org
         Authenticator:
           allowed_users: &ohw_users
             - ocefpaf

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -6,6 +6,7 @@ basehub:
   jupyterhub:
     prePuller:
       continuous:
+        # Todo: turn this off after the event
         enabled: true
     singleuser:
       networkPolicy:
@@ -30,14 +31,23 @@ basehub:
           - ports:
               - port: 22
                 protocol: TCP
-      image:
-        name: ghcr.io/oceanhackweek/jupyer-image
-        tag: "9efd4fb"
-      memory:
-        # Increase memory alloted during the workshop
-        #  https://github.com/2i2c-org/infrastructure/issues/549#issuecomment-891264570
-        guarantee: 7G
-        limit: 8G
+      profileList:
+        - display_name: "Python image"
+          description: "~2 CPU, ~8G RAM"
+          default: true
+          kubespawner_override:
+            # todo: find out the correct image
+            image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            mem_limit: 8G
+            mem_guarantee: 4G
+        - display_name: "R image"
+          description: "~2 CPU, ~8G RAM"
+          default: true
+          kubespawner_override:
+            # todo: find out the correct image
+            image: ghcr.io/oceanhackweek/jupyer-image:9efd4fb
+            mem_limit: 8G
+            mem_guarantee: 4G
     custom:
       cloudResources:
         provider: gcp


### PR DESCRIPTION
- [x] Github teams based auth
   team that should have access:
    - [x] @oceanhackweek/participants_2022
    - [x] @oceanhackweek/ohw22-organizers
    - [x] check if sub-teams get access too: so far it looks like people were able to login. Not 100% it was because they were authorized from last year's event, but will keep an eye on it.
- [x] have different Python/R profiles
- [x] figure out bumping the image tag given different profiles -> we should probably use https://github.com/sgibson91/bump-jhub-image-action
- [x] check if there can be different defaultUrls for different profiles
- [x] make sure the user image uses at least jupyterhub 2.3.1 otherwise default_url won't work
- [x] why is this error still showing up in the hub logs:
   ```
    WARNING: hub.config.JupyterHub.authenticator_class was set to github and c.Authenticator.allowed_users was set, custom 2i2c jupyterhub config is now resetting allowed_users to an empty set.
  ```
- [ ] remove existing auth0 oauth2 app for ohw hub

Reference: https://github.com/2i2c-org/infrastructure/issues/1515