### PR TITLE
Add workflow job to find specific workflow run URL when a PR is merged

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -114,7 +114,7 @@ jobs:
 
   # This job depends on the get-pr-number and get-workflow-url jobs to have completed
   # successfully and set the get-pr-number.outputs.continue-workflow variable to 'True'
-  # and the get-workflow-url.outputs.workflow-url to something other than 'False'. This
+  # and the get-workflow-url.outputs.workflow-url variable to something other than 'False'. This
   # job consumes the pr-number and workflow-url variables to comment on the matching
   # Pull Request with the workflow URL to the running deployment workflow.
   add-pr-comment:

--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -41,16 +41,91 @@ jobs:
           else:
               print(f"::set-output name=pr-number::{None}")
 
-  add-pr-comment:
-    # This job depends on the get-pr-number job to have completed successfully and set
-    # the continue-workflow variable to True. It consumes the pr-number variable to
-    # comment on that Pull Request with a link to the deploy-hubs.yaml wiorkflow running
-    # on the master branch.
+  # The other piece of information we require is the URL of the running workflow
+  # triggered by merging the Pull Request. We use the ghapi Python package to interact
+  # with the GitHub REST API and pull a list of workflow runs for the repository.
+  # We filter these runs by the following criteria: event that triggered the workflow,
+  # branch the workflow run is associated with, workflows that were created within a
+  # given date-time period, the head commit of the workflow run contains the relevant
+  # Pull Request number, and the name of the *other* workflow that we want to provide
+  # a link to. The URL for the matching workflow run is set as an output.
+  #
+  # This job depends on the get-pr-number job to have completed successfully and set
+  # the continue-workflow variable to True.
+  get-workflow-url:
     runs-on: ubuntu-latest
-    needs: [get-pr-number]
-    permissions:
-      pull-requests: write
+    needs: get-pr-number
     if: needs.get-pr-number.outputs.continue-workflow == 'True'
+    permissions:
+      # Grant GITHUB_TOKEN permissions to read a list of workflows for the repo
+      actions: read
+    outputs:
+      workflow-url: ${{ steps.get-workflow-url.outputs.workflow-url}}
+    steps:
+      - name: Install ghapi to interact with the GitHub REST API via Python
+        run: pip install ghapi
+
+      - name: Find workflow URL
+        id: get-workflow-url
+        shell: python
+        run: |
+          from datetime import datetime
+          from ghapi.all import GhApi, paged
+
+          # Get today's date in ISO format
+          today = datetime.now().strftime("%Y-%m-%d")
+
+          # Get variables from the environment
+          owner, repo = r"""${{ github.repository }}""".split("/")
+
+          # Authenticate against the REST API
+          api = GhApi(token=r"""${{ secrets.GITHUB_TOKEN }}""")
+
+          # List workflow runs for the repository. Filtered by event, branch, and
+          # creation time.
+          all_workflow_runs = paged(
+              api.actions.list_workflow_runs_for_repo,
+              owner=owner,
+              repo=repo,
+              branch=r"""${{ env.BRANCH }}""",
+              event=r"""${{ env.EVENT }}""",
+              per_page=100,
+              # Reduce the number of results by only checking workflow runs that were
+              # created today
+              created=f">={today}",
+          )
+
+          for wf_runs in all_workflow_runs:
+              for workflow_run in wf_runs:
+                  if (
+                      (workflow_run.name == r"""${{ env.WORKFLOW_NAME }}""")
+                      and (workflow_run.head_commit.message == r"""${{ github.event.head_commit.message }}""")
+                  ):
+                      print(f"::set-output name=workflow-url::{workflow_run.html_url}")
+                  else:
+                      print(f"::set-output name=workflow-url::{False}")
+        env:
+          BRANCH: "master"
+          EVENT: "push"
+          # WORKFLOW_NAME *MUST* match what is set in the name field in the
+          # deploy-hubs.yaml workflow file
+          # https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/deploy-hubs.yaml
+          WORKFLOW_NAME: "Deploy and test hubs"
+
+  # This job depends on the get-pr-number and get-workflow-url jobs to have completed
+  # successfully and set the get-pr-number.outputs.continue-workflow variable to 'True'
+  # and the get-workflow-url.outputs.workflow-url to something other than 'False'. This
+  # job consumes the pr-number and workflow-url variables to comment on the matching
+  # Pull Request with the workflow URL to the running deployment workflow.
+  add-pr-comment:
+    runs-on: ubuntu-latest
+    needs: [get-pr-number, get-workflow-url]
+    permissions:
+      # Grant GITHUB_TOKEN enough permissions to comment on Pull Requests
+      pull-requests: write
+    if: |
+      (needs.get-pr-number.outputs.continue-workflow == 'True')
+      && (needs.get-workflow-url.outputs.workflow-url != 'False')
     steps:
       - name: Comment on merged PR with GitHub Actions link
         uses: actions/github-script@v6
@@ -58,16 +133,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var PR_NUMBER = process.env.PR_NUMBER;
-            var WORKFLOW_FILENAME = process.env.WORKFLOW_FILENAME;
-            var BRANCH = process.env.BRANCH;
+            var WORKFLOW_URL = process.env.WORKFLOW_URL;
 
             github.rest.issues.createComment({
               issue_number: `${PR_NUMBER}`,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `:tada::tada::tada::tada:\n\nMonitor the deployment of the hubs here :point_right: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/${WORKFLOW_FILENAME}?query=branch%3A${BRANCH}`
+              body: `:tada::tada::tada::tada:\n\nMonitor the deployment of the hubs here :point_right: ${WORKFLOW_URL}`
             })
         env:
           PR_NUMBER: "${{ needs.get-pr-number.outputs.pr-number }}"
-          WORKFLOW_FILENAME: deploy-hubs.yaml
-          BRANCH: master
+          WORKFLOW_URL: "${{ needs.get-workflow-url.outputs.workflow-url }}"

--- a/docs/reference/ci-cd/index.md
+++ b/docs/reference/ci-cd/index.md
@@ -29,5 +29,5 @@ This workflow is only triggered when related configuration has changed.
 
 GitHub's UI is slightly confusing for distinguishing between _workflows that ran on a Pull Request_ and _workflows that ran on the merge commit to the default branch_.
 
-To help contributors to our `infrastructure` repository find the right workflow run, we have a GitHub Actions workflow that [posts a comment on a just merged Pull Request](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/comment-test-link-merged-pr.yaml) with a link to the GitHub Actions UI filtered for the `deploy-hubs.yaml` workflow (described above) running on the default branch.
-Hence, it should be much easier to find the current deployments happening on `master` than just following GitHub's UI.
+To help contributors to our `infrastructure` repository find the right workflow run, we have a GitHub Actions workflow that [posts a comment on a just merged Pull Request](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/comment-test-link-merged-pr.yaml) with a link to the GitHub Actions run of the `deploy-hubs.yaml` workflow (described in [](cicd/hub)) that the merge triggered.
+Hence, it should be much easier to find the current deployments caused by merges than just following GitHub's UI.


### PR DESCRIPTION
### Motivation

We currently have a workflow that posts this link on merged PRs that require a hub redeployment: https://github.com/2i2c-org/infrastructure/actions/workflows/deploy-hubs.yaml?query=branch%3Amaster However, this is a _generic_ link that shows the most recent runs of that workflow on that branch. If we were looking through old PRs, it would be difficult to associate a given PR with the specific workflow run since new merges would have triggered new runs which would have populated the top of the list.

This PR is adding a new job to the `comment-test-link-merged-pr.yaml` workflow file which uses the GitHub API to identify which _specific_ run was triggered by merging a PR and return the _specific_ URL, which will end in something like `.../actions/runs/<run_id>`. We list the workflow runs for the repo and filter the results down by the following criteria:

- event that triggered the workflow was `push`
- branch associated with the workflow is our default `master`
- the workflow was created "today" (where "today" is calculated dynamically when this workflow runs)
- the name of the workflow matches our target workflow, i.e., "Deploy and test hubs" (defined in the `deploy-hubs.yaml` file)
- the head commit message of this workflow and our target workflow match (In the previous `get-pr-number` job, we will have already established that the head commit contains a merge and extracted the PR number from that message)

### Overview of the whole workflow after this PR is merged

1. `get-pr-number` job:
   - Establishes that the head commit that triggered the workflow is a merge commit and extracts the number of the PR from the message
   - Sets output variables `continue-workflow` and `pr-number`
2. `get-workflow-url` job
   - Only runs if `get-pr-number` job completes successfully and `continue-workflow == True`
   - Locates the `.../actions/runs/<run_id>` URL associated with the PR identified in the previous job
   - Sets the URL as the output variable `workflow-url`
3. `add-pr-comment` job
   - Only runs if both `get-pr-number` and `get-workflow-url` complete successfully, `continue-workflow == True` and `workflow-url != False`
   - Consumes `pr-number` and `workflow-url` variables to post the URL as a comment on the PR