### PR TITLE
Run ohw bump image tags workflow more frequently

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -30,12 +30,6 @@ jobs:
             # Note: if position of images in profileList changes, update the index in these expressions
             images_info: '[{"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
 
-          # Bump user images in ohw hub
-          - name: "OceanHackWeek profiles"
-            config_path: "config/clusters/2i2c/ohw.values.yaml"
-            # Note: if position of images in profileList changes, update the index in these expressions
-            images_info: '[{"values_path": ".basehub.jupyterhub.profileList[0].kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[1].kubespawner_override.image"}]'
-
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,
       # so we generate a token from a GitHub App that would allow this.

--- a/.github/workflows/bump-ohw-image-tags.yaml
+++ b/.github/workflows/bump-ohw-image-tags.yaml
@@ -1,0 +1,36 @@
+name: Bump Ohw Image Tags
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */6 * * *" # Run every 6th hour.
+env:
+  team_reviewers: tech-team
+
+jobs:
+  bump-image-tags:
+    runs-on: ubuntu-latest
+    environment: github-app-token-generator
+    steps:
+      # We want tests to be run on the Pull Request that gets opened by the next step,
+      # so we generate a token from a GitHub App that would allow this.
+      # By default, secrets.GITHUB_TOKEN is prevented from triggering
+      # secondary workflows.
+      #
+      # Action: https://github.com/marketplace/actions/github-app-token
+      - name: Fetch a token from GitHub App
+        id: generate_token
+        uses: tibdex/github-app-token@v1.6
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      # Action repo: https://github.com/sgibson91/bump-jhub-image-action
+      - name: "Bump image tags for OceanHackWeek user profiles"
+        uses: sgibson91/bump-jhub-image-action@main
+        with:
+          config_path: "config/clusters/2i2c/ohw.values.yaml"
+          images_info: '[{"values_path": ".basehub.jupyterhub.profileList[0].kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[1].kubespawner_override.image"}]'
+          github_token: ${{ steps.generate_token.outputs.token }}
+          # team_reviewers: ${{ env.team_reviewers }}
+          base_branch: "master"


### PR DESCRIPTION
Adds a new workflow to bump ohw image tags more frequently.

The current `bump-image-tags` workflow runs once every week, so this temporarily adds a new workflow that runs every 6 hours and checks for new image tags for the ohw hub. We should keep this probably only during the event https://github.com/2i2c-org/infrastructure/issues/1576.

I chose 6h as the interval since this means 4 times a day and it means about two times during someone's awake time. But feel free to suggest another value if it makes more sense.

TODO:
- [x] add removing this workflow on the todo list of the issue tracking the event once this PR is accepted
- [x] add this as a suggested practice in the event issue template for hubs that run multiple images per user profile and hence the configurator doesn't work for them. -> https://github.com/2i2c-org/infrastructure/issues/1590