### PR TITLE
Increase resources available for gridsst

### DIFF
--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -39,11 +39,20 @@ basehub:
         Authenticator:
           allowed_users: &gridsst_users
             - alisonrgray
+            - nikki-t
             - dgumustel
           admin_users: *gridsst_users
         JupyterHub:
           authenticator_class: github
     singleuser:
+      memory:
+        guarantee: 15G
+        limit: 16G
+      cpu:
+        guarantee: 4
+        limit: 8
+      nodeSelector:
+        node.kubernetes.io/instance-type: m5.8xlarge
       defaultUrl: /lab
       # User image: https://quay.io/repository/uwhackweek/snowex?tab=tags
       image:


### PR DESCRIPTION
- Earlier, it was inheriting the default 1G memory values. Increase it per https://github.com/2i2c-org/infrastructure/issues/1832#issuecomment-1299083691
- Put all users on bigger nodes, as this leads to faster autoscaling.
- Add another admin

Ref https://github.com/2i2c-org/infrastructure/issues/1832