### PR TITLE
Provide better GPU support in m2lines & LEAP hubs

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -105,29 +105,48 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-        - display_name: Large + Nvidia K80 GPU
-          description: 24GB RAM, 8 CPUs, Nvidia Tesla K80 GPU + Tensorflow
+
+        - display_name: Large + GPU
+          description: 24GB RAM, 8 CPUs
           allowed_teams:
             - leap-stc:leap-pangeo-research
             - 2i2c-org:tech-team
+          profile_options:
+            gpu:
+              display_name: GPU
+              choices:
+                k80:
+                  display_name: NVidia Tesla K80
+                  default: true
+                  slug: k80
+                  kubespawner_override:
+                    node_selector:
+                      node.kubernetes.io/instance-type: n1-standard-8
+                      cloud.google.com/gke-nodepool: nb-gpu-k80
+                t4:
+                  display_name: NVidia Tesla T4
+                  slug: t4
+                  kubespawner_override:
+                    node_selector:
+                      node.kubernetes.io/instance-type: n1-standard-8
+                      cloud.google.com/gke-nodepool: nb-gpu-t4
+            image:
+              display_name: Image
+              choices:
+                tensorflow:
+                  display_name: Pangeo Tensorflow ML Notebook
+                  default: true
+                  slug: "tensorflow"
+                  kubespawner_override:
+                    image: "pangeo/ml-notebook:f84546a"
+                pytorch:
+                  display_name: Pangeo PyTorch ML Notebook
+                  slug: "pytorch"
+                  kubespawner_override:
+                    image: "pangeo/pytorch-notebook:f84546a"
           kubespawner_override:
-            image: "pangeo/ml-notebook:2022.09.21"
             mem_limit: 30G
             mem_guarantee: 24G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-8
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
-            extra_resource_limits:
-              nvidia.com/gpu: "1"
-        - display_name: Large + Nvidia K80 GPU + PyTorch
-          description: 24GB RAM, 8 CPUs
-          kubespawner_override:
-            image: "pangeo/pytorch-notebook:2022.09.21"
-            mem_limit: 30G
-            mem_guarantee: 24G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-8
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:

--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -1,6 +1,7 @@
 nvidiaDevicePlugin:
   gke:
     enabled: true
+    version: "latest"
 
 prometheusIngressAuthSecret:
   enabled: true

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -91,26 +91,44 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-        - display_name: Large + Nvidia K80 GPU + Tensorflow
+        - display_name: Large + GPU
           description: 24GB RAM, 8 CPUs
+          profile_options:
+            gpu:
+              display_name: GPU
+              choices:
+                k80:
+                  display_name: NVidia Tesla K80
+                  default: true
+                  slug: k80
+                  kubespawner_override:
+                    node_selector:
+                      node.kubernetes.io/instance-type: n1-standard-8
+                      cloud.google.com/gke-nodepool: nb-gpu-k80
+                t4:
+                  display_name: NVidia Tesla T4
+                  slug: t4
+                  kubespawner_override:
+                    node_selector:
+                      node.kubernetes.io/instance-type: n1-standard-8
+                      cloud.google.com/gke-nodepool: nb-gpu-t4
+            image:
+              display_name: Image
+              choices:
+                tensorflow:
+                  display_name: Pangeo Tensorflow ML Notebook
+                  default: true
+                  slug: "tensorflow"
+                  kubespawner_override:
+                    image: "pangeo/ml-notebook:f84546a"
+                pytorch:
+                  display_name: Pangeo PyTorch ML Notebook
+                  slug: "pytorch"
+                  kubespawner_override:
+                    image: "pangeo/pytorch-notebook:f84546a"
           kubespawner_override:
-            image: "pangeo/ml-notebook:f84546a"
             mem_limit: 30G
             mem_guarantee: 24G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-8
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
-            extra_resource_limits:
-              nvidia.com/gpu: "1"
-        - display_name: Large + Nvidia K80 GPU + PyTorch
-          description: 24GB RAM, 8 CPUs
-          kubespawner_override:
-            image: "pangeo/pytorch-notebook:2022.09.21"
-            mem_limit: 30G
-            mem_guarantee: 24G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-8
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:

--- a/config/clusters/m2lines/support.values.yaml
+++ b/config/clusters/m2lines/support.values.yaml
@@ -1,6 +1,7 @@
 nvidiaDevicePlugin:
   gke:
     enabled: true
+    version: "latest"
 
 grafana:
   ingress:

--- a/helm-charts/support/templates/nvidiaDevicePlugin/gke/stable.yaml
+++ b/helm-charts/support/templates/nvidiaDevicePlugin/gke/stable.yaml
@@ -21,6 +21,7 @@
 # node and the daemonset can just use that image.
 
 {{- if .Values.nvidiaDevicePlugin.gke.enabled -}}
+{{- if eq .Values.nvidiaDevicePlugin.gke.version "stable" }}
 # Documented from https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers
 # From https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
 apiVersion: apps/v1
@@ -107,4 +108,5 @@ spec:
       containers:
       - image: "gcr.io/google-containers/pause:2.0"
         name: pause
+{{- end }}
 {{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -83,9 +83,22 @@ properties:
         additionalProperties: false
         required:
           - enabled
+          - version
         properties:
           enabled:
             type: boolean
+          version:
+            type: string
+            enum:
+              - stable
+              - latest
+            description: |
+              Install the stable or latest version of nvidia GPU drivers for the node.
+
+              See table in https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers
+              to determine what versions would be installed. Might need to be matched with appropriate
+              version of the CUDA libraries used in the images users use.
+
   prometheusIngressAuthSecret:
     type: object
     # prometheusIngressAuthSecret is _not a dependent helm chart_. It is values directly

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -103,6 +103,7 @@ nvidiaDevicePlugin:
   # For GKE specific image, defaults to false
   gke:
     enabled: false
+    version: "stable"
   # For eksctl / AWS specific daemonset, defaults to false
   aws:
     enabled: false

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -96,6 +96,17 @@ notebook_nodes = {
       count: 1
     }
   },
+  "gpu-t4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {},
+    gpu: {
+      enabled: true,
+      type: "nvidia-tesla-t4",
+      count: 1
+    }
+  },
 }
 
 dask_nodes = {

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -79,6 +79,17 @@ notebook_nodes = {
       count: 1
     }
   },
+  "gpu-t4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {},
+    gpu: {
+      enabled: true,
+      type: "nvidia-tesla-t4",
+      count: 1
+    }
+  },
 }
 
 dask_nodes = {


### PR DESCRIPTION
- Add T4 GPUs in addition to K80 GPUs currently available
- Use newer profile dropdowns to make choice of GPUs and images easier
- Switch to a newer GPU driver version to allow using newer CUDA, based on
  conversation in https://github.com/pangeo-data/pangeo-docker-images/issues/387

Ref https://github.com/2i2c-org/infrastructure/issues/1765
![image](https://user-images.githubusercontent.com/30430/195436551-55243e9f-790c-4f8c-a576-c91cf002faba.png)
