### PR TITLE
[CI/CD] Swap jitterbit/get-changed-files action for dorny/paths-filter in deploy-hubs workflow

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -57,10 +57,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          # Fetch-depth is required for the jitterbit/get-changed-files action
-          # https://github.com/jitterbit/get-changed-files/issues/24#issuecomment-1047442168
-          fetch-depth: 0
 
       - name: Install Python 3.9
         uses: actions/setup-python@v4
@@ -86,11 +82,20 @@ jobs:
           pip list
 
       - name: Identify files that have been added or modified
-        uses: jitterbit/get-changed-files@v1
+        # Action repo: https://github.com/dorny/paths-filter
+        uses: dorny/paths-filter@v2
         id: changed-files
         with:
-          format: space-delimited
-          token: ${{ secrets.GITHUB_TOKEN }}
+          list-files: csv
+          filters: |
+            changed:
+              - added|modified: deployer/**
+              - added|modified: requirements.txt
+              - added|modified: .github/actions/setup-deploy/**
+              - added|modified: helm-charts/basehub/**
+              - added|modified: helm-charts/daskhub/**
+              - added|modified: helm-charts/support/**
+              - added|modified: config/clusters/**
 
       # This step will create a comment-body.txt file containing the jobs to be run in a
       # Markdown table format to be posted on a Pull Request, if this job is triggered
@@ -98,7 +103,7 @@ jobs:
       - name: Generate matrix jobs
         id: generate-jobs
         run: |
-          python deployer generate-helm-upgrade-jobs "${{ steps.changed-files.outputs.added_modified }}"
+          python deployer generate-helm-upgrade-jobs "${{ steps.changed-files.outputs.changed_files }}"
 
       # The comment-deployment-plan-pr.yaml workflow won't have the correct context to
       # know the PR number, so we save it to a file to pass to that workflow

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -10,10 +10,6 @@ on:
       - .github/actions/setup-deploy/**
       - helm-charts/**
       - config/clusters/**
-      # We no longer trigger on this file since it does not contain any logic
-      # concerning setting up the clusters for deploy. This now all lives in the
-      # setup-deploy local action
-      # - .github/workflows/deploy-hubs.yaml
   pull_request:
     branches:
       - master
@@ -23,10 +19,6 @@ on:
       - .github/actions/setup-deploy/**
       - helm-charts/**
       - config/clusters/**
-      # We no longer trigger on this file since it does not contain any logic
-      # concerning setting up the clusters for deploy. This now all lives in the
-      # setup-deploy local action
-      # - .github/workflows/deploy-hubs.yaml
 
 # When multiple PRs triggering this workflow are merged, queue them instead
 # of running them in parallel

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -23,13 +23,13 @@ from generate_cluster import generate_cluster
 
 def _converted_string_to_list(full_str: str) -> list:
     """
-    Take a SPACE-DELIMITED string and split it into a list.
+    Take a COMMA-DELIMITED string and split it into a list.
 
     This function is used by the generate-helm-upgrade-jobs subcommand to ensure that
     the list os added or modified files parsed from the command line is transformed
-    into a list of strings instead of one long string with spaces between the elements
+    into a list of strings instead of one long string with commas between the elements
     """
-    return full_str.split(" ")
+    return full_str.split(",")
 
 
 def main():

--- a/docs/reference/ci-cd/hub-deploy.md
+++ b/docs/reference/ci-cd/hub-deploy.md
@@ -62,16 +62,6 @@ This job reads in the production hub job definitions generated in job 1 and the 
 
 This last job deploys all production hubs that require it in parallel to the clusters that successfully completed job 2.
 
-## Known issues with this workflow
-
-Sometimes the [`generate-jobs` job](cicd/hub/generate-jobs) fails with the following message:
-
-```
-The head commit for this pull_request event is not ahead of the base commit. Please submit an issue on this action's GitHub repo.
-```
-
-This issue is [tracked upstream](https://github.com/jitterbit/get-changed-files/issues/11) and can be resolved by rebasing your branch against `master`.
-
 ## Posting the deployment plan as a comment on a Pull Request
 
 The [`generate-jobs`](cicd/hub/generate-jobs) job outputs tables of all the hubs across all the clusters that will be upgraded as a result of changes in the repository.

--- a/docs/reference/ci-cd/hub-deploy.md
+++ b/docs/reference/ci-cd/hub-deploy.md
@@ -9,8 +9,10 @@ The best place to learn about the latest state of our *automatic* hub deployment
 is to look at [the `deploy-hubs.yaml` GitHub Actions workflow file](https://github.com/2i2c-org/infrastructure/tree/HEAD/.github/workflows/deploy-hubs.yaml).
 This workflow file depends on a locally defined action that [sets up access to a given cluster](https://github.com/2i2c-org/infrastructure/blob/master/.github/actions/setup-deploy/action.yaml) and itself contains four main jobs, detailed below.
 
+## Main hub deployment workflow
+
 (cicd/hub/generate-jobs)=
-## 1. `generate-jobs`: Generate Helm upgrade jobs
+### 1. `generate-jobs`: Generate Helm upgrade jobs
 
 The first job takes a list of files that have been added/modified as part of a Pull Request and pipes them into the [`generate-helm-upgrade-jobs` sub-command](https://github.com/2i2c-org/infrastructure/blob/master/deployer/helm_upgrade_decision.py) of the [deployer module](https://github.com/2i2c-org/infrastructure/tree/master/deployer).
 This sub-command uses a set of functions to calculate which hubs on which clusters require a helm upgrade, alongside whether the support chart and staging hub on that cluster should also be upgraded.
@@ -22,8 +24,7 @@ This job provides the following outputs:
   These JSON objects detail: which clusters require their support chart and/or staging hub to be upgraded, and which production hubs require an upgrade.
 - The above JSON objects are also rendered as human-readable tables using [`rich`](https://github.com/Textualize/rich).
 
-### Some special cased filepaths
-
+````{admonition} Some special cased filepaths
 While the aim of this workflow is to only upgrade the pieces of the infrastructure that require it with every change, some changes do require us to redeploy everything.
 
 - If a cluster's `cluster.yaml` file has been modified, we upgrade the support chart and **all** hubs on **that** cluster. This is because we cannot tell what has been changed without inspecting the diff of the file.
@@ -31,12 +32,13 @@ While the aim of this workflow is to only upgrade the pieces of the infrastructu
 - If the support Helm chart has additions/modifications in its path, we redeploy the support chart on **all** clusters.
 - If the deployer module has additions/modifications in its path, then we redeploy **all** hubs on **all** clusters.
 
-```{note}
+```{attention}
 Right now, we redeploy everything when the deployer changes since the deployer undertakes some tasks that generates config related to authentication.
 This may change in the future as we move towards the deployer becoming a separable, stand-alone package.
 ```
+````
 
-## 2. `upgrade-support-and-staging`: Upgrade support and staging hub Helm charts on clusters that require it
+### 2. `upgrade-support-and-staging`: Upgrade support and staging hub Helm charts on clusters that require it
 
 The next job reads in one of the JSON objects detailed above that defines which clusters need their support chart and/or staging hub upgrading.
 *Note that it is not a requirement for both the support chart and staging hub to be upgraded during this job.*
@@ -51,14 +53,14 @@ We therefore run extra steps for the 2i2c cluster to upgrade these hubs (if requ
 We use staging hubs as [canary deployments](https://sre.google/workbook/canarying-releases/) and prevent deploying production hubs if a staging deployment fails.
 Hence, the last step of this job is to set an output variable that stores if the job completed successfully or failed.
 
-## 3. `filter-generate-jobs`: Filter out jobs for clusters whose support/staging job failed
+### 3. `filter-generate-jobs`: Filter out jobs for clusters whose support/staging job failed
 
 This job is an optimisation job.
 While we do want to prevent all production hubs on Cluster X from being upgraded if its support/staging job fails, we **don't** want to prevent the production hubs on Cluster Y from being upgraded because the support/staging job for Cluster X failed.
 
 This job reads in the production hub job definitions generated in job 1 and the support/staging success/failure variables set in job 2, then proceeds to filter out the productions hub upgrade jobs that were due to be run on a cluster whose support/staging job failed.
 
-## 4. `upgrade-prod-hubs`: Upgrade Helm chart for production hubs in parallel
+### 4. `upgrade-prod-hubs`: Upgrade Helm chart for production hubs in parallel
 
 This last job deploys all production hubs that require it in parallel to the clusters that successfully completed job 2.
 


### PR DESCRIPTION
fixes #1807 

We swap out an action that was using an old version of node for a more actively maintained action. They both provide methods of determining what file changes occur in PRs.