### PR TITLE
Allow running deployer from any path

### DIFF
--- a/deployer/config_validation.py
+++ b/deployer/config_validation.py
@@ -68,9 +68,8 @@ def validate_cluster_config(cluster_name):
     """
     Validates cluster.yaml configuration against a JSONSchema.
     """
-    cluster_schema_file = Path(os.getcwd()).joinpath(
-        "shared", "deployer", "cluster.schema.yaml"
-    )
+    root_dir = Path(__file__).parent.parent
+    cluster_schema_file = root_dir.joinpath("shared", "deployer", "cluster.schema.yaml")
     cluster_file = find_absolute_path_to_cluster_file(cluster_name)
 
     with open(cluster_file) as cf, open(cluster_schema_file) as sf:

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -245,9 +245,8 @@ def generate_helm_upgrade_jobs(changed_filepaths):
     ) = discover_modified_common_files(changed_filepaths)
 
     # Convert changed filepaths into absolute Posix Paths
-    changed_filepaths = [
-        Path(os.getcwd()).joinpath(filepath) for filepath in changed_filepaths
-    ]
+    root_dir = Path(__file__).parent.parent
+    changed_filepaths = [root_dir.joinpath(filepath) for filepath in changed_filepaths]
 
     # Get a list of filepaths to all cluster.yaml files in the repo
     cluster_files = get_all_cluster_yaml_files()

--- a/deployer/file_acquisition.py
+++ b/deployer/file_acquisition.py
@@ -40,55 +40,32 @@ def find_absolute_path_to_cluster_file(cluster_name: str, is_test: bool = False)
         cluster_name (str): The name of the cluster we wish to perform actions on.
             This corresponds to a folder name, and that folder should contain a
             cluster.yaml file.
-        is_test (bool, optional): A flag to determine whether we are running a test
-            suite or not. If True, only return the paths to cluster.yaml files under the
-            'tests/' directory. If False, explicitly exclude the cluster.yaml files
-            nested under the 'tests/' directory. Defaults to False.
 
     Returns:
         Path object: The absolute path to the cluster.yaml file for the named cluster
     """
-    if is_test:
-        # We are running a test via pytest. We only want to focus on the cluster
-        # folders nested under the `tests/` folder.
-        filepaths = [
-            filepath
-            for filepath in Path(os.getcwd()).glob(f"**/{cluster_name}/cluster.yaml")
-            if "tests/" in str(filepath)
-        ]
-    else:
-        # We are NOT running a test via pytest. We want to explicitly ignore the
-        # cluster folders nested under the `tests/` folder.
-        filepaths = [
-            filepath
-            for filepath in Path(os.getcwd()).glob(f"**/{cluster_name}/cluster.yaml")
-            if "tests/" not in str(filepath)
-        ]
+    root_dir = Path(__file__).parent.parent
+    cluster_yaml_path = root_dir.joinpath(
+        f"config/clusters/{cluster_name}/cluster.yaml"
+    )
 
-    if len(filepaths) > 1:
-        raise FileExistsError(
-            "Multiple files found. "
-            + "Only ONE (1) cluster.yaml file should exist per cluster folder."
-        )
-    elif len(filepaths) == 0:
+    if not cluster_yaml_path.exists():
         raise FileNotFoundError(
             f"No cluster.yaml file exists for cluster {cluster_name}. "
             + "Please create one and then continue."
         )
-    else:
-        cluster_file = filepaths[0]
 
-    with open(cluster_file) as cf:
+    with open(cluster_yaml_path) as cf:
         cluster_config = yaml.load(cf)
 
-    if not os.path.dirname(cluster_file).endswith(cluster_config["name"]):
+    if cluster_yaml_path.parent.name != cluster_config["name"]:
         warnings.warn(
             "Cluster Name Mismatch: It is convention that the cluster name defined "
             + "in cluster.yaml matches the name of the parent directory. "
             + "Deployment won't be halted but please update this for consistency!"
         )
 
-    return cluster_file
+    return cluster_yaml_path
 
 
 @contextmanager

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -4,7 +4,6 @@ support helm chart upgrading depending on an input list of filenames that have b
 added or modified in a GitHub Pull Request.
 """
 import fnmatch
-import os
 from pathlib import Path
 
 from rich.console import Console
@@ -84,26 +83,16 @@ def get_all_cluster_yaml_files(is_test=False):
     Returns:
         set[path obj]: A set of absolute paths to all cluster.yaml files in the repo
     """
+    root_path = Path(__file__).parent.parent
     # Get absolute paths
     if is_test:
         # We are running a test via pytest. We only want to focus on the cluster
         # folders nested under the `tests/` folder.
-        cluster_files = [
-            filepath
-            for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
-            if "tests" in str(filepath)
-        ]
+        return root_path.glob("tests/test-clusters/**/cluster.yaml")
     else:
         # We are NOT running a test via pytest. We want to explicitly ignore the
         # cluster folders nested under the `tests/` folder.
-        cluster_files = [
-            filepath
-            for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
-            if "tests" not in str(filepath)
-        ]
-
-    # Return unique absolute paths
-    return set(cluster_files)
+        return root_path.glob("config/clusters/**/cluster.yaml")
 
 
 def generate_hub_matrix_jobs(

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -89,10 +89,10 @@ def get_all_cluster_yaml_files(is_test=False):
         # We are running a test via pytest. We only want to focus on the cluster
         # folders nested under the `tests/` folder.
         return set(root_path.glob("tests/test-clusters/**/cluster.yaml"))
-    else:
-        # We are NOT running a test via pytest. We want to explicitly ignore the
-        # cluster folders nested under the `tests/` folder.
-        return set(root_path.glob("config/clusters/**/cluster.yaml"))
+
+    # We are NOT running a test via pytest. We want to explicitly ignore the
+    # cluster folders nested under the `tests/` folder.
+    return set(root_path.glob("config/clusters/**/cluster.yaml"))
 
 
 def generate_hub_matrix_jobs(

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -90,8 +90,7 @@ def get_all_cluster_yaml_files(is_test=False):
         # folders nested under the `tests/` folder.
         return set(root_path.glob("tests/test-clusters/**/cluster.yaml"))
 
-    # We are NOT running a test via pytest. We want to explicitly ignore the
-    # cluster folders nested under the `tests/` folder.
+    # We are NOT running a test via pytest. We only care about the clusters under config/clusters
     return set(root_path.glob("config/clusters/**/cluster.yaml"))
 
 

--- a/deployer/helm_upgrade_decision.py
+++ b/deployer/helm_upgrade_decision.py
@@ -88,11 +88,11 @@ def get_all_cluster_yaml_files(is_test=False):
     if is_test:
         # We are running a test via pytest. We only want to focus on the cluster
         # folders nested under the `tests/` folder.
-        return root_path.glob("tests/test-clusters/**/cluster.yaml")
+        return set(root_path.glob("tests/test-clusters/**/cluster.yaml"))
     else:
         # We are NOT running a test via pytest. We want to explicitly ignore the
         # cluster folders nested under the `tests/` folder.
-        return root_path.glob("config/clusters/**/cluster.yaml")
+        return set(root_path.glob("config/clusters/**/cluster.yaml"))
 
 
 def generate_hub_matrix_jobs(

--- a/extra_scripts/count-auth0-apps.py
+++ b/extra_scripts/count-auth0-apps.py
@@ -30,6 +30,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
+from pathlib import Path
 
 from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
@@ -88,7 +89,8 @@ def get_auth0_inst(domain, client_id, client_secret):
 
 
 # Read in the auth0 client id and secret from a file
-auth0_secret_path = os.path.join(os.getcwd(), "config", "secrets.yaml")
+root_dir = Path(__file__).parent.parent
+auth0_secret_path = os.path.join(root_dir, "config", "secrets.yaml")
 with decrypt_file(auth0_secret_path) as decrypted_file_path:
     with open(decrypted_file_path) as f:
         auth0_config = yaml.load(f)

--- a/tests/test_helm_upgrade_decision.py
+++ b/tests/test_helm_upgrade_decision.py
@@ -16,24 +16,23 @@ from deployer.helm_upgrade_decision import (
 
 yaml = YAML(typ="safe", pure=True)
 case = TestCase()
+root_path = Path(__file__).parent.parent
 
 
 def test_get_all_cluster_yaml_files():
     expected_cluster_files = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml"),
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster2/cluster.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster2/cluster.yaml"),
     }
 
-    result_cluster_files = get_all_cluster_yaml_files(is_test=True)
+    result_cluster_files = set(get_all_cluster_yaml_files(is_test=True))
 
     assert result_cluster_files == expected_cluster_files
     assert isinstance(result_cluster_files, set)
 
 
 def test_generate_hub_matrix_jobs_one_hub():
-    cluster_file = Path(os.getcwd()).joinpath(
-        "tests/test-clusters/cluster1/cluster.yaml"
-    )
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -44,7 +43,7 @@ def test_generate_hub_matrix_jobs_one_hub():
     }
 
     modified_file = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
     }
 
     expected_matrix_jobs = [
@@ -66,9 +65,7 @@ def test_generate_hub_matrix_jobs_one_hub():
 
 
 def test_generate_hub_matrix_jobs_many_hubs():
-    cluster_file = Path(os.getcwd()).joinpath(
-        "tests/test-clusters/cluster1/cluster.yaml"
-    )
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -79,8 +76,8 @@ def test_generate_hub_matrix_jobs_many_hubs():
     }
 
     modified_files = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub2.values.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster1/hub2.values.yaml"),
     }
 
     expected_matrix_jobs = [
@@ -111,9 +108,7 @@ def test_generate_hub_matrix_jobs_many_hubs():
 
 
 def test_generate_hub_matrix_jobs_all_hubs():
-    cluster_file = Path(os.getcwd()).joinpath(
-        "tests/test-clusters/cluster1/cluster.yaml"
-    )
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -173,9 +168,7 @@ def test_generate_hub_matrix_jobs_all_hubs():
 
 
 def test_generate_support_matrix_jobs_one_cluster():
-    cluster_file = Path(os.getcwd()).joinpath(
-        "tests/test-clusters/cluster1/cluster.yaml"
-    )
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -186,7 +179,7 @@ def test_generate_support_matrix_jobs_one_cluster():
     }
 
     modified_file = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/support.values.yaml"),
+        root_path.joinpath("tests/test-clusters/cluster1/support.values.yaml"),
     }
 
     expected_matrix_jobs = [
@@ -208,9 +201,7 @@ def test_generate_support_matrix_jobs_one_cluster():
 
 
 def test_generate_support_matrix_jobs_all_clusters():
-    cluster_file = Path(os.getcwd()).joinpath(
-        "tests/test-clusters/cluster1/cluster.yaml"
-    )
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 

--- a/tests/test_helm_upgrade_decision.py
+++ b/tests/test_helm_upgrade_decision.py
@@ -25,7 +25,7 @@ def test_get_all_cluster_yaml_files():
         root_path.joinpath("tests/test-clusters/cluster2/cluster.yaml"),
     }
 
-    result_cluster_files = set(get_all_cluster_yaml_files(is_test=True))
+    result_cluster_files = get_all_cluster_yaml_files(is_test=True)
 
     assert result_cluster_files == expected_cluster_files
     assert isinstance(result_cluster_files, set)


### PR DESCRIPTION
Previously, the deployer could only be run if the current working directory of the running it is the root of the repository. This commit removes that dependency, and allows the deployer to be called from any working directory.