### PR TITLE
fix: explicitly write a newline when adding multiple vars to GITHUB_ENV

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -52,8 +52,7 @@ jobs:
           # GITHUB_ENV file in GitHub Actions
           with open(env_file, "a") as f:
               f.write(f"continue-workflow={'Merge pull request' in commit_msg}")
-
-          with open(env_file, "a") as f:
+              f.write("\n")
               f.write(f"pr-number={pr_number}")
 
   # The other piece of information we require is the URL of the running workflow

--- a/deployer/deploy_actions.py
+++ b/deployer/deploy_actions.py
@@ -340,8 +340,7 @@ def generate_helm_upgrade_jobs(changed_filepaths):
         # Add these matrix jobs as environment variables for use in another job
         with open(env_file, "a") as f:
             f.write(f"prod-hub-matrix-jobs={json.dumps(prod_hub_matrix_jobs)}")
-
-        with open(env_file, "a") as f:
+            f.write("\n")
             f.write(
                 f"support-and-staging-matrix-jobs={json.dumps(support_and_staging_matrix_jobs)}"
             )


### PR DESCRIPTION
We want each env var of form NAME=VALUE on a new line within the GITHUB_ENV file. Python's f.write() method does not append a newline by default, even if you open in append mode