### PR TITLE
Set NVIDIA_DRIVER_CAPABILITIES globally

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -58,6 +58,9 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
+        # Temporarily set for *all* pods, including pods without any GPUs,
+        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
@@ -147,8 +150,6 @@ basehub:
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
 dask-gateway:

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -53,6 +53,9 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.1c4d967ffc205f98"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/m2lines-pangeo-hub-push-access
+        # Temporarily set for *all* pods, including pods without any GPUs,
+        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
@@ -129,8 +132,6 @@ basehub:
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
 dask-gateway:


### PR DESCRIPTION
There's a bug in kubespawner that causes dictionary overrides to replace settings rather than merge with them. This is fixed by https://github.com/jupyterhub/kubespawner/pull/650, but until then, we just unconditionally set this env var (required for GPUs to function) on all pods. Seems to be harmless when set on non-GPU pods.

Should be reverted once that PR lands.

Fixes https://github.com/2i2c-org/infrastructure/issues/1775 Fixes https://github.com/2i2c-org/infrastructure/issues/1774

Ref https://github.com/2i2c-org/infrastructure/issues/1530