### PR TITLE
Keep a placeholder node around for UToronto Hub

### DIFF
--- a/config/clusters/utoronto/prod.values.yaml
+++ b/config/clusters/utoronto/prod.values.yaml
@@ -1,4 +1,15 @@
 jupyterhub:
+  scheduling:
+    userPlaceholder:
+      # Keep at least one spare node around
+      replicas: 1
+      resources:
+        requests:
+          # Each node on the UToronto cluster has 59350076Ki of RAM
+          # You can find this out by looking at the output of `kubectl get node <node-name> -o yaml`
+          # Look under `allocatable`, not `capacity`
+          # So even though this is under `userPlaceholder`, it really is operating as a `nodePlaceholder`
+          memory: 57350076Ki
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/prod.values.yaml
+++ b/config/clusters/utoronto/prod.values.yaml
@@ -7,7 +7,9 @@ jupyterhub:
         requests:
           # Each node on the UToronto cluster has 59350076Ki of RAM
           # You can find this out by looking at the output of `kubectl get node <node-name> -o yaml`
-          # Look under `allocatable`, not `capacity`
+          # Look under `allocatable`, not `capacity`. Unfortunately then you have to fiddle with it to
+          # find the right number that's big enough that no user pods will schedule here, but small enough
+          # that pods in `kube-system` will still schedule.
           # So even though this is under `userPlaceholder`, it really is operating as a `nodePlaceholder`
           memory: 57350076Ki
   hub:


### PR DESCRIPTION
Users were reporting slow starts and timeouts in the morning, as many users come on at the same time. This change keeps a placeholder *node* around, with a placeholder pod that will get displaced whenever a user needs that node. This should increase the odds of a new node being up by the time more than 1 node worth of users pop in.

Ref https://2i2c.freshdesk.com/a/tickets/201