### PR TITLE
For version bumping workflows, add dry-run input for manual triggers

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -2,6 +2,14 @@ name: Bump Helm Chart Versions
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: |
+          Perform a dry-run of the action and don't open a Pull Request. Information
+          as to which subcharts need bumping to which versions will be printed to stdout.
+        default: false
+        required: false
   schedule:
     - cron: "0 0 * * 1" # Run every Monday at 00:00 UTC
 
@@ -50,3 +58,4 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"
+          dry_run: ${{ github.event.inputs.dry_run || true }}

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -2,6 +2,14 @@ name: Bump Image Tags
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: |
+          Perform a dry-run of the action and don't open a Pull Request. Information
+          on which images need to be bumped to which versions will be printed to stdout.
+        default: false
+        required: false
   schedule:
     - cron: "0 0 * * 1" # Run at 00:00 UTC every Monday
 
@@ -53,3 +61,4 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"
+          dry_run: ${{ github.event.inputs.dry_run || true}}

--- a/.github/workflows/bump-ohw-image-tags.yaml
+++ b/.github/workflows/bump-ohw-image-tags.yaml
@@ -2,8 +2,17 @@ name: Bump Ohw Image Tags
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        description: |
+          Perform a dry-run of the action and don't open a Pull Request. Information
+          on which images need to be bumped to which tags will be printed to stdout.
+        default: false
+        required: false
   schedule:
     - cron: "0 */6 * * *" # Run every 6th hour.
+
 env:
   team_reviewers: tech-team
 
@@ -34,3 +43,4 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"
+          dry_run: ${{ github.event.inputs.dry_run || true }}


### PR DESCRIPTION
This allows manual deploys of the actions that bump helm subchart versions or docker image tags to perform a dry-run, i.e., not open a Pull Request. This can be useful for testing. When dry-run is enabled, information about the bump will be printed to stdout.