### PR TITLE
Move github authenticator allowed list validation to the validate workflow

### DIFF
--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -7,6 +7,7 @@ from config_validation import (
     validate_cluster_config,
     validate_hub_config,
     validate_support_config,
+    validate_authenticator_config,
 )
 from deploy_actions import (
     deploy,
@@ -174,6 +175,7 @@ def main():
         validate_cluster_config(args.cluster_name)
         validate_support_config(args.cluster_name)
         validate_hub_config(args.cluster_name, args.hub_name)
+        validate_authenticator_config(args.cluster_name, args.hub_name)
     elif args.action == "deploy-support":
         deploy_support(
             args.cluster_name, cert_manager_version=args.cert_manager_version

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -4,10 +4,10 @@ Command line interface for deployer
 import argparse
 
 from config_validation import (
+    validate_authenticator_config,
     validate_cluster_config,
     validate_hub_config,
     validate_support_config,
-    validate_authenticator_config,
 )
 from deploy_actions import (
     deploy,

--- a/deployer/config_validation.py
+++ b/deployer/config_validation.py
@@ -197,14 +197,14 @@ def validate_authenticator_config(cluster_name, hub_name):
                         authenticator_class = config["basehub"]["jupyterhub"]["hub"][
                             "config"
                         ]["JupyterHub"]["authenticator_class"]
-                        allowed_users= config["basehub"]["jupyterhub"]["hub"][
+                        allowed_users = config["basehub"]["jupyterhub"]["hub"][
                             "config"
                         ]["Authenticator"]["allowed_users"]
                     else:
                         authenticator_class = config["jupyterhub"]["hub"]["config"][
                             "JupyterHub"
                         ]["authenticator_class"]
-                        allowed_users= config["jupyterhub"]["hub"]["config"][
+                        allowed_users = config["jupyterhub"]["hub"]["config"][
                             "Authenticator"
                         ]["allowed_users"]
                 except KeyError:

--- a/deployer/config_validation.py
+++ b/deployer/config_validation.py
@@ -157,11 +157,15 @@ def validate_support_config(cluster_name):
         print_colour(f"No support defined for {cluster_name}. Nothing to validate!")
 
 
-def assert_single_auth_method_enabled(cluster_name, hub_name):
+def validate_authenticator_config(cluster_name, hub_name):
     """
-    For each hub of a specific cluster, it asserts that only a single auth
-    method is enabled. An error is raised when an authenticator
-    other than Auth0 is enabled and `auth0` is not explicitly disabled.
+    For each hub of a specific cluster:
+     - It asserts that only a single auth method is enabled.
+       An error is raised when an authenticator other than Auth0
+       is enabled and `auth0` is not explicitly disabled.
+     - It asserts that when the JupyterHub GitHubOAuthenticator is used,
+       then `Authenticator.allowed_users` is not set.
+       An error is raised otherwise.
     """
     _prepare_helm_charts_dependencies_and_schemas()
 
@@ -181,6 +185,7 @@ def assert_single_auth_method_enabled(cluster_name, hub_name):
         )
 
         authenticator_class = "auth0"
+        allowed_users = []
         for values_file_name in hub.spec["helm_chart_values_files"]:
             if "secret" not in os.path.basename(values_file_name):
                 values_file = config_file_path.parent.joinpath(values_file_name)
@@ -192,10 +197,16 @@ def assert_single_auth_method_enabled(cluster_name, hub_name):
                         authenticator_class = config["basehub"]["jupyterhub"]["hub"][
                             "config"
                         ]["JupyterHub"]["authenticator_class"]
+                        allowed_users= config["basehub"]["jupyterhub"]["hub"][
+                            "config"
+                        ]["Authenticator"]["allowed_users"]
                     else:
                         authenticator_class = config["jupyterhub"]["hub"]["config"][
                             "JupyterHub"
                         ]["authenticator_class"]
+                        allowed_users= config["jupyterhub"]["hub"]["config"][
+                            "Authenticator"
+                        ]["allowed_users"]
                 except KeyError:
                     pass
 
@@ -204,4 +215,14 @@ def assert_single_auth_method_enabled(cluster_name, hub_name):
         if authenticator_class != "auth0" and hub.spec["auth0"].get("enabled", True):
             raise ValueError(
                 f"Please disable auth0 for {hub.spec['name']} hub before using another authenticator class!"
+            )
+
+        # If the authenticator class is github, then raise an error
+        # if `Authenticator.allowed_users` is set
+        if authenticator_class == "github" and allowed_users:
+            raise ValueError(
+                f"""
+                    Please unset `Authenticator.allowed_users` for {hub.spec['name']} when GitHub Orgs/Teams is
+                    being used for auth so valid members are not refused access.
+                """
             )

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -14,7 +14,7 @@ import pytest
 from auth import KeyProvider
 from cluster import Cluster
 from config_validation import (
-    assert_single_auth_method_enabled,
+    validate_authenticator_config,
     validate_cluster_config,
     validate_hub_config,
     validate_support_config,
@@ -186,7 +186,7 @@ def deploy(cluster_name, hub_name, config_path, dask_gateway_version):
     """
     validate_cluster_config(cluster_name)
     validate_hub_config(cluster_name, hub_name)
-    assert_single_auth_method_enabled(cluster_name, hub_name)
+    validate_authenticator_config(cluster_name, hub_name)
 
     with get_decrypted_file(config_path) as decrypted_file_path:
         with open(decrypted_file_path) as f:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -455,18 +455,6 @@ jupyterhub:
             user_id_type = get_config("custom.2i2c.add_staff_user_ids_of_type")
             staff_user_ids = get_config(f"custom.2i2c.staff_{user_id_type}_ids", [])
             c.Authenticator.admin_users.extend(staff_user_ids)
-
-            # Check what authenticator class is set. If it's "github", we assume
-            # GitHub Orgs/Teams is being used for auth and unset allowed_users
-            # so valid members are not refused access.
-            # FIXME: This should be handled in basehub's schema validation file
-            # so that we get useful feedback about config. But at time of writing,
-            # it doesn't have one! Issue to track the creation of such files is:
-            # https://github.com/2i2c-org/infrastructure/issues/937
-            authenticator_class = get_config("hub.config.JupyterHub.authenticator_class")
-            if authenticator_class == "github" and c.Authenticator.allowed_users:
-                print("WARNING: hub.config.JupyterHub.authenticator_class was set to github and c.Authenticator.allowed_users was set, custom 2i2c jupyterhub config is now resetting allowed_users to an empty set.")
-                c.Authenticator.allowed_users = set()
       05-gh-teams: |
         from textwrap import dedent
         from tornado import gen, web


### PR DESCRIPTION
While investigating why this warning message was present in the logs for https://github.com/2i2c-org/infrastructure/pull/1560 even though an allowed_users list was not set, I noticed the fixme comment 😅

~Also, the `auth0` config was never validated either because we were never calling the assert func in the validate step.~ 
We were actually calling it in the `deploy` function.

So this PR:
- changes the assert auth0 config method be a a generic `validate_authenticator_config`
- this func does two things now:
  -  It asserts that only a single auth method is enabled.
       An error is raised when an authenticator other than Auth0
       is enabled and `auth0` is not explicitly disabled.
  - It asserts that when the JupyterHub GitHubOAuthenticator is used,
       then `Authenticator.allowed_users` is not set.
       An error is raised otherwise.
       
I remember last time there were some objections against naming this function `validate_...` when what it does is to `assert`. So, happy to consider changing this if people thing that this should instead be two `assert` functions.