### PR TITLE
Fix CarbonPlan hub health check failures

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -44,6 +44,7 @@ basehub:
         # on these nodes.
         - display_name: "Small: r5.large"
           description: "~2 CPU, ~15G RAM"
+          slug: "small"
           default: true
           profile_options: &profile_options
             image:
@@ -52,14 +53,17 @@ basehub:
                 python_trace:
                   display_name: Trace Python Notebook
                   default: true
+                  slug: "python"
                   kubespawner_override:
                     image: carbonplan/trace-python-notebook:latest
                 main_single_user:
                   display_name: Main Single User
+                  slug: "main"
                   kubespawner_override:
                     image: carbonplan/main-single-user:latest
                 cmip6_downscaling:
                   display_name: CMIP6 Downscaling
+                  slug: "cmip6"
                   kubespawner_override:
                     image: carbonplan/cmip6-downscaling-single-user:latest
           kubespawner_override:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -50,18 +50,18 @@ basehub:
             image:
               display_name: Image
               choices:
-                python_trace:
+                python:
                   display_name: Trace Python Notebook
                   default: true
                   slug: "python"
                   kubespawner_override:
                     image: carbonplan/trace-python-notebook:latest
-                main_single_user:
+                main:
                   display_name: Main Single User
                   slug: "main"
                   kubespawner_override:
                     image: carbonplan/main-single-user:latest
-                cmip6_downscaling:
+                cmip6:
                   display_name: CMIP6 Downscaling
                   slug: "cmip6"
                   kubespawner_override:

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -44,8 +44,6 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
         # Temporary fix for https://github.com/2i2c-org/infrastructure/issues/1611
         # FIXME: Remove this once https://github.com/jupyterhub/kubespawner/pull/631 gets merged
         user_options = None
-        print(hub_url)
-        print("carbonplan" in hub_url)
         if ("openscapes" in hub_url) or ("carbonplan" in hub_url):
             user_options = {"profile": "small", "image": "python"}
         # Create a new user, start a server and execute a notebook

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -44,7 +44,9 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
         # Temporary fix for https://github.com/2i2c-org/infrastructure/issues/1611
         # FIXME: Remove this once https://github.com/jupyterhub/kubespawner/pull/631 gets merged
         user_options = None
-        if "openscapes" in hub_url:
+        print(hub_url)
+        print("carbonplan" in hub_url)
+        if ("openscapes" in hub_url) or ("carbonplan" in hub_url):
             user_options = {"profile": "small", "image": "python"}
         # Create a new user, start a server and execute a notebook
         await execute_notebook(


### PR DESCRIPTION
After deploying #1642, I ran into the same error message I reported in #1611. Since both the CarbonPlan and Openscapes hubs allow choosing of environment images for each machine profile, I figured it was the same bug and applied the fix from #1639 to the CarbonPlan hubs.