### PR TITLE
Keep prometheus data for 1 year rather than 90 days

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -3,7 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    retention: 365d
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -3,7 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    retention: 365d
     ingress:
       enabled: true
       hosts:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -60,7 +60,8 @@ prometheus:
       hub.jupyter.org/network-access-hub: "true"
     persistentVolume:
       size: 100Gi
-    retention: 90d
+    # Keep data for at least 1 year
+    retention: 366d
     service:
       type: ClusterIP
   # make sure we collect metrics on pods by app/component at least


### PR DESCRIPTION
I think this is broadly useful for everyone, and we now have uptime checks for prometheuses so if they go down we can know.