### PR TITLE
[ci/cd] Improve the loop through workflow runs in comment-test-link-merged-pr.yaml

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -108,7 +108,7 @@ jobs:
               if workflow_url:
                   break
 
-          print(f"::set-output name=workflow-url::{workflow_run.html_url}")
+          print(f"::set-output name=workflow-url::{workflow_url}")
         env:
           BRANCH: "master"
           EVENT: "push"

--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -96,14 +96,19 @@ jobs:
           )
 
           for wf_runs in all_workflow_runs:
-              for workflow_run in wf_runs.workflow_runs:
-                  if (
-                      (workflow_run.name == r"""${{ env.WORKFLOW_NAME }}""")
-                      and (workflow_run.head_commit.message == r"""${{ github.event.head_commit.message }}""")
-                  ):
-                      print(f"::set-output name=workflow-url::{workflow_run.html_url}")
-                  else:
-                      print(f"::set-output name=workflow-url::{False}")
+              workflow_url = next(
+                  (
+                      workflow_run.html_url
+                      for workflow_run in wf_runs.workflow_runs
+                      if workflow_run.name == r"""${{ env.WORKFLOW_NAME }}"""
+                      and workflow_run.head_commit.message == r"""${{ github.event.head_commit.message }}"""
+                  ),
+                  False,
+              )
+              if workflow_url:
+                  break
+
+          print(f"::set-output name=workflow-url::{workflow_run.html_url}")
         env:
           BRANCH: "master"
           EVENT: "push"


### PR DESCRIPTION
I tried to improve this workflow to provide a specific link to a running workflow, as opposed to the general link. Ever since then, we have been hitting the following error which I believe is rate limiting of the API. ghapi's error messages aren't incredibly clear here, but since I have a working version elsewhere of this, I assume it is due to the larger volume of workflow runs to sift through in this repo than my test one.

```
Traceback (most recent call last):
  File "/home/runner/work/_temp/c2c[45](https://github.com/2i2c-org/infrastructure/runs/7952490768?check_suite_focus=true#step:3:46)581-0ea1-4b6c-9638-4d791c70f531.py", line 27, in <module>
    for wf_runs in all_workflow_runs:
  File "/home/runner/.local/lib/python3.8/site-packages/ghapi/page.py", line 16, in paged
    yield from itertools.takewhile(noop, (oper(*args, per_page=per_page, page=i, **kwargs) for i in range(1,max_pages+1)))
  File "/home/runner/.local/lib/python3.8/site-packages/ghapi/page.py", line 16, in <genexpr>
    yield from itertools.takewhile(noop, (oper(*args, per_page=per_page, page=i, **kwargs) for i in range(1,max_pages+1)))
  File "/home/runner/.local/lib/python3.8/site-packages/ghapi/core.py", line 61, in __call__
    return self.client(self.path, self.verb, headers=headers, route=route_p, query=query_p, data=data_p)
  File "/home/runner/.local/lib/python3.8/site-packages/ghapi/core.py", line 118, in __call__
    res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, debug=debug, return_headers=True,
  File "/home/runner/.local/lib/python3.8/site-packages/fastcore/net.py", line 214, in urlsend
    return urlread(req, return_json=return_json, return_headers=return_headers)
  File "/home/runner/.local/lib/python3.8/site-packages/fastcore/net.py", line 115, in urlread
    if 400 <= e.code < [50](https://github.com/2i2c-org/infrastructure/runs/7952490768?check_suite_focus=true#step:3:51)0: raise ExceptionsHTTP[e.code](e.url, e.hdrs, e.fp) from None
fastcore.basics.HTTP403ForbiddenError: HTTP Error 403: Forbidden
```

In order to try and avoid this, I have improved the loop to exit as soon as we find a match. Fingers crossed that it works 🤞🏻 