### PR TITLE
Update new hub issue template to ask specifics when setting up GitHub auth

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -62,7 +62,7 @@ body:
       required: true
 
   - type: dropdown
-    attributes: 
+    attributes:
       label: "[GitHub Auth only] How would you like to manage your users?"
       description: |
         Please describe how you would prefer to manage your users accessing the hub via GitHub Auth.
@@ -72,7 +72,7 @@ body:
         - Allowing members of specific GitHub team(s)
 
   - type: textarea
-    attributes: 
+    attributes:
       label: "[GitHub Teams Auth only] Profile restriction based on team membership"
       description: |
         If you wish to offer a range of machine sizes/image types but to only a subset of your users, we can facilitate this through GitHub Teams.

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -62,13 +62,14 @@ body:
       required: true
 
   - type: dropdown
-    label: "[GitHub Auth only] How would you like to manage your users?"
-    description: |
-      Please describe how you would prefer to manage your users accessing the hub via GitHub Auth.
-    options:
-      - Manually, by adding specific GitHub handles in the JupyterHub Admin panel
-      - Allowing members of a specific GitHub organization
-      - Allowing members of specific GitHub team(s)
+    attributes: 
+      label: "[GitHub Auth only] How would you like to manage your users?"
+      description: |
+        Please describe how you would prefer to manage your users accessing the hub via GitHub Auth.
+      options:
+        - Manually, by adding specific GitHub handles in the [JupyterHub Admin panel](https://docs.2i2c.org/en/latest/admin/howto/manage-users.html#manage-users-from-the-administrator-panel)
+        - Allowing members of a specific GitHub organization
+        - Allowing members of specific GitHub team(s)
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -67,7 +67,7 @@ body:
       description: |
         Please describe how you would prefer to manage your users accessing the hub via GitHub Auth.
       options:
-        - Manually, by adding specific GitHub handles in the [JupyterHub Admin panel](https://docs.2i2c.org/en/latest/admin/howto/manage-users.html#manage-users-from-the-administrator-panel)
+        - Manually, by adding specific GitHub handles in the JupyterHub Admin panel
         - Allowing members of a specific GitHub organization
         - Allowing members of specific GitHub team(s)
 

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -61,6 +61,15 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    label: "[GitHub Auth only] How would you like to manage your users?"
+    description: |
+      Please describe how you would prefer to manage your users accessing the hub via GitHub Auth.
+    options:
+      - Manually, by adding specific GitHub handles in the JupyterHub Admin panel
+      - Allowing members of a specific GitHub organization
+      - Allowing members of specific GitHub team(s)
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -71,6 +71,16 @@ body:
         - Allowing members of a specific GitHub organization
         - Allowing members of specific GitHub team(s)
 
+  - type: textarea
+    attributes: 
+      label: "[GitHub Teams Auth only] Profile restriction based on team membership"
+      description: |
+        If you wish to offer a range of machine sizes/image types but to only a subset of your users, we can facilitate this through GitHub Teams.
+        Please provide a list of GitHub Teams in your org and what resources you'd like each to access.
+      placeholder: |
+        @MyCoolOrg/all-users: Small and Medium sized machines
+        @MyCoolOrg/advanced-users: Small, Medium, Large and GPU machines
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -209,7 +209,8 @@ body:
       options:
         - label: 1. Deploy information filled in above
         - label: 2. Engineer who will deploy the hub is assigned
-        - label: 3. Initial Hub deployment PR <link to PR>
-        - label: 4. Administrators able to log on -> Hub now in steady-state
+        - label: 3. If using GitHub Orgs/Teams Auth, Engineer is given Owner rights to the org to set this up.
+        - label: 4. Initial Hub deployment PR <link to PR>
+        - label: 5. Administrators able to log on -> Hub now in steady-state
     validations:
       required: false


### PR DESCRIPTION
Just selecting "I want to login with GitHub" is not sufficient information for the engineer now since we support multiple features that rely on GitHub auth, such as:

- Org-based auth,
- Teams-based auth
- Profile options restricted by Teams membership

This PR attempts to update the template to also collect this information.

It also adds an extra step that the engineer should be given Owner rights on the target Org in order to setup authentication properly.

fixes #1806 

See rendered template [here](https://github.com/sgibson91/infrastructure/blob/update-auth-info-template/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml)