### PR TITLE
Only schedule the dask worker and scheduler pods in the new node pool

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,7 +1,16 @@
 dask-gateway:
   gateway:
     nodeSelector:
-      2i2c.org/community: ohw
+      k8s.dask.org/node-purpose: core
+    backend:
+      scheduler:
+        extraPodConfig:
+          nodeSelector:
+            2i2c.org/community: ohw
+      worker:
+        extraPodConfig:
+          nodeSelector:
+            2i2c.org/community: ohw
 basehub:
   userServiceAccount:
     annotations:

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,7 +1,5 @@
 dask-gateway:
   gateway:
-    nodeSelector:
-      k8s.dask.org/node-purpose: core
     backend:
       scheduler:
         extraPodConfig:


### PR DESCRIPTION
Apparently setting the nodeSelector on the gateway object, sets the selector on other pods too (the `api` one for example), not just on worker and scheduler ones (which was the desired).

reference: I believe @yuvipanda's comment in the previous PR was a valid concern https://github.com/2i2c-org/infrastructure/pull/1569/files#r932768688


### However

I'm still unable to succesfully deploy the `ohw` hub. The `api-ohw-dask-gateway` is stuck in `pending` state.

```
Node-Selectors:              2i2c.org/community=ohw
                             k8s.dask.org/node-purpose=core
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason             Age                  From                                   Message
  ----     ------             ----                 ----                                   -------
  Warning  FailedScheduling   18m                  gke.io/optimize-utilization-scheduler  0/6 nodes are available: 2 node(s) didn't match Pod's node affinity/selector, 4 node(s) had taint {hub.jupyter.org_dedicated: user}, that the pod didn't tolerate.
  Warning  FailedScheduling   17m (x1 over 18m)    gke.io/optimize-utilization-scheduler  0/6 nodes are available: 2 node(s) didn't match Pod's node affinity/selector, 4 node(s) had taint {hub.jupyter.org_dedicated: user}, that the pod didn't tolerate.
  Normal   NotTriggerScaleUp  8m7s (x49 over 18m)  cluster-autoscaler                     pod didn't trigger scale-up: 3 node(s) had taint {hub.jupyter.org_dedicated: user}, that the pod didn't tolerate, 2 node(s) had taint {k8s.dask.org_dedicated: worker}, that the pod didn't tolerate, 1 node(s) didn't match Pod's node affinity/selector
  Normal   NotTriggerScaleUp  3m5s (x32 over 16m)  cluster-autoscaler                     pod didn't trigger scale-up: 2 node(s) had taint {k8s.dask.org_dedicated: worker}, that the pod didn't tolerate, 1 node(s) didn't match Pod's node affinity/selector, 3 node(s) had taint {hub.jupyter.org_dedicated: user}, that the pod didn't tolerate
```