### PR TITLE
Use correct version of dask-gateway

### DIFF
--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -199,7 +199,7 @@ def deploy(
         help="File to read secret deployment config from",
     ),
     dask_gateway_version: str = typer.Option(
-        "v2022.10.0", help="Version of dask-gateway to install CRDs for"
+        "2022.10.0", help="Version of dask-gateway to install CRDs for"
     ),
 ):
     """


### PR DESCRIPTION
Dask gateway versions don't have a `v` in front of them.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/1869