### PR TITLE
Update Openscapes python image on staging

### DIFF
--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -18,7 +18,7 @@ basehub:
                   default: true
                   slug: "python"
                   kubespawner_override:
-                    image: openscapes/python:11de2c5
+                    image: openscapes/python:7bc507a
                 rocker:
                   display_name: R
                   slug: "rocker"


### PR DESCRIPTION
We're testing a new Python image on staging.

* Updating Python to 3.11 and xarray to 2022.12.0 