### PR TITLE
Document policy for self-merging as a partner

### DIFF
--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -50,7 +50,18 @@ merge rights to partner engineers. Ideally, they would be only allowed to
 merge PRs related to their own cluster - we currently do not have an automatic
 way of enforcing this. 
 
-They *may* self-merge if they want to, provided the following conditions are met:
+```{note}
+While our current two partners who have such access (Cloudbank & Callysto)
+are grandparented in, we must have such technical enforcement mechanism
+in place before adding more such partners with merge rights
+```
+
+The goal here is that 2i2c is ultimately responsible for the configuration, so
+we do not want it to get too funky without 2i2c engineers knowing
+about it. As a community partner, if you think what you are doing
+*might* be funky, err on the side of asking for review!
+
+Community partners *may* self-merge if they want to, provided the following conditions are met:
 
 1. They have cloud access to the cluster, and are confident of being able to either
    debug the issues that may arise from the *particular* change they are making,
@@ -67,13 +78,11 @@ They *may* self-merge if they want to, provided the following conditions are met
    Here are some examples of *novel* configuration that requires approval from a 2i2c engineer before merging:
    - Adding python code to `hub.extraConfig` to enable new functionality, such as
      adding a postgres database to each user pod.
-   - Significant alterations to the shape of the user pod, such as setting
+   - Significant alterations to the configuration of the user pod, such as setting
      `singleuser.extraContainers`.
    - Modifications to how NFS home directory storage is managed.
    
-   The goal here is that 2i2c is ultimately responsible for the configuration, so
-   we do not want it to get too funky without us knowing about it. If you think
-   what you are doing *might* be funky, err on the side of asking for review!
+As a general rule, when in doubt, ask for review :)
 
 ## Changing authentication related configuration
 

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -60,7 +60,7 @@ However, merge rights are a big responsibility, so please be careful in your act
 
 Community partners *may* self-merge if they want to, provided the following conditions are met:
 
-1. **They are confident debugging any issues that arise from the issue**.
+1. **They are confident debugging any issues that arise from the self-merged PR**.
    If any issues arise from your self-merge, **you are responsible for resolving them, or reverting the change**.
    You should understand the potential repurcussions of your change, and be ready to fix things if they break.
 2. **They have access to their cloud cluster to debug changes**.

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -42,6 +42,38 @@ Here are some guidelines for merging and reviewing in this case:
   make sure you push a PR with the change *and merge it quickly* to make sure that the changes
   are persisted across future deploys. Self merging is acceptable here, although this general
   class of changes should be limited as much as possible.
+  
+## Self-merging as a partner
+
+In some cases, as part of our shared responsibility model, we have granted
+merge rights to partner engineers. Ideally, they would be only allowed to
+merge PRs related to their own cluster - we currently do not have an automatic
+way of enforcing this. 
+
+They *may* self-merge if they want to, provided the following conditions are met:
+
+1. They have cloud access to the cluster, and are confident of being able to either
+   debug the issues that may arise from the *particular* change they are making,
+   or be able to revert it.
+2. The change *only* touches files inside the `config/clusters/<cluster-name>`
+   directory for their cluster.
+3. The change is fairly routine, and not a super novel configuration. This is hard
+   to quantify, but here are some examples of *routine* changes:
+   - Adding a new hub that looks exactly like other hubs in the cluster
+   - Changing resources provided to the hub
+   - Adding / removing admin users
+   - Changing profile options available to the hub
+   
+   Here are some examples of *novel* configuration:
+   - Adding python code to `hub.extraConfig` to enable new functionality, such as
+     adding a postgres database to each user pod.
+   - Significant alterations to the shape of the user pod, such as setting
+     `singleuser.extraContainers`.
+   - Modifications to how NFS home directory storage is managed.
+   
+   The goal here is that 2i2c is ultimately responsible for the configuration, so
+   we do not want it to get too funky without us knowing about it. If you think
+   what you are doing *might* be funky, err on the side of asking for review!
 
 ## Changing authentication related configuration
 

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -56,7 +56,7 @@ Merge rights are only given for partners with which we have built a relationship
 ### Guidelines for community partners
 
 Our goal is to provide trusted communities the ability to more quickly make changes to their infrastructure in order to lead to a better, more collaborative service for their community.
-However, merge rights it a big responsibility, so please be careful in your actions.
+However, merge rights are a big responsibility, so please be careful in your actions.
 
 Community partners *may* self-merge if they want to, provided the following conditions are met:
 

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -43,9 +43,9 @@ Here are some guidelines for merging and reviewing in this case:
   are persisted across future deploys. Self merging is acceptable here, although this general
   class of changes should be limited as much as possible.
   
-## Self-merging as a partner
+## Self-merging as a community partner
 
-In some cases, as part of our shared responsibility model, we have granted
+In some cases, as part of our [shared responsibility model](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html), we grant
 merge rights to partner engineers. Ideally, they would be only allowed to
 merge PRs related to their own cluster - we currently do not have an automatic
 way of enforcing this. 
@@ -64,7 +64,7 @@ They *may* self-merge if they want to, provided the following conditions are met
    - Adding / removing admin users
    - Changing profile options available to the hub
    
-   Here are some examples of *novel* configuration:
+   Here are some examples of *novel* configuration that requires approval from a 2i2c engineer before merging:
    - Adding python code to `hub.extraConfig` to enable new functionality, such as
      adding a postgres database to each user pod.
    - Significant alterations to the shape of the user pod, such as setting

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -45,37 +45,42 @@ Here are some guidelines for merging and reviewing in this case:
   
 ## Self-merging as a community partner
 
-In some cases, as part of our [shared responsibility model](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html), we grant
-merge rights to partner engineers. Ideally, they would be only allowed to
-merge PRs related to their own cluster - we currently do not have an automatic
-way of enforcing this. 
+As part of our [shared responsibility model](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html), we may grant merge rights to partner engineers.
+This allows others to merge changes that impact their community's infrastructure without requiring intervention from a 2i2c engineer.
 
-```{note}
-While our current two partners who have such access (Cloudbank & Callysto)
-are grandparented in, we must have such technical enforcement mechanism
-in place before adding more such partners with merge rights
-```
+Merge rights are only given for partners with which we have built a relationship of trust, on a case-by-case basis.
+2i2c ultimately retains responsibility for the configuration of this infrastructure and its configuration.
 
-The goal here is that 2i2c is ultimately responsible for the configuration, so
-we do not want it to get too funky without 2i2c engineers knowing
-about it. As a community partner, if you think what you are doing
-*might* be funky, err on the side of asking for review!
+[See the `2i2c-org/collaborators` team](https://github.com/orgs/2i2c-org/teams/collaborators) for a list of sub-teams and individuals with write access to this repository.
+
+### Guidelines for community partners
+
+Our goal is to provide trusted communities the ability to more quickly make changes to their infrastructure in order to lead to a better, more collaborative service for their community.
+However, merge rights it a big responsibility, so please be careful in your actions.
 
 Community partners *may* self-merge if they want to, provided the following conditions are met:
 
-1. They have cloud access to the cluster, and are confident of being able to either
-   debug the issues that may arise from the *particular* change they are making,
-   or be able to revert it.
-2. The change *only* touches files inside the `config/clusters/<cluster-name>`
-   directory for their cluster.
-3. The change is fairly routine, and not a super novel configuration. This is hard
-   to quantify, but here are some examples of *routine* changes:
+1. **They are confident debugging any issues that arise from the issue**.
+   If any issues arise from your self-merge, **you are responsible for resolving them, or reverting the change**.
+   You should understand the potential repurcussions of your change, and be ready to fix things if they break.
+2. **They have access to their cloud cluster to debug changes**.
+   Sometimes an issue requires intervention directly in the cloud infrastructure.
+   Before self-merging, ensure that you are authorized and have login-access to this infrastructure.
+3. **The change *only* touches files inside the `config/clusters/<cluster-name>` directory for their cluster.**
+   Do not change configuration or code outside of your community's cluster folder without a review from a 2i2c engineer.
+4. **The change is fairly standard, and not a novel configuration**.
+   If something is straightforward (e.g., updating an environment image tag), then go for it.
+   If you aren't quite sure what a change will impact, or you think you're doing something non-standard, ask for some help first.
+
+   This is hard to quantify, but here are some examples of *routine* changes:
+
    - Adding a new hub that looks exactly like other hubs in the cluster
    - Changing resources provided to the hub
    - Adding / removing admin users
    - Changing profile options available to the hub
    
    Here are some examples of *novel* configuration that requires approval from a 2i2c engineer before merging:
+
    - Adding python code to `hub.extraConfig` to enable new functionality, such as
      adding a postgres database to each user pod.
    - Significant alterations to the configuration of the user pod, such as setting
@@ -83,6 +88,12 @@ Community partners *may* self-merge if they want to, provided the following cond
    - Modifications to how NFS home directory storage is managed.
    
 As a general rule, when in doubt, ask for review :)
+
+```{note}
+These policies assume trust and good faith from the individuals to which we grant write-access.
+We recognize that this will not scale as the communities we work with grows.
+In the future, we plan to make **technical** restrictions on which folders a user may write to.
+```
 
 ## Changing authentication related configuration
 


### PR DESCRIPTION
Starts working on the specifics of our shared responsibility model, as we currently have two orgs (Cloudbank & Callysto) who have engnineers with merge rights in our repo.