### PR TITLE
Pin our packages

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,10 +4,10 @@
 
 # chartpress is relevant to build and push helm-charts/images/hub/Dockerfile and
 # update basehub's default values to reference the new image.
-chartpress
+chartpress==1.3.0
 
 # requests is used by extra_scripts/rsync-active-users.py
-requests
+requests==2.28.1
 
 # rich is used by extra_scripts/count-auth0-apps.py
-rich
+rich==12.5.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: infrastructure-docs
 channels:
   - conda-forge
 dependencies:
-  - go-terraform-docs
-  - python=3.8
+  - go-terraform-docs=0.15.0
+  - python=3.10
   - pip:
       - -r requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-myst-parser[sphinx,linkify]
-pandas
-pyyaml
-requests
-sphinx-autobuild
-sphinx-copybutton
-sphinx-panels
+myst-parser[sphinx,linkify]==0.18.0
+pandas==1.4.3
+pyyaml==6.0
+requests==2.28.1
+sphinx-autobuild==2021.3.14
+sphinx-copybutton==0.5.0
+sphinx-panels==0.6.0
 git+https://github.com/2i2c-org/sphinx-2i2c-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,21 +3,21 @@
 #
 
 # ruamel.yaml is used to read and write .yaml files.
-ruamel.yaml
+ruamel.yaml==0.17.21
 
 # auth0 is used to communicate with Auth0's REST API that we integrate with in
 # various ways.
-auth0-python
+auth0-python==3.23.1
 
 # jsonschema is used for validating cluster.yaml configurations
-jsonschema
+jsonschema==4.7.2
 
 # rich and py-markdown-table are used for pretty printing outputs that would otherwise
 # be difficult to parse by a human
-rich
-py-markdown-table
+rich==12.5.1
+py-markdown-table==0.2.2
 
 # jhub_client, pytest, and pytest-asyncio are used for our health checks
 jhub-client==0.1.6
-pytest
+pytest==7.1.2
 pytest-asyncio>=0.17


### PR DESCRIPTION
This PR pins packages in the following files:

- ./requirements.txt
- ./dev-requirements.txt
- ./docs/requirements.txt
- ./docs/environment.yml

The version of Python listed in docs/environment.yml was bumped from 3.8 to 3.10 as well.

Related issues:

- https://github.com/2i2c-org/infrastructure/issues/1012
- https://github.com/2i2c-org/infrastructure/issues/1559