### PR TITLE
Stop storing hub logs in the db disk dir for UToronto

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -85,8 +85,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: azuread
         concurrent_spawn_limit: 100
-        # We wanna keep logs long term, primarily for analytics
-        extra_log_file: /srv/jupyterhub/jupyterhub.log
       AzureAdOAuthenticator:
         username_claim: oid
         login_service: "University of Toronto ID"


### PR DESCRIPTION
Per https://github.com/2i2c-org/infrastructure/pull/886/commits/9c30396a46202de639f12f5b924cd9fe03a8f086, this matched prior config. This usually is used for analytics purposes, particularly to figure out nbigpuller usage. However, by putting it in the same disk as the hub database, we can accidentally cause outages when the log file fills up the disk.

This PR completely removes this logging, although we could perhaps figure out a way to keep logs on a more specific basis.