### PR TITLE
Disable upgrading binder-staging on 2i2c cluster

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -202,10 +202,10 @@ jobs:
         run: |
           python deployer deploy ${{ matrix.jobs.cluster_name }} dask-staging
 
-      - name: Upgrade binder-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
-        if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
-        run: |
-          python deployer deploy ${{ matrix.jobs.cluster_name }} binder-staging
+      # - name: Upgrade binder-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
+      #   if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
+      #   run: |
+      #     python deployer deploy ${{ matrix.jobs.cluster_name }} binder-staging
 
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists


### PR DESCRIPTION
We had cryptominers on the binder-staging deployment. https://github.com/2i2c-org/infrastructure/pull/1579 was a failed attempt to enable CILogon to lock it down. Instead I deleted the proxy-public service to make the hub unreachable. However, we don't want an automatic deployment recreating that service and making the hub vulnerable again. Hence this PR disables the upgrade step for the binder-staging hub.