### PR TITLE
Remove nfs-server-provisioner

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -30,12 +30,6 @@ dependencies:
     repository: https://kubernetes.github.io/autoscaler
     condition: cluster-autoscaler.enabled
 
-  # In-cluster NFS server provisioner
-  - name: nfs-server-provisioner
-    version: 1.3.1
-    repository: https://kvaps.github.io/charts
-    condition: nfs-server-provisioner.enabled
-
   # cryptnono, counters crypto mining
   # Source code: https://github.com/yuvipanda/cryptnono/
   - name: cryptnono

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -15,7 +15,6 @@ required:
   - ingress-nginx
   - prometheus
   - grafana
-  - nfs-server-provisioner
   - nvidiaDevicePlugin
   - prometheusIngressAuthSecret
   - cryptnono
@@ -43,12 +42,6 @@ properties:
   # values passed to it and are not imposing restrictions on them in this helm
   # chart.
   grafana:
-    type: object
-    additionalProperties: true
-  # nfs-server-provisioner is a dependent helm chart, we rely on its schema
-  # validation for values passed to it and are not imposing restrictions on them
-  # in this helm chart.
-  nfs-server-provisioner:
     type: object
     additionalProperties: true
   # Enables  https://github.com/yuvipanda/cryptnono/ to prevent cryptomining

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -95,37 +95,6 @@ grafana:
           isDefault: true
           editable: false
 
-# Values reference for nfs-server-provisioner
-# https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/blob/master/deploy/helm/values.yaml
-nfs-server-provisioner:
-  enabled: false
-  storageClass:
-    # Users will have to opt-in to using NFS-type storage under
-    # singleuser.storage.dynamic.storageClass
-    name: incluster-nfs
-    create: true
-    defaultClass: false
-    mountOptions:
-      - vers=4.2
-      - soft
-      - noatime
-  persistence:
-    enabled: true
-    accessMode: ReadWriteOnce
-    # Ideally, this *must* be set by each cluster's config. But there's no
-    # easy way for us to force this.
-    # This is the total size of the disk to contain *all* the home directories
-    # of *all* the hubs on the cluster. Each hub gets a directory, with quotas
-    # enforced by XFS. If the size here is lower than the sum of all the requests
-    # for all the home directories PVCs on the cluster, hub deployment will
-    # fail with an error. You have to increase the size here, do a deploy-support,
-    # and try again.
-    size: 100Gi
-    # Selects for SSD vs HDD for base storage of the files.
-    # On Google cloud, this is `standard-rwo` for HDD and `premium-rwo` for ssds.
-    # Standard will do for most use cases.
-    storageClass: standard-rwo
-
 # Enable a daemonset to install nvidia device plugin to GPU nodes
 nvidiaDevicePlugin:
   # For Azure-specific image, default to false


### PR DESCRIPTION
We don't actually use this anywhere, and I think we have decided to eat the cost of using a managed NFS service (AWS EFS, Google Filestore, etc) wherever possible to minimize effort it takes for us.

Fixes https://github.com/2i2c-org/infrastructure/issues/629