### PR TITLE
binderhub: migrate config to new version of binderhub

### DIFF
--- a/helm-charts/binderhub/values.yaml
+++ b/helm-charts/binderhub/values.yaml
@@ -17,16 +17,13 @@ binderhub:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
       kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
-  dind:
-    enabled: true
+  imageBuilderType: dind
   imageCleaner:
     enabled: true
     # when 80% of inodes are used,
     # cull images until only 40% are used.
     imageGCThresholdHigh: 80
     imageGCThresholdLow: 40
-    host:
-      enabled: false
   jupyterhub:
     ingress:
       enabled: true


### PR DESCRIPTION
- The following error message showed up in our CI system following #2066, so even though the binderhub isn't used, I want to patch this.

I've reviewed the PRs introducing these breaking changes and feel confident that this PR is an acceptable change to migrate the config.

```
#################################################################################
######   BREAKING: The config values passed contained no longer accepted    #####
######             options. See the messages below for more details.        #####
######                                                                      #####
######             To verify your updated config is accepted, you can use   #####
######             the `helm template` command.                             #####
#################################################################################

CHANGED:

dind:
  enabled: true

must as of version 0.3.0 be replace by

imageBuilderType: dind

CHANGED:

imageCleaner:
  host:
    enabled: true

as of version 0.3.0 is not used anymore.

The image cleaner is either disabled or adapted to the value of imageBuilderType.
```