### PR TITLE
Use the latest kubespawner release in hub image

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -388,7 +388,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n4378.h27667b54"
+      tag: "0.0.1-n4497.haed80ebb"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -1,4 +1,3 @@
 oauthenticator==15.1.0
+jupyterhub-kubespawner==4.3.0
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
-# Reference https://github.com/2i2c-org/infrastructure/issues/1825
-git+https://github.com/jupyterhub/kubespawner@a666d22609f0acd2db4bd3dd62472f9fb82867a0


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/issues/1825

Also,  because this PR wasn't opened by dependabot on Monday, I believe it means dependabot doesn't work for git pip packages :/?

So maybe it's worth reopening https://github.com/2i2c-org/infrastructure/issues/1589?