### PR TITLE
Bumping image version to include new packages

### DIFF
--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -39,7 +39,7 @@ jupyterhub:
   singleuser:
     image:
       name: callysto/2i2c
-      tag: 0.1.1
+      tag: 0.1.2
     extraFiles:
       tree.html:
         mountPath: /usr/local/share/jupyter/custom_template/tree.html


### PR DESCRIPTION
Byron wants haversine installed. It has been added to this environment and relocked as https://github.com/callysto/2i2c-image/commit/1c8498b404f2e8d9863a53d89bb89e0c3d5b6d89

Signed-off-by: Ian Allison <iana@pims.math.ca>