### PR TITLE
[CI/CD] Refactor cluster validation workflow file

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -1,7 +1,7 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps. ref:
 # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
-# Runs the deployer script to validate clusters. This will both validate
+# Runs the deployer module to validate clusters. This will both validate
 # cluster.yaml files, any non-encrypted values files for the support chart (if they
 # exist), as well as each hubs passed non-encrypted values files against the Helm
 # charts' values schema.
@@ -99,7 +99,7 @@ jobs:
           with open(env_file, "a") as f:
               f.write(f"MATRIX={matrix}")
 
-      # Only run this step if there are *NO* changes under the common filepaths,
+      # Only run this step if there are *NO* changes under the common filter,
       # but *ARE* changes under the cluster_specific filter
       - name: Generate a matrix containing only clusters that have changes
         if: |
@@ -135,70 +135,40 @@ jobs:
           with open(env_file, "a") as f:
               f.write(f"matrix={matrix}")
 
+  # This job runs the 'deployer validate' subcommand across a matrix of
+  # cluster names.
+  #
+  # It relies on the generate-clusters-to-validate job to have completed and
+  # set the following outputs:
+  # - continue_workflow (bool): This job will only run if this output is set to
+  #     'true'. The value of this output is calculated based on detected file
+  #     changes.
+  # - cluster_matrix (json obj): A matrix of cluster names that require validation
+  #     due to detected changes. This job will not run if this output is empty,
+  #     i.e., '[]'.
+  #
   validate-helm-charts-values-files:
     runs-on: ubuntu-latest
+    needs: [generate-clusters-to-validate]
+    if: |
+      needs.generate-clusters-to-validate.outputs.continue_workflow == 'true' &&
+      needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - cluster_name: 2i2c
-          - cluster_name: 2i2c-uk
-          - cluster_name: carbonplan
-          - cluster_name: cloudbank
-          - cluster_name: meom-ige
-          - cluster_name: openscapes
-          - cluster_name: pangeo-hubs
-          - cluster_name: m2lines
-          - cluster_name: utoronto
-          - cluster_name: uwhackweeks
-          - cluster_name: linked-earth
-          - cluster_name: awi-ciroh
-          - cluster_name: callysto
-          - cluster_name: nasa-cryo
-          - cluster_name: gridsst
+        jobs: ${{ fromJson(needs.generate-clusters-to-validate.outputs.cluster_matrix) }}
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Check if any cluster common files has changed
-        uses: dorny/paths-filter@v2
-        id: cluster_common_files
-        with:
-          filters: |
-            files:
-              - deployer/**
-              - helm-charts/basehub/**
-              - helm-charts/daskhub/**
-              - helm-charts/support/**
-              - requirements.txt
-              - .github/workflows/validate-hubs.yaml
-
-      - name: Check if cluster specific files has changes
-        uses: dorny/paths-filter@v2
-        id: cluster_specific_files
-        with:
-          filters: |
-            changes:
-              - config/clusters/${{ matrix.cluster_name }}/**
-
-      # To continue this cluster specific job we must either have manually
-      # invoked this workflow to run for all clusters, or there should have been
-      # changes to the cluster common files or cluster specific files.
-      - name: Decide if the job should continue
-        id: decision
-        run: |
-          echo ::set-output name=continue-job::${{ github.event_name == 'workflow_dispatch' || (steps.cluster_common_files.outputs.files == 'true' || steps.cluster_specific_files.outputs.changes == 'true') }}
-
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
-      - name: Install deployer script dependencies
+      - name: Install deployer module dependencies
         run: |
           pip install -r requirements.txt
 
       - name: "Validate cluster: ${{ matrix.cluster_name }}"
-        if: steps.decision.outputs.continue-job == 'true'
         env:
           TERM: xterm
         run: |

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -10,6 +10,8 @@ name: Validate clusters
 
 on:
   pull_request:
+    branches:
+      - master
     paths:
       - config/clusters/**
       - helm-charts/**
@@ -17,15 +19,14 @@ on:
       - requirements.txt
       - .github/workflows/validate-hubs.yaml
   push:
+    branches:
+      - master
     paths:
       - config/clusters/**
       - helm-charts/**
       - deployer/**
       - requirements.txt
       - .github/workflows/validate-hubs.yaml
-    branches-ignore:
-      - "dependabot/**"
-      - "pre-commit-ci-update-config"
     tags:
       - "**"
   workflow_dispatch:

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -38,7 +38,8 @@ jobs:
   # validate-helm-charts-values-files job to define a matrix strategy.
   # We also set a continue_workflow job output that determines if either the
   # common or cluster_specific files have changed and whether the next job
-  # should be run.
+  # should be run. We always run the next job if the workflow was manually
+  # triggered.
   #
   # === Notes on dorny/paths-filter syntax ===
   # 1. Setting 'list-files: csv' sets an output called '${FILTER_NAME}_files'
@@ -53,8 +54,9 @@ jobs:
       pull-requests: read
     outputs:
       continue_workflow: |
-        ${{ steps.file_changes.outputs.common == 'true' }} ||
-        ${{ steps.file_changes.outputs.cluster_specific == 'true' }}
+        ${{ github.event_name == 'workflow_dispatch' }} ||  # Continue the workflow if it was manually triggered
+        (${{ steps.file_changes.outputs.common == 'true' }} ||
+        ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
       cluster_matrix: ${{ env.MATRIX }}
     steps:
       - uses: actions/checkout@v3
@@ -63,6 +65,8 @@ jobs:
           python-version: "3.10"
 
       - name: Check for file changes
+        # Don't run this step when we manually trigger the workflow
+        if: github.event_name != 'workflow_dispatch'
         # Action repo: https://github.com/dorny/paths-filter
         uses: dorny/paths-filter@v2
         id: file_changes
@@ -79,9 +83,12 @@ jobs:
             cluster_specific:
               - added|modified: config/clusters/**
 
-      # Only run this step if there *ARE* changes under the common filter
+      # Only run this step if there *ARE* changes under the common filter, *OR*
+      # we have manually triggered the workflow
       - name: Generate a matrix containing all clusters
-        if: steps.file_changes.outputs.common == 'true'
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          steps.file_changes.outputs.common == 'true'
         shell: python
         run: |
           import os
@@ -100,9 +107,11 @@ jobs:
               f.write(f"MATRIX={matrix}")
 
       # Only run this step if there are *NO* changes under the common filter,
-      # but *ARE* changes under the cluster_specific filter
+      # but *ARE* changes under the cluster_specific filter, *AND* we have not
+      # manually triggered the workflow
       - name: Generate a matrix containing only clusters that have changes
         if: |
+          github.event_name != 'workflow_dispatch' &&
           steps.file_changes.outputs.common != 'true' &&
           steps.file_changes.outputs.cluster_specific == 'true'
         shell: python

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -31,6 +31,110 @@ on:
   workflow_dispatch:
 
 jobs:
+  # This job inspects changed files in order to determine which cluster files
+  # should be validated. If helm-chart files change, then all clusters will be
+  # validated. The output of this job is a json-encoded dictionary of the
+  # cluster names to be validated. This is passed to the
+  # validate-helm-charts-values-files job to define a matrix strategy.
+  # We also set a continue_workflow job output that determines if either the
+  # common or cluster_specific files have changed and whether the next job
+  # should be run.
+  #
+  # === Notes on dorny/paths-filter syntax ===
+  # 1. Setting 'list-files: csv' sets an output called '${FILTER_NAME}_files'
+  #    that we use to determine which specific clusters have file changes
+  # 2. The 'added|modified:' syntax before a path glob pattern means that we
+  #    only care about files that have been added or modified, not deleted
+  # 3. We can also group filters together and hence only need to run the action
+  #    step *once* with the 'common' and 'cluster-specific' filters together
+  generate-clusters-to-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      continue_workflow: |
+        ${{ steps.file_changes.outputs.common == 'true' }} ||
+        ${{ steps.file_changes.outputs.cluster_specific == 'true' }}
+      cluster_matrix: ${{ env.MATRIX }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Check for file changes
+        # Action repo: https://github.com/dorny/paths-filter
+        uses: dorny/paths-filter@v2
+        id: file_changes
+        with:
+          list-files: csv
+          filters: |
+            common:
+              - added|modified: deployer/**
+              - added|modified: helm-charts/basehub/**
+              - added|modified: helm-charts/daskhub/**
+              - added|modified: helm-charts/support/**
+              - added|modified: requirements.txt
+              - added|modified: .github/workflows/validate-hubs.yaml
+            cluster_specific:
+              - added|modified: config/clusters/**
+
+      # Only run this step if there *ARE* changes under the common filter
+      - name: Generate a matrix containing all clusters
+        if: steps.file_changes.outputs.common == 'true'
+        shell: python
+        run: |
+          import os
+
+          # List all cluster folders
+          cluster_folders = os.listdir("config/clusters")
+
+          # Construct a matrix of all clusters
+          matrix = []
+          for cluster in cluster_folders:
+              matrix.append({"cluster_name": cluster})
+
+          # Write matrix to the GITHUB_ENV file in GitHub Actions
+          env_file = os.getenv("GITHUB_ENV")
+          with open(env_file, "a") as f:
+              f.write(f"MATRIX={matrix}")
+
+      # Only run this step if there are *NO* changes under the common filepaths,
+      # but *ARE* changes under the cluster_specific filter
+      - name: Generate a matrix containing only clusters that have changes
+        if: |
+          steps.file_changes.outputs.common != 'true' &&
+          steps.file_changes.outputs.cluster_specific == 'true'
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+
+          # Consume list of changed cluster files and convert to list by splitting
+          # on the comma character
+          cluster_files = r"""${{ steps.cluster_specific_files.outputs.cluster_specific_files }}"""
+          cluster_files = cluster_files.split(",")
+          assert isinstance(cluster_files, list)
+
+          # Extract the cluster names from the paths of the changed files
+          clusters = []
+          for cluster_file in cluster_files:
+              clusters.append(Path(cluster_file).parent.stem)
+
+          # Ensure each cluster name only appears once by transforming the list
+          # into a set
+          clusters = set(clusters)
+
+          # Construct a matrix of clusters that have changes
+          matrix = []
+          for cluster in clusters:
+              matrix.append({"cluster_name": cluster})
+
+          # Write the matrix to the GITHUB_ENV file in GitHub Actions
+          env_file = os.getenv("GITHUB_ENV")
+          with open(env_file, "a") as f:
+              f.write(f"matrix={matrix}")
+
   validate-helm-charts-values-files:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -59,6 +59,16 @@ jobs:
         (${{ steps.file_changes.outputs.common == 'true' }} ||
         ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
       cluster_matrix: ${{ env.MATRIX }}
+    # Only run this job if one of the following conditions is true:
+    # - The workflow was manually triggered
+    # - The event is a push to the master branch
+    # - The event is a pull request where the head branch is *NOT* a dependabot
+    #   or pre-commit generated branch
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.ref, 'master')) ||
+      (github.event_name == 'pull_request' && contains(github.head_ref, fromJson('["dependabot", "pre-commit"]')) == 'false')
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -329,4 +329,3 @@ Commit this file to the repo.
 To ensure the new cluster is appropriately handled by our CI/CD system, please add it as an entry in the following places:
 
 - The [`deploy-hubs.yaml`](https://github.com/2i2c-org/infrastructure/blob/008ae2c1deb3f5b97d0c334ed124fa090df1f0c6/.github/workflows/deploy-hubs.yaml#L121) workflow file
-- The [`validate-clusters.yaml`](https://github.com/2i2c-org/infrastructure/blob/008ae2c1deb3f5b97d0c334ed124fa090df1f0c6/.github/workflows/validate-clusters.yaml#L43) workflow file


### PR DESCRIPTION
fixes #1862 

## Motivation

Over in #1686, it is reported that we are running into rate-limits on the use of `GITHUB_TOKEN` on a semi-regular basis and so the restructuring of this workflow is motivated by the desire to reduce the number of times we use `GITHUB_TOKEN` both in terms of times per workflow and workflow triggers.

## Changes

### Structure

The big change here is that the original job in the workflow has been split into two jobs. The first job now inspects file changes caused by a Pull Request and dynamically generates a matrix strategy of which clusters to validate based on those changed files (similar to our deploy-hubs workflow). This is the part that uses `GITHUB_TOKEN` in order to inspect the changed files as part of the `dorny/paths-filter` action and **crucially this job is now only executed once per workflow run**. The second job runs cluster validation over the matrix generated by the first job and does not require use of the `GITHUB_TOKEN`.

The original workflow singular job had a matrix strategy that ran the `dorny/paths-filter` step in each matrix job which was very wasteful in terms of `GITHUB_TOKEN` since this would have generated the same results in each matrix job.

### The `dorny/paths-filter` action

This action uses `GITHUB_TOKEN` to inspect what files have changed, either in a Pull Request or from the `HEAD~1` commit in the case of push events.

Originally, we called this action twice: once to establish which 'common' files had changed (which would trigger all clusters to be validated), and again to establish which 'cluster-specific' files had changed (to decide whether or not the validate the cluster at all, providing common files hadn't changed).

Actually, we could combine these two filters into a single call, again saving the number of times `GITHUB_TOKEN` is used - so we do that now. Each filter is given its own output so we can still reference each filter individually despite the combination of the execution.

I also added some improvements to the invocation of this action:

1. **Set `list-files: csv` so we can access a csv formatted string of changed files for each defined filter.** We specifically use `outputs.cluster_specific_files` to dynamically generate the matrix of clusters to validate when validating _all_ clusters is not required.
2. **Use `added|modified` syntax to restrict what kind of changes we care about.** We generally only care about validating files when they are added or changed, not when they are deleted.

### Branch triggers

**Note:** If this section doesn't resonate, we can drop the following commits on this PR to revert: [`c8614ce` (#1864)](https://github.com/2i2c-org/infrastructure/pull/1864/commits/c8614ce27a53aa2d84646dadfe631a4fb3112e6d) and [`8d9e7a3` (#1864)](https://github.com/2i2c-org/infrastructure/pull/1864/commits/8d9e7a343aba02ccd6f35e9945dc425d6e089bbd)

<img width="339" alt="Screenshot 2022-11-03 at 14 37 08" src="https://user-images.githubusercontent.com/44771837/199750537-fa65c808-2f7b-4366-a081-2ac7d6b4f938.png">

Above is a screenshot of the original trigger settings. The problems with these settings are:

1. We were running this workflow on every pull request opened, not only the ones that will be merged in to `master` so that is more unnecessary invocations of `GITHUB_TOKEN` (at least for PRs within this repo, forks will use their own token).
2. We were running this workflow on every push to any branch and only excluding branches that were created by dependabot or pre-commit. So the workflow would be triggered twice in a pull request: once from the PR trigger, once from the push trigger. Again, wasteful for `GITHUB_TOKEN` use within the main repo.

To address these issues I set the following so the workflow only runs in relation to the master branch:

```yaml
push:
  branches:
    - master
pull_request:
  branches:
    - master
```

Unfortunately when using the `pull_request` trigger, the branches listed refer to the **target** branch of the merge, and not the head branch of the merge. Therefore, it is not trivial to restrict workflows running on PRs _from_ certain branches (unless you use the `pull_request_target` trigger, which comes with its own difficulties). And so I wrote a condition for the first job such that it runs when:

- the workflow was manually triggered
- the event is a push to master
- the event is a PR to master that is **not** dependabot or pre-commit generated