### PR TITLE
Sett grafana root URL for all our grafanas

### DIFF
--- a/config/clusters/2i2c-uk/support.values.yaml
+++ b/config/clusters/2i2c-uk/support.values.yaml
@@ -12,6 +12,9 @@ prometheus:
           hosts:
             - prometheus.uk.2i2c.cloud
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.uk.2i2c.cloud/
   ingress:
     hosts:
       - grafana.uk.2i2c.cloud

--- a/config/clusters/awi-ciroh/support.values.yaml
+++ b/config/clusters/awi-ciroh/support.values.yaml
@@ -2,6 +2,9 @@ prometheusIngressAuthSecret:
   enabled: true
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.ciroh.awi.2i2c.cloud/
   ingress:
     hosts:
       - grafana.ciroh.awi.2i2c.cloud

--- a/config/clusters/callysto/support.values.yaml
+++ b/config/clusters/callysto/support.values.yaml
@@ -12,6 +12,9 @@ prometheus:
           hosts:
             - prometheus.callysto.2i2c.cloud
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.callysto.2i2c.cloud/
   ingress:
     hosts:
       - grafana.callysto.2i2c.cloud

--- a/config/clusters/carbonplan/support.values.yaml
+++ b/config/clusters/carbonplan/support.values.yaml
@@ -24,6 +24,9 @@ cluster-autoscaler:
     clusterName: carbonplanhub
   awsRegion: us-west-2
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.carbonplan.2i2c.cloud/
   ingress:
     hosts:
       - grafana.carbonplan.2i2c.cloud

--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -12,6 +12,9 @@ prometheus:
           hosts:
             - prometheus.cloudbank.2i2c.cloud
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.cloudbank.2i2c.cloud/
   ingress:
     hosts:
       - grafana.cloudbank.2i2c.cloud

--- a/config/clusters/gridsst/support.values.yaml
+++ b/config/clusters/gridsst/support.values.yaml
@@ -8,6 +8,9 @@ cluster-autoscaler:
   awsRegion: us-west-2
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.gridsst.2i2c.cloud/
   ingress:
     hosts:
       - grafana.gridsst.2i2c.cloud

--- a/config/clusters/linked-earth/support.values.yaml
+++ b/config/clusters/linked-earth/support.values.yaml
@@ -13,6 +13,9 @@ prometheus:
             - prometheus.linkedearth.2i2c.cloud
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.linkedearth.2i2c.cloud/
   ingress:
     hosts:
       - grafana.linkedearth.2i2c.cloud

--- a/config/clusters/m2lines/support.values.yaml
+++ b/config/clusters/m2lines/support.values.yaml
@@ -4,6 +4,9 @@ nvidiaDevicePlugin:
     version: "latest"
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.m2lines.2i2c.cloud/
   ingress:
     hosts:
       - grafana.m2lines.2i2c.cloud

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -19,6 +19,9 @@ prometheus:
         cpu: 2
         memory: 16Gi
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.utoronto.2i2c.cloud/
   ingress:
     hosts:
       - grafana.utoronto.2i2c.cloud

--- a/config/clusters/uwhackweeks/support.values.yaml
+++ b/config/clusters/uwhackweeks/support.values.yaml
@@ -24,6 +24,9 @@ cluster-autoscaler:
     clusterName: uwhackweeks
   awsRegion: us-west-2
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.uwhackweeks.2i2c.cloud/
   ingress:
     hosts:
       - grafana.uwhackweeks.2i2c.cloud


### PR DESCRIPTION
This allows us to make 'invite links' to give access to grafana (https://grafana.com/docs/grafana/latest/administration/user-management/manage-org-users/#invite-a-user-to-join-an-organization).

https://github.com/2i2c-org/infrastructure/issues/1827 is the long-term fix.

Ref https://2i2c.freshdesk.com/a/tickets/248