### PR TITLE
Bump pangeo image tags for LEAP & m2lines

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -54,7 +54,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.10.13"
+        tag: "2022.10.18"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
@@ -141,12 +141,12 @@ basehub:
                   default: true
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2022.10.13"
+                    image: "pangeo/ml-notebook:2022.10.18"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2022.10.13"
+                    image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -59,7 +59,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.10.13"
+        tag: "2022.10.18"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
@@ -122,13 +122,13 @@ basehub:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2022.10.13"
+                    image: "pangeo/ml-notebook:2022.10.18"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   default: true
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2022.10.13"
+                    image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G


### PR DESCRIPTION
Brings in https://github.com/pangeo-data/pangeo-docker-images/pull/395, which brings in https://github.com/conda-forge/pangeo-dask-feedstock/pull/96, which brings in newer versions of dask and dask-gateway.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/1769