### PR TITLE
Fix a typo in comment test link workflow

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -125,7 +125,7 @@ jobs:
           # Write the workflow URL to the GITHUB_ENV file in GitHub Actions
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as f:
-              f.write(f"workflow-url={workflow_url")
+              f.write(f"workflow-url={workflow_url}")
         env:
           BRANCH: "master"
           EVENT: "push"


### PR DESCRIPTION
Another typo fix that will unbreak CI so I will self-merge