### PR TITLE
Don't require 'confirm' step before sending users to configurator

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -370,6 +370,8 @@ jupyterhub:
     services:
       configurator:
         url: http://configurator:10101
+        # Don't require users to explicitly 'confirm' before sending them to configurator
+        oauth_no_confirm: true
         command:
           - python3
           - -m


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/1615