### PR TITLE
Increase mem limits for aup

### DIFF
--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -20,8 +20,8 @@ jupyterhub:
           url: https://www.aup.edu/
   singleuser:
     memory:
-      limit: 2G
-      guarantee: 2G
+      limit: 8G
+      guarantee: 6G
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/1718, guarantees 6G per request and adds a stretch on the limit to 8G

