### PR TITLE
Move UToronto R hub URL

### DIFF
--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -32,7 +32,7 @@ hubs:
       - enc-default-prod.secret.values.yaml
   - name: r-staging
     display_name: "University of Toronto (r-staging)"
-    domain: r-staging.utoronto.2i2c.cloud
+    domain: r-staging.datatools.utoronto.ca
     helm_chart: basehub
     auth0:
       enabled: false
@@ -43,7 +43,7 @@ hubs:
       - enc-r-staging.secret.values.yaml
   - name: r-prod
     display_name: "University of Toronto (R)"
-    domain: r.utoronto.2i2c.cloud
+    domain: r.datatools.utoronto.ca
     helm_chart: basehub
     auth0:
       enabled: false

--- a/config/clusters/utoronto/r-prod.values.yaml
+++ b/config/clusters/utoronto/r-prod.values.yaml
@@ -6,5 +6,5 @@ jupyterhub:
         storage: 60Gi
     config:
       AzureAdOAuthenticator:
-        oauth_callback_url: https://r.utoronto.2i2c.cloud/hub/oauth_callback
-        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r.utoronto.2i2c.cloud
+        oauth_callback_url: https://r.datatools.utoronto.ca/hub/oauth_callback
+        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r.datatools.utoronto.ca

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -2,5 +2,5 @@ jupyterhub:
   hub:
     config:
       AzureAdOAuthenticator:
-        oauth_callback_url: https://r-staging.utoronto.2i2c.cloud/hub/oauth_callback
-        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r-staging.utoronto.2i2c.cloud
+        oauth_callback_url: https://r-staging.datatools.utoronto.ca/hub/oauth_callback
+        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r-staging.datatools.utoronto.ca


### PR DESCRIPTION
Requires the following changes to be done before we merge this

- [x] A wildcard CNAME entry for *.datatools.utoronto.ca, pointing to utoronto.2i2c.cloud. You can verify this by running `dig blah.datatools.utoronto.ca` - it should return the CNAME, not a `NXDOMAIN`
- [x] The AzureAD OAuth client for r-staging (with id e82637aa-3c28-489a-b91c-a87c7510359d) has the following URL added as an allowed oauth callback URL: https://r-staging.datatools.utoronto.ca/hub/oauth-callback
- [x] The AzureAD OAuth client for r-prod (with id de1b459c-5a90-432f-80fa-d0fe3b68a79b) has the following URL added as an allowed oauth callback URL: https://r.datatools.utoronto.ca/hub/oauth-callback

All three must be done before this PR is merged.