### PR TITLE
Remove image_repo from our clusters

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -1,5 +1,4 @@
 name: 2i2c
-image_repo: "quay.io/2i2c/2i2c-hubs-image"
 provider: gcp
 gcp:
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -1,5 +1,4 @@
 name: cloudbank
-image_repo: "quay.io/2i2c/2i2c-hubs-image"
 provider: gcp
 gcp:
   key: enc-deployer-credentials.secret.json

--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -34,40 +34,6 @@ class Cluster:
         else:
             raise ValueError(f'Provider {self.spec["provider"]} not supported')
 
-    def ensure_docker_credhelpers(self):
-        """
-        Setup credHelper for current hub's image registry.
-
-        Most image registries (like ECR, GCP Artifact registry, etc) use
-        a docker credHelper (https://docs.docker.com/engine/reference/commandline/login/#credential-helpers)
-        to authenticate, rather than a username & password. This requires an
-        entry per registry in ~/.docker/config.json.
-
-        This method ensures the appropriate credential helper is present
-        """
-        image_name = self.spec["image_repo"]
-        registry = image_name.split("/")[0]
-
-        helper = None
-        # pkg.dev is used by Google Cloud Artifact registry
-        if registry.endswith("pkg.dev"):
-            helper = "gcloud"
-
-        if helper is not None:
-            dockercfg_path = os.path.expanduser("~/.docker/config.json")
-            try:
-                with open(dockercfg_path) as f:
-                    config = json.load(f)
-            except FileNotFoundError:
-                config = {}
-
-            helpers = config.get("credHelpers", {})
-            if helpers.get(registry) != helper:
-                helpers[registry] = helper
-                config["credHelpers"] = helpers
-                with open(dockercfg_path, "w") as f:
-                    json.dump(config, f, indent=4)
-
     def deploy_support(self, cert_manager_version):
         cert_manager_url = "https://charts.jetstack.io"
 

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -91,12 +91,6 @@ class Hub:
                             }
                         ],
                     },
-                    "singleuser": {
-                        # If image_repo isn't set, just have an empty image dict
-                        "image": {"name": self.cluster.spec["image_repo"]}
-                        if "image_repo" in self.cluster.spec
-                        else {},
-                    },
                     "hub": {
                         "config": {},
                         "initContainers": [

--- a/shared/deployer/cluster.schema.yaml
+++ b/shared/deployer/cluster.schema.yaml
@@ -7,8 +7,6 @@ properties:
     description: |
       Name of the cluster, used primarily to identify it in
       the deploy script. This value should match the parent folder name.
-  image_repo:
-    type: string
   support:
     type: object
     additionalProperties: false


### PR DESCRIPTION
We don't actually use it - default image is now set in basehub/values.yaml. The python code was not called from anywhere either