### PR TITLE
Allow self merges for increasing max nodes in a node-pool

### DIFF
--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -33,6 +33,7 @@ Here are some guidelines for merging and reviewing in this case:
   - Updating admin users for a hub
   - Changing basic hub configuration such as the URL of its landing page image
   - Updating the user image of a hub.
+  - Updating the max number of nodes for nodepools in a cluster
   :::
 - **Be careful when changing config of a hub *during* an event**
   Sometimes, a hub config change needs to happen *immediately*, to help debug something


### PR DESCRIPTION
This is a fairly safe operation, and reducing the amount of review load also helps our engineers!

Based on doing https://github.com/2i2c-org/infrastructure/pull/1907