### PR TITLE
[CI/CD] Fix reference to step

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -132,7 +132,7 @@ jobs:
 
           # Consume list of changed cluster files and convert to list by splitting
           # on the comma character
-          cluster_files = r"""${{ steps.cluster_specific_files.outputs.cluster_specific_files }}"""
+          cluster_files = r"""${{ steps.file_changes.outputs.cluster_specific_files }}"""
           cluster_files = cluster_files.split(",")
           assert isinstance(cluster_files, list)
 


### PR DESCRIPTION
This workflow was breaking when validating _specific_ clusters, e.g., https://github.com/2i2c-org/infrastructure/actions/runs/3430858556. This is because the ID of the step had been changed, but the reference to this step, that brought in the list of file changes into the Python code, had not also been updated. This resulted in an empty variable and a failure of the code.

This PR now updates the reference to match the ID of the step. ID in question is set on [L83](https://github.com/2i2c-org/infrastructure/blob/a82852142d4b9d613cc6ee02d9bde6705d99acfa/.github/workflows/validate-clusters.yaml#L83)