### PR TITLE
Setup domain redirects for UToronto R hub

### DIFF
--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -1,6 +1,13 @@
 prometheusIngressAuthSecret:
   enabled: true
 
+redirects:
+  rules:
+    - from: r-staging.utoronto.2i2c.cloud
+      to: r-staging.datatools.utoronto.ca
+    - from: r.utoronto.2i2c.cloud
+      to: r.datatools.utoronto.ca
+
 prometheus:
   server:
     ingress:

--- a/docs/howto/features/index.md
+++ b/docs/howto/features/index.md
@@ -18,6 +18,7 @@ github.md
 :caption: Configuring pages
 login-page.md
 static-sites.md
+redirects.md
 ```
 
 ```{toctree}

--- a/docs/howto/features/redirects.md
+++ b/docs/howto/features/redirects.md
@@ -1,0 +1,19 @@
+# Setup Domain Redirects
+
+Sometimes, when we move a hub, we want to redirect users from the
+old hub to the new hub. While this will still break users *currently*
+on the hub, it should work seamlessly for anyone trying to login.
+
+You can set up redirects by adding something like this to the appropriate
+`support.values.yaml` file for the *cluster* the hub is on:
+
+```yaml
+redirects:
+  rules:
+    - from: <old-hub-domain>
+      to: <new-hub-domain>
+```
+
+You can add any number of such redirects. They will all be `302 Temporary`
+redirects, in case we want to re-use the old domain for something else in
+the future.

--- a/helm-charts/support/templates/redirects.yaml
+++ b/helm-charts/support/templates/redirects.yaml
@@ -1,0 +1,19 @@
+{{ range .Values.redirects.rules }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/server-snippet: |
+      return {{ .code | default 302 }} $scheme://{{ .to }}$request_uri;
+  name: ingress-redirect
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .from }}
+    # .from is a DNS name, but dots aren't allo
+    secretName: redirect-{{ .from }}-tls
+  rules:
+  - host: {{ .from }}
+{{ end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -18,6 +18,7 @@ required:
   - nvidiaDevicePlugin
   - prometheusIngressAuthSecret
   - cryptnono
+  - redirects
   - global
 properties:
   # cluster-autoscaler is a dependent helm chart, we rely on its schema
@@ -48,6 +49,34 @@ properties:
   cryptnono:
     type: object
     additionalProperties: true
+  redirects:
+    type: object
+    required:
+      - rules
+    properties:
+      rules:
+        type: array
+        items:
+          type: object
+          required:
+            - from
+            - to
+          properties:
+            from:
+              type: string
+              description: |
+                Domain to redirect from
+            to:
+              type: string
+              description: |
+                Domain to redirect to
+            code:
+              type: integer
+              description: |
+                HTTP Status code to use for the redirect.
+
+                302 (Temporary Redirect) is used if none is specified
+
   # nvidiaDevicePlugin is _not a dependent helm chart_. It is values directly
   # coupled with this helm chart and are influencing the rendering of templates
   # we provide as part of this helm chart.

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -3,6 +3,9 @@ prometheusIngressAuthSecret:
   username: ""
   password: ""
 
+redirects:
+  rules: []
+
 cluster-autoscaler:
   enabled: false
 ingress-nginx:


### PR DESCRIPTION
We want to make sure that users who were given the old R hub's URL have a smooth experience.

Ref https://github.com/2i2c-org/infrastructure/issues/1961