### PR TITLE
Update pangeo images to latest versions

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -54,7 +54,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.06.02"
+        tag: "2022.09.21"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
@@ -106,12 +106,24 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
         - display_name: Large + Nvidia K80 GPU
-          description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU
+          description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU + Tensorflow
           allowed_teams:
             - leap-stc:leap-pangeo-research
             - 2i2c-org:tech-team
           kubespawner_override:
-            image: "pangeo/ml-notebook:master"
+            image: "pangeo/ml-notebook:2022.09.21"
+            mem_limit: 30G
+            mem_guarantee: 24G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-8
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
+            extra_resource_limits:
+              nvidia.com/gpu: "1"
+        - display_name: Large + Nvidia K80 GPU + PyTorch
+          description: 24GB RAM, 8 CPUs
+          kubespawner_override:
+            image: "pangeo/pytorch-notebook:2022.09.21"
             mem_limit: 30G
             mem_guarantee: 24G
             node_selector:

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -56,7 +56,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.06.02"
+        tag: "2022.09.21"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
@@ -94,7 +94,7 @@ basehub:
         - display_name: Large + Nvidia K80 GPU + Tensorflow
           description: 24GB RAM, 8 CPUs
           kubespawner_override:
-            image: "pangeo/ml-notebook:7181f87"
+            image: "pangeo/ml-notebook:2022.09.21"
             mem_limit: 30G
             mem_guarantee: 24G
             node_selector:
@@ -106,7 +106,7 @@ basehub:
         - display_name: Large + Nvidia K80 GPU + PyTorch
           description: 24GB RAM, 8 CPUs
           kubespawner_override:
-            image: "pangeo/pytorch-notebook:7181f87"
+            image: "pangeo/pytorch-notebook:2022.09.21"
             mem_limit: 30G
             mem_guarantee: 24G
             node_selector:

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -64,7 +64,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.06.02"
+        tag: "2022.09.21"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable


### PR DESCRIPTION
We have had several reports of performance issues on the Pangeo hubs that might be fixed by using a new image

- https://discourse.pangeo.io/t/dask-cluster-stays-idle-for-a-long-time-before-computing/2742
- https://discourse.pangeo.io/t/dask-not-completing-large-operations-on-sose-data/2788 

Some questions

- Is it possible to make an announcement to the hub users that the image is being updated?
- If this update breaks user code, how should we respond? It would be great to allow users to select their own images (a feature I've been requesting for a long time).
- Is there a way to automate or otherwise obliviate the need for me to make PRs like this every time an update is needed? The release cadence of Pangeo docker images is approximately [two per month](https://hub.docker.com/r/pangeo/ml-notebook/tags). This reflects the pace of innovation in the Pangeo software ecosystem.


