### PR TITLE
Increase memory & disk size limit for pangeo prometheus

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -18,6 +18,8 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    persistentVolume:
+      size: 200Gi
     ingress:
       enabled: true
       hosts:
@@ -27,7 +29,16 @@ prometheus:
           hosts:
             - prometheus.gcp.pangeo.2i2c.cloud
     resources:
+      requests:
+        # Set requests here as well, to make sure we don't trample on the other pods (hub, proxy, etc)
+        # too much
+        cpu: 1
+        memory: 2Gi
       limits:
-        # Increase limits here as this isn't too small a cluster
         cpu: 2
-        memory: 4Gi
+        # Specifically set a really high memory limit,
+        # as prometheus memory can sometimes spike up to 2x regular use or more when replaying
+        # WAL after a restart (https://github.com/prometheus/prometheus/issues/6934). This was
+        # causing prometheus to crash forever, as the memory spike would get it killed. The
+        # higher limit helps with this
+        memory: 8Gi


### PR DESCRIPTION
While investigating why the pangeo hubs prometheus was dead, I discovered https://github.com/prometheus/prometheus/issues/6934 - where there can be a big temporary *spike* in memory usage when prometheus is recovering from a restart. It tries to read the WAL (the write-ahead log), to make sure it hasn't lost any data during the restart process itself. The details of the WAL are unimportant (in this specific case), but just the fact that prometheus spikes memory usage on restarts!

I manually hand edited the prometheus deployment with `k -n support edit deployment support-prometheus-server`, and gave it a higher limit (8G). Then I watched actual memory usage, with `watch kubectl -n support top pod`. I noticed that it momentarily spiked to almost 5G, before settling back to about 1.5G. The old memory limit was 4G, so during the spike the server gets killed! And then enters crashloopbackoff, as it can never survive.

This commit raises the memory limit, so it won't keep crashing :)

I also actually manually increased the size of the disk (with `kubectl -n support edit pvc`), but that wasn't the problem. However, we need to persist the change regardless, so here it is.

Hopefully this will fix https://github.com/2i2c-org/infrastructure/issues/1843