### PR TITLE
OceanHackWeek image updates

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -47,7 +47,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/python:f6f8b9f"
+            image: "ghcr.io/oceanhackweek/python:d98b914"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
@@ -56,7 +56,7 @@ basehub:
         - display_name: "R image"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/r:f6f8b9f"
+            image: "ghcr.io/oceanhackweek/r:d98b914"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
Updates to both the Python and R images for OceanHackWeek.

I was hoping to see the image updater (#1588) do it's thing, but it [didn't appear to recognize the new tags on the run after these were pushed](https://github.com/2i2c-org/infrastructure/runs/7683672070?check_suite_focus=true#step:4:19)?