### PR TITLE
Enable named servers for m2lines & pangeo-hubs

### DIFF
--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -33,6 +33,7 @@ basehub:
             name: M²LInES
             url: https://m2lines.github.io/
     hub:
+      allowNamedServers: true
       config:
         Authenticator:
           # This hub uses GitHub Teams auth and so we don't set

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -39,6 +39,7 @@ basehub:
             name: NSF EarthCube Program (Award ICER-2026932)
             url: "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2026932"
     hub:
+      allowNamedServers: true
       config:
         Authenticator:
           # This hub uses GitHub Teams auth and so we don't set


### PR DESCRIPTION
I think we should enable this for all research hubs.

Based on request by @dhruvbalwada