### PR TITLE
[ci/cd] Properly cycle through the issue comments in post deployment plan workflow

### DIFF
--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -123,15 +123,19 @@ jobs:
           )
 
           # Find if a deployment-plan comment has been previously posted
-          comment = next(
-              (
-                  comment[0]
-                  for comment in issue_comments
-                  if comment[0].user.login == "github-actions[bot]"
-                  and "<!-- deployment-plan -->" in comment[0].body
-              ),
-              False,
-          )
+          for page in issue_comments:
+              comment = next(
+                  (
+                      comment
+                      for comment in page
+                      if comment.user.login == "github-actions[bot]"
+                      and "<!-- deployment-plan -->" in comment.body
+                  ),
+                  False,
+              )
+
+              if comment:
+                  break
 
           if comment:
               # Comment exists - update it


### PR DESCRIPTION
fixes #1675

The issue was not accessing the correct part of the returned dictionary and hence always behaving as if a comment didn't already exist