### PR TITLE
Set dry_run to default to false so PRs are actually opened

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -58,4 +58,4 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"
-          dry_run: ${{ github.event.inputs.dry_run || true }}
+          dry_run: ${{ github.event.inputs.dry_run || false }}

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -66,4 +66,4 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           # team_reviewers: ${{ env.team_reviewers }}
           base_branch: "master"
-          dry_run: ${{ github.event.inputs.dry_run || true}}
+          dry_run: ${{ github.event.inputs.dry_run || false }}


### PR DESCRIPTION
An error in logic meant these workflows were not opening PRs automatically when they should have