### PR TITLE
Enable dependabot version bumps for the setup-deploy action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,7 +23,7 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions in workflow files
-  # By default, the directory will check .github/workflows for the github-actions
+  # By default, the directory to be checked is .github/workflows for the github-actions
   # package ecosystem
   # ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,9 +22,24 @@
 
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions in workflow files
+  # By default, the directory will check .github/workflows for the github-actions
+  # package ecosystem
+  # ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      # Check for updates once a week. By default, this check happens on a Monday.
+      interval: "weekly"
+    ignore:
+      # Ignore patch upgrades to further reduce noise
+      - update-types: ["version-update:semver-patch"]
+        dependency-name: "*" # Match all packages
+    reviewers:
+      - "2i2c-org/tech-team"
+  # Maintain dependencies for GitHub Actions in our setup-deploy action
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-deploy/"
     schedule:
       # Check for updates once a week. By default, this check happens on a Monday.
       interval: "weekly"


### PR DESCRIPTION
In our original config, dependabot only checks actions to bump under the `.github/workflows` folder. This PR adds an extra rule to also check actions under the `.github/actions/setup-deploy` folder.

**Note:** We may have to rename `action.yaml` to `action.yml` for this to work, but let's try it first and see.
ref: https://github.com/dependabot/dependabot-core/issues/5970