### PR TITLE
Add cluster provider and location info to list of running hubs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,16 @@ def render_hubs():
         # Incase we don't find any Grafana config, use an empty string as default
         grafana_url = ""
 
+        # Try to identify the data centre location of the cluster
+        # For kubeconfig and Azure providers, this will always default to None since
+        # we do not store that information in the cluster.yaml file
+        #
+        # First try "zone" for GCP clusters
+        datacentre_loc = cluster.get(cluster["provider"], {}).get("zone", None)
+        if datacentre_loc is None:
+            # Try "region" for AWS clusters
+            datacentre_loc = cluster.get(cluster["provider"], {}).get("region", None)
+
         # Loop through support files, look for Grafana config, and grab the URL
         if support_files is not None:
             for support_file in support_files:
@@ -138,6 +148,8 @@ def render_hubs():
                     "id": hub["name"],
                     "hub_type": hub["helm_chart"],
                     "grafana": grafana_url,
+                    "provider": cluster["provider"],
+                    "data center location": datacentre_loc,  # Americanising for you ;)
                 }
             )
     df = pd.DataFrame(hub_list)

--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -1,6 +1,14 @@
 # List of running hubs
 
 Here's a list of running hubs.
+It is automatically generated from the config stored in the [`config/clusters` folder of the `infrastructure` repository](https://github.com/2i2c-org/infrastructure/tree/HEAD/config/clusters) and can therefore be limited in the information it provides.
+
+```{admonition} Missing information for Azure hubs
+Hubs that have `kubeconfig` listed as their provider are most likely running on Azure.
+The reason `kubeconfig` is listed as a provider is because that is the mechanism we are using to authenticate to that cluster in the case where we do not have a Service Principal.
+
+Unlike GCP and AWS, Azure does not require the location for authentication and it is therefore not listed in our config files and hence cannot be populated in this table.
+```
 
 <div class="full-width">
 
@@ -23,7 +31,7 @@ Team members should feel free to experiment with this hub and try out new functi
 <!-- DataTables to make the table above look nice -->
 <link rel="stylesheet"
       href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css">
-<script type="text/javascript" 
+<script type="text/javascript"
         src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
 
 <script>


### PR DESCRIPTION
related https://github.com/2i2c-org/leads/issues/89

This adds two new columns to our list of running hubs: provider (GCP/AWS/Azure) and location (e.g., us-central1-c)

It also adds an explainer to the page about why some information may be missing or not what we expect (an artefact of automatically generating this table)