### PR TITLE
Temporarily increase HTTP timeout

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -326,6 +326,9 @@ jupyterhub:
       KubeSpawner:
         # Make sure working directory is ${HOME}
         working_dir: /home/jovyan
+        # Increase timeout for Jupyter server to become 'ready', until
+        # https://github.com/2i2c-org/infrastructure/issues/2047 is fixed
+        http_timeout: 120
       Authenticator:
         # Don't allow test username to login into the hub
         # The test service will still be able to create this hub username


### PR DESCRIPTION
This gives the single user server process more time to start up, pending investigation in https://github.com/2i2c-org/infrastructure/issues/2047