### PR TITLE
Reduce memory limit for pangeo-hubs prometheus

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -28,5 +28,6 @@ prometheus:
             - prometheus.gcp.pangeo.2i2c.cloud
     resources:
       limits:
+        # Increase limits here as this isn't too small a cluster
         cpu: 2
-        memory: 16Gi
+        memory: 4Gi


### PR DESCRIPTION
It was down because it was crashing trying to reload from WAL, not because it was running out of RAM. `kubectl top pod -n support` shows it using under 2G, so a 4G limit seems appropriate