### PR TITLE
Add a separate nodepool for ohw

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,12 +1,7 @@
 dask-gateway:
   gateway:
-    backend:
-      scheduler:
-        nodeSelector:
-          2i2c.org/community: ohw
-      worker:
-        nodeSelector:
-          2i2c.org/community: ohw
+    nodeSelector:
+      2i2c.org/community: ohw
 basehub:
   userServiceAccount:
     annotations:

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -44,6 +44,8 @@ basehub:
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
+            cpu_limit: 2
+            cpu_guarantee: 0.5
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
@@ -51,6 +53,8 @@ basehub:
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G
+            cpu_limit: 2
+            cpu_guarantee: 0.5
       nodeSelector:
         2i2c.org/community: ohw
     custom:

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,3 +1,12 @@
+dask-gateway:
+  gateway:
+    backend:
+      scheduler:
+        nodeSelector:
+          2i2c.org/community: ohw
+      worker:
+        nodeSelector:
+          2i2c.org/community: ohw
 basehub:
   userServiceAccount:
     annotations:
@@ -47,6 +56,8 @@ basehub:
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G
+      nodeSelector:
+        2i2c.org/community: ohw
     custom:
       cloudResources:
         provider: gcp

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -44,6 +44,11 @@ notebook_nodes = {
     labels: {
       "2i2c.org/community": "ohw"
     },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
   }
 }
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -36,6 +36,14 @@ notebook_nodes = {
       type: "",
       count: 0
     }
+  },
+  "ohw": {
+    min: 0,
+    max: 100,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
   }
 }
 
@@ -45,6 +53,19 @@ dask_nodes = {
     max : 100,
     machine_type : "n1-highmem-4",
     labels: { },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  }
+  "ohw": {
+    min: 0,
+    max: 100,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
     gpu: {
       enabled: false,
       type: "",

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -40,7 +40,7 @@ notebook_nodes = {
   "ohw": {
     min: 0,
     max: 100,
-    machine_type: "n1-highmem-4",
+    machine_type: "n1-highmem-8",
     labels: {
       "2i2c.org/community": "ohw"
     },


### PR DESCRIPTION
Wondering if we could deploy and merge this now, before the event, since we're only defining a node pool and not pre-starting any node. Also, we shouldn't need a machine more powerful than the one we're using anyway by default, `n1-highmem-4`. I believe this was what it was used for last year's event too.

Todo:
- [x] paste `terraform plan` output once I have a working terraform local setup