### PR TITLE
Add a link to JHub's docs on interpreting common log messages to our SRE guide

### DIFF
--- a/docs/sre-guide/common-problems-solutions.md
+++ b/docs/sre-guide/common-problems-solutions.md
@@ -3,6 +3,12 @@
 
 These sections describe a few common problems we face on our infrastructure and tips on how to solve them.
 
+```{seealso}
+The JupyterHub project maintains documentation on
+[interpreting common log messages](https://jupyterhub.readthedocs.io/en/stable/admin/log-messages.html)
+it produces, which is an incredibly useful resource when debugging problems.
+```
+
 ```{contents}
 :local:
 ```


### PR DESCRIPTION
We should link these two sources of truth as it's incredibly useful info for engineers to have. And by linking, we aren't duplicating or explicitly committing to maintaining the docs (though I have no doubt we'll contribute upstream at some point 😉 )