### PR TITLE
Remove proxy.https.hosts from generated config

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -82,7 +82,6 @@ class Hub:
         else:
             generated_config = {
                 "jupyterhub": {
-                    "proxy": {"https": {"hosts": [self.spec["domain"]]}},
                     "ingress": {
                         "hosts": [self.spec["domain"]],
                         "tls": [


### PR DESCRIPTION
We purely use ingress for HTTPS everywhere, so this is a noop.

Ref https://github.com/2i2c-org/infrastructure/issues/1925