### PR TITLE
basehub: add custom.2i2c.temp_folder config for ~/temp ephemeral storage

### DIFF
--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -414,3 +414,19 @@ properties:
                 type: array
                 items:
                   type: string
+              temp_folder:
+                type: object
+                additionalProperties: false
+                required:
+                  - enabled
+                  - mountPath
+                  - emptyDir
+                properties:
+                  enabled:
+                    type: boolean
+                  mountPath:
+                    type: string
+                  emptyDir:
+                    type: object
+                    # k8s schema: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core
+                    additionalProperties: true

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -99,6 +99,10 @@ jupyterhub:
         - jmunroe@2i2c.org
         - sgibson@2i2c.org
         - yuvipanda@2i2c.org
+      temp_folder:
+        enabled: false
+        mountPath: /home/jovyan/temp
+        emptyDir: {}
   ingress:
     enabled: true
     annotations:
@@ -648,3 +652,48 @@ jupyterhub:
             # Customize list of profiles dynamically, rather than override options form.
             # This is more secure, as users can't override the options available to them via the hub API
             c.KubeSpawner.profile_list = custom_profile_list
+
+      # About temp_folder:
+      #
+      # This config snippet provides users with a ~/temp directory in the home
+      # folder to put ephemeral data.
+      #
+      # It is enabled/disabled via custom.2i2c.temp_folder.enabled, where
+      # emptyDir (medium, sizeLimit) and mountPath are other configuration
+      # options.
+      #
+      # Technical notes:
+      # - The folders file permissions will be root:root unless the pod's
+      #   securityContext includes fsGroup to influence this, which it does by
+      #   default in the jupyterhub chart via singleuser.fsGid. Due to this,
+      #   users will have read/write permissions on this folder.
+      #
+      # - Unless emptyDir.medium="Memory", this storage space counts towards the
+      #   k8s node's ephemeral storage and could run out just like as if a user
+      #   was filling up the /tmp folder.
+      #
+      # - The jupyterhub chart configurations singleuser.extraVolumes and
+      #   singleuser.extraVolumeMounts are not used as lists aren't merged but
+      #   instead replaces each other.
+      #
+      # References:
+      # - emptyDir volumes: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
+      # - ephemeral storage: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage
+      # - feature request: https://2i2c.freshdesk.com/a/tickets/375
+      #
+      2i2c_temp_folder: |
+        from z2jh import get_config
+        temp_folder = get_config("custom.2i2c.temp_folder")
+
+        if temp_folder["enabled"]:
+            temp_folder_volume = {
+                "name": "2i2c-temp-folder-volume",
+                "emptyDir": temp_folder["emptyDir"],
+            }
+            c.KubeSpawner.volumes.append(temp_folder_volume)
+
+            temp_folder_volume_mount = {
+                "name": "2i2c-temp-folder-volume",
+                "mountPath": temp_folder["mountPath"],
+            }
+            c.KubeSpawner.volume_mounts.append(temp_folder_volume_mount)


### PR DESCRIPTION
@jbusecke requested a temporary storage folder under the home folder in https://2i2c.freshdesk.com/a/tickets/375, so I added this feature to meet that need. It is currently trialed out in https://staging.leap.2i2c.cloud and it seems to work out well there.

Going onwards, any hub that wants this feature can toggle `jupyterhub.custom.2i2c.temp_folder.enabled=true` and they will get it.

![image](https://user-images.githubusercontent.com/3837114/213653592-7512064d-dfd7-4867-950a-9000448a46f6.png)

