### PR TITLE
Enable continuous pre-puller for gridsst

### DIFF
--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -12,6 +12,9 @@ basehub:
       serverIP: fs-05f68d7e096d7cf16.efs.us-west-2.amazonaws.com
       baseShareName: /
   jupyterhub:
+    prePuller:
+      continuous:
+        enabled: true
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/1836

If we scale up nodes, we want to pre-pull images too so node startup is faster.

Ref https://github.com/2i2c-org/infrastructure/issues/1832