### PR TITLE
Bump version of z2jh

### DIFF
--- a/config/clusters/utoronto/enc-staging.secret.values.yaml
+++ b/config/clusters/utoronto/enc-staging.secret.values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
     hub:
         config:
             AzureAdOAuthenticator:
-                client_id: ENC[AES256_GCM,data:2VsVIdZz00pEw6Kx7XK3MIAEg6uiKpx1rM0qg/xxbaIK5Kb+,iv:1dRncU6jIZS90x5T24TSLpXEq5CUAtBsLNbT2iJthEU=,tag:6tjpXI+Cw0BEK5+seCXxCA==,type:str]
+                client_id: ENC[AES256_GCM,data:082nKaBVlegQiGmtVti7PPBz+T7GLTCyB6910E6EgXnedDJZ,iv:mqE0/hkXIp2leSohgkdgdEB7cy6rgy7nH+2NkJCcZ6o=,tag:Ii23/LAfbXi0F66GPmpmRQ==,type:str]
                 client_secret: ENC[AES256_GCM,data:DEYYnc/bxBcJtAJ/TBY/IggBbqdp8tVUM1GgdsayEUGelEtvhmbarQ==,iv:5hWqi8Cag0wRYnfA82I8FI58mQUi4Rm0TRaCr764sb0=,tag:uj91hvmqqc2FwJkYeo1Ebw==,type:str]
 sops:
     kms: []
@@ -17,8 +17,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-31T20:06:49Z"
-    mac: ENC[AES256_GCM,data:jIEmi9syyD+TmOsyb9TC7CLhV/8FGgkuL9TMfp0L6B8vJpaWqk8CYleC0eycS9cTvd5Qa3fKC+odQy4mLm7zFBJq4bjBsF2/TN2r1QSE68gmdCHIkYMrQDoJtwWfROaWY6StRccrewRVZz6hrKgSRQdFNskY1wHgnIirRrvyWwA=,iv:QmndTBrVaGaAEPJHutmEET0eEu4jtOJU5lHhv5IzRm4=,tag:LxLB3Ys4vlDO/3+STNAAng==,type:str]
+    lastmodified: "2022-09-08T07:48:01Z"
+    mac: ENC[AES256_GCM,data:rr/BWRngZh08Su8zP+eJ4OqLuT7IbG7/voAh1iPuwHPPLIeeNTnIopelD/6OLjhCbkiZhtij2y6lASwa5xzwmLuvvxiAdQrX6f+ZqOgBZ1KxuJzELQxSY4X2L6cgCeGFnhHhQY1EoYqsGEwjSk6zrPPtR93sBL80ZmL+swHtz3E=,iv:jFbf45ItjJV/ALnyk0xNyy7dnvtcGuIj3+pQNTqWcaM=,tag:mYHTUwzMJSERSvya1OMNGQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 1.1.3-n648.hab95aa08
+    version: 2.0.0-beta.1.git.5783.h867f4331
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -373,7 +373,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n3784.hc740a271"
+      tag: "0.0.1-0.dev.git.3958.h4fe1156b"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -11,18 +11,11 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:1.1.3-n644.h35436cda
+FROM jupyterhub/k8s-hub:2.0.0-beta.1.git.5781.hc5adeae4
 
 ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}
-
-# Needed to install JupyterHub from source
-USER root
-RUN apt update --yes > /dev/null && apt install --yes --no-install-recommends nodejs npm > /dev/null
-USER $NB_USER
-# Until https://github.com/jupyterhub/jupyterhub/pull/3984 is merged
-RUN pip install --upgrade git+https://github.com/meeseeksmachine/jupyterhub@72e4119e1a9f5fead690cb399dba36143d6d2ecc
 
 # Latest version comes with some breaking changes https://oauthenticator.readthedocs.io/en/latest/migrations.html#migrating-cilogonoauthenticator-to-version-15-0
 RUN pip install --no-cache --upgrade git+https://github.com/jupyterhub/oauthenticator@6cf6599d99b47f99db3826ceaaedf467af14a05d


### PR DESCRIPTION
- Removes custom version of jupyterhub installed, as that has been merged into latest z2jh
- We keep the version of oauthenticator, as I'm not sure it has been merged and released

Ref https://github.com/2i2c-org/infrastructure/issues/1055 Ref https://github.com/2i2c-org/infrastructure/issues/1102 Ref https://github.com/2i2c-org/infrastructure/issues/1589