### PR TITLE
Scale up the notebook nodepool for the gridsst cluster

### DIFF
--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -11,10 +11,10 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "m5.large" },
-    { instanceType: "m5.xlarge" },
-    { instanceType: "m5.2xlarge" },
-    { instanceType: "m5.8xlarge" },
+    { instanceType: "m5.large", minSize: 50 },
+    { instanceType: "m5.xlarge", minSize: 0 },
+    { instanceType: "m5.2xlarge", minSize: 0 },
+    { instanceType: "m5.8xlarge", minSize: 0 },
 ];
 
 // Node definitions for dask worker nodes. Config here is merged
@@ -63,7 +63,7 @@ local daskNodes = [
             // instanceTypes always have a .
             name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
-            minSize: 0,
+            minSize: n.minSize,
             maxSize: 500,
             instanceType: n.instanceType,
             ssh: {


### PR DESCRIPTION
Reference https://github.com/2i2c-org/infrastructure/issues/1832

~I haven't run the `eksctl scale nodegroup` command for these 50 nodes yet.~
~But I have run it for 10 to test it out.~

Question for the @2i2c-org/tech-team: Should we also have a min number of dask nodes too? I don't think we have docs about this, so I'm not sure if this is something that we have done before or if we should.

## Update

I am now running the scale up for 50 m5.large nodes

P.S.

@yuvipanda, I know you are the one assigned to  https://github.com/2i2c-org/infrastructure/issues/1832, but I wanted to experiment with scaling up an aws cluster and see how it goes, because I never did that. Hope that's ok! 
The event is outside of my timezone however, so you'll probably still need to put off any fires that will come up, sorry about that :/ 