### PR TITLE
Remove k80 GPUs from all GCP hubs

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -115,24 +115,6 @@ basehub:
             - leap-stc:leap-pangeo-research
             - 2i2c-org:tech-team
           profile_options:
-            gpu:
-              display_name: GPU
-              choices:
-                k80:
-                  display_name: NVidia Tesla K80
-                  slug: k80
-                  kubespawner_override:
-                    node_selector:
-                      node.kubernetes.io/instance-type: n1-standard-8
-                      cloud.google.com/gke-nodepool: nb-gpu-k80
-                t4:
-                  display_name: NVidia Tesla T4
-                  slug: t4
-                  default: true
-                  kubespawner_override:
-                    node_selector:
-                      node.kubernetes.io/instance-type: n1-standard-8
-                      cloud.google.com/gke-nodepool: nb-gpu-t4
             image:
               display_name: Image
               choices:
@@ -148,6 +130,8 @@ basehub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
+            node_selector:
+              cloud.google.com/gke-nodepool: nb-gpu-t4
             mem_limit: 30G
             mem_guarantee: 24G
             extra_resource_limits:

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -97,24 +97,6 @@ basehub:
         - display_name: Large + GPU
           description: 24GB RAM, 8 CPUs
           profile_options:
-            gpu:
-              display_name: GPU
-              choices:
-                k80:
-                  display_name: NVidia Tesla K80
-                  default: true
-                  slug: k80
-                  kubespawner_override:
-                    node_selector:
-                      node.kubernetes.io/instance-type: n1-standard-8
-                      cloud.google.com/gke-nodepool: nb-gpu-k80
-                t4:
-                  display_name: NVidia Tesla T4
-                  slug: t4
-                  kubespawner_override:
-                    node_selector:
-                      node.kubernetes.io/instance-type: n1-standard-8
-                      cloud.google.com/gke-nodepool: nb-gpu-t4
             image:
               display_name: Image
               choices:
@@ -130,6 +112,8 @@ basehub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
+            node_selector:
+              cloud.google.com/gke-nodepool: nb-gpu-t4
             mem_limit: 30G
             mem_guarantee: 24G
             extra_resource_limits:

--- a/docs/howto/features/gpu.md
+++ b/docs/howto/features/gpu.md
@@ -25,7 +25,7 @@ series nodes.
 6. Input the *number of vCPUs* needed. This translates to a total
    number of GPU nodes based on how many CPUs the nodes we want have.
    For example, if we are using [G4 nodes](https://aws.amazon.com/ec2/instance-types/g4/)
-   with NVIDIA K80 GPUs, each `g4dn.xlarge` node gives us 1 GPU and
+   with NVIDIA T4 GPUs, each `g4dn.xlarge` node gives us 1 GPU and
    4 vCPUs, so a quota of 8 vCPUs will allow us to spawn 2 GPU nodes.
    We should fine tune this calculation for later, but for now, the
    recommendation is to give users a single `g4dn.xlarge` each, so the number

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -92,17 +92,6 @@ notebook_nodes = {
       count: 0
     }
   },
-  "gpu-k80" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: true,
-      type: "nvidia-tesla-k80",
-      count: 1
-    }
-  },
   "gpu-t4" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -64,17 +64,6 @@ notebook_nodes = {
       count: 0
     }
   },
-  "gpu-k80" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: true,
-      type: "nvidia-tesla-k80",
-      count: 1
-    }
-  },
 }
 
 dask_nodes = {

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -76,17 +76,6 @@ notebook_nodes = {
       count: 0
     }
   },
-  "gpu-k80" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: true,
-      type: "nvidia-tesla-k80",
-      count: 1
-    }
-  },
   "gpu-t4" : {
     min : 0,
     max : 100,


### PR DESCRIPTION
This was never exposed in the linked-earth hub via hub config, so we can remove this

Ref: https://github.com/2i2c-org/infrastructure/issues/1765