### PR TITLE
Add more docs about Grafana

### DIFF
--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -65,7 +65,7 @@ This provides info about the NFS usage and monitors things like CPU, memory, dis
 
 5. **Usage Dashboard**
 
-This has onformation about the number of users using the cluster over various periods of time.
+This has information about the number of users using the cluster over various periods of time.
 
 6. **Usage Report**
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -149,7 +149,7 @@ support:
 
 #### (Optional) Enable GitHub authentication
 
-You can enable users and/community members to authenticate Grafana, through GitHub by following the next steps:
+To enable logging in Grafana using GitHub, follow the next steps:
 
 1. Create a GitHub OAuth application following [Grafana's documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/#configure-github-oauth-application).
   - Create [a new app](https://github.com/organizations/2i2c-org/settings/applications/new) inside the `2i2c-org`.
@@ -261,10 +261,6 @@ sops --output config/clusters/<cluster>/enc-grafana-token.secret.yaml --encrypt 
 The encrypted file can now be committed to the repository.
 
 This key will be used by the [`deploy-grafana-dashboards` workflow](https://github.com/2i2c-org/infrastructure/tree/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
-
-### Enable GitHub authentication
-
-You can enable users and/community members to authenticate a Grafana, through GitHub.
 
 ### Deploying the Grafana Dashboards from CI/CD
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -3,7 +3,7 @@
 
 Each 2i2c Hub is set up with [a Prometheus server](https://prometheus.io/) to generate metrics and information about activity on the hub, and each cluster of hubs has a [Grafana deployment](https://grafana.com/) to ingest and visualize this data.
 
-The following sections describe how access, use and deploy these dashboards for a cluster.
+The following sections describe how to access, use and deploy these dashboards for a cluster.
 
 ## 1. How to access and use the Grafana Dashboards
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -13,7 +13,7 @@ This section provides information for both engineers and non-engineers about whe
 ### Logging in
 
 Each cluster's Grafana deployment can be accessed at `grafana.<cluster-name>.2i2c.cloud`.
-For example, the Grafana for the community hubs running on our GCP project is accessible at `grafana.pilot.2i2c.cloud`.
+For example, the Grafana for the community hubs running on our GCP project is accessible at `grafana.pilot.2i2c.cloud`. Checkout the list of all 2i2c running clusters and their Grafana [here](https://infrastructure.2i2c.org/en/latest/reference/hubs.html).
 
 To access the Grafana dashboards you have two options:
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -3,27 +3,76 @@
 
 Each 2i2c Hub is set up with [a Prometheus server](https://prometheus.io/) to generate metrics and information about activity on the hub, and each cluster of hubs has a [Grafana deployment](https://grafana.com/) to ingest and visualize this data.
 
-This section describes how to use these dashboards for a cluster.
+The following sections describe how access, use and deploy these dashboards for a cluster.
 
-## Access Hub Grafana Dashboards
+## 1. How to access and use the Grafana Dashboards
 
-The Grafana for each cluster can be accessed at `grafana.<cluster-name>.2i2c.cloud`.
-For example, the Grafana for community hubs running on our GCP project is accessible at `grafana.pilot.2i2c.cloud`.
+This section provides information for both engineers and non-engineers about where to find each of 2i2c Grafana deployments, how to get access and what to expect.
 
-To access the Grafana dashboards you'll need a **username** and **password**.
-These can be accessed using `sops` (see {ref}`tc:secrets:sops` for how to set up `sops` on your machine).
-See [](grafana:log-in) for how to find the credentials information.
+(grafana:access-grafana)=
+### Logging in
 
-## The Central Grafana
+Each cluster's Grafana deployment can be accessed at `grafana.<cluster-name>.2i2c.cloud`.
+For example, the Grafana for the community hubs running on our GCP project is accessible at `grafana.pilot.2i2c.cloud`.
 
-The Grafana deployment in the `2i2c` cluster ingests data from all the 2i2c clusters and will soon be able to be used as "the central Grafana".
+To access the Grafana dashboards you have two options:
 
-```{note}
-TODO: should add more info once this is ready to use.
-```
+- Get `Viewer` access into the Grafana.
+  This is the recommended way of accessing grafana if modifying/creating dashboards is not needed.
+  To get access, ask a 2i2c engineer to enable **GitHub authentication** following [](grafana:enable-github-auth) for that particular Grafana (if it's not already) and allow you access.
+
+- Use a **username** and **password** to get `Admin` access into the Grafana.
+  These credentials can be accessed using `sops` (see {ref `tc:secrets:sops` for how to set up `sops` on your machine). See [](grafana:log-in) for how to find the credentials information.
+
+### The Central Grafana
+
+The Grafana deployment in the `2i2c` cluster is *"the 2i2c central Grafana"* because it ingests data from all of the 2i2c clusters. This is useful because it can be used to access information about all the clusters that 2i2c manages from one central place.
+
+The central Grafana is running at https://grafana.pilot.2i2c.cloud and you can use the two authentication mechanisms listed in the [](grafana:access-grafana) section above to access it.
+
+The dashboards available at https://grafana.pilot.2i2c.cloud/dashboards are the default Grafana dashboards from JupyterHub. The following list provides some information about the structure of the dashboards folder in Grafana, but this info is subject to change based on how upstream repository changes. So more information about the metrics and graphs available can be found at [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
+
+#### The `JupyterHub Default Dashboards` Grafana folder structure
+
+Navigating at https://grafana.pilot.2i2c.cloud/dashboards, shows a `JupyterHub Default Dashboards` where all the dashboards are available, each of the Grafana panels, being grouped in sub-folders (dashboards) based on the component they are monitoring:
+
+1. **Cluster Information**
+
+Contains panels with different cluster usage statistics about things like:
+  - nodes
+  - memory
+  - cpu
+  - running users per hub in cluster
+
+2. **Global Usage Dashboard**
+
+This dashboard contains information about the weekly active users we get on each of the clusters we manage.
+
+3. **JupyterHub Dashboard**
+
+This is the place to find information about the hub usage stats and hub diagnostics, like
+- number of active users
+- user CPU usage distribution
+- user memory usage distribution
+- server start times
+- hub respone latency
+
+There is also a Panel section about `Anomalous user pods` where pods with high CPU usage or high memory usage are tracked.
+
+4. **NFS and Support Information**
+
+This provides info about the NFS usage and monitors things like CPU, memory, disk and network usage of the Prometheus instance.
+
+5. **Usage Dashboard**
+
+This has onformation about the number of users using the cluster over various periods of time.
+
+6. **Usage Report**
+
+This provides a report about the memory requests, grouped by username, for notebook nodes and dask-gateway nodes. It also provides a graph that monitors GPU requests per user pod.
 
 (grafana:new-grafana)=
-## Set up Grafana Dashboards for a cluster
+## 2. Set up Grafana Dashboards for a cluster
 
 This guide will walk through the steps required to setup a suite of Grafana dashboards for a cluster.
 
@@ -98,6 +147,47 @@ support:
     - enc-support.secret.values.yaml
 ```
 
+#### (Optional) Enable GitHub authentication
+
+You can enable users and/community members to authenticate Grafana, through GitHub by following the next steps:
+
+1. Create a GitHub OAuth application following [Grafana's documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/#configure-github-oauth-application).
+  - Create [a new app](https://github.com/organizations/2i2c-org/settings/applications/new) inside the `2i2c-org`.
+  - When naming the application, please follow the convention `<cluster_name>-grafana` for consistency, e.g. `2i2c-grafana` is the OAuth app for the Grafana running in the 2i2c cluster
+  - The Homepage URL should match that in the `grafana.ingress.hosts` field of the appropriate cluster `support.values.yaml` file in the `infrastructure` repo. For example, `ghttps://grafana.pilot.2i2c.cloud`
+  - The authorisation callback URL is the homepage url appended with `/login/github`. For example, `https://grafana.pilot.2i2c.cloud/login/github`.
+  - Once you have created the OAuth app, create a new client ID, generate a client secret and then hold on to these values for a future step
+
+2. Edit using `sops` the encrypted `enc-support.secret.values.yaml` file in the chosen cluster directory and add the credentials created in step one:
+
+  ```yaml
+  grafana:
+      grafana.ini:
+          auth.github:
+              client_id: <client-id>
+              client_secret: <client-secret>
+  ```
+
+3. Edit the `support.values.yaml` file in your chosen cluster directory and add the Grafana GitHub auth config, allowing the specific GitHub organization you wish to allow login.
+
+  ```yaml
+  grafana.ini:
+    server:
+      root_url: https://<grafana.ingress.hosts[0]>
+    auth.github:
+      enabled: true
+      allow_sign_up: false
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      allowed_organizations: 2i2c-org
+  ```
+
+  ```{note}
+  Checkout the [Grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github) for more info about authorizing users using other types of membership than GitHub organizations.
+  ```
+
 #### Deploy the `support` chart via the `deployer`
 
 Use the `deployer` tool to deploy the support chart to the cluster.
@@ -127,7 +217,7 @@ IPv4 address), or `CNAME` records if using AWS (where external IP is a domain na
 **Wait a while for the DNS to propagate!**
 
 (grafana:log-in)=
-### Log in to the cluster-spcific Grafana dashboard
+### Log in to the cluster-specific Grafana dashboard
 
 Eventually, visiting `GRAFANA_URL` will present you with a login page.
 Here are the credentials for logging in:
@@ -171,6 +261,10 @@ sops --output config/clusters/<cluster>/enc-grafana-token.secret.yaml --encrypt 
 The encrypted file can now be committed to the repository.
 
 This key will be used by the [`deploy-grafana-dashboards` workflow](https://github.com/2i2c-org/infrastructure/tree/HEAD/.github/workflows/deploy-grafana-dashboards.yaml) to deploy some default grafana dashboards for JupyterHub using [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
+
+### Enable GitHub authentication
+
+You can enable users and/community members to authenticate a Grafana, through GitHub.
 
 ### Deploying the Grafana Dashboards from CI/CD
 

--- a/docs/howto/operate/grafana.md
+++ b/docs/howto/operate/grafana.md
@@ -18,10 +18,12 @@ For example, the Grafana for the community hubs running on our GCP project is ac
 To access the Grafana dashboards you have two options:
 
 - Get `Viewer` access into the Grafana.
+
   This is the recommended way of accessing grafana if modifying/creating dashboards is not needed.
   To get access, ask a 2i2c engineer to enable **GitHub authentication** following [](grafana:enable-github-auth) for that particular Grafana (if it's not already) and allow you access.
 
 - Use a **username** and **password** to get `Admin` access into the Grafana.
+
   These credentials can be accessed using `sops` (see {ref `tc:secrets:sops` for how to set up `sops` on your machine). See [](grafana:log-in) for how to find the credentials information.
 
 ### The Central Grafana
@@ -32,44 +34,44 @@ The central Grafana is running at https://grafana.pilot.2i2c.cloud and you can u
 
 The dashboards available at https://grafana.pilot.2i2c.cloud/dashboards are the default Grafana dashboards from JupyterHub. The following list provides some information about the structure of the dashboards folder in Grafana, but this info is subject to change based on how upstream repository changes. So more information about the metrics and graphs available can be found at [`jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards).
 
-#### The `JupyterHub Default Dashboards` Grafana folder structure
+### The `JupyterHub Default Dashboards` Grafana folder structure
 
 Navigating at https://grafana.pilot.2i2c.cloud/dashboards, shows a `JupyterHub Default Dashboards` where all the dashboards are available, each of the Grafana panels, being grouped in sub-folders (dashboards) based on the component they are monitoring:
 
 1. **Cluster Information**
 
-Contains panels with different cluster usage statistics about things like:
-  - nodes
-  - memory
-  - cpu
-  - running users per hub in cluster
+  Contains panels with different cluster usage statistics about things like:
+    - nodes
+    - memory
+    - cpu
+    - running users per hub in cluster
 
 2. **Global Usage Dashboard**
 
-This dashboard contains information about the weekly active users we get on each of the clusters we manage.
+  This dashboard contains information about the weekly active users we get on each of the clusters we manage.
 
 3. **JupyterHub Dashboard**
 
-This is the place to find information about the hub usage stats and hub diagnostics, like
-- number of active users
-- user CPU usage distribution
-- user memory usage distribution
-- server start times
-- hub respone latency
+  This is the place to find information about the hub usage stats and hub diagnostics, like
+  - number of active users
+  - user CPU usage distribution
+  - user memory usage distribution
+  - server start times
+  - hub respone latency
 
-There is also a Panel section about `Anomalous user pods` where pods with high CPU usage or high memory usage are tracked.
+  There is also a Panel section about `Anomalous user pods` where pods with high CPU usage or high memory usage are tracked.
 
 4. **NFS and Support Information**
 
-This provides info about the NFS usage and monitors things like CPU, memory, disk and network usage of the Prometheus instance.
+  This provides info about the NFS usage and monitors things like CPU, memory, disk and network usage of the Prometheus instance.
 
 5. **Usage Dashboard**
 
-This has information about the number of users using the cluster over various periods of time.
+  This has information about the number of users using the cluster over various periods of time.
 
 6. **Usage Report**
 
-This provides a report about the memory requests, grouped by username, for notebook nodes and dask-gateway nodes. It also provides a graph that monitors GPU requests per user pod.
+  This provides a report about the memory requests, grouped by username, for notebook nodes and dask-gateway nodes. It also provides a graph that monitors GPU requests per user pod.
 
 (grafana:new-grafana)=
 ## 2. Set up Grafana Dashboards for a cluster


### PR DESCRIPTION
This adds docs about:

- how to enable GitHub auth for a grafana instance
- the central grafana and the jupyterhub default dashbords there

Fixes https://github.com/2i2c-org/infrastructure/issues/1438.

Probably at some point, part of these docs should move to the user-facing docs and we should also try to add more docs upstream. But I believe separating the current `Grafana Dashboards` into two main sections: `usage and access` and `deploying` provides a decent enough scope for engineers and non-engineers.