### PR TITLE
Added Correct Student Domain to Fresno CC

### DIFF
--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -31,4 +31,4 @@ jupyterhub:
           - ericvd@berkeley.edu
           - k_usovich@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@fresnocitycollege\.edu|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@my\.scccd\.edu|.+@fresnocitycollege\.edu|deployment-service-check)$'


### PR DESCRIPTION
The student email address domain is my.scccd.edu and the instructor domain is fresnocitycollege.edu 