### PR TITLE
AWS EKS infra: transition to k8s 1.24 and add required storage addon

### DIFF
--- a/eksctl/libsonnet/nodegroup.jsonnet
+++ b/eksctl/libsonnet/nodegroup.jsonnet
@@ -1,10 +1,15 @@
-// Make ASG tags for given set of k8s labels
+// This file is referenced by ../template.jsonnet. It declares an object
+// representing a node group that is used as a common foundation for all
+// our node groups.
+//
+
+// Make Auto Scaling Group (ASG) tags for given set of k8s labels
 local makeCloudLabels(labels) = {
   ['k8s.io/cluster-autoscaler/node-template/label/%s' % key]: labels[key]
   for key in std.objectFields(labels)
 };
 
-# Make asg tags for given set of k8s taints
+# Make ASG tags for given set of k8s taints
 local makeCloudTaints(taints) = {
   ['k8s.io/cluster-autoscaler/node-template/taint/%s' % key]: taints[key]
   for key in std.objectFields(taints)
@@ -27,6 +32,9 @@ local makeCloudTaints(taints) = {
   iam: {
     withAddonPolicies: {
       autoScaler: true,
+      // ebs: true is believed by Erik to be required for all nodes that should
+      // be able to schedule a pod mounting a PVC bound to a EBS based PV.
+      ebs: true,
     },
   },
 }

--- a/eksctl/libsonnet/nodegroup.jsonnet
+++ b/eksctl/libsonnet/nodegroup.jsonnet
@@ -32,9 +32,6 @@ local makeCloudTaints(taints) = {
   iam: {
     withAddonPolicies: {
       autoScaler: true,
-      // ebs: true is believed by Erik to be required for all nodes that should
-      // be able to schedule a pod mounting a PVC bound to a EBS based PV.
-      ebs: true,
     },
   },
 }


### PR DESCRIPTION
This adds the required changes to the eksctl cluster configuration files, as generated from a template.jsonnet file (depending on a libsonnet/nodegroup.jsonnet file).

## Questions

1. Should we add iam.withAddonPolicies.ebs=true to the default node group object so all node groups get support for mounting PVCs using EBS storage, or should we just add it to the core node-group that is known to need it?

Closes #2054, but work to migrate existing hubs remain, this is covered by #2057.