### PR TITLE
Fix Callysto prod hub's display name

### DIFF
--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -21,7 +21,7 @@ hubs:
       - staging.values.yaml
       - enc-staging.secret.values.yaml
   - name: prod
-    display_name: "Callysto Staging"
+    display_name: "Callysto Prod"
     domain: 2i2c.callysto.ca
     helm_chart: basehub
     auth0:


### PR DESCRIPTION
This affects the [list of running hubs](https://infrastructure.2i2c.org/en/latest/reference/hubs.html) and just makes the table more readable