### PR TITLE
Add budget alerts based on forecasts

### DIFF
--- a/docs/howto/operate/new-cluster/new-cluster.md
+++ b/docs/howto/operate/new-cluster/new-cluster.md
@@ -30,6 +30,17 @@ The _minimum_ inputs this file requires are:
   Primary identifier to 'group' together resources.
 - `project_id`: GCP Project ID to create resources in.
   Should be the id, rather than display name of the project.
+- `billing_account_id`: The billing account id associated with the
+  project, used to setup budget alerts. You can find this by going
+  into the `Billing` panel on the cloud console. If we don't have
+  access to the billing account, set `budget_alert_enabled` variable
+  to false.
+- `budget_alert_amount`: The amount of money that we don't want to go
+  over every month for this project. An alert will be sent to
+  `support@2i2c.org` if the *forecasted* spend at the end of the month
+  goves over this number, or if actual spend goes over 80% of this number.
+  See [](topic:budget-alerts) for more information. It defaults to USD as
+  currency, but you can choose other currencies by setting `budget_alert_currency`.
 - `regional_cluster`: Set to true to provision a [GKE Regional
   Highly Available cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters).
   Costs ~70$ a month, but worth it for the added reliability for most

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ topic/cluster-design.md
 topic/secrets.md
 topic/troubleshooting.md
 topic/uptime-checks.md
+topic/budget-alerts.md
 ```
 
 ## Reference

--- a/docs/topic/budget-alerts.md
+++ b/docs/topic/budget-alerts.md
@@ -1,0 +1,35 @@
+(topic:budget-alerts)=
+# Cloud Billing Budget Alerts
+
+"I forgot to turn off my cloud resources, your honor" as a reason for declaring
+bankruptcy is second only to "The US healthcare system sucks, your honor" in the
+US court system. "How much is my cloud going to cost?" is a big anxiety for a lot
+of our users, and hence us. We set up billing alerts to help deal with this anxiety.
+
+## When are the alerts triggered?
+
+Budget alerts are sent under two conditions:
+
+1. When *forecasted monthly spend* at end of the month goes over our spending limit.
+   This is an *early warning* system, that helps us evaluate where spend is going
+   and make sure this is expected.
+2. When *current actual spend* goves over 80% of our spending limit.
+
+## What to do when we receive an alert?
+
+The current goal is to just make sure we don't end up spending *wildly* more money
+than budgeted. So if the forecasted spend busts through on day 5 of the month,
+we might need to do something different than if it does on day 30. If it is expected
+to overshoot by 500% vs by 10$, our actions might be different. One valid action is
+we just adjust the forecast. As an organization, we need more experience with costs
+to figure out what the right thing to do is. So our current primary goal would
+be to work with our stakeholders and gather that texperience.
+
+## Where are these alerts sent?
+
+Budget alerts are "Cliff Alerts" - they don't indicate a current outage (unlike
+uptime checks), but indicate that we are perhaps heading in a direction that will
+cause problems soon if we do not course correct. Hence, we do not send them to
+PagerDuty but to our `support@2i2c.org` email address.
+
+

--- a/docs/topic/budget-alerts.md
+++ b/docs/topic/budget-alerts.md
@@ -13,7 +13,7 @@ Budget alerts are sent under two conditions:
 1. When *forecasted monthly spend* at end of the month goes over our spending limit.
    This is an *early warning* system, that helps us evaluate where spend is going
    and make sure this is expected.
-2. When *current actual spend* goves over 80% of our spending limit.
+2. When *current actual spend* goves over 100% of our spending limit.
 
 ## What to do when we receive an alert?
 

--- a/docs/topic/budget-alerts.md
+++ b/docs/topic/budget-alerts.md
@@ -23,7 +23,7 @@ we might need to do something different than if it does on day 30. If it is expe
 to overshoot by 500% vs by 10$, our actions might be different. One valid action is
 we just adjust the forecast. As an organization, we need more experience with costs
 to figure out what the right thing to do is. So our current primary goal would
-be to work with our stakeholders and gather that texperience.
+be to work with our stakeholders and gather that experience.
 
 ## Where are these alerts sent?
 

--- a/terraform/gcp/budget-alerts.tf
+++ b/terraform/gcp/budget-alerts.tf
@@ -48,12 +48,13 @@ resource "google_billing_budget" "budget" {
   # and terraform apply won't be clean.
   threshold_rules {
     # Alert when *actual* spend reached 80% of budget
-    threshold_percent = 0.8
+    threshold_percent = 1.0
     spend_basis       = "CURRENT_SPEND"
   }
   threshold_rules {
     # Alert when *forecasted* spend is about to blow over our budget
-    threshold_percent = 1.0
+    # Adding the extra 1% to help terraform not redo this each time.
+    threshold_percent = 1.01
     spend_basis       = "FORECASTED_SPEND"
   }
 

--- a/terraform/gcp/budget-alerts.tf
+++ b/terraform/gcp/budget-alerts.tf
@@ -39,7 +39,7 @@ resource "google_billing_budget" "budget" {
 
   all_updates_rule {
     monitoring_notification_channels = [
-      google_monitoring_notification_channel.support_email.id,
+      google_monitoring_notification_channel.support_email[0].id,
     ]
     disable_default_iam_recipients = true
   }

--- a/terraform/gcp/budget-alerts.tf
+++ b/terraform/gcp/budget-alerts.tf
@@ -1,0 +1,60 @@
+# Alerts sent to support@2i2c.org for things that *will go bad* in the future
+# if left unattended. Should *not* be used for immediate outages
+
+resource "google_monitoring_notification_channel" "support_email" {
+  count        = var.budget_alert_enabled ? 1 : 0
+  project      = var.project_id
+  display_name = "support@2i2c.org email"
+  type         = "email"
+  labels = {
+    email_address = "support@2i2c.org"
+  }
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Need to explicitly enable https://console.cloud.google.com/apis/library/billingbudgets.googleapis.com?project=two-eye-two-see
+resource "google_billing_budget" "budget" {
+  count = var.budget_alert_enabled ? 1 : 0
+
+  billing_account = var.billing_account_id
+  display_name    = "Billing alert"
+
+  budget_filter {
+    # Use project number here, as project_name seems to be converted internally to number
+    # If we don't do this, `terraform apply` is not clean
+    # This is a bug in the google provider / budgets API https://github.com/hashicorp/terraform-provider-google/issues/8444
+    projects               = ["projects/${data.google_project.project.number}"]
+    credit_types_treatment = "INCLUDE_ALL_CREDITS"
+  }
+
+  amount {
+    specified_amount {
+      currency_code = var.budget_alert_currency
+      units         = var.budget_alert_amount
+    }
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.support_email.id,
+    ]
+    disable_default_iam_recipients = true
+  }
+  # NOTE: These threshold_rules *MUST BE ORDERED BY threshold_percent* in ascending order!
+  # If not, we'll run into https://github.com/hashicorp/terraform-provider-google/issues/8444
+  # and terraform apply won't be clean.
+  threshold_rules {
+    # Alert when *actual* spend reached 80% of budget
+    threshold_percent = 0.8
+    spend_basis       = "CURRENT_SPEND"
+  }
+  threshold_rules {
+    # Alert when *forecasted* spend is about to blow over our budget
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+}

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "google"
-      version = "4.11.0"
+      version = "4.40.0"
     }
     google-beta = {
       source  = "google-beta"
-      version = "4.11.0"
+      version = "4.40.0"
     }
     kubernetes = {
       version = "2.8.0"
@@ -15,6 +15,12 @@ terraform {
   }
 }
 
+provider "google" {
+  # This is required for Billing Alerts to work
+  # See warning in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget
+  user_project_override = true
+  billing_project       = var.project_id
+}
 data "google_client_config" "default" {}
 
 provider "kubernetes" {

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -1,3 +1,6 @@
+billing_account_id = "0157F7-E3EA8C-25AC3C"
+budget_alert_amount = "500"
+
 prefix                 = "two-eye-two-see-uk"
 project_id             = "two-eye-two-see-uk"
 

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -1,3 +1,6 @@
+billing_account_id = "0157F7-E3EA8C-25AC3C"
+budget_alert_amount = "800"
+
 prefix                 = "awi-ciroh"
 project_id             = "awi-ciroh"
 zone                   = "us-central1-b"

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -4,6 +4,9 @@ project_id             = "callysto-202316"
 zone                   = "northamerica-northeast1-b"
 region                 = "northamerica-northeast1"
 
+# We don't have enough rights to make billing alerts
+billing_alert_enabled = false
+
 core_node_machine_type = "n1-highmem-4"
 enable_network_policy  = true
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -6,6 +6,9 @@ core_node_machine_type = "n1-highmem-4"
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy    = true
 
+# We don't have enough access to enable this
+budget_alert_enabled = false
+
 regional_cluster = false
 
 # No plans to provide storage buckets to users on this hub, so no need to deploy

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -1,3 +1,6 @@
+billing_account_id = "01A164-923D17-3199D9"
+budget_alert_amount = "2000"
+
 prefix                 = "leap"
 project_id             = "leap-pangeo"
 core_node_machine_type = "n1-highmem-4"

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -1,3 +1,6 @@
+billing_account_id = "018C36-9A47B4-82AE21"
+budget_alert_amount = "800"
+
 prefix           = "linked-earth"
 project_id       = "linked-earth-hubs"
 zone             = "us-central1-c"

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -1,3 +1,6 @@
+billing_account_id = "0157F7-E3EA8C-25AC3C"
+budget_alert_amount = "1000"
+
 prefix                 = "m2lines"
 project_id             = "m2lines-hub"
 core_node_machine_type = "n1-highmem-4"

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -1,3 +1,7 @@
+billing_account_id = "015AF3-346967-3DD18B"
+budget_alert_currency = "EUR"
+budget_alert_amount = "600"
+
 prefix     = "meom-ige"
 project_id = "meom-ige-cnrs"
 

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -3,6 +3,9 @@ project_id             = "pangeo-integration-te-3eea"
 core_node_machine_type = "n1-highmem-4"
 enable_private_cluster = true
 
+# We don't have enough rights to make billing alerts
+billing_alert_enabled = false
+
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy  = true
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -1,6 +1,9 @@
 prefix     = "pilot-hubs"
 project_id = "two-eye-two-see"
 
+billing_account_id = "0157F7-E3EA8C-25AC3C"
+budget_alert_amount = "1250"
+
 core_node_machine_type = "n1-highmem-4"
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -299,12 +299,45 @@ variable "hub_cloud_permissions" {
 }
 
 variable "container_repos" {
-  type        = list
+  type        = list(any)
   default     = []
   description = <<-EOT
   A list of container repositories to create in Google Artifact Registry to store Docker
   images. Each entry is the name of the hub namespace in the cluster. If deploying a
   BinderHub, definitely add the namespace here so that there is somewhere to push the
   repo2docker-built images to.
+  EOT
+}
+
+variable "billing_account_id" {
+  type        = string
+  description = <<-EOT
+  ID of the billing account used for this project. Used to set up alerts
+  for budget forecasts
+  EOT
+}
+
+variable "budget_alert_currency" {
+  type        = string
+  default     = "USD"
+  description = <<-EOT
+  Currency used for budget alerts
+  EOT
+}
+
+variable "budget_alert_amount" {
+  type        = string
+  description = <<-EOT
+  Amount of *forecasted spend* at which to send a billing alert
+  EOT
+}
+
+variable "budget_alert_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Enable budget alerts.
+
+  Disable in cases where we do not have enough permissions on the billing account.
   EOT
 }


### PR DESCRIPTION
Just for GCP, this will email support@2i2c.org whenever forecasted spend for the month goes over a $$$ we set. Currently, I've set the numbers arbitrarily based on median spend for the project in question based on looking at history of spends.

pangeo-hubs and cloudbank don't give us enough permissions to set up these alerts, so we don't.