### PR TITLE
Cleanup mysql shared db support on AWS

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -6,8 +6,8 @@ terraform {
     }
 
     mysql = {
-      source  = "winebarrel/mysql"
-      version = "1.10.6"
+      source  = "petoju/mysql"
+      version = "3.0.20"
     }
 
   }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -109,6 +109,7 @@ variable "db_engine_version" {
 }
 
 variable "db_instance_identifier" {
+  default     = "shared-db"
   description = <<-EOT
   Human readable instance name to give the database server.
 


### PR DESCRIPTION
- Don't set up mysql provider when db is not enabled
- Make sure all db related resources are conditional on db being enabled
- Switch to a maintained fork of the mysql provider

Unblocks https://github.com/2i2c-org/infrastructure/pull/1768