### PR TITLE
Add deployment to measure free space in hub home dir

### DIFF
--- a/helm-charts/basehub/templates/home-space-reporter.yaml
+++ b/helm-charts/basehub/templates/home-space-reporter.yaml
@@ -1,0 +1,58 @@
+# Deploy a prometheus node_exporter with the same home directory
+# we have for our hub mounted so we can monitor free space usage.
+{{- if or .Values.nfs.enabled .Values.azureFile.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jupyterhub
+    component: home-metrics
+  name: home-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: home-metrics
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+      labels:
+        app: jupyterhub
+        component: home-metrics
+    spec:
+      containers:
+      - args:
+        # We only want filesystem stats
+        - --collector.disable-defaults
+        - --collector.filesystem
+        - --web.listen-address=:9100
+        image: quay.io/prometheus/node-exporter:v1.3.1
+        name: home-directory-exporter
+        ports:
+        - containerPort: 9100
+          name: metrics
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+          - name: home
+            mountPath: /home
+            # Mount it readonly to prevent accidental writes
+            readOnly: true
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      volumes:
+        - name: home
+          persistentVolumeClaim:
+            {{- if .Values.azureFile.enabled }}
+            claimName: home-azurefile
+            {{- else }}
+            claimName: home-nfs
+            {{- end }}
+{{- end }}

--- a/helm-charts/basehub/templates/home-space-reporter.yaml
+++ b/helm-charts/basehub/templates/home-space-reporter.yaml
@@ -43,6 +43,9 @@ spec:
             # Mount it readonly to prevent accidental writes
             readOnly: true
       securityContext:
+        # This is the 'nobody' user that the node-exporter image expects
+        # to be run as, and has no privileges.
+        # https://wiki.ubuntu.com/nobody has more info
         fsGroup: 65534
         runAsGroup: 65534
         runAsNonRoot: true


### PR DESCRIPTION
This adds a deployment with a single pod of
[node_exporter](https://github.com/prometheus/node_exporter) running, configured only to report filesystem statistics. We mount the same home directory configuration that is used in the hub to this pod, so it will provide us with information on total disk size and used disk. This would allow us to have a Grafana panel with 'disk used %' for each of these hubs! We can even alert on those later.