### PR TITLE
Remove CPU guarantee from gridsst

### DIFF
--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -82,9 +82,6 @@ basehub:
       memory:
         guarantee: 15G
         limit: 16G
-      cpu:
-        guarantee: 4
-        limit: 8
       nodeSelector:
         node.kubernetes.io/instance-type: m5.8xlarge
       defaultUrl: /lab


### PR DESCRIPTION
This was making the smaller instances be unable to start.

Reported in https://github.com/2i2c-org/infrastructure/issues/1832#issuecomment-1301489142