### PR TITLE
Add ML notebook choice to medium server at leap hub

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -83,6 +83,26 @@ basehub:
           allowed_teams:
             - leap-stc:leap-pangeo-users
             - 2i2c-org:tech-team
+          profile_options:
+            image:
+              display_name: Image
+              choices:
+                pangeo:
+                  display_name: Base Pangeo Notebook
+                  default: true
+                  slug: "pangeo"
+                  kubespawner_override:
+                    image: "pangeo/pangeo-notebook:2022.10.18"
+                tensorflow:
+                  display_name: Pangeo Tensorflow ML Notebook
+                  slug: "tensorflow"
+                  kubespawner_override:
+                    image: "pangeo/ml-notebook:2022.10.18"
+                pytorch:
+                  display_name: Pangeo PyTorch ML Notebook
+                  slug: "pytorch"
+                  kubespawner_override:
+                    image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G


### PR DESCRIPTION
We would like to be able to select the ML specific images not just for the GPU specific server, but also for the medium server. This option is available for more members and will in particular be used for an upcoming workshop. I am not sure if this simple change does the trick or if anything elsewhere needs to be specified.