### PR TITLE
Auto-bump the subchart versions in our support chart

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -31,9 +31,9 @@ jobs:
             # To bump multiple subchart versions, provide the chart name and a URL to
             # a published list of versions in this dictionary.
             chart_urls: '{"binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml"}'
-          - name: "cryptnono"
+          - name: "support"
             chart_path: "helm-charts/support/Chart.yaml"
-            chart_urls: '{"cryptnono": "https://yuvipanda.github.io/cryptnono/index.yaml"}'
+            chart_urls: '{"cryptnono": "https://yuvipanda.github.io/cryptnono/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx", "grafana": "https://grafana.github.io/helm-charts", "prometheus": "https://prometheus-community.github.io/helm-charts"}'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,

--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -33,7 +33,7 @@ jobs:
             chart_urls: '{"binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml"}'
           - name: "support"
             chart_path: "helm-charts/support/Chart.yaml"
-            chart_urls: '{"cryptnono": "https://yuvipanda.github.io/cryptnono/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx", "grafana": "https://grafana.github.io/helm-charts", "prometheus": "https://prometheus-community.github.io/helm-charts"}'
+            chart_urls: '{"cryptnono": "https://yuvipanda.github.io/cryptnono/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx/index.yaml", "grafana": "https://grafana.github.io/helm-charts/index.yaml", "prometheus": "https://prometheus-community.github.io/helm-charts/index.yaml"}'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,


### PR DESCRIPTION
This PR will enable auto-opened PRs to bump the versions of the following subcharts for our support chart:

- ingress-nginx
- grafana
- prometheus

The cryptnono subchart already had auto-bumping setup.

This leaves the cluster-autoscaler as the only remaining subchart not being auto-bumped for the the support chart.

Follow up to https://github.com/2i2c-org/infrastructure/pull/1781