### PR TITLE
Use dask-gateway 2022.10.0 and rely on mounted api-token from jupyterhub chart, also revert the workaround removing the hub NetworkPolicy

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -54,7 +54,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.09.21"
+        tag: "2022.10.13"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -56,7 +56,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.09.21"
+        tag: "2022.10.13"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -75,7 +75,7 @@ optional arguments:
   --config-path CONFIG_PATH
                         File to read secret deployment configuration from
   --dask-gateway-version DASK_GATEWAY_VERSION
-                        For daskhubs, the version of dask-gateway to install for the CRDs. Default: 2022.6.1
+                        For daskhubs, the version of dask-gateway to install for the CRDs. Default: 2022.10.0
 ```
 
 ### `validate`

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -77,8 +77,8 @@ def main():
         type=str,
         # This version must match what is listed in daskhub's Chart.yaml file
         # https://github.com/2i2c-org/infrastructure/blob/HEAD/helm-charts/daskhub/Chart.yaml#L14
-        default="2022.6.1",
-        help="For daskhubs, the version of dask-gateway to install for the CRDs. Default: 2022.6.1",
+        default="2022.10.0",
+        help="For daskhubs, the version of dask-gateway to install for the CRDs. Default: 2022.10.0",
     )
 
     # Validate subcommand

--- a/helm-charts/binderhub/Chart.yaml
+++ b/helm-charts/binderhub/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: "0.2.0-n988.h72e1852"
     repository: "https://jupyterhub.github.io/helm-chart/"
   - name: dask-gateway
-    version: "2022.4.0"
+    version: "2022.10.0"
     repository: "https://helm.dask.org/"

--- a/helm-charts/binderhub/values.yaml
+++ b/helm-charts/binderhub/values.yaml
@@ -201,9 +201,6 @@ binderhub:
           admin: true
       nodeSelector:
         hub.jupyter.org/node-purpose: core
-      networkPolicy:
-        # FIXME: Enable this when dask-gateway chart v0.9.1 or higher is used
-        enabled: false
       extraConfig:
         daskhub-01-add-dask-gateway-values: |
           # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.

--- a/helm-charts/binderhub/values.yaml
+++ b/helm-charts/binderhub/values.yaml
@@ -237,7 +237,7 @@ binderhub:
                       service.setdefault("url", service_url)
                   break
           else:
-              print("dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?")
+              print("dask-gateway service not found, this should not happen!")
 dask-gateway:
   #=== VALUES BELOW HERE ARE COPIED FROM DASKHUB VALUES AND SHOULD BE UPDATED ===#
   #=== IF DASKHUB CHANGES ===#
@@ -292,24 +292,49 @@ dask-gateway:
           nodeSelector:
             # Dask workers get their own pre-emptible pool
             k8s.dask.org/node-purpose: worker
+
     # TODO: figure out a replacement for userLimits.
     extraConfig:
       optionHandler: |
         from dask_gateway_server.options import Options, Integer, Float, String, Mapping
+        import string
+
+        # Escape a string to be dns-safe in the same way that KubeSpawner does it.
+        # Reference https://github.com/jupyterhub/kubespawner/blob/616f72c4aee26c3d2127c6af6086ec50d6cda383/kubespawner/spawner.py#L1828-L1835
+        # Adapted from https://github.com/minrk/escapism to avoid installing the package
+        # in the dask-gateway api pod which would have been problematic.
+        def escape_string_label_safe(to_escape):
+            safe_chars = set(string.ascii_lowercase + string.digits)
+            escape_char = "-"
+            chars = []
+            for c in to_escape:
+                if c in safe_chars:
+                    chars.append(c)
+                else:
+                    # escape one character
+                    buf = []
+                    # UTF-8 uses 1 to 4 bytes per character, depending on the Unicode symbol
+                    # so we need to transform each byte to its hex value
+                    for byte in c.encode("utf8"):
+                        buf.append(escape_char)
+                        # %X is the hex value of the byte
+                        buf.append('%X' % byte)
+                    escaped_hex_char = "".join(buf)
+                    chars.append(escaped_hex_char)
+            return u''.join(chars)
 
         def cluster_options(user):
+            safe_username = escape_string_label_safe(user.name)
             def option_handler(options):
                 if ":" not in options.image:
                     raise ValueError("When specifying an image you must also provide a tag")
-                # FIXME: No user labels or annotations, until https://github.com/pangeo-data/pangeo-cloud-federation/issues/879
-                # is fixed.
                 extra_annotations = {
-                    # "hub.jupyter.org/username": safe_username,
+                    "hub.jupyter.org/username": safe_username,
                     "prometheus.io/scrape": "true",
                     "prometheus.io/port": "8787",
                 }
                 extra_labels = {
-                    # "hub.jupyter.org/username": safe_username,
+                    "hub.jupyter.org/username": safe_username,
                 }
                 return {
                     "worker_cores_limit": options.worker_cores,
@@ -342,6 +367,7 @@ dask-gateway:
       k8s.dask.org/node-purpose: core
     service:
       type: ClusterIP # Access Dask Gateway through JupyterHub. To access the Gateway from outside JupyterHub, this must be changed to a `LoadBalancer`.
+
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or
 # used.

--- a/helm-charts/daskhub/Chart.yaml
+++ b/helm-charts/daskhub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # in the deployer's CLI
     # https://github.com/2i2c-org/infrastructure/blob/HEAD/deployer/cli.py#L73-L80
   - name: dask-gateway
-    version: "2022.6.1"
+    version: "2022.10.0"
     repository: "https://helm.dask.org/"

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -57,9 +57,6 @@ basehub:
           # Don't display a dask-gateway entry under 'services',
           # as dask-gateway has no UI
           display: false
-      networkPolicy:
-        # FIXME: Enable this when dask-gateway chart v0.9.1 or higher is used
-        enabled: false
       extraConfig:
         daskhub-01-add-dask-gateway-values: |
           # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -96,7 +96,7 @@ basehub:
                       service.setdefault("url", service_url)
                   break
           else:
-              print("dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?")
+              print("dask-gateway service not found, this should not happen!")
 
 dask-gateway:
   enabled: true # Enabling dask-gateway will install Dask Gateway as a dependency.


### PR DESCRIPTION
Relies on https://github.com/dask/dask-gateway/pull/612 released in 2022.10.0 so we don't have to set this explicitly.

While I've tested this in the JMTE hub. I've not tested the adjustments I've made to the binderhub chart that includes another dask-gateway installation. I made the changes I think is required for it though and think it should work fine there as well.

- Closes #1754

---

I'd be thankful if someone else can go for a merge of this and ensure that things work in all the 2i2c hubs. I opted to go for a PR as that felt like a clear way of documenting what I thought should be done to resolve #1754.