### PR TITLE
Remove the templates directory from the list of hubs

### DIFF
--- a/docs/scripts/render_hubs.py
+++ b/docs/scripts/render_hubs.py
@@ -13,7 +13,7 @@ path_clusters = path_root / "../config/clusters"
 clusters = [
     filepath
     for filepath in path_clusters.glob("**/*cluster.yaml")
-    if "tests/" not in str(filepath)
+    if "tests/" not in str(filepath) and "templates" not in str(filepath)
 ]
 
 hub_list = []


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/1972

Running `make clean` and then `make html` revealed the following error:

<img width="702" alt="Screenshot 2022-12-06 at 11 03 10" src="https://user-images.githubusercontent.com/7579677/205868501-af6248df-90c0-46df-be74-4ed6c7494673.png">

This probably originated when the `templates` directory was added.