### PR TITLE
[Merge on Dec 14, 2022] Give all students equal resources during exam

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -48,8 +48,12 @@ jupyterhub:
             </div>
   singleuser:
     memory:
+      # Ensure all students get equal resources during the exam
       limit: 2G
-      guarantee: 1G
+      guarantee: 2G
+    cpu:
+      limit: 1
+      guarantee: 1
     extraFiles:
       github-app-private-key.pem:
         mountPath: /etc/github/github-app-private-key.pem


### PR DESCRIPTION
During an exam, it is important that all students have access to the same computational resources. 2G should be enough, given it was the limit for everyone in general. We are *adding* a CPU limit here, where we did not have one before - so this must be validated beforehand to make sure it doesn't have adverse effects.

Ref https://github.com/2i2c-org/infrastructure/issues/1905