### PR TITLE
Swap tech-team for hub-access-for-2i2c-staff in GitHub teams-based auth config

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -82,7 +82,7 @@ basehub:
         GitHubOAuthenticator:
           oauth_callback_url: https://oceanhackweek.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - oceanhackweek:participants_2022
             - oceanhackweek:ohw22-organizers
             - oceanhackweek:ohw22-mentor-helper-presenter

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -54,7 +54,7 @@ basehub:
           populate_teams_in_auth_state: true
           allowed_organizations:
             - leap-stc:leap-pangeo-users
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
     singleuser:
@@ -77,7 +77,7 @@ basehub:
           default: true
           allowed_teams:
             - leap-stc:leap-pangeo-users
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 7G
             mem_guarantee: 4.5G
@@ -87,7 +87,7 @@ basehub:
           description: 11GB RAM, 4 CPUs
           allowed_teams:
             - leap-stc:leap-pangeo-users
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           profile_options:
             image:
               display_name: Image
@@ -118,7 +118,7 @@ basehub:
           allowed_teams:
             - leap-stc:leap-pangeo-education
             - leap-stc:leap-pangeo-research
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G
@@ -128,7 +128,7 @@ basehub:
           description: 52GB RAM, 16 CPUs
           allowed_teams:
             - leap-stc:leap-pangeo-research
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 60G
             mem_guarantee: 52G
@@ -139,7 +139,7 @@ basehub:
           description: 24GB RAM, 8 CPUs
           allowed_teams:
             - leap-stc:leap-pangeo-research
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           profile_options:
             image:
               display_name: Image

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -47,7 +47,7 @@ basehub:
         GitHubOAuthenticator:
           allowed_organizations:
             - m2lines
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
     singleuser:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -61,7 +61,7 @@ basehub:
           # so need to populate the teams in the auth state
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryoclouduser
             - CryoInTheCloud:cryocloudadvanced
           scope:
@@ -85,7 +85,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           allowed_teams:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryoclouduser
             - CryoInTheCloud:cryocloudadvanced
           kubespawner_override:
@@ -98,7 +98,7 @@ basehub:
         - display_name: "Medium: m5.xlarge"
           description: "~4 CPU, ~15G RAM"
           allowed_teams:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryoclouduser
             - CryoInTheCloud:cryocloudadvanced
           kubespawner_override:
@@ -109,7 +109,7 @@ basehub:
         - display_name: "Large: m5.2xlarge"
           description: "~8 CPU, ~30G RAM"
           allowed_teams:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryocloudadvanced
           kubespawner_override:
             mem_limit: null
@@ -119,7 +119,7 @@ basehub:
         - display_name: "Huge: m5.8xlarge"
           description: "~32 CPU, ~128G RAM"
           allowed_teams:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryocloudadvanced
           kubespawner_override:
             mem_limit: null

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -55,7 +55,7 @@ basehub:
         GitHubOAuthenticator:
           allowed_organizations:
             - pangeo-data:us-central1-b-gcp
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
     singleuser:
@@ -76,7 +76,7 @@ basehub:
           default: true
           allowed_teams:
             - pangeo-data:us-central1-b-gcp
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 7G
             mem_guarantee: 4.5G
@@ -86,7 +86,7 @@ basehub:
           description: 11GB RAM, 4 CPUs
           allowed_teams:
             - pangeo-data:us-central1-b-gcp
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G
@@ -96,7 +96,7 @@ basehub:
           description: 24GB RAM, 8 CPUs
           allowed_teams:
             - pangeo-data:cds-lab
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 30G
             mem_guarantee: 24G
@@ -106,7 +106,7 @@ basehub:
           description: 52GB RAM, 16 CPUs
           allowed_teams:
             - pangeo-data:cds-lab
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
             mem_limit: 60G
             mem_guarantee: 52G

--- a/config/clusters/uwhackweeks/snowex.values.yaml
+++ b/config/clusters/uwhackweeks/snowex.values.yaml
@@ -24,6 +24,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - snowex-hackweek:participants-2022
           oauth_callback_url: https://snowex.uwhackweeks.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/uwhackweeks/staging.values.yaml
+++ b/config/clusters/uwhackweeks/staging.values.yaml
@@ -18,6 +18,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org:tech-team
+            - 2i2c-org:hub-access-for-2i2c-staff
             - ICESAT-2HackWeek:jupyterhub-2022
           oauth_callback_url: https://staging.uwhackweeks.2i2c.cloud/hub/oauth_callback

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -114,7 +114,7 @@ You can remove yourself from the org once you have confirmed that login is worki
           GitHubOAuthenticator:
             oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
             allowed_organizations:
-              - 2i2c-org:tech-team
+              - 2i2c-org:hub-access-for-2i2c-staff
               - ORG_NAME:TEAM_NAME
             scope:
               - read:org
@@ -220,7 +220,7 @@ To enable this access,
             default: true
             allowed_teams:
               - <org-name>:<team-name>
-              - 2i2c-org:tech-team
+              - 2i2c-org:hub-access-for-2i2c-staff
             kubespawner_override:
               mem_limit: 7G
               mem_guarantee: 4.5G
@@ -230,7 +230,7 @@ To enable this access,
             description: 11GB RAM, 4 CPUs
             allowed_teams:
               - <org-name>:<team-name>
-              - 2i2c-org:tech-team
+              - 2i2c-org:hub-access-for-2i2c-staff
             kubespawner_override:
               mem_limit: 15G
               mem_guarantee: 11G


### PR DESCRIPTION
This allows us to grant hub access to 2i2c staff without also adding them to the GitHub team that maps to the engineering team

ref: https://github.com/2i2c-org/team-compass/issues/511