### PR TITLE
Revert "Bumping helm chart dependency versions: support"

### DIFF
--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -61,19 +61,6 @@ class Cluster:
         )
         print_colour("Done!")
 
-        # FIXME: Revert this addition after one upgrade is made
-        print_colour("Preparing for prometheus v16 v19 migration...")
-        subprocess.check_call(
-            [
-                "kubectl",
-                "delete",
-                "daemonset",
-                "--namespace=support",
-                "support-prometheus-node-exporter",
-            ]
-        )
-        print_colour("Done!")
-
         print_colour("Provisioning support charts...")
 
         support_dir = (Path(__file__).parent.parent).joinpath("helm-charts", "support")

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -7,20 +7,20 @@ dependencies:
   # Prometheus for collection of metrics.
   # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
   - name: prometheus
-    version: 19.3.1
+    version: 15.16.1
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 6.50.1
+    version: 6.42.2
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from
   # a single IP entrypoint to various services exposed via k8s Ingress resources
   # that references this controller.
   - name: ingress-nginx
-    version: 4.4.2
+    version: 4.1.4
     repository: https://kubernetes.github.io/ingress-nginx
 
   # cluster-autoscaler for k8s clusters where it doesn't come out of the box (EKS)

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -24,7 +24,7 @@ prometheus:
     # Grafana also has alerts, and the UI of grafana is much better than that of alertmanager
     # We also expose Grafana publicly behind auth anyway, so we can consolidate alerting with Grafana too
     enabled: false
-  prometheus-node-exporter:
+  nodeExporter:
     tolerations:
       # Tolerate tainted jupyterhub user nodes
       - key: hub.jupyter.org_dedicated
@@ -42,7 +42,7 @@ prometheus:
         effect: NoSchedule
     updateStrategy:
       type: RollingUpdate
-  prometheus-pushgateway:
+  pushgateway:
     enabled: false
   server:
     ingress:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2067

This seemed to have caused an outage, not sure in how many hubs, but among them carbonplan for example.