### PR TITLE
Ensure actions consistency across workflows

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -31,24 +31,20 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup dependencies
+      - name: Install deployer
         run: |
           python3 -m pip install --editable .
           sudo apt install jsonnet
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
-          export_default_credentials: true
-
-      - name: Setup sops
+      - name: Install sops
         uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.1
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"
 
       - name: Deploy grafana dashboards for ${{ matrix.cluster_name }}
         run: |

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -41,14 +41,10 @@ jobs:
         uses: mdgreenwald/mozilla-sops-action@v1
 
       # Authenticate with the correct KMS key that sops will use.
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v1
         with:
-          version: "290.0.1"
-          # This is used for KMS only
-          project_id: two-eye-two-see
-          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
-          export_default_credentials: true
+          credentials_json: "${{ inputs.GCP_KMS_DECRYPTOR_KEY }}"
 
       - name: ensure uptime checks are set up
         run: |


### PR DESCRIPTION
- Swap google-github-actions/setup-gcloud for google-github-actions/auth. Consistent with what we use in the setup-deploy action
- The setup-gcloud action failed after being bumped, ref: https://github.com/2i2c-org/infrastructure/pull/1908