### PR TITLE
Update the lis user image repository too

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -31,7 +31,7 @@ jupyterhub:
   singleuser:
     image:
       # Image build repo: https://github.com/lisds/lisds-images
-      name: "lisds/lisds-base"
+      name: "lisacuk/lishub-base"
       tag: "b183052"
   hub:
     config:

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
           url: https://www.lis.ac.uk
   singleuser:
     image:
-      # Image build repo: https://github.com/lisds/lisds-images
+      # https://hub.docker.com/r/lisacuk/lishub-base
       name: "lisacuk/lishub-base"
       tag: "b183052"
   hub:


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/1742

I just noticed that the container image changed too, not just the tag.
 It's this one https://hub.docker.com/r/lisacuk/lishub-base now

Also, the GitHub repository that generates it might be private (https://github.com/orgs/lisacuk/repositories?), so I removed the link to it and replaced it with a dockerhub one.