### PR TITLE
Bump up prometheus & grafana versions

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -7,13 +7,13 @@ dependencies:
   # Prometheus for collection of metrics.
   # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
   - name: prometheus
-    version: 15.10.1
+    version: 15.16.1
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 6.11.0
+    version: 6.42.2
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from


### PR DESCRIPTION
Good to keep these up to date, and the problem with our pangeo-hubs prometheus was a [WAL replay](https://www.postgresql.org/docs/current/wal-intro.html) bug causing a crash - perhaps a newer version will not have that.