### PR TITLE
Update bump-ohw-image-tags.yaml

### DIFF
--- a/.github/workflows/bump-ohw-image-tags.yaml
+++ b/.github/workflows/bump-ohw-image-tags.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: sgibson91/bump-jhub-image-action@main
         with:
           config_path: "config/clusters/2i2c/ohw.values.yaml"
-          images_info: '[{"values_path": ".basehub.jupyterhub.profileList[0].kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[1].kubespawner_override.image"}]'
+          images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.profileList[0].kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[1].kubespawner_override.image"}]'
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"


### PR DESCRIPTION
Right now, it doesn't look like its getting correct info about image tags and might be because we're missing a level in the config dict.

(I plan to self merge this so I can test quickly if this works or know by manually triggering the action)