### PR TITLE
Change how `comment` variable is defined in `comment-deployment-plan-pr.yaml` workflow file

### DIFF
--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -124,25 +124,25 @@ jobs:
 
           # Find if a deployment-plan comment has been previously posted
           for page in issue_comments:
-              comment = next(
+              comment_id = next(
                   (
-                      comment
+                      comment["id"]
                       for comment in page
-                      if comment.user.login == "github-actions[bot]"
-                      and "<!-- deployment-plan -->" in comment.body
+                      if comment["user"]["login"] == "github-actions[bot]"
+                      and "<!-- deployment-plan -->" in comment["body"]
                   ),
-                  False,
+                  None,
               )
 
-              if comment:
+              if comment_id is not None:
                   break
 
-          if comment:
+          if comment_id is not None:
               # Comment exists - update it
               api.issues.update_comment(
                   owner=owner,
                   repo=repo,
-                  comment_id=comment.id,
+                  comment_id=comment_id,
                   body=comment_body,
               )
           else:


### PR DESCRIPTION
In CI/CD, this was breaking due to [`comment` not being set](https://github.com/2i2c-org/infrastructure/runs/8297082132?check_suite_focus=true), which I don't believe should happen using the `next(...)` function. This PR makes the code look more like the block that extracts the artifact ID further up in the code in the hopes that this will alleviate this issue.