### PR TITLE
Update ohw hub

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -73,7 +73,7 @@ hubs:
       - neurohackademy.values.yaml
   - name: ohw
     display_name: "Ocean Hack Week"
-    domain: ohw.pilot.2i2c.cloud
+    domain: oceanhackweek.2i2c.cloud
     helm_chart: daskhub
     auth0:
       enabled: false

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -36,16 +36,14 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            # todo: change this with the community image
-            image: quay.io/2i2c/2i2c-hubs-image:69b1f9dff7c7
+            image: ghcr.io/oceanhackweek/python:e7303ce
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            # todo: change this with the community image
-            image: quay.io/2i2c/2i2c-hubs-image:69b1f9dff7c7
+            image: ghcr.io/oceanhackweek/r:e7303ce
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -82,8 +82,10 @@ basehub:
             - 2i2c-org:tech-team
             - oceanhackweek:participants_2022
             - oceanhackweek:ohw22-organizers
+            - oceanhackweek:ohw22-mentor-helper-presenter
           scope:
             - read:org
         Authenticator:
           admin_users:
             - ocefpaf
+            - abkfenris

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -77,7 +77,7 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
-          oauth_callback_url: https://ohw.pilot.2i2c.cloud/hub/oauth_callback
+          oauth_callback_url: https://oceanhackweek.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
             - 2i2c-org:tech-team
             - oceanhackweek:participants_2022

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -36,14 +36,14 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: ghcr.io/oceanhackweek/python:e7303ce
+            image: "ghcr.io/oceanhackweek/python:e7303ce"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: ghcr.io/oceanhackweek/r:e7303ce
+            image: "ghcr.io/oceanhackweek/r:e7303ce"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
Updates the ohw hub per last requests:
- updates R and Python user images
- hub domain changes from `ohw.pilot.2i2c.cloud` to `oceanhackweek.2i2c.cloud`
- adds a new team to the list of allowed teams

Ref: https://github.com/2i2c-org/infrastructure/issues/1515#issuecomment-1195722944

Unfortunately the community images are hosted on GitHub, so we won't be able to setup https://github.com/sgibson91/bump-jhub-image-action for them, right @sgibson91 ?