### PR TITLE
Adding jbusecke as admin user

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -42,6 +42,7 @@ basehub:
           # the listed teams. These people should have admin access though.
           admin_users:
             - rabernat
+            - jbusecke
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:


### PR DESCRIPTION
Redirecting this to the 2i2c repo as mentioned in https://github.com/jbusecke/infrastructure/pull/1