### PR TITLE
Explicitly allow requstor-pays access to usgs-landsat

### DIFF
--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -13,16 +13,75 @@ user_buckets = {
     },
 }
 
-
 hub_cloud_permissions = {
   "staging" : {
     requestor_pays: true,
     bucket_admin_access: ["scratch-staging"],
-    extra_iam_policy: ""
+    # Provides readonly requestor-pays access to usgs-landsat bucket
+    # FIXME: We should find a way to allow access to *all* requestor pays
+    # buckets, without having to explicitly list them. However, we don't want
+    # to give access to all *internal* s3 buckets willy-nilly - this can be
+    # a massive security hole, especially if terraform state is also here.
+    # As a temporary measure, we allow-list buckets here. Same as uwhackweeks.
+    extra_iam_policy: <<-EOT
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::usgs-landsat"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::usgs-landsat/*"
+                ]
+            }
+        ]
+      }
+  EOT
   },
   "prod" : {
     requestor_pays: true,
     bucket_admin_access: ["scratch"],
-    extra_iam_policy: ""
+    # Provides readonly requestor-pays access to usgs-landsat bucket
+    # FIXME: We should find a way to allow access to *all* requestor pays
+    # buckets, without having to explicitly list them. However, we don't want
+    # to give access to all *internal* s3 buckets willy-nilly - this can be
+    # a massive security hole, especially if terraform state is also here.
+    # As a temporary measure, we allow-list buckets here. Same as uwhackweeks.
+    extra_iam_policy: <<-EOT
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::usgs-landsat"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:*"
+                ],
+                "Resource": [
+                  "arn:aws:s3:::usgs-landsat/*"
+                ]
+            }
+        ]
+      }
+  EOT
   },
 }


### PR DESCRIPTION
Without this, only the s3 buckets we explicitly create (scratch) can be accessed by the users on the hub. Ideally, we want to allow access to:

1. Allow-listed buckets inside the AWS account hub is in,
2. *All* buckets outside the AWS account, based on access control ( including requstor pays) on the external bucket itself.

Unsure quite yet how to do this, we allow-list the external buckets too for now. This doesn't scale and we should fix this up!

Thanks to @scottyhq for helping debug