### PR TITLE
Transition to explicitly use gke auth plugin

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -88,6 +88,27 @@ runs:
       with:
         version: v3.7.2
 
+    # Install pre-requisite for "gcloud container clusters get-credentials"
+    # command with a modern k8s client.
+    #
+    # A manual install step has been needed as they opted to not provide it in
+    # the github-runner image. See
+    # https://github.com/actions/runner-images/issues/5925#issuecomment-1216417721.
+    #
+    # Snippet based on
+    # https://github.com/actions/runner-images/blob/9753e7301e19e29b89b0622b811bbb9b3891d02e/images/linux/scripts/installers/google-cloud-sdk.sh#L9-L13.
+    #
+    - name: Install gke-gcloud-auth-plugin
+      if: inputs.provider == 'gcp'
+      run: |
+        REPO_URL="https://packages.cloud.google.com/apt"
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
+        sudo wget -q https://packages.cloud.google.com/apt/doc/apt-key.gpg -O /usr/share/keyrings/cloud.google.gpg
+
+        sudo apt-get update -y
+        sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+      shell: bash
+
     - name: Setup sops credentials to decrypt repo secrets
       uses: google-github-actions/auth@v1
       with:

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     # This action use the github official cache mechanism internally
-    - uses: azure/setup-helm@v3.5
+    - uses: azure/setup-helm@v3
       with:
         # version is pinned for helm to avoid an automatic update of its version
         # which would cause something unexpected without an action on our

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -80,7 +80,7 @@ runs:
     # See https://github.com/2i2c-org/infrastructure/issues/1271.
     - uses: azure/setup-kubectl@v3
       with:
-        version: "v1.23.5"
+        version: "v1.23.16"
 
     # This action use the github official cache mechanism internally
     - name: Install sops

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -36,6 +36,9 @@ concurrency: deploy
 # GitHug Actions logs for easy reading
 env:
   TERM: xterm
+  # This may not be required any more, and it may depend on the kubectl version
+  # we use etc as well. For now, we have it added to avoid issues.
+  USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
 
 jobs:
   # This job runs in Pull Requests and on pushes to the default branch. It identifies


### PR DESCRIPTION
- deploy setup action: use latest patch version for kubectl 1.23
- deploy setup action: pin only major version for setup-helm action
- deploy action/workflow: setup and opt-in to use gke auth plugin
