### PR TITLE
Reduce UToronto memory guarantee

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -50,7 +50,7 @@ jupyterhub:
   singleuser:
     memory:
       limit: 2G
-      guarantee: 2G
+      guarantee: 1G
     extraFiles:
       github-app-private-key.pem:
         mountPath: /etc/github/github-app-private-key.pem


### PR DESCRIPTION
Based on actual memory usage, most users are well under 1G, with few spiking to 2G. This reduction will put ~55 users on one node (instead of the current 27), and decrease the chances of timeouts + slow pod startups for users.

Ref https://2i2c.freshdesk.com/a/tickets/201