### PR TITLE
Explicitly json encode output to GITHUB_ENV

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -109,6 +109,7 @@ jobs:
         shell: python
         run: |
           import os
+          import json
 
           # List all cluster folders
           cluster_folders = os.listdir("config/clusters")
@@ -126,7 +127,10 @@ jobs:
           # Write matrix to the GITHUB_ENV file in GitHub Actions
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as f:
-              f.write(f"MATRIX={matrix}")
+              # Explicitly dump these as JSON, as that is what they are read as
+              # General python object syntax sometimes works but sometimes does
+              # not - for example, single quotes are not valid in JSON.
+              f.write(f"MATRIX={json.dumps(matrix)}")
 
       # Only run this step if there are *NO* changes under the common filter,
       # but *ARE* changes under the cluster_specific filter, *AND* we have not
@@ -139,6 +143,7 @@ jobs:
         shell: python
         run: |
           import os
+          import json
           from pathlib import Path
 
           # Consume list of changed cluster files and convert to list by splitting
@@ -164,7 +169,10 @@ jobs:
           # Write the matrix to the GITHUB_ENV file in GitHub Actions
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as f:
-              f.write(f"matrix={matrix}")
+              # Explicitly dump these as JSON, as that is what they are read as
+              # General python object syntax sometimes works but sometimes does
+              # not - for example, single quotes are not valid in JSON.
+              f.write(f"MATRIX={json.dumps(matrix)}")
 
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.


### PR DESCRIPTION
An attempt to fix up
https://github.com/2i2c-org/infrastructure/actions/runs/3687975422, which currently fails with:

Error when evaluating 'strategy' for job 'validate-helm-charts-values-files'. .github/workflows/validate-clusters.yaml (Line: 190, Col: 15): Error parsing fromJson,.github/workflows/validate-clusters.yaml (Line: 190, Col: 15): Error reading JToken from JsonReader. Path '', line 0, position 0.,.github/workflows/validate-clusters.yaml (Line: 190, Col: 15): Unexpected type of value '', expected type: Sequence.

The JSON it's trying to read, I believe, is:

> matrix='[{'cluster_name': 'utoronto'}]'

If I try out with some python,

```python
>>> matrix=[{"cluster_name": "utoronto"}]
>>> f"{matrix}"
"[{'cluster_name': 'utoronto'}]"
>>> import json
>>> f"{json.dumps(matrix)}"
'[{"cluster_name": "utoronto"}]'
```

You'll see that json.dumps produces double quotes, while just plain output produces single quotes. I don't actually know if this is the exact problem, nor do I know why it would be an issue *now* when it has not been before! But I'm going to try.

Also setting the MATRIX env var to be all caps, for consistency with the other place we set MATRIX