### PR TITLE
Use gs:// as protocol for GCP buckets

### DIFF
--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -5,8 +5,8 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -5,8 +5,8 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://awi-ciroh-scratch-staging/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://awi-ciroh-scratch-staging/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://awi-ciroh-scratch-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://awi-ciroh-scratch-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -5,9 +5,9 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://leap-scratch/$(JUPYTERHUB_USER)
-        PERSISTENT_BUCKET: gcs://leap-persistent/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://leap-scratch/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: gs://leap-persistent/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://leap-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -5,9 +5,9 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://leap-scratch-staging/$(JUPYTERHUB_USER)
-        PERSISTENT_BUCKET: gcs://leap-persistent-staging/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://leap-scratch-staging/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: gs://leap-persistent-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/linked-earth/prod.values.yaml
+++ b/config/clusters/linked-earth/prod.values.yaml
@@ -5,8 +5,8 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://linked-earth-scratch/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://linked-earth-scratch/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://linked-earth-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://linked-earth-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/linked-earth/staging.values.yaml
+++ b/config/clusters/linked-earth/staging.values.yaml
@@ -5,8 +5,8 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://linked-earth-scratch-staging/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://linked-earth-scratch-staging/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://linked-earth-scratch-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://linked-earth-scratch-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -5,9 +5,9 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://m2lines-scratch/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://m2lines-scratch/$(JUPYTERHUB_USER)
-        PERSISTENT_BUCKET: gcs://m2lines-persistent/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://m2lines-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://m2lines-scratch/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: gs://m2lines-persistent/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/staging.values.yaml
+++ b/config/clusters/m2lines/staging.values.yaml
@@ -5,9 +5,9 @@ basehub:
   jupyterhub:
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: gcs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gcs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
-        PERSISTENT_BUCKET: gcs://m2lines-persistent-staging/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: gs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://m2lines-scratch-staging/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: gs://m2lines-persistent-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -33,8 +33,8 @@ basehub:
             url: https://meom-group.github.io/
     singleuser:
       extraEnv:
-        DATA_BUCKET: gcs://meom-ige-data
-        SCRATCH_BUCKET: "gcs://meom-ige-scratch/$(JUPYTERHUB_USER)"
+        DATA_BUCKET: gs://meom-ige-data
+        SCRATCH_BUCKET: "gs://meom-ige-scratch/$(JUPYTERHUB_USER)"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable

--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -42,14 +42,14 @@ on why users want this!
     jupyterhub:
       singleuser:
          extraEnv:
-            SCRATCH_BUCKET: <s3 or gcs>://<bucket-full-name>/$(JUPYTERHUB_USER)
-            PANGEO_SCRATCH: <s3 or gcs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            SCRATCH_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            PANGEO_SCRATCH: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
             # If we have a bucket that does not have a `delete_after`
-            PERSISTENT_BUCKET: <s3 or gcs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            PERSISTENT_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
    ```
 
    ```{note}
-   Use s3 on AWS and gcs on GCP for the protocol part
+   Use s3 on AWS and gs on GCP for the protocol part
    ```
    ```{note}
    If the hub is a `daskhub`, nest the config under a `basehub` key


### PR DESCRIPTION
gcs:// was also valid for fsspec but not for gcloud, so let's switch to gs://

Ref https://2i2c.freshdesk.com/a/tickets/231