### PR TITLE
Add a --previous flag to user-logs

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -301,10 +301,11 @@ they are ignored and only the notebook logs are provided. You can pass
 │ *    username          TEXT  Name of the JupyterHub user to get logs for [default: None] [required]                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --follow    --no-follow      Live update new logs as they show up [default: follow]                                  │
-│ --help                       Show this message and exit.                                                             │
+│ --follow      --no-follow        Live update new logs as they show up [default: follow]                              │
+│ --previous    --no-previous      If user pod has restarted, show logs from just before the restart                   │
+│                                  [default: no-previous]                                                              │
+│ --help                           Show this message and exit.                                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-
 ```
 
 ### `exec-hub-shell`

--- a/deployer/debug.py
+++ b/deployer/debug.py
@@ -79,6 +79,10 @@ def user_logs(
         ..., help="Name of the JupyterHub user to get logs for"
     ),
     follow: bool = typer.Option(True, help="Live update new logs as they show up"),
+    previous: bool = typer.Option(
+        False,
+        help="If user pod has restarted, show logs from just before the restart",
+    ),
 ):
     """
     Display logs from the notebook pod of a given user
@@ -106,6 +110,8 @@ def user_logs(
 
     if follow:
         cmd += ["-f"]
+    if previous:
+        cmd += ["--previous"]
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
     with open(config_file_path) as f:
         cluster = Cluster(yaml.load(f), config_file_path.parent)


### PR DESCRIPTION
In case the user pod has restarted, this gives us the ability to look at the logs from the previous instance