### PR TITLE
Deploy node_exporter everywhere

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -31,7 +31,13 @@ prometheus:
         key: hub.jupyter.org_dedicated
         value: user
       - effect: NoSchedule
-        # Deploy onto user nodes
+        key: hub.jupyter.org/dedicated
+        value: user
+      # Deploy onto dask worker nodes
+      - effect: NoSchedule
+        key: k8s.dask.org_dedicated
+        value: worker
+      - effect: NoSchedule
         key: k8s.dask.org_dedicated
         value: worker
     updateStrategy:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -26,20 +26,20 @@ prometheus:
     enabled: false
   nodeExporter:
     tolerations:
-      - effect: NoSchedule
-        # Deploy onto user nodes
-        key: hub.jupyter.org_dedicated
+      # Tolerate tainted jupyterhub user nodes
+      - key: hub.jupyter.org_dedicated
         value: user
-      - effect: NoSchedule
-        key: hub.jupyter.org/dedicated
+        effect: NoSchedule
+      - key: hub.jupyter.org/dedicated
         value: user
-      # Deploy onto dask worker nodes
-      - effect: NoSchedule
-        key: k8s.dask.org_dedicated
+        effect: NoSchedule
+      # Tolerate tainted dask worker nodes
+      - key: k8s.dask.org_dedicated
         value: worker
-      - effect: NoSchedule
-        key: k8s.dask.org_dedicated
+        effect: NoSchedule
+      - key: k8s.dask.org/dedicated
         value: worker
+        effect: NoSchedule
     updateStrategy:
       type: RollingUpdate
   pushgateway:


### PR DESCRIPTION
While exploring some questions about kernel restarts (courtesy a request by @briannalind) I realized that node_exporters were not actually running on all the nodes - only on core nodes! This prevents some helpful node info (such as oom kill count, etc) from being captured.

This PR will deploy node_exporter on all nodes as intended, and I've tested it on the openscapes cluster.