### PR TITLE
Centralize the initContainer that fixes ownership

### DIFF
--- a/config/clusters/2i2c/utexas.values.yaml
+++ b/config/clusters/2i2c/utexas.values.yaml
@@ -89,6 +89,26 @@ jupyterhub:
           # So we put data in a subpath
           subPath: data
     initContainers:
+      # Repeat this here even though it's defined in basehub/values.yaml - otherwise
+      # tthe other initContainer we define here will overwrite this
+      - name: volume-mount-ownership-fix
+        image: busybox
+        command:
+          [
+            "sh",
+            "-c",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
+          ]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{username}"
+          # Here so we can chown it appropriately
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
       # /var/lib/postgresql should be writeable by uid 1000, so students
       # can blow out their db directories if need to. Also lets postgres actually
       # write to its data directory

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -90,22 +90,6 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -33,22 +33,6 @@ basehub:
             url: https://carbonplan.org
     singleuser:
       serviceAccountName: cloud-user-sa
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
       image:
         name: carbonplan/trace-python-notebook
         # pullPolicy set to "Always" because we use the changing over time tag

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -120,26 +120,6 @@ basehub:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
-            # Here so we can chown it appropriately
-            - name: home
-              mountPath: /home/jovyan/shared-readwrite
-              subPath: _shared
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -87,22 +87,6 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -115,22 +115,6 @@ basehub:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -34,25 +34,6 @@ basehub:
     singleuser:
       serviceAccountName: cloud-user-sa
       defaultUrl: /lab
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command: [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan /home/jovyan/shared\
-              \ && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
-            - name: home
-              mountPath: /home/jovyan/shared
-              subPath: _shared
       # User image repo: https://github.com/NASA-Openscapes/corn
       image:
         name: 783616723547.dkr.ecr.us-west-2.amazonaws.com/user-image

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -17,26 +17,6 @@ basehub:
             url: https://coessing.org/
             logo_url: "https://coessing.files.wordpress.com/2016/08/ghana-logo-21.png?w=262&h=376&zoom=2"
     singleuser:
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
-            # Here so we can chown it appropriately
-            - name: home
-              mountPath: /home/jovyan/shared-readwrite
-              subPath: _shared
       extraEnv:
         SCRATCH_BUCKET: gcs://pangeo-hubs-coessing-scratch/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gcs://pangeo-hubs-coessing-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -111,22 +111,6 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -65,22 +65,6 @@ jupyterhub:
           [credential "https://github.com"]
           helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
           useHttpPath = true
-    initContainers:
-      # Need to explicitly fix ownership here, since Azure File doesn't do anonuid
-      - name: volume-mount-ownership-fix
-        image: busybox
-        command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan",
-          ]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: home
-            mountPath: /home/jovyan
-            subPath: "{username}"
     image:
       name: quay.io/2i2c/utoronto-image
       tag: "d422076c3695"

--- a/config/clusters/uwhackweeks/common.values.yaml
+++ b/config/clusters/uwhackweeks/common.values.yaml
@@ -29,25 +29,6 @@ basehub:
             url: https://icesat-2.hackweek.io
     singleuser:
       defaultUrl: /lab
-      initContainers:
-        # Need to explicitly fix ownership here, since EFS doesn't do anonuid
-        - name: volume-mount-ownership-fix
-          image: busybox
-          command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan /home/jovyan/shared && ls -lhd /home/jovyan",
-            ]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: home
-              mountPath: /home/jovyan
-              subPath: "{username}"
-            - name: home
-              mountPath: /home/jovyan/shared
-              subPath: _shared
       # User image repo: https://github.com/ICESAT-2HackWeek/website2022
       image:
         name: quay.io/uwhackweek/icesat2

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -150,6 +150,27 @@ jupyterhub:
         limits:
           memory: 1Gi
   singleuser:
+    # Need to explicitly fix ownership here, as otherwise these directories will be owned
+    # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
+    initContainers:
+      - name: volume-mount-ownership-fix
+        image: busybox
+        command:
+          [
+            "sh",
+            "-c",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
+          ]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{username}"
+          # Here so we can chown it appropriately
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
     cmd:
       # Explicitly define this, as it's no longer set by z2jh
       # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449


### PR DESCRIPTION
We were copy-pasting this, and it was causing shared-readwrite
to not be functional in some cases.

Fixes https://github.com/2i2c-org/infrastructure/issues/440