### PR TITLE
Increase UToronto Prod DB Disk to 60G

### DIFF
--- a/config/clusters/utoronto/prod.values.yaml
+++ b/config/clusters/utoronto/prod.values.yaml
@@ -16,7 +16,7 @@ jupyterhub:
     db:
       pvc:
         # prod stores logs, so let's make it big
-        storage: 10Gi
+        storage: 60Gi
     config:
       AzureAdOAuthenticator:
         oauth_callback_url: https://jupyter.utoronto.ca/hub/oauth_callback


### PR DESCRIPTION
This was increased manually during the incident referenced in https://github.com/2i2c-org/infrastructure/issues/1845. This PR makes sure the config matches, otherwise during next deploy we will try to reduce the size of the disk, which will fail.