### PR TITLE
Bump third party actions to latest versions

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -84,7 +84,7 @@ runs:
 
     # This action use the github official cache mechanism internally
     - name: Install sops
-      uses: mdgreenwald/mozilla-sops-action@v1
+      uses: mdgreenwald/mozilla-sops-action@v1.4.1
       with:
         version: v3.7.2
 

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -39,7 +39,7 @@ jobs:
           sudo apt install jsonnet
 
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.1
 

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -198,7 +198,7 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for staging hub on cluster ${{ matrix.jobs.cluster_name }}
         if: matrix.jobs.upgrade_staging
-        uses: nick-fields/retry@v2.8.3
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -218,7 +218,7 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
         if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
-        uses: nick-fields/retry@v2.8.3
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -328,7 +328,7 @@ jobs:
 
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check against ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name}}
-        uses: nick-fields/retry@v2.8.3
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -198,7 +198,7 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for staging hub on cluster ${{ matrix.jobs.cluster_name }}
         if: matrix.jobs.upgrade_staging
-        uses: nick-fields/retry@v2.8.1
+        uses: nick-fields/retry@v2.8.3
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -218,7 +218,7 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check for dask-staging hub on cluster ${{ matrix.jobs.cluster_name }} if it exists
         if: matrix.jobs.upgrade_staging && matrix.jobs.cluster_name == '2i2c'
-        uses: nick-fields/retry@v2.8.1
+        uses: nick-fields/retry@v2.8.3
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -328,7 +328,7 @@ jobs:
 
       # Retry action: https://github.com/marketplace/actions/retry-step
       - name: Run health check against ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name}}
-        uses: nick-fields/retry@v2.8.1
+        uses: nick-fields/retry@v2.8.3
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -38,7 +38,7 @@ jobs:
       # We use sops to store encrypted GCP ServiceAccount Key that terraform uses
       # to run, as well as PagerDuty config terraform uses
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
 
       # Authenticate with the correct KMS key that sops will use.
       - name: Setup sops credentials to decrypt repo secrets


### PR DESCRIPTION
Both of these actions are now running node 16, but our GitHub Actions log is still reporting the node 12 annotation. I'm hoping updating these tags will reset the cache and remove that annotation.

Actions that are bumped are: mdgreenwald/mozilla-sops-action, nick-fields/retry

ref: #1807 