### PR TITLE
Iterate through the workflow_runs object instead

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -96,7 +96,7 @@ jobs:
           )
 
           for wf_runs in all_workflow_runs:
-              for workflow_run in wf_runs:
+              for workflow_run in wf_runs.workflow_runs:
                   if (
                       (workflow_run.name == r"""${{ env.WORKFLOW_NAME }}""")
                       and (workflow_run.head_commit.message == r"""${{ github.event.head_commit.message }}""")


### PR DESCRIPTION
Follow up to #1633 

Fixes a broken workflow, e.g., https://github.com/2i2c-org/infrastructure/actions/runs/2876499696

Example of functional workflow: https://github.com/sgibson91/testing-gh-actions/blob/main/.github/workflows/comment-link-to-merged-pr-2.yaml