### PR TITLE
Move allowNamedServers under hub config

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -35,6 +35,7 @@ basehub:
             name: "NASA ICESat-2 Science Team"
             url: https://icesat-2.gsfc.nasa.gov/science_definition_team
     hub:
+      allowNamedServers: true
       config:
         Authenticator:
           # We are restricting profiles based on GitHub Team membership and
@@ -61,7 +62,6 @@ basehub:
           scope:
             - read:org
     singleuser:
-      allowNamedServers: true
       defaultUrl: /lab
       # Image repo: https://github.com/CryoInTheCloud/hub-image
       image:


### PR DESCRIPTION
Validation now fails https://github.com/2i2c-org/infrastructure/actions/runs/3582885457/jobs/6027642147

According to https://z2jh.jupyter.org/en/latest/resources/reference.html#hub-allownamedservers `allowNamedServers` is a hub config option.