### PR TITLE
Fix spawning a server for the deployment-service-check user on openscapes hubs

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -68,6 +68,7 @@ basehub:
         # on these nodes.
         - display_name: "Small: m5.large"
           description: "~2 CPU, ~8G RAM"
+          slug: "small"
           profile_options: &profile_options
             image:
               display_name: Image
@@ -75,14 +76,17 @@ basehub:
                 python:
                   display_name: Python
                   default: true
+                  slug: "python"
                   kubespawner_override:
                     image: openscapes/python:431a94c
                 rocker:
                   display_name: R
+                  slug: "rocker"
                   kubespawner_override:
                     image: openscapes/rocker:b88a034
                 matlab:
                   display_name: Matlab
+                  slug: "matlab"
                   kubespawner_override:
                     image: openscapes/matlab:fb41496
           kubespawner_override:

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -41,6 +41,14 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
                 # This is because we would have lost its api token from the previous run.
                 await hub.delete_user(username)
 
+        # Temporary fix for https://github.com/2i2c-org/infrastructure/issues/1611
+        # FIXME: Remove this once https://github.com/jupyterhub/kubespawner/pull/631 gets merged
+        user_options = None
+        if "openscapes" in hub_url:
+            user_options={
+                "profile": "small",
+                "image": "python"
+            }
         # Create a new user, start a server and execute a notebook
         await execute_notebook(
             hub_url,
@@ -52,6 +60,7 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             delete_user=False,  # To be able to delete its server in case of failure
             stop_server=True,  # If the health check succeeds, this will delete the server
             validate=False,  # Don't validate notebook outputs. We only care that it runs top-to-bottom without error.
+            user_options=user_options
         )
     finally:
         if orig_service_token:

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -45,10 +45,7 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
         # FIXME: Remove this once https://github.com/jupyterhub/kubespawner/pull/631 gets merged
         user_options = None
         if "openscapes" in hub_url:
-            user_options={
-                "profile": "small",
-                "image": "python"
-            }
+            user_options = {"profile": "small", "image": "python"}
         # Create a new user, start a server and execute a notebook
         await execute_notebook(
             hub_url,
@@ -60,7 +57,7 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             delete_user=False,  # To be able to delete its server in case of failure
             stop_server=True,  # If the health check succeeds, this will delete the server
             validate=False,  # Don't validate notebook outputs. We only care that it runs top-to-bottom without error.
-            user_options=user_options
+            user_options=user_options,
         )
     finally:
         if orig_service_token:


### PR DESCRIPTION
Temporarily fixes https://github.com/2i2c-org/infrastructure/issues/1611
 
Hopefully, https://github.com/jupyterhub/kubespawner/pull/631 is the more sustainable solution, but until/if that gets merged/released, this PR hacks the test so that we're passing a dict of `user-options` when spawning a test server on the openscapes hub.

More details in [this comment](https://github.com/2i2c-org/infrastructure/issues/1611#issuecomment-1219466905). 