### PR TITLE
[CI/CD] Bugfix the refactored cluster validation workflow

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -157,9 +157,10 @@ jobs:
 
       - name: Test outputs
         run: |
-          echo ${{ steps.file_changes.outputs.common }}
-          echo ${{ steps.file_changes.outputs.cluster_specific }}
-          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
+          echo "common file changes?: ${{ steps.file_changes.outputs.common }}""
+          echo "cluster specific file changes?: ${{ steps.file_changes.outputs.cluster_specific }}""
+          echo "combined conditional: ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}"
+          echo "check matrix is not empty: ${{ env.MATRIX != '[]' }}"
 
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -17,7 +17,7 @@ on:
       - helm-charts/**
       - deployer/**
       - requirements.txt
-      - .github/workflows/validate-hubs.yaml
+      - .github/workflows/validate-clusters.yaml
   push:
     branches:
       - master
@@ -26,7 +26,7 @@ on:
       - helm-charts/**
       - deployer/**
       - requirements.txt
-      - .github/workflows/validate-hubs.yaml
+      - .github/workflows/validate-clusters.yaml
     tags:
       - "**"
   workflow_dispatch:
@@ -90,7 +90,7 @@ jobs:
               - added|modified: helm-charts/daskhub/**
               - added|modified: helm-charts/support/**
               - added|modified: requirements.txt
-              - added|modified: .github/workflows/validate-hubs.yaml
+              - added|modified: .github/workflows/validate-clusters.yaml
             cluster_specific:
               - added|modified: config/clusters/**
 

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
     if: |
-      needs.generate-clusters-to-validate.outputs.continue_workflow == true &&
+      needs.generate-clusters-to-validate.outputs.continue_workflow &&
       needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -157,8 +157,8 @@ jobs:
 
       - name: Test outputs
         run: |
-          echo "common file changes?: ${{ steps.file_changes.outputs.common }}""
-          echo "cluster specific file changes?: ${{ steps.file_changes.outputs.cluster_specific }}""
+          echo "common file changes?: ${{ steps.file_changes.outputs.common }}"
+          echo "cluster specific file changes?: ${{ steps.file_changes.outputs.cluster_specific }}"
           echo "combined conditional: ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}"
           echo "check matrix is not empty: ${{ env.MATRIX != '[]' }}"
 
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
     if: |
-      needs.generate-clusters-to-validate.outputs.continue_workflow == 'true' &&
+      needs.generate-clusters-to-validate.outputs.continue_workflow == true &&
       needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -67,7 +67,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && contains(github.ref, 'master')) ||
-      (github.event_name == 'pull_request' && contains(github.head_ref, fromJson('["dependabot", "pre-commit"]')) == 'false')
+      (github.event_name == 'pull_request' && contains(github.head_ref, fromJson('["dependabot", "pre-commit"]')) == false)
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -55,9 +55,9 @@ jobs:
       pull-requests: read
     outputs:
       continue_workflow: |
-        ${{ github.event_name == 'workflow_dispatch' }} ||
-        (${{ steps.file_changes.outputs.common == 'true' }} ||
-        ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
+        ${{ github.event_name == 'workflow_dispatch' ||
+        (steps.file_changes.outputs.common == 'true' ||
+        steps.file_changes.outputs.cluster_specific == 'true') }}
       cluster_matrix: ${{ env.MATRIX }}
     # Only run this job if one of the following conditions is true:
     # - The workflow was manually triggered

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -195,8 +195,8 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: "Validate cluster: ${{ matrix.cluster_name }}"
+      - name: "Validate cluster: ${{ matrix.jobs.cluster_name }}"
         env:
           TERM: xterm
         run: |
-          python deployer validate ${{ matrix.cluster_name }}
+          python deployer validate ${{ matrix.jobs.cluster_name }}

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -55,7 +55,7 @@ jobs:
       pull-requests: read
     outputs:
       continue_workflow: |
-        ${{ github.event_name == 'workflow_dispatch' }} ||  # Continue the workflow if it was manually triggered
+        ${{ github.event_name == 'workflow_dispatch' }} ||
         (${{ steps.file_changes.outputs.common == 'true' }} ||
         ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
       cluster_matrix: ${{ env.MATRIX }}
@@ -154,6 +154,12 @@ jobs:
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as f:
               f.write(f"matrix={matrix}")
+
+      - name: Test outputs
+        run: |
+          echo ${{ steps.file_changes.outputs.common }}
+          echo ${{ steps.file_changes.outputs.cluster_specific }}
+          echo ${{ github.event_name == 'workflow_dispatch' }} || (${{ steps.file_changes.outputs.common == 'true' }} || ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
 
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -159,7 +159,7 @@ jobs:
         run: |
           echo ${{ steps.file_changes.outputs.common }}
           echo ${{ steps.file_changes.outputs.cluster_specific }}
-          echo ${{ github.event_name == 'workflow_dispatch' }} || (${{ steps.file_changes.outputs.common == 'true' }} || ${{ steps.file_changes.outputs.cluster_specific == 'true' }})
+          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
 
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -155,13 +155,6 @@ jobs:
           with open(env_file, "a") as f:
               f.write(f"matrix={matrix}")
 
-      - name: Test outputs
-        run: |
-          echo "common file changes?: ${{ steps.file_changes.outputs.common }}"
-          echo "cluster specific file changes?: ${{ steps.file_changes.outputs.cluster_specific }}"
-          echo "combined conditional: ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}"
-          echo "check matrix is not empty: ${{ env.MATRIX != '[]' }}"
-
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.
   #


### PR DESCRIPTION
follow-up to #1864 

Catching a few bugs and tweaked a few things so this runs as expected

- Fix reference to filename: The file is now called 'validate-clusters' but we were still referencing 'validate-hubs'
- Fix `if` statements to ensure the logic is correct
- Fix matrix reference so the cluster name gets parsed to the deployer correctly