### PR TITLE
FIX TYPO: Correct variable name for AWS creds setup

### DIFF
--- a/docs/topic/access-creds/cloud-auth.md
+++ b/docs/topic/access-creds/cloud-auth.md
@@ -148,7 +148,7 @@ are used to provide access to the AWS account from your terminal.
    ```ini
    [your-cluster-name]
    aws_access_key_id = <key-id>
-   aws_access_secret_key = <access-key>
+   aws_secret_access_key = <access-key>
    ```
 
    When you want to use these credentials, you can simply run `export AWS_PROFILE=<your-cluster-name>`.


### PR DESCRIPTION
Having just gone through these docs, the `aws sts get-caller-identity` command returns

```bash
Partial credentials found in shared-credentials-file, missing: aws_secret_access_key
```

without this change