### PR TITLE
[RECONSTRUCTION] Setup shared cluster on AWS and deploy 'researchdelight' hub

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -27,6 +27,8 @@ jobs:
           - cluster_name: nasa-cryo
           - cluster_name: gridsst
           - cluster_name: victor
+          - cluster_name: 2i2c-aws-us
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -162,6 +162,7 @@ jobs:
       failure_nasa-cryo: "${{ env.failure_nasa-cryo }}"
       failure_gridsst: "${{ env.failure_gridsst }}"
       failure_victor: "${{ env.failure_victor }}"
+      failure_2i2c-aws-us: "${{ env.failure_2i2c-aws-us }}"
 
     # Only run this job on pushes to the default branch and when the job output is not
     # an empty list

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -28,3 +28,11 @@ hubs:
     helm_chart_values_files:
       - dask-staging.values.yaml
       - enc-dask-staging.secret.values.yaml
+  - name: researchdelight
+    display_name: "2i2c Research Delight"
+    domain: researchdelight.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      connection: github
+    helm_chart_values_files:
+      - researchdelight.values.yaml

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -1,0 +1,11 @@
+name: 2i2c-aws-us
+provider: aws
+aws:
+  key: enc-deployer-credentials.secret.json
+  clusterType: eks
+  clusterName: 2i2c-aws-us
+  region: us-west-2
+support:
+  helm_chart_values_files:
+    - support.values.yaml
+    - enc-support.secret.values.yaml

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -9,3 +9,13 @@ support:
   helm_chart_values_files:
     - support.values.yaml
     - enc-support.secret.values.yaml
+hubs:
+  - name: staging
+    display_name: "2i2c AWS staging"
+    domain: staging.aws.2i2c.cloud
+    helm_chart: basehub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - staging.values.yaml
+      - enc-staging.secret.values.yaml

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -19,3 +19,12 @@ hubs:
     helm_chart_values_files:
       - staging.values.yaml
       - enc-staging.secret.values.yaml
+  - name: dask-staging
+    display_name: "2i2c AWS dask-staging"
+    domain: dask-staging.aws.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - dask-staging.values.yaml
+      - enc-dask-staging.secret.values.yaml

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -56,4 +56,4 @@ basehub:
           allowed_organizations:
             - 2i2c-org
           scope:
-            - read:org  
+            - read:org

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -1,0 +1,59 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-dask-staging
+  nfs:
+    pv:
+      # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+      mountOptions:
+        - rsize=1048576
+        - wsize=1048576
+        - timeo=600
+        - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
+        - retrans=2
+        - noresvport
+      serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
+      baseShareName: /
+  jupyterhub:
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: true
+        add_staff_user_ids_of_type: "github"
+      homepage:
+        templateVars:
+          org:
+            name: 2i2c Dask Staging
+            url: https://2i2c.org
+            logo_url: https://2i2c.org/media/logo.png
+          designed_by:
+            name: 2i2c
+            url: https://2i2c.org
+          operated_by:
+            name: 2i2c
+            url: https://2i2c.org
+          funded_by:
+            name: 2i2c
+            url: https://2i2c.org
+    singleuser:
+      image:
+        name: pangeo/pangeo-notebook
+        tag: "2022.06.02"
+    hub:
+      config:
+        Authenticator:
+          # This hub uses GitHub Org auth and so we don't set
+          # allowed_users in order to not deny access to valid members of
+          # the listed orgs.
+          #
+          # You must always set admin_users, even if it is an empty list,
+          # otherwise `add_staff_user_ids_to_admin_users: true` will fail
+          # silently and no staff members will have admin access.
+          admin_users: []
+        JupyterHub:
+          authenticator_class: "github"
+        GitHubOAuthenticator:
+          oauth_callback_url: "https://dask-staging.aws.2i2c.cloud/hub/oauth_callback"
+          allowed_organizations:
+            - 2i2c-org
+          scope:
+            - read:org  

--- a/config/clusters/2i2c-aws-us/enc-dask-staging.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-dask-staging.secret.values.yaml
@@ -1,0 +1,21 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:ZiUCM3p/hY+y/zpQFS+R13pd7wY=,iv:M3N7NmEtE5qngrCwlr2vLxTUaFvbQM+q6uOGsw3Vmbg=,tag:TtN0bMLKmSiSSiPipWCEAw==,type:str]
+                    client_secret: ENC[AES256_GCM,data:46JoY+yo01tG12QsaIlpuZ9hX00YfHHmL+MXKkyl4ncHQjVbj+4hNQ==,iv:T1YQnD2mr2JKhAtSHaPXTTlD8CreiHOxAxG1wfueNME=,tag:s0xmzKuhqUKaWy6pmJzQUw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-01-05T15:25:09Z"
+          enc: CiUA4OM7eN6ULedt07hrYSuCYNviz84p6Myz4gLx0SHi2soZ8b5JEkkA+0T9hZ0nLyBqO0b1X7/wXW+AXp9K52uffuEDJvyCG97WP75nEi2k0QqjCsLQGaIr7QuYzkVkvMWf6bfJeLE8DravcpVoVqUH
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-01-05T15:25:09Z"
+    mac: ENC[AES256_GCM,data:4rpy/3DM8UDSnyeB+B2JLWE/xaucbCvwucTv3cU5rItFZaUIlmynLcXpqhOBCoEEfPbAFG+eTo3Kdm8qEETFl4Ssd8yNU9kedgOn8V64LT/hTWaPzmGkzTx3bdjXIjHJwuvLpMItSonItapwSbN4ZOSdRUETylzpxr+zYhJySvw=,iv:PP+vA0UrQmlCXMwVzzWrIT+fF9TvZxad4VXLA16EsUw=,tag:D3qv+InhBs6Najw0E7gIXA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/2i2c-aws-us/enc-deployer-credentials.secret.json
+++ b/config/clusters/2i2c-aws-us/enc-deployer-credentials.secret.json
@@ -1,0 +1,25 @@
+{
+	"AccessKey": {
+		"AccessKeyId": "ENC[AES256_GCM,data:6PvELWFuIRU3X/xw0KFAUB9tALw=,iv:qAUuL9XpmqVfmIPAg1jVLw6BOgOLdI6Nh9ciGoYR1ko=,tag:YkB81KaQkneoErdvbA+gcQ==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:yL9fFhLZwIwYGIcH0rMlom1AMf8SP8rHuqIaFcCMHgxJrvBwrIjEtA==,iv:QUL+KmQVs+fqwei8qATePtz7DYRGISeqK76C3C6ZYHQ=,tag:1JKsN+6MwzrwncgcnJOY0Q==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:uINElYnC8kT9jENDB0HZobYeJRtg0pQ=,iv:6WcmGN4Uo/0ESepK+6GnNJzqhOiKN7XUlyCmDBV9wbs=,tag:rtoBQVLgs4iwHF9xxWY5LA==,type:str]"
+	},
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-12-02T16:26:52Z",
+				"enc": "CiUA4OM7eOLLa/imL4GpHRd9gcsB84MVB/Ad4qDdcZR1yN5dCQEEEkkA+0T9hZ4MsWpzgSLLO687tPm2nrUQ+Ah6/7KRQH66x5sYPrKozkBm5ch5T2Y8YTXSb2stXzIlTqQA9Eq8sBc7rTyEG0G+Ryad"
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-12-02T16:26:52Z",
+		"mac": "ENC[AES256_GCM,data:csHlSvetk7n+RSN1OK5ZbFND3bRd/liGLiStaY0XsXTXjzq2okXjazEKeS6tNIRt6MKsLNQ3LOv84q7nmHnbLx2/jlBhmKu9oRwd5CBdponB/14CRnPhpI/cVm9i6D/FTUi/Wy5MVojJZdj/4DIMyN5cjpWeQSYAATuFzbsYPKU=,iv:JZAhUHxxurCQRStaMCoL6qu5JihtVOrnFpXFWQDx8Xk=,tag:azOozPUyO9iz0SnVfbt+Sw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/config/clusters/2i2c-aws-us/enc-grafana-token.secret.yaml
+++ b/config/clusters/2i2c-aws-us/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:t2qk7Ze8CPLm04pnwFDpqhoXv430t1wBH+o4H3KxGLLPZXeeBfMgHNTjOFeX0xABJ8eZw8yRi/TRXHfil9QQ+OKoTIMJ9olTr++YdBEVBRqQijlFJTc5IVRQQXNR9LhG,iv:9vVNYHRyCOexYjx49JMHqxD8RbYSs4OaU2RsDFjW1N4=,tag:Wgnr/0UIGJiCuQPULCfgbA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-12-02T17:06:57Z"
+          enc: CiUA4OM7eE9zAnsvqqZ1DkU29yZuDSdm7AoElAMABbgu9/p8tLGkEkkA+0T9hXy+VFXSo6A4H8d8HFNwQBsm67tqAGBBUQ7SlIoWIz28wMPTIez5sNPBziRv9VrsXuIFJozC+Z2oqwexcy6Wy6663t9I
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-12-02T17:06:58Z"
+    mac: ENC[AES256_GCM,data:NHmFKLI8yUkZW+lhh9+rZl0LhTjBFbVgAua1M4E2+5DcDY+tA1tO87T1QcPcX+PPAPIXTO41eofFB01MbfG1FbsXjPYQE3235pmA2WNEIaeY2fTAdKylrUfbiICV/2doex/eXLdQwIrXJeyyrIYXA0Sjj1hDBkuV6DCU8HbKQ+s=,iv:1XrSnJHntEpQ9qx0MbOEfHpzpeFiIIoK0eCsEQCVI40=,tag:4+9qqk4LXBriUpPMSbTlew==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:cCcFsREidFJE+8mNguzsiglaDNU=,iv:8/ONoisn8fresVPcztUejV5j1njBJe1TiyTPbzsl9ag=,tag:1zUsouNBoTdAAoVwZCrXNw==,type:str]
+                client_secret: ENC[AES256_GCM,data:QVmzgFYEGKPgTrj6bCrumcQp5mZreLFrw6G+zITLOSJtydDY62zD/Q==,iv:nAdsoPGHyPhFzFPU4uxRAbQOm4fuZSD4IKtZYAHx3vU=,tag:jV9OsG1sy/OyOTUp7M9pvA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-01-05T15:13:06Z"
+          enc: CiUA4OM7ePFTK8jhF1PvaNsOlsH2PwopRPJE7K+2pVikF/Brl4zPEkkA+0T9hUjgsZa2zAOVqZHOAjeg91553kP+YnHnIW2QPPnSha1dlGfrTcesxV5hsrbeqc3fxs7OnKow5KK3fr48Djf31CYGOgLY
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-01-05T15:13:06Z"
+    mac: ENC[AES256_GCM,data:tSbbwxnJEQflFUma0Ou0Faci4nypPH7UDFkPe6jyfnNEckteG9qviBk9pUbpuR404NOZp8QtVqB0Vqv3fwo1EBGrmeT0E0zhgz0RR2/k85nDnPD9mLYWq4xtestHQOdibmMAFe4D2QbVSgI4t8NiYAWLPqKaH8UGKFgiFAV9pnU=,iv:yPX35eIVYw1rh9BTmPpc3P+DzEu499Wk/GJkwN4AcUs=,tag:mWr1ieAR7bZ605gA2tHHdA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
@@ -1,0 +1,17 @@
+prometheusIngressAuthSecret:
+    username: ENC[AES256_GCM,data:4DPd7lTWaJ8ND8GceLh6wNzHAY1LeqMIokEHBqObThtXtnfpmE11z7FIMb1Vant+di7SbbCAPcoGgUdvUOsXLQ==,iv:kj0DnH2cCzw7iBraX/dfjENXOIgk/ZC/qCjseisno/c=,tag:AgGZJfGRBsqaYlzqpvSpbg==,type:str]
+    password: ENC[AES256_GCM,data:Yt6DejIrACYstASWXxBPshCm6/n4vsSw7NK1RxH9fKMxjn+Bs1x6+MKD7Im2IRxWzSoP3XtURJjmaYdio98U/Q==,iv:HGnhJhRX7O/nn4y4HujGT18nJoB3kPMD0x+x/PSbjps=,tag:hCnTt0eWn57EH/3k5HXexQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-12-02T16:48:54Z"
+          enc: CiUA4OM7eJkeDQA+Fs2q6h7jkeWzZ2OWVQlePA+DEhpqTrCjE2EQEkkA+0T9hez3llYUQUfMYkGtA1OlIM9nfVFocn4ceORhXKFmBGIsVBP352iqjf+YFQMLHdLh2LJx4PdrpvkgNhW/M5dGa+41P1px
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-12-02T16:48:55Z"
+    mac: ENC[AES256_GCM,data:0jbzDZ/5aY022XU6u3ftcafKdnujPZNOowH4zyafVDSkDAZJAKQE4GnJpW9s32NVSkptmnCA6Xr2u0dm7UAuWBFrepnHt0PLTJaUr33DtgAO8QfwXbDAD2MdrAPoH1Lvd43XwTqCY4ujX8Of/Vd6FsfIToHdKrDv3znI+6g6UTs=,iv:56pLW3wQ7AenXVl9GaI/A/e09co9F2gLdVznX57w66E=,tag:QWr3kQuOuGRaCWXIYE7Xtg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -1,0 +1,108 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-researchdelight
+  nfs:
+    pv:
+      # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+      mountOptions:
+        - rsize=1048576
+        - wsize=1048576
+        - timeo=600
+        - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
+        - retrans=2
+        - noresvport
+      serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
+      baseShareName: /
+  jupyterhub:
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: true
+        add_staff_user_ids_of_type: "github"
+      homepage:
+        templateVars:
+          org:
+            name: 2i2c Research Delight
+            url: https://2i2c.org
+            logo_url: https://2i2c.org/media/logo.png
+          designed_by:
+            name: 2i2c
+            url: https://2i2c.org
+          operated_by:
+            name: 2i2c
+            url: https://2i2c.org
+          funded_by:
+            name: 2i2c
+            url: https://2i2c.org
+    singleuser:
+      image:
+        name: quay.io/2i2c/researchdelight-image
+        tag: "872f0c4578af"
+      extraEnv:
+        # Temporarily set for *all* pods, including pods without any GPUs,
+        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      profileList:
+        # The mem-guarantees are here so k8s doesn't schedule other pods
+        # on these nodes.
+        - display_name: "Small: m5.large"
+          description: "~2 CPU, ~8G RAM"
+          default: true
+          kubespawner_override:
+            # Explicitly unset mem_limit, so it overrides the default memory limit we set in
+            # basehub/values.yaml
+            mem_limit: 8G
+            mem_guarantee: 6.5G
+            node_selector:
+              node.kubernetes.io/instance-type: m5.large
+        - display_name: "Medium: m5.xlarge"
+          description: "~4 CPU, ~15G RAM"
+          kubespawner_override:
+            mem_limit: 15G
+            mem_guarantee: 12G
+            node_selector:
+              node.kubernetes.io/instance-type: m5.xlarge
+        - display_name: "Large: m5.2xlarge"
+          description: "~8 CPU, ~30G RAM"
+          kubespawner_override:
+            mem_limit: 30G
+            mem_guarantee: 25G
+            node_selector:
+              node.kubernetes.io/instance-type: m5.2xlarge
+        - display_name: "Huge: m5.8xlarge"
+          description: "~16 CPU, ~60G RAM"
+          kubespawner_override:
+            mem_limit: 60G
+            mem_guarantee: 50G
+            node_selector:
+              node.kubernetes.io/instance-type: m5.8xlarge
+        - display_name: "Large + GPU"
+          description: "14GB RAM, 4 CPUs, T4 GPU"
+          profile_options:
+            image:
+              display_name: Image
+              choices:
+                tensorflow:
+                  display_name: Pangeo Tensorflow ML Notebook
+                  slug: "tensorflow"
+                  kubespawner_override:
+                    node.kubernetes.io/instance-type: g4dn.xlarge
+                    image: "pangeo/ml-notebook:b9584f6"
+                pytorch:
+                  display_name: Pangeo PyTorch ML Notebook
+                  default: true
+                  slug: "pytorch"
+                  kubespawner_override:
+                    node.kubernetes.io/instance-type: g4dn.xlarge
+                    image: "pangeo/pytorch-notebook:b9584f6"
+          kubespawner_override:
+            mem_limit: null
+            mem_guarantee: 14G
+            extra_resource_limits:
+              nvidia.com/gpu: "1"
+    hub:
+      config:
+        Authenticator:
+          allowed_users: &allowed_users
+            - jmunroe
+          admin_users: *allowed_users

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -1,0 +1,54 @@
+userServiceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-staging
+nfs:
+  pv:
+    # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
+    mountOptions:
+      - rsize=1048576
+      - wsize=1048576
+      - timeo=600
+      - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
+      - retrans=2
+      - noresvport
+    serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
+    baseShareName: /
+jupyterhub:
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    homepage:
+      templateVars:
+        org:
+          name: 2i2c AWS Staging
+          url: https://2i2c.org
+          logo_url: https://2i2c.org/media/logo.png
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: 2i2c
+          url: https://2i2c.org
+  hub:
+    config:
+      Authenticator:
+        # This hub uses GitHub Org auth and so we don't set
+        # allowed_users in order to not deny access to valid members of
+        # the listed orgs.
+        #
+        # You must always set admin_users, even if it is an empty list,
+        # otherwise `add_staff_user_ids_to_admin_users: true` will fail
+        # silently and no staff members will have admin access.
+        admin_users: []
+      JupyterHub:
+        authenticator_class: "github"
+      GitHubOAuthenticator:
+        oauth_callback_url: "https://staging.aws.2i2c.cloud/hub/oauth_callback"
+        allowed_organizations:
+          - 2i2c-org
+        scope:
+          - read:org

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -1,0 +1,31 @@
+prometheusIngressAuthSecret:
+  enabled: true
+
+grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.aws.2i2c.cloud/
+  ingress:
+    hosts:
+      - grafana.aws.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.aws.2i2c.cloud
+
+prometheus:
+  server:
+    ingress:
+      enabled: true
+      hosts:
+        - prometheus.aws.2i2c.cloud
+      tls:
+        - secretName: prometheus-tls
+          hosts:
+            - prometheus.aws.2i2c.cloud
+
+cluster-autoscaler:
+  enabled: true
+  autoDiscovery:
+    clusterName: 2i2c-aws-us
+  awsRegion: us-west-2

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -1,0 +1,36 @@
+region = "us-west-2"
+
+cluster_name = "2i2c-aws-us"
+
+cluster_nodes_location = "us-west-2a"
+
+user_buckets = {
+    "scratch-staging": {
+        "delete_after" : 7
+    },
+    "scratch-dask-staging": {
+        "delete_after": 7
+    },
+    "scratch-researchdelight": {
+        "delete_after": 7
+    },
+}
+
+
+hub_cloud_permissions = {
+  "staging" : {
+    requestor_pays: true,
+    bucket_admin_access: ["scratch-staging"],
+    extra_iam_policy: ""
+  },
+  "dask-staging" : {
+    requestor_pays: true,
+    bucket_admin_access: ["scratch-dask-staging"],
+    extra_iam_policy: ""
+  },
+  "researchdelight" : {
+    requestor_pays: true,
+    bucket_admin_access: ["scratch-researchdelight"],
+    extra_iam_policy: ""
+  },
+}


### PR DESCRIPTION
Reconstruction of #1967 since something went horribly wrong git-wise over there.

Adds 2i2c-aws-us cluster with staging, dask-staging and researchdelight hubs.

fixes #1949 