### PR TITLE
Init `comment_id` in comment plan workflow

### DIFF
--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -121,7 +121,7 @@ jobs:
               issue_number=pr_number,
               per_page=100,
           )
-          
+
           # Otherwise, if no `issue_comments`, this will be undefined
           comment_id = None
           # Find if a deployment-plan comment has been previously posted

--- a/.github/workflows/comment-deployment-plan-pr.yaml
+++ b/.github/workflows/comment-deployment-plan-pr.yaml
@@ -121,7 +121,9 @@ jobs:
               issue_number=pr_number,
               per_page=100,
           )
-
+          
+          # Otherwise, if no `issue_comments`, this will be undefined
+          comment_id = None
           # Find if a deployment-plan comment has been previously posted
           for page in issue_comments:
               comment_id = next(


### PR DESCRIPTION
I believe an empty `issue_comments` might be what's causing the undefined `comment_id` issues?

Ref: https://github.com/2i2c-org/infrastructure/pull/1701