### PR TITLE
 Fix the openscapes values_path config used in bump-image-tags.yaml

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -28,7 +28,7 @@ jobs:
           - name: "OpenScapes profiles"
             config_path: "config/clusters/openscapes/common.values.yaml"
             # Note: if position of images in profileList changes, update the index in these expressions
-            images_info: '[{"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
+            images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,


### PR DESCRIPTION
Similar to https://github.com/2i2c-org/infrastructure/pull/1600 the `profileList` option is under the `singleuser` config, and this layer was missing I believe.