### PR TITLE
Add callysto cluster and hub

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -22,6 +22,7 @@ jobs:
           - cluster_name: utoronto
           - cluster_name: uwhackweeks
           - cluster_name: awi-ciroh
+          - cluster_name: callysto
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -154,6 +154,7 @@ jobs:
       failure_m2lines: "${{ steps.declare-failure-status.outputs.failure_m2lines }}"
       failure_linked-earth: "${{ steps.declare-failure-status.outputs.failure_linked-earth }}"
       failure_awi-ciroh: "${{ steps.declare-failure-status.outputs.failure_awi-ciroh }}"
+      failure_callysto: "${{ steps.declare-failure-status.outputs.failure_callysto }}"
 
     # Only run this job on pushes to the default branch and when the job output is not
     # an empty list

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -48,6 +48,7 @@ jobs:
           - cluster_name: uwhackweeks
           - cluster_name: linked-earth
           - cluster_name: awi-ciroh
+          - cluster_name: callysto
 
     steps:
       - uses: actions/checkout@v3

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -20,3 +20,13 @@ hubs:
       - common.values.yaml
       - staging.values.yaml
       - enc-staging.secret.values.yaml
+  - name: prod
+    display_name: "Callysto Staging"
+    domain: callysto.2i2c.cloud
+    helm_chart: basehub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - common.values.yaml
+      - prod.values.yaml
+      - enc-prod.secret.values.yaml

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -6,19 +6,7 @@ gcp:
   cluster: callysto-cluster
   zone: northamerica-northeast1
 support:
-  helm_chart_values_files: []
-hubs:
-  - name: staging
-    display_name: "Callysto Staging"
-    domain: staging.callysto.2i2c.cloud
-    helm_chart: basehub
-    auth0:
-      enabled: false
-    helm_chart_values_files: []
-  # - name: prod
-  #   display_name: "Callysto"
-  #   domain: 2i2c.callysto.ca
-  #   helm_chart: basehub
-  #   auth0:
-  #     enabled: false
-  #   helm_chart_values_files: []
+  helm_chart_values_files:
+    - support.values.yaml
+    - enc-support.secret.values.yaml
+hubs: []

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -1,0 +1,24 @@
+name: callysto
+provider: gcp
+gcp:
+  key: enc-deployer-credentials.secret.json
+  project: callysto-202316
+  cluster: callysto-cluster
+  zone: northamerica-northeast1
+support:
+  helm_chart_values_files: []
+hubs:
+  - name: staging
+    display_name: "Callysto Staging"
+    domain: staging.callysto.2i2c.cloud
+    helm_chart: basehub
+    auth0:
+      enabled: false
+    helm_chart_values_files: []
+  # - name: prod
+  #   display_name: "Callysto"
+  #   domain: 2i2c.callysto.ca
+  #   helm_chart: basehub
+  #   auth0:
+  #     enabled: false
+  #   helm_chart_values_files: []

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -22,7 +22,7 @@ hubs:
       - enc-staging.secret.values.yaml
   - name: prod
     display_name: "Callysto Staging"
-    domain: callysto.2i2c.cloud
+    domain: 2i2c.callysto.ca
     helm_chart: basehub
     auth0:
       enabled: false

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -9,4 +9,14 @@ support:
   helm_chart_values_files:
     - support.values.yaml
     - enc-support.secret.values.yaml
-hubs: []
+hubs:
+  - name: staging
+    display_name: "Callysto Staging"
+    domain: staging.callysto.2i2c.cloud
+    helm_chart: basehub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - common.values.yaml
+      - staging.values.yaml
+      - enc-staging.secret.values.yaml

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -33,10 +33,10 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        # Only show the option to login with Google and Mirosoft
         admin_users:
           - "117859169473992122769"
           - "111953611001323379758"
+        # Only show the option to login with Google and Mirosoft
         shown_idps:
           - https://accounts.google.com/o/oauth2/auth
           - https://login.microsoftonline.com/common/oauth2/v2.0/authorize

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -34,10 +34,9 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         # Only show the option to login with Google and Mirosoft
-        allowed_users:
-          - "117859169473992122769"
         admin_users:
           - "117859169473992122769"
+          - "111953611001323379758"
         shown_idps:
           - https://accounts.google.com/o/oauth2/auth
           - https://login.microsoftonline.com/common/oauth2/v2.0/authorize

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -1,15 +1,15 @@
 nfs:
-    pv:
-      # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
-      mountOptions:
-        - rsize=1048576
-        - wsize=1048576
-        - timeo=600
-        - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
-        - retrans=2
-        - noresvport
-      serverIP: nfs-server-01
-      baseShareName: /export/home-01/homes/
+  pv:
+    # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+    mountOptions:
+      - rsize=1048576
+      - wsize=1048576
+      - timeo=600
+      - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
+      - retrans=2
+      - noresvport
+    serverIP: nfs-server-01
+    baseShareName: /export/home-01/homes/
 jupyterhub:
   custom:
     2i2c:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -34,8 +34,8 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         admin_users:
-          - "117859169473992122769"
-          - "111953611001323379758"
+          - "117859169473992122769" #Georgiana
+          - "115722756968212778437" #Sarah
         # Only show the option to login with Google and Mirosoft
         shown_idps:
           - https://accounts.google.com/o/oauth2/auth

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -1,15 +1,13 @@
 nfs:
+  enabled: true
   pv:
-    # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
     mountOptions:
-      - rsize=1048576
-      - wsize=1048576
-      - timeo=600
       - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
-      - retrans=2
-      - noresvport
-    serverIP: nfs-server-01
-    baseShareName: /export/home-01/homes/
+      - noatime
+    # Google FileStore IP
+    serverIP: 10.93.235.178
+    # Name of Google Filestore share
+    baseShareName: /homes/
 jupyterhub:
   custom:
     2i2c:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -11,8 +11,8 @@ nfs:
 jupyterhub:
   custom:
     2i2c:
-      add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "google"
+      add_staff_user_ids_to_admin_users: false
+      # add_staff_user_ids_of_type: "google"
     homepage:
       templateVars:
         org:
@@ -34,13 +34,17 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         # Only show the option to login with Google and Mirosoft
+        allowed_users:
+          - "117859169473992122769"
+        admin_users:
+          - "117859169473992122769"
         shown_idps:
           - https://accounts.google.com/o/oauth2/auth
           - https://login.microsoftonline.com/common/oauth2/v2.0/authorize
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
-              username_claim: "sub"
-          https://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+              username_claim: "oidc"
+          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:
-              username_claim: "sub"
+              username_claim: "oidc"

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -28,6 +28,10 @@ jupyterhub:
         funded_by:
           name: Callysto
           url: https://www.callysto.ca
+  singleuser:
+    image:
+      name: callysto/2i2c
+      tag: 0.1.0
   hub:
     config:
       JupyterHub:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -1,0 +1,48 @@
+nfs:
+    pv:
+      # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+      mountOptions:
+        - rsize=1048576
+        - wsize=1048576
+        - timeo=600
+        - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
+        - retrans=2
+        - noresvport
+      serverIP: nfs-server-01
+      baseShareName: /export/home-01/homes/
+jupyterhub:
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "google"
+    homepage:
+      templateVars:
+        org:
+          name: Callysto
+          url: https://www.callysto.ca
+          logo_url: https://www.callysto.ca/wp-content/uploads/2022/08/Callysto-HUB_vertical.png
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: TODO
+          url: https://2i2c.org
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: cilogon
+      CILogonOAuthenticator:
+        # Only show the option to login with Google and Mirosoft
+        shown_idps:
+          - https://accounts.google.com/o/oauth2/auth
+          - https://login.microsoftonline.com/common/oauth2/v2.0/authorize
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "sub"
+          https://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            username_derivation:
+              username_claim: "sub"

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -26,8 +26,8 @@ jupyterhub:
           name: 2i2c
           url: https://2i2c.org
         funded_by:
-          name: TODO
-          url: https://2i2c.org
+          name: Callysto
+          url: https://www.callysto.ca
   hub:
     config:
       JupyterHub:

--- a/config/clusters/callysto/enc-deployer-credentials.secret.json
+++ b/config/clusters/callysto/enc-deployer-credentials.secret.json
@@ -1,0 +1,30 @@
+{
+	"type": "ENC[AES256_GCM,data:jLxq+8Yw1WQf2LeGKDqJ,iv:mvsyVv2DbvlOWzeus8vfipBjWtK18d7ncgd5xmzC7yU=,tag:bZ+/QPlyd4kELjDqmMZ0gg==,type:str]",
+	"project_id": "ENC[AES256_GCM,data:/oT3AuZ/PaFUGVyJqvTQ,iv:sHphaqeS4FEBIKvaoi5vh617Z3YN42GMABzYWAsE1Cc=,tag:qR9XPC/pQsSvfv64W7Vq5g==,type:str]",
+	"private_key_id": "ENC[AES256_GCM,data:1z7ZI2Ca9Is/S6Sd+/i5x5ToKTZlhnimR4AF7i078wG1/T3Rn/z08g==,iv:GWDlub5VKcThxJ4GgSEJftKY/GoT2J+Y9NuJeZyJlko=,tag:NocH+qc9QDpMKSUwoZE9dw==,type:str]",
+	"private_key": "ENC[AES256_GCM,data:vUjNhDaoJ7doc/fcKqwCkODVZ6pj6Sc5aA9CmA4IAzLsAlyDpLPGBI32gIAPEwvsAE1yHNi6MOX4g+Uvk9qjwibhhaYBJTz7mzfDjcctoz12afGkCdmP8DCpILvNcXs/G4cmAb8VFVPvDnWX45aP1F0IgTPcvOXZRxuY24EOITzxSf75WWMXrKYCLI86xbF2d5ov5MGukP3bZlJWVDyGbU10JVjfZniv/YVvOrLGIayM5I92ANwjLTD7sLNpHmhuFsMQJVGYep5yWxQNFIDzqUl1PVFO9k5wt+yrCifOgdEOCM0OrONoV/RVNHbVENvvJFPRFMRAELcxWgrNun3xjKiXsQNCNgyDetImXZ5cmdB02H10vTjauf0n5RLedcBxbQTrsCOfRYyqAsc+tg6PkoNpSRJsfd7ji3iJ7VtKsfOS7JkXCEHmLnmD18xYw3l1sSM6Eb/Lg6a+m8SfkQYkKKSy142kPTclkQP0euLwjPHXeBXmjd4eKFGMXNN1Ut47oR1S85MQHN5ONYkq0ZIt2BVPuiAFH7QbPz4fT5wmw00L6KlqL3Y6dCYM11v8jRWCl+SUhnSwfu8aUXEFtwdftxOkEi8OvK11CwIQEIiHrCcO8yIhX5BtxeLePVgPgmIy0fII+lkdEd5OQ3Yx2SHA5OdRwS+p37EGe175YnPZGPzKO0CQyp+Y2wl4X8WqZ/Z3Myhy+cEbb+OrnLQiOHQ/xgrta5HJlVcAZ/MtDCliRtxDeRZrkevcXzO9tl+Yw+ivERsxzq4OJS6qsN0E/r4qHz4IHXPEakG0INEvwnv78M8mtTB7dDUTmS5viODKP1PW0QcA8LCs28pQrlL7Urw85aYM6nHd+xA80tsQuymJ9UeHllqWl4ZN/7ByLQFv9b8/GeZPjr/GRWn48FDigQwZRmTAYuhjakCZhI5AKR5wZq5HUvhUvg96AU7QetpTcSCg0J/wVIURU7C5ZUzN6kIjAYBbOD2NQwyHPp4QE4+bf53ESdapuJHrAYqX54eoShqDy+I7RtcRRjIgzkIde8+/pUF8MKbKbElnovKP61FoU2WCCmvnbVdGdteJi/Y+vktbxsOpRt7L/xPp5jyoUQZJE8mqS8jGnXBJXRW5sO50FogWKP4G21NkGS99sQZXpmCw9uS3akPILi1kyw3DSTsamEdE9TS+3CXG7VPSME1DleQXq69PU7gyzA7qALamZQRK8SBYS0e198HYSupNBu0YFe8Ci8WHi+DH+22Pt4KlOdaMyB3KgddwVsVSHZIGUsiOEBSJ8jDTmXaSdLZWlAjnoIWb1TrFb6BdKEolBE3rz1Bw5SDgYgnQM64n7hBQEpb4ml0JLAwMln+gi31ugdvHbMlTMjgZwvOEEGaE0qfbEOZNPot+fXTzwaV6th56IGVb3HT9m8ue86R0aeIPCXR9It7UuQAE4c6qMHY1q7B9lXk/2z53RDTENp+HdBf6fttkMjFX9fl4sxyr0ObqnLDb7SVaw0DOTywsnpflJxr3wAxayGiRxSUJL7S6PVKZnPlg9jCdcx8MB+NhMohE+d1UwjczWle+2y/t9uhCYpeaDLnQVJla1jQfZ9ogZdsPhAiXg3gzhHmrGwyrhERVJTAEudJQOLjsYZDtQ55dB7hFWy/5JVWIPgtdSX58Bj2Ao/sJDXF7B6fHVkAd8JFgT0JdknSpvfMzcvE8maj9fB6e6N0FsrlfPZEcFFIxiMP/iPA5wBqsCs5LR7r7G7n/INaX3uF1uuGqzGHzuSh5ogMQ6/q9dGpL4nrRulo4fz9LMBKyMcyouC7pz7AScpWgvyYPGeTC6zev4Uz6lP2OhHkn4ApeJ8I8pE3BA5lAZvtuvwtX2vq6e22U//Lva9NSsgNHlUk4zV+WcOZxMoimFteZ08WMoi+hMXDVcRV08amMt0STKY80QfNDHtISg4ay7BWlU+czoP1xMX/itaZqBpOpYqNRtPr8TCD3/J4OWrZ+LFyN22JmG6Z6IaU8z2V0Pe7jMG6ixpil3NgKwZWgghX8kFZk/++4YKa/mD/QLPo/ghi9um159JaKgU+EIrQVHAcYkRFqM+DbKXQYpIG7pmX9KLmb/Q2SY7PvuQsJICCoap5MVSfckiN+YQp6uxdjG72rSa0Hh9FbJMIn/FVO/33I8Nr2CMaSoD/qtyqe5HJtspi5kv5BXI+EtQKhbhB2KQfBM8MU5aGwvtb2D9vM+puBHGSF/xhR99B8+VMxJZOTrCXovCkLFB/5JIA9KSoUovxI5W3GzkmDa1+N,iv:QlmlLCJvkXH1fh2V9n+0Ud2bwiCSbNeLe8Sx6Al+t/k=,tag:B2QJN3oF8Sxvc2VfQRQJ5w==,type:str]",
+	"client_email": "ENC[AES256_GCM,data:7o95KOWmXHMBx5+I7cNLpZPGJ8ALp0C5est9tam8puEn4jGQwMI+LVuL5F8CJ2f72isEmv8p,iv:5nxtrHsqVfmcfKDQAog4i2KChyNVgX8zBnRJfOyubX4=,tag:TFVkcNYsf+/ZkD3qkUkIqw==,type:str]",
+	"client_id": "ENC[AES256_GCM,data:ViNSS/FEkNzc/DG2luTXtLgAyyS7,iv:k0o8k8J/mlLlvSleltA9oQbbxHGPedd7YCjdwWLUC1I=,tag:5b2wv7dmWXkCA6DKL+fZtg==,type:str]",
+	"auth_uri": "ENC[AES256_GCM,data:L0DSSF7MsP7Jm/zfRYvc12Ig2rSwi+IUOLCTYuSp5iRjEgD/8qz6cBk=,iv:p+JiUJ1Trswbsq+UYgmGBeYqIt2Qpgmhix3seQMVnuI=,tag:M50xJagDNsWqPgCYac3aiw==,type:str]",
+	"token_uri": "ENC[AES256_GCM,data:FNgE3aClBnbjhOgcjum5cp8GBx7F6SFsHR0SHfgTT5fUhR8=,iv:CjYp2WJG/wVDZ7U5XnwmLycAidWgoCX9EM5qjHRnbuA=,tag:+2mAUgk9YIK6QNBvYMIIRA==,type:str]",
+	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:8eyI6CuYG1KZTUasBazXkwtjqLFMCboArHkLcvPdbY1tpjac1A+SnUon,iv:jdWStvR6KL/YGZToBXlHj+2TVmk9EUEqO9IoF/d12MQ=,tag:dyZFN6hzqQ7yDefOcVvIEw==,type:str]",
+	"client_x509_cert_url": "ENC[AES256_GCM,data:EWPsqxfyY0RqwE1ptObkSw5uEuanRwPGAHj5ySt2DZ1+WbhQzE/ZhEqFWaBE3ZYgaws8K2SOTo6IJdNrPKpv6MeMKJzyKAvWD2GojbNU+l34fx1BbChw2HBDozCWZRzqP+SkRquAF41yXg==,iv:w1nNA7HMlu+BenWhNKY2Cb5/GStIFDfUTQGGbt/clL4=,tag:cFRPU+oxuOPjFCk6QTNpPw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-08-25T10:53:25Z",
+				"enc": "CiQA4OM7eJb89U2i9YVone8gQ3u7TZuRon9jLWD0rSWwkvGHqo8SSQDuy/p8LqA/v+aDq09ittMSQUdaRLjOptN/Em1+4OkLeSzFx4jeBWJ27qTqv+bhfQqyEBEVfcPJYAiiDqQsw/GmBTjs1BIQboc="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-08-25T10:53:25Z",
+		"mac": "ENC[AES256_GCM,data:gsW8fvG21o83+a8x2mukFmo04yqi3s6ko0szfOKrXd8yFAoJSBsF+7+wuMH2wSsivuhKqTwWm0VWXplvWLf+II6Ou3C67/kgrI3GQmswx5enVUVRkSQvJXdFeQ2Zn4EulNcr03OGSrN9Tt6+gQvRdH4U/vL/mHt/BV27cn9/kxc=,iv:OlmJoR43Frv0iRcH9w/ZFrqkPtINCzf39gXxggrfl6g=,tag:U7Eo2JxZupOFiR7OpQQOaA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/config/clusters/callysto/enc-deployer-credentials.secret.json
+++ b/config/clusters/callysto/enc-deployer-credentials.secret.json
@@ -1,30 +1,30 @@
 {
-	"type": "ENC[AES256_GCM,data:jLxq+8Yw1WQf2LeGKDqJ,iv:mvsyVv2DbvlOWzeus8vfipBjWtK18d7ncgd5xmzC7yU=,tag:bZ+/QPlyd4kELjDqmMZ0gg==,type:str]",
-	"project_id": "ENC[AES256_GCM,data:/oT3AuZ/PaFUGVyJqvTQ,iv:sHphaqeS4FEBIKvaoi5vh617Z3YN42GMABzYWAsE1Cc=,tag:qR9XPC/pQsSvfv64W7Vq5g==,type:str]",
-	"private_key_id": "ENC[AES256_GCM,data:1z7ZI2Ca9Is/S6Sd+/i5x5ToKTZlhnimR4AF7i078wG1/T3Rn/z08g==,iv:GWDlub5VKcThxJ4GgSEJftKY/GoT2J+Y9NuJeZyJlko=,tag:NocH+qc9QDpMKSUwoZE9dw==,type:str]",
-	"private_key": "ENC[AES256_GCM,data:vUjNhDaoJ7doc/fcKqwCkODVZ6pj6Sc5aA9CmA4IAzLsAlyDpLPGBI32gIAPEwvsAE1yHNi6MOX4g+Uvk9qjwibhhaYBJTz7mzfDjcctoz12afGkCdmP8DCpILvNcXs/G4cmAb8VFVPvDnWX45aP1F0IgTPcvOXZRxuY24EOITzxSf75WWMXrKYCLI86xbF2d5ov5MGukP3bZlJWVDyGbU10JVjfZniv/YVvOrLGIayM5I92ANwjLTD7sLNpHmhuFsMQJVGYep5yWxQNFIDzqUl1PVFO9k5wt+yrCifOgdEOCM0OrONoV/RVNHbVENvvJFPRFMRAELcxWgrNun3xjKiXsQNCNgyDetImXZ5cmdB02H10vTjauf0n5RLedcBxbQTrsCOfRYyqAsc+tg6PkoNpSRJsfd7ji3iJ7VtKsfOS7JkXCEHmLnmD18xYw3l1sSM6Eb/Lg6a+m8SfkQYkKKSy142kPTclkQP0euLwjPHXeBXmjd4eKFGMXNN1Ut47oR1S85MQHN5ONYkq0ZIt2BVPuiAFH7QbPz4fT5wmw00L6KlqL3Y6dCYM11v8jRWCl+SUhnSwfu8aUXEFtwdftxOkEi8OvK11CwIQEIiHrCcO8yIhX5BtxeLePVgPgmIy0fII+lkdEd5OQ3Yx2SHA5OdRwS+p37EGe175YnPZGPzKO0CQyp+Y2wl4X8WqZ/Z3Myhy+cEbb+OrnLQiOHQ/xgrta5HJlVcAZ/MtDCliRtxDeRZrkevcXzO9tl+Yw+ivERsxzq4OJS6qsN0E/r4qHz4IHXPEakG0INEvwnv78M8mtTB7dDUTmS5viODKP1PW0QcA8LCs28pQrlL7Urw85aYM6nHd+xA80tsQuymJ9UeHllqWl4ZN/7ByLQFv9b8/GeZPjr/GRWn48FDigQwZRmTAYuhjakCZhI5AKR5wZq5HUvhUvg96AU7QetpTcSCg0J/wVIURU7C5ZUzN6kIjAYBbOD2NQwyHPp4QE4+bf53ESdapuJHrAYqX54eoShqDy+I7RtcRRjIgzkIde8+/pUF8MKbKbElnovKP61FoU2WCCmvnbVdGdteJi/Y+vktbxsOpRt7L/xPp5jyoUQZJE8mqS8jGnXBJXRW5sO50FogWKP4G21NkGS99sQZXpmCw9uS3akPILi1kyw3DSTsamEdE9TS+3CXG7VPSME1DleQXq69PU7gyzA7qALamZQRK8SBYS0e198HYSupNBu0YFe8Ci8WHi+DH+22Pt4KlOdaMyB3KgddwVsVSHZIGUsiOEBSJ8jDTmXaSdLZWlAjnoIWb1TrFb6BdKEolBE3rz1Bw5SDgYgnQM64n7hBQEpb4ml0JLAwMln+gi31ugdvHbMlTMjgZwvOEEGaE0qfbEOZNPot+fXTzwaV6th56IGVb3HT9m8ue86R0aeIPCXR9It7UuQAE4c6qMHY1q7B9lXk/2z53RDTENp+HdBf6fttkMjFX9fl4sxyr0ObqnLDb7SVaw0DOTywsnpflJxr3wAxayGiRxSUJL7S6PVKZnPlg9jCdcx8MB+NhMohE+d1UwjczWle+2y/t9uhCYpeaDLnQVJla1jQfZ9ogZdsPhAiXg3gzhHmrGwyrhERVJTAEudJQOLjsYZDtQ55dB7hFWy/5JVWIPgtdSX58Bj2Ao/sJDXF7B6fHVkAd8JFgT0JdknSpvfMzcvE8maj9fB6e6N0FsrlfPZEcFFIxiMP/iPA5wBqsCs5LR7r7G7n/INaX3uF1uuGqzGHzuSh5ogMQ6/q9dGpL4nrRulo4fz9LMBKyMcyouC7pz7AScpWgvyYPGeTC6zev4Uz6lP2OhHkn4ApeJ8I8pE3BA5lAZvtuvwtX2vq6e22U//Lva9NSsgNHlUk4zV+WcOZxMoimFteZ08WMoi+hMXDVcRV08amMt0STKY80QfNDHtISg4ay7BWlU+czoP1xMX/itaZqBpOpYqNRtPr8TCD3/J4OWrZ+LFyN22JmG6Z6IaU8z2V0Pe7jMG6ixpil3NgKwZWgghX8kFZk/++4YKa/mD/QLPo/ghi9um159JaKgU+EIrQVHAcYkRFqM+DbKXQYpIG7pmX9KLmb/Q2SY7PvuQsJICCoap5MVSfckiN+YQp6uxdjG72rSa0Hh9FbJMIn/FVO/33I8Nr2CMaSoD/qtyqe5HJtspi5kv5BXI+EtQKhbhB2KQfBM8MU5aGwvtb2D9vM+puBHGSF/xhR99B8+VMxJZOTrCXovCkLFB/5JIA9KSoUovxI5W3GzkmDa1+N,iv:QlmlLCJvkXH1fh2V9n+0Ud2bwiCSbNeLe8Sx6Al+t/k=,tag:B2QJN3oF8Sxvc2VfQRQJ5w==,type:str]",
-	"client_email": "ENC[AES256_GCM,data:7o95KOWmXHMBx5+I7cNLpZPGJ8ALp0C5est9tam8puEn4jGQwMI+LVuL5F8CJ2f72isEmv8p,iv:5nxtrHsqVfmcfKDQAog4i2KChyNVgX8zBnRJfOyubX4=,tag:TFVkcNYsf+/ZkD3qkUkIqw==,type:str]",
-	"client_id": "ENC[AES256_GCM,data:ViNSS/FEkNzc/DG2luTXtLgAyyS7,iv:k0o8k8J/mlLlvSleltA9oQbbxHGPedd7YCjdwWLUC1I=,tag:5b2wv7dmWXkCA6DKL+fZtg==,type:str]",
-	"auth_uri": "ENC[AES256_GCM,data:L0DSSF7MsP7Jm/zfRYvc12Ig2rSwi+IUOLCTYuSp5iRjEgD/8qz6cBk=,iv:p+JiUJ1Trswbsq+UYgmGBeYqIt2Qpgmhix3seQMVnuI=,tag:M50xJagDNsWqPgCYac3aiw==,type:str]",
-	"token_uri": "ENC[AES256_GCM,data:FNgE3aClBnbjhOgcjum5cp8GBx7F6SFsHR0SHfgTT5fUhR8=,iv:CjYp2WJG/wVDZ7U5XnwmLycAidWgoCX9EM5qjHRnbuA=,tag:+2mAUgk9YIK6QNBvYMIIRA==,type:str]",
-	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:8eyI6CuYG1KZTUasBazXkwtjqLFMCboArHkLcvPdbY1tpjac1A+SnUon,iv:jdWStvR6KL/YGZToBXlHj+2TVmk9EUEqO9IoF/d12MQ=,tag:dyZFN6hzqQ7yDefOcVvIEw==,type:str]",
-	"client_x509_cert_url": "ENC[AES256_GCM,data:EWPsqxfyY0RqwE1ptObkSw5uEuanRwPGAHj5ySt2DZ1+WbhQzE/ZhEqFWaBE3ZYgaws8K2SOTo6IJdNrPKpv6MeMKJzyKAvWD2GojbNU+l34fx1BbChw2HBDozCWZRzqP+SkRquAF41yXg==,iv:w1nNA7HMlu+BenWhNKY2Cb5/GStIFDfUTQGGbt/clL4=,tag:cFRPU+oxuOPjFCk6QTNpPw==,type:str]",
-	"sops": {
-		"kms": null,
-		"gcp_kms": [
-			{
-				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2022-08-25T10:53:25Z",
-				"enc": "CiQA4OM7eJb89U2i9YVone8gQ3u7TZuRon9jLWD0rSWwkvGHqo8SSQDuy/p8LqA/v+aDq09ittMSQUdaRLjOptN/Em1+4OkLeSzFx4jeBWJ27qTqv+bhfQqyEBEVfcPJYAiiDqQsw/GmBTjs1BIQboc="
-			}
-		],
-		"azure_kv": null,
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2022-08-25T10:53:25Z",
-		"mac": "ENC[AES256_GCM,data:gsW8fvG21o83+a8x2mukFmo04yqi3s6ko0szfOKrXd8yFAoJSBsF+7+wuMH2wSsivuhKqTwWm0VWXplvWLf+II6Ou3C67/kgrI3GQmswx5enVUVRkSQvJXdFeQ2Zn4EulNcr03OGSrN9Tt6+gQvRdH4U/vL/mHt/BV27cn9/kxc=,iv:OlmJoR43Frv0iRcH9w/ZFrqkPtINCzf39gXxggrfl6g=,tag:U7Eo2JxZupOFiR7OpQQOaA==,type:str]",
-		"pgp": null,
-		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.3"
-	}
+  "type": "ENC[AES256_GCM,data:jLxq+8Yw1WQf2LeGKDqJ,iv:mvsyVv2DbvlOWzeus8vfipBjWtK18d7ncgd5xmzC7yU=,tag:bZ+/QPlyd4kELjDqmMZ0gg==,type:str]",
+  "project_id": "ENC[AES256_GCM,data:/oT3AuZ/PaFUGVyJqvTQ,iv:sHphaqeS4FEBIKvaoi5vh617Z3YN42GMABzYWAsE1Cc=,tag:qR9XPC/pQsSvfv64W7Vq5g==,type:str]",
+  "private_key_id": "ENC[AES256_GCM,data:1z7ZI2Ca9Is/S6Sd+/i5x5ToKTZlhnimR4AF7i078wG1/T3Rn/z08g==,iv:GWDlub5VKcThxJ4GgSEJftKY/GoT2J+Y9NuJeZyJlko=,tag:NocH+qc9QDpMKSUwoZE9dw==,type:str]",
+  "private_key": "ENC[AES256_GCM,data:vUjNhDaoJ7doc/fcKqwCkODVZ6pj6Sc5aA9CmA4IAzLsAlyDpLPGBI32gIAPEwvsAE1yHNi6MOX4g+Uvk9qjwibhhaYBJTz7mzfDjcctoz12afGkCdmP8DCpILvNcXs/G4cmAb8VFVPvDnWX45aP1F0IgTPcvOXZRxuY24EOITzxSf75WWMXrKYCLI86xbF2d5ov5MGukP3bZlJWVDyGbU10JVjfZniv/YVvOrLGIayM5I92ANwjLTD7sLNpHmhuFsMQJVGYep5yWxQNFIDzqUl1PVFO9k5wt+yrCifOgdEOCM0OrONoV/RVNHbVENvvJFPRFMRAELcxWgrNun3xjKiXsQNCNgyDetImXZ5cmdB02H10vTjauf0n5RLedcBxbQTrsCOfRYyqAsc+tg6PkoNpSRJsfd7ji3iJ7VtKsfOS7JkXCEHmLnmD18xYw3l1sSM6Eb/Lg6a+m8SfkQYkKKSy142kPTclkQP0euLwjPHXeBXmjd4eKFGMXNN1Ut47oR1S85MQHN5ONYkq0ZIt2BVPuiAFH7QbPz4fT5wmw00L6KlqL3Y6dCYM11v8jRWCl+SUhnSwfu8aUXEFtwdftxOkEi8OvK11CwIQEIiHrCcO8yIhX5BtxeLePVgPgmIy0fII+lkdEd5OQ3Yx2SHA5OdRwS+p37EGe175YnPZGPzKO0CQyp+Y2wl4X8WqZ/Z3Myhy+cEbb+OrnLQiOHQ/xgrta5HJlVcAZ/MtDCliRtxDeRZrkevcXzO9tl+Yw+ivERsxzq4OJS6qsN0E/r4qHz4IHXPEakG0INEvwnv78M8mtTB7dDUTmS5viODKP1PW0QcA8LCs28pQrlL7Urw85aYM6nHd+xA80tsQuymJ9UeHllqWl4ZN/7ByLQFv9b8/GeZPjr/GRWn48FDigQwZRmTAYuhjakCZhI5AKR5wZq5HUvhUvg96AU7QetpTcSCg0J/wVIURU7C5ZUzN6kIjAYBbOD2NQwyHPp4QE4+bf53ESdapuJHrAYqX54eoShqDy+I7RtcRRjIgzkIde8+/pUF8MKbKbElnovKP61FoU2WCCmvnbVdGdteJi/Y+vktbxsOpRt7L/xPp5jyoUQZJE8mqS8jGnXBJXRW5sO50FogWKP4G21NkGS99sQZXpmCw9uS3akPILi1kyw3DSTsamEdE9TS+3CXG7VPSME1DleQXq69PU7gyzA7qALamZQRK8SBYS0e198HYSupNBu0YFe8Ci8WHi+DH+22Pt4KlOdaMyB3KgddwVsVSHZIGUsiOEBSJ8jDTmXaSdLZWlAjnoIWb1TrFb6BdKEolBE3rz1Bw5SDgYgnQM64n7hBQEpb4ml0JLAwMln+gi31ugdvHbMlTMjgZwvOEEGaE0qfbEOZNPot+fXTzwaV6th56IGVb3HT9m8ue86R0aeIPCXR9It7UuQAE4c6qMHY1q7B9lXk/2z53RDTENp+HdBf6fttkMjFX9fl4sxyr0ObqnLDb7SVaw0DOTywsnpflJxr3wAxayGiRxSUJL7S6PVKZnPlg9jCdcx8MB+NhMohE+d1UwjczWle+2y/t9uhCYpeaDLnQVJla1jQfZ9ogZdsPhAiXg3gzhHmrGwyrhERVJTAEudJQOLjsYZDtQ55dB7hFWy/5JVWIPgtdSX58Bj2Ao/sJDXF7B6fHVkAd8JFgT0JdknSpvfMzcvE8maj9fB6e6N0FsrlfPZEcFFIxiMP/iPA5wBqsCs5LR7r7G7n/INaX3uF1uuGqzGHzuSh5ogMQ6/q9dGpL4nrRulo4fz9LMBKyMcyouC7pz7AScpWgvyYPGeTC6zev4Uz6lP2OhHkn4ApeJ8I8pE3BA5lAZvtuvwtX2vq6e22U//Lva9NSsgNHlUk4zV+WcOZxMoimFteZ08WMoi+hMXDVcRV08amMt0STKY80QfNDHtISg4ay7BWlU+czoP1xMX/itaZqBpOpYqNRtPr8TCD3/J4OWrZ+LFyN22JmG6Z6IaU8z2V0Pe7jMG6ixpil3NgKwZWgghX8kFZk/++4YKa/mD/QLPo/ghi9um159JaKgU+EIrQVHAcYkRFqM+DbKXQYpIG7pmX9KLmb/Q2SY7PvuQsJICCoap5MVSfckiN+YQp6uxdjG72rSa0Hh9FbJMIn/FVO/33I8Nr2CMaSoD/qtyqe5HJtspi5kv5BXI+EtQKhbhB2KQfBM8MU5aGwvtb2D9vM+puBHGSF/xhR99B8+VMxJZOTrCXovCkLFB/5JIA9KSoUovxI5W3GzkmDa1+N,iv:QlmlLCJvkXH1fh2V9n+0Ud2bwiCSbNeLe8Sx6Al+t/k=,tag:B2QJN3oF8Sxvc2VfQRQJ5w==,type:str]",
+  "client_email": "ENC[AES256_GCM,data:7o95KOWmXHMBx5+I7cNLpZPGJ8ALp0C5est9tam8puEn4jGQwMI+LVuL5F8CJ2f72isEmv8p,iv:5nxtrHsqVfmcfKDQAog4i2KChyNVgX8zBnRJfOyubX4=,tag:TFVkcNYsf+/ZkD3qkUkIqw==,type:str]",
+  "client_id": "ENC[AES256_GCM,data:ViNSS/FEkNzc/DG2luTXtLgAyyS7,iv:k0o8k8J/mlLlvSleltA9oQbbxHGPedd7YCjdwWLUC1I=,tag:5b2wv7dmWXkCA6DKL+fZtg==,type:str]",
+  "auth_uri": "ENC[AES256_GCM,data:L0DSSF7MsP7Jm/zfRYvc12Ig2rSwi+IUOLCTYuSp5iRjEgD/8qz6cBk=,iv:p+JiUJ1Trswbsq+UYgmGBeYqIt2Qpgmhix3seQMVnuI=,tag:M50xJagDNsWqPgCYac3aiw==,type:str]",
+  "token_uri": "ENC[AES256_GCM,data:FNgE3aClBnbjhOgcjum5cp8GBx7F6SFsHR0SHfgTT5fUhR8=,iv:CjYp2WJG/wVDZ7U5XnwmLycAidWgoCX9EM5qjHRnbuA=,tag:+2mAUgk9YIK6QNBvYMIIRA==,type:str]",
+  "auth_provider_x509_cert_url": "ENC[AES256_GCM,data:8eyI6CuYG1KZTUasBazXkwtjqLFMCboArHkLcvPdbY1tpjac1A+SnUon,iv:jdWStvR6KL/YGZToBXlHj+2TVmk9EUEqO9IoF/d12MQ=,tag:dyZFN6hzqQ7yDefOcVvIEw==,type:str]",
+  "client_x509_cert_url": "ENC[AES256_GCM,data:EWPsqxfyY0RqwE1ptObkSw5uEuanRwPGAHj5ySt2DZ1+WbhQzE/ZhEqFWaBE3ZYgaws8K2SOTo6IJdNrPKpv6MeMKJzyKAvWD2GojbNU+l34fx1BbChw2HBDozCWZRzqP+SkRquAF41yXg==,iv:w1nNA7HMlu+BenWhNKY2Cb5/GStIFDfUTQGGbt/clL4=,tag:cFRPU+oxuOPjFCk6QTNpPw==,type:str]",
+  "sops": {
+    "kms": null,
+    "gcp_kms": [
+      {
+        "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+        "created_at": "2022-08-25T10:53:25Z",
+        "enc": "CiQA4OM7eJb89U2i9YVone8gQ3u7TZuRon9jLWD0rSWwkvGHqo8SSQDuy/p8LqA/v+aDq09ittMSQUdaRLjOptN/Em1+4OkLeSzFx4jeBWJ27qTqv+bhfQqyEBEVfcPJYAiiDqQsw/GmBTjs1BIQboc="
+      }
+    ],
+    "azure_kv": null,
+    "hc_vault": null,
+    "age": null,
+    "lastmodified": "2022-08-25T11:28:14Z",
+    "mac": "ENC[AES256_GCM,data:6TUvA+akSeL+Nnuq4MFjRXyv33SlEPj1MtqBej38eBV4aUs3ssqxiLxQiyfRH+61sqtHazZq1o4r9i0YVkhkv37iauApyctQeeh0WFAMXKfmuBf9pQHsYToP9rcAj/fmMrWM35AU4jLNl+ChcJNSy97k59laNYu1FK2u2kq2DVg=,iv:1kf/lWoD8JBJhaB/nOA1tqKNw7BtAinVUughjuVuZz0=,tag:AumEJbN3sQQ3SCGl/SofLQ==,type:str]",
+    "pgp": null,
+    "unencrypted_suffix": "_unencrypted",
+    "version": "3.7.3"
+  }
 }

--- a/config/clusters/callysto/enc-grafana-token.secret.yaml
+++ b/config/clusters/callysto/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:lpFQ/cYY5blAhNAZ0ANG9AXmoUEjTXcPtvxEQsxvTJwkd+HCq7h+bTnyyS2N62fF059KOVOzDa6WELCT0uwx0p3kgTjN2CvtRY2asBpwxMySxAhrodvMWYYFmFuPRT+sh4M8o+vKpzAn+LQ3,iv:2FEtw1DkowLMeYslLHXCqoaIngfrxyw7fSSsnDLcX3s=,tag:OsxPJraC2PhmwQby2pyRSQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-08-25T19:48:34Z"
+          enc: CiQA4OM7eNtEJVA9HZFHSJnoWCJFJcqq5SXnuwhx3CsZ5Vifjh8SSQDuy/p8FzcrFbYdXV4CzEhdRN0WnftfQygFe70+TWoh2wslepnl5QQ1fLr0fWxrfORLFmUDdb4wZi67LIhFrBV8gTCYd+QSrpk=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-08-25T19:48:35Z"
+    mac: ENC[AES256_GCM,data:e8TcGvhEWdKQh3kiNk8KxNAqmHctUeecm1WEpErstmuZIqm20Ayd2povxpzWGtXv7OKiBiBVJacbx6VnFv/X2NZAUNIal3mGTgu2XOiCcjaZQrxLSkjBskS/2qSaa874Hd+Q35t0XZ93u3nbQWD1zbyWnY3NThXG0msnVQ3eC3c=,iv:x57QXWh1nNz1WCzOSeyWnGolX7G966XlTi9jqvUQKzE=,tag:kPSD2+tkVAvFd23qMwjLKQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/callysto/enc-prod.secret.values.yaml
+++ b/config/clusters/callysto/enc-prod.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:M7nv2cuJcMnncX9m5VVCsrvJZhN9y5TaDFLIlGF9HiBmrr55E+lkOuLEEiELoMdNm7ZH,iv:GPGk450O7s2Ov2UGutovASaMazDCZk/ZOCu9nvmVEmA=,tag:MQ1q+4/cYoasefAxaGrpJg==,type:str]
+                client_secret: ENC[AES256_GCM,data:Dcw8vS+UxplT/lpKxKzQiBwwGhaJ+ztBZvEmG+AmOajzP54CZ29m1S/WG/sYnfnaejdalf2IOPovfxz/kLlIo88Nt+erZQ2W8nbBXMNgJcgPVogrHeo=,iv:KW0TJtlEu4fsS9cvT85lX7SQLFmRGA43poG2TF1f+ro=,tag:d+P0jP6L+zVop+SYuwZBjA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-08-31T14:25:29Z"
+          enc: CiQA4OM7eLf5bySrmyjqO6xMUXkHmfoLG5E+yUXj28xmb1ewqFESSQDuy/p82HNXyF+9DNah6E5/TfFxAj1dzow+PFBzg420SIuNgGhIfBVJAOFE4NKwQW5ZuOfYjtewD2hF4qNNw0qOj6iYD3nAxUI=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-08-31T14:25:30Z"
+    mac: ENC[AES256_GCM,data:zxrTwhkaGzf8Go8HP9U4bwOeonerYANnmBQnBkYrCGYo25QzC8uCBXDm77DowUSwcgLxyy59YCzXyh8e4l4w851io8d8ftipQjZwtaoiDTNpXfYJw9YoG1U18h9xC9fYawEuNGDEOYQx/cal9Ysnwy7JctGu6t6SYj1c8gTkAIM=,iv:NNUvuGiV++wgBVfAP6M0R7AtOyx2l082vsSaZX6zZgs=,tag:6UQuF6XUM4yY4eDBrUSRpg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/callysto/enc-prod.secret.values.yaml
+++ b/config/clusters/callysto/enc-prod.secret.values.yaml
@@ -2,19 +2,19 @@ jupyterhub:
     hub:
         config:
             CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:M7nv2cuJcMnncX9m5VVCsrvJZhN9y5TaDFLIlGF9HiBmrr55E+lkOuLEEiELoMdNm7ZH,iv:GPGk450O7s2Ov2UGutovASaMazDCZk/ZOCu9nvmVEmA=,tag:MQ1q+4/cYoasefAxaGrpJg==,type:str]
-                client_secret: ENC[AES256_GCM,data:Dcw8vS+UxplT/lpKxKzQiBwwGhaJ+ztBZvEmG+AmOajzP54CZ29m1S/WG/sYnfnaejdalf2IOPovfxz/kLlIo88Nt+erZQ2W8nbBXMNgJcgPVogrHeo=,iv:KW0TJtlEu4fsS9cvT85lX7SQLFmRGA43poG2TF1f+ro=,tag:d+P0jP6L+zVop+SYuwZBjA==,type:str]
+                client_id: ENC[AES256_GCM,data:hDvmVElKOzOit25g/6dwr8cuxtxomTTWGau98geXsCYUImn/ah7jSQVk4ThEuICT99Ur,iv:9mLxAJE/6+BDns4frcx/+b3khNPvmR8fb+1a75gboe4=,tag:hRvx43HTMv6RR/qyFHfFkw==,type:str]
+                client_secret: ENC[AES256_GCM,data:pfuxypyKp0gLyadQLTW/4Us3eFT2Gq1LFVVR2XuI5OrLSJ/1r/9ZxjyfudzeHVIt0uj+TBMzIm3KZy0iuxUVC37xxWdNT4edqfWKS0DzourtWNjw7hI=,iv:ZEFOAjCiOHcECHhYhZGdEvkzgimIPp6IbnaNcRzJDmQ=,tag:XTKAl/cKyUVMoYI0RhWyyQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2022-08-31T14:25:29Z"
-          enc: CiQA4OM7eLf5bySrmyjqO6xMUXkHmfoLG5E+yUXj28xmb1ewqFESSQDuy/p82HNXyF+9DNah6E5/TfFxAj1dzow+PFBzg420SIuNgGhIfBVJAOFE4NKwQW5ZuOfYjtewD2hF4qNNw0qOj6iYD3nAxUI=
+          created_at: "2022-09-01T08:14:40Z"
+          enc: CiQA4OM7eBuDtViKx8a4ai2VE6WlL5Egd8jfhl9dQyxoKHzxc58SSQDuy/p8FNJmSh+QHjrmZ0CwdBcXPmDDIUWVl+pOvPkeKXf9BUhBlKDXs/UVn6JbXDlxYMOVuWRrtPUTxK4+RqofYCxEXlLFBuE=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-31T14:25:30Z"
-    mac: ENC[AES256_GCM,data:zxrTwhkaGzf8Go8HP9U4bwOeonerYANnmBQnBkYrCGYo25QzC8uCBXDm77DowUSwcgLxyy59YCzXyh8e4l4w851io8d8ftipQjZwtaoiDTNpXfYJw9YoG1U18h9xC9fYawEuNGDEOYQx/cal9Ysnwy7JctGu6t6SYj1c8gTkAIM=,iv:NNUvuGiV++wgBVfAP6M0R7AtOyx2l082vsSaZX6zZgs=,tag:6UQuF6XUM4yY4eDBrUSRpg==,type:str]
+    lastmodified: "2022-09-01T08:14:40Z"
+    mac: ENC[AES256_GCM,data:hrzSUn7szHDXUdbmwCiNXaz1Yyn2gF/QVToYwaKSD6jZX459viLWcJwcBcGDdhC7EoycpPaEhCf88xsRC7aJaWq/xhHjGgcxC8MxKjyBQYBx5CKFmrYwOhxrlJuVBnM80kgXoi+EHKlzVf/2k2Y6unCqKyjs2cPx/H8R00a7/NQ=,iv:84Ik3Jd7+XSk3ldBMnwlRAPL1bPc0MMwq/QXl7nHXwg=,tag:+fnpq1dgvamKhkWqKeyAdw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/callysto/enc-staging.secret.values.yaml
+++ b/config/clusters/callysto/enc-staging.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:hUwFQGdeR8v3E8f1QIf0CWS3VIL/CMVjd8n6dZbkIi9PcoKfSEnTBXCgqBVcB0Qq9Fg=,iv:CUPKWHMIeOHJy0QKwQZbKn+tbh6tIAMbC73HMGDGJyk=,tag:ZpYhXNXoANURxlwtoTtyrQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:M7xNlBrWqmOOt8B/v0HhisBlX3haZWFnQOPoucQdUtq+J0rjE5NdlY3t5XrFBdzBUM1l8Szc1OucJunpLRaMH9Mk7nYsK2dOtS8/JjJq7vASJPLIZ+o=,iv:ycH+HJwoEViPaxXQCOVBQ5uHmyzKCIVLK8VpLIY4r2A=,tag:T9W84ealMLHFIG3zSQl3lw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-08-26T07:06:08Z"
+          enc: CiQA4OM7eOcDPtgayKH1sVxMED3Sdo++ww+ytiPWDa9bTIBiFG0SSQDuy/p8rfPkrcELUB/ZZPtsacL2beuCL4m/qHeavx0xj9jZv/dHsvLNfyoXpBsMYSkKTcW2pzvZbXRR7VAGlJIsx3bA3cK5lCs=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-08-26T07:06:09Z"
+    mac: ENC[AES256_GCM,data:4zjXLg6CaYq3RC/1g7eS05aTDPKAIMnDcAWuHXQUmp/mPM774urSXz/eKc587tEoWlERKgljVMbOmr59hExa0Qt05LizsbMoSEo4V/a/aJcYeas0fbSZ5oJbD7IcBkqb4oYX0CKN8ILXtKC67NooD2etbpN9FNC2am5IE7FmYmE=,iv:RpxlPYb6y2UPWL3IR/5hTmhIWgEcSNWQmZJE18uIncg=,tag:KIGvvpo0S1Lq3v4ohHHXSQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/callysto/enc-support.secret.values.yaml
+++ b/config/clusters/callysto/enc-support.secret.values.yaml
@@ -1,0 +1,17 @@
+prometheusIngressAuthSecret:
+    username: ENC[AES256_GCM,data:PRxijXnlvkmjCkQyK/I+l2wWbaDkaJP94EmX7URKnBwZgokrPVG8azrHDJt5lEGo5PhX6waXTLHVgpK+ocP3Kg==,iv:HOVnan28Mpfg0X8jo284ZVdHUtV1CmgW3fR3hd+Vah8=,tag:vc2rLFUvs/p6JpoaIvQp5Q==,type:str]
+    password: ENC[AES256_GCM,data:mKNG8ASGy/G0fR3i6iOumvofaecFsT/lgZgKf3EitAz/bjqZ1MS4ofV73TQDdfxPx8/xYXjg1xH37mWd9s19aw==,iv:2AWZ1wnbBY+MFxtfu9SKPykIU6zih+7a+VhvTxWKM3A=,tag:uEH9uCPrIjywqcC53CZZTQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-08-25T11:12:05Z"
+          enc: CiQA4OM7eEd2fDWFZwDNAGHxtrOPsIVHXHJuJAAGI3LveTlj5kMSSQDuy/p8fj5K2nUPys2R/te2CsQxDY1yHAMwfYWqx7bFI1Fb6i4GMGbUMvsdd6iiiSIscQnU1CJvKhGRvr4ABt5IeP2MHTTfPhc=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-08-25T11:13:09Z"
+    mac: ENC[AES256_GCM,data:CUb2/JqU7OnlIzdiSDwhYP6YurH26B1nQi+n2TSwOb4kTapWeMnx8qxvl1LIW4WkXHsBdKtZ7CPXp0gKuD+vlsLafWNLACl+R6bRF5YqHqBU+VvapcITnwiDOF809MrpR1Rj0x4iDmICrzjOGGBCdLitCcIe9X8P8FHZc2ocr3k=,iv:4OXNg885TP4FVNRitthgUOaPHfHuwuQ8kWq1W12E98U=,tag:ocMeOFCY56gnb6zC0EaYpw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/callysto/prod.values.yaml
+++ b/config/clusters/callysto/prod.values.yaml
@@ -1,0 +1,5 @@
+jupyterhub:
+  hub:
+    config:
+      CILogonOAuthenticator:
+        oauth_callback_url: https://callysto.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/callysto/prod.values.yaml
+++ b/config/clusters/callysto/prod.values.yaml
@@ -2,4 +2,4 @@ jupyterhub:
   hub:
     config:
       CILogonOAuthenticator:
-        oauth_callback_url: https://callysto.2i2c.cloud/hub/oauth_callback
+        oauth_callback_url: https://2i2c.callysto.ca/hub/oauth_callback

--- a/config/clusters/callysto/staging.values.yaml
+++ b/config/clusters/callysto/staging.values.yaml
@@ -1,0 +1,5 @@
+jupyterhub:
+  hub:
+    config:
+      CILogonOAuthenticator:
+        oauth_callback_url: https://staging.callysto.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/callysto/support.values.yaml
+++ b/config/clusters/callysto/support.values.yaml
@@ -1,0 +1,21 @@
+prometheusIngressAuthSecret:
+  enabled: true
+
+prometheus:
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - prometheus.callysto.2i2c.cloud
+      tls:
+        - secretName: prometheus-tls
+          hosts:
+            - prometheus.callysto.2i2c.cloud
+grafana:
+  ingress:
+    hosts:
+      - grafana.callysto.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.callysto.2i2c.cloud

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -7,8 +7,7 @@ region                 = "northamerica-northeast1"
 core_node_machine_type = "n1-highmem-4"
 enable_network_policy  = true
 
-# No plans to provide storage buckets to users on this hub, so no need to deploy
-# config connector
+# No plans to provide storage buckets to users on this hub, so no need to deploy config connector
 config_connector_enabled = false
 
 notebook_nodes = {

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -1,0 +1,28 @@
+prefix                 = "callysto"
+project_id             = "callysto-202316"
+
+zone                   = "northamerica-northeast1-b"
+region                 = "northamerica-northeast1"
+
+core_node_machine_type = "n1-highmem-4"
+enable_network_policy  = true
+
+# No plans to provide storage buckets to users on this hub, so no need to deploy
+# config connector
+config_connector_enabled = false
+
+notebook_nodes = {
+  "user" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-highmem-4",
+    labels: {},
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+}
+
+user_buckets = {}

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -7,6 +7,10 @@ region                 = "northamerica-northeast1"
 core_node_machine_type = "n1-highmem-4"
 enable_network_policy  = true
 
+# Setup a filestore for in-cluster NFS
+enable_filestore       = true
+filestore_capacity_gb  = 1024
+
 # No plans to provide storage buckets to users on this hub, so no need to deploy config connector
 config_connector_enabled = false
 


### PR DESCRIPTION
Reference https://github.com/2i2c-org/infrastructure/issues/1439

Creates a regional cluster in `northamerica-northeast1-b` (Montreal, gpu machines are available in this zone also, just in case we need them).

Other assumptions made would be that the storage buckets will be disabled since they won't probably be needed, as this hub is an educational one. Also, although right now it would be a single tenant cluster, maybe this would change in the future, so I left `enable_network_policy` set to true since I don't think we are so strict on the costs.

Config inspiration was from the cloudbank cluster, since that holds edu hubs