### PR TITLE
Pass in KMS decryptor key properly

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -351,7 +351,7 @@ jobs:
       - name: Setup sops credentials to decrypt repo secrets
         uses: google-github-actions/auth@v0
         with:
-          credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
 
       - name: ensure uptime checks are set up
         run: |

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -3,6 +3,7 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    retention: 365d
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
Also increases UToronto prometheus data retention to 1 year,
so we re-trigger a deployment. Ref https://2i2c.freshdesk.com/a/tickets/214