### PR TITLE
Ensure deployer code is tested when requirements change

### DIFF
--- a/.github/workflows/test-deployer-code.yaml
+++ b/.github/workflows/test-deployer-code.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - deployer/**
       - tests/**
+      - requirements.txt
+      - dev-requirements.txt
     tags:
       - "**"
   pull_request:
@@ -15,6 +17,8 @@ on:
     paths:
       - deployer/**
       - tests/**
+      - requirements.txt
+      - dev-requirements.txt
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
E.g. we should run these tests when PRs like https://github.com/2i2c-org/infrastructure/pull/1626 are opened