### PR TITLE
Personalize callysto singleuser server page

### DIFF
--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -33,7 +33,7 @@ jupyterhub:
       name: callysto/2i2c
       tag: 0.1.0
     extraFiles:
-      page.html:
+      tree.html:
         mountPath: /usr/local/share/jupyter/custom_template/tree.html
         stringData: |
           {% extends "templates/tree.html" %}

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -32,6 +32,28 @@ jupyterhub:
     image:
       name: callysto/2i2c
       tag: 0.1.0
+    extraFiles:
+      page.html:
+        mountPath: /usr/local/share/jupyter/custom_template/tree.html
+        stringData: |
+          {% extends "templates/tree.html" %}
+          {% block header %}
+          <style>
+          .clusters_tab_link {
+            visibility: hidden;
+          }
+          </style>
+          {% endblock %}
+          {% block logo %}
+            <img src="https://www.callysto.ca/wp-content/uploads/2022/08/Callysto-HUB_horizontal.png" alt="CallystoHub"/>
+          {% endblock %}
+      notebook.html:
+        mountPath: /usr/local/share/jupyter/custom_template/notebook.html
+        stringData: |
+          {% extends "templates/notebook.html" %}
+          {% block logo %}
+            <img src="https://www.callysto.ca/wp-content/uploads/2022/08/Callysto-HUB_horizontal.png" alt="CallystoHub"/>
+          {% endblock %}
   hub:
     config:
       JupyterHub:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -206,6 +206,9 @@ jupyterhub:
             # this is what allows us to shutdown servers
             # when people leave a notebook open and wander off
             cull_connected: true
+          NotebookApp:
+            extra_template_paths:
+              - /usr/local/share/jupyter/custom_template
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     nodeSelector:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -178,6 +178,8 @@ jupyterhub:
     extraEnv:
       # until https://github.com/jupyterhub/jupyterhub/pull/3918 or equivalent lands,
       # and we upgrade to jupyterhub >= 2.3.1 on all images.
+      # Note: please checkout all occurences of `NotebookApp` configurations
+      # when moving away from it.
       JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
       # notebook writes secure files that don't need to survive a
       # restart here. Writing 'secure' files on some file systems (like
@@ -206,6 +208,8 @@ jupyterhub:
             # this is what allows us to shutdown servers
             # when people leave a notebook open and wander off
             cull_connected: true
+          # If we switch from setting `JUPYTERHUB_SINGLEUSER_APP` to be the NotebookApp
+          # this config kere might need to go under ServerApp instead
           NotebookApp:
             extra_template_paths:
               - /usr/local/share/jupyter/custom_template


### PR DESCRIPTION
This uses the [`singleuser.extraFiles` config](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#singleuser-extrafiles) to add a custom logo for the singleuser server dashboard and notebook, i.e. the Callysto one and hides the `Clusters` tab from the dashboard.

The Hub interface has been customized too through the https://github.com/2i2c-org/default-hub-homepage/tree/callysto-staging, but only for the staging hub at the moment. I will add a new branch `callysto-prod` to override the prod hub also.

Closes https://github.com/2i2c-org/infrastructure/issues/1439

Note that I will leave a couple of comments in the code to explain some of the assumptions/compromises I've made.