### PR TITLE
Add two more redirects for UToronto

### DIFF
--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -7,6 +7,10 @@ redirects:
       to: r-staging.datatools.utoronto.ca
     - from: r.utoronto.2i2c.cloud
       to: r.datatools.utoronto.ca
+    - from: jupyter-staging.datatools.utoronto.ca
+      to: staging.utoronto.2i2c.cloud
+    - from: jupyter.datatools.utoronto.ca
+      to: jupyter.utoronto.ca
 
 prometheus:
   server:


### PR DESCRIPTION
In https://2i2c.freshdesk.com/a/tickets/331, UToronto is going to be using *.datatools.utoronto.ca as the domain for most hubs. The current hub is at jupyter.utoronto.ca, and will eventually be at jupyter.datatools.utoronto.ca. This sets up a redirect from that *future* domain to current domain so the future domain can also be advertised now.