### PR TITLE
Bumping helm chart dependency versions: support (again)

### DIFF
--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -61,6 +61,19 @@ class Cluster:
         )
         print_colour("Done!")
 
+        # FIXME: Revert this addition after one upgrade is made
+        print_colour("Preparing for prometheus v16 v19 migration...")
+        subprocess.check_call(
+            [
+                "kubectl",
+                "delete",
+                "daemonset",
+                "--namespace=support",
+                "support-prometheus-node-exporter",
+            ]
+        )
+        print_colour("Done!")
+
         print_colour("Provisioning support charts...")
 
         support_dir = (Path(__file__).parent.parent).joinpath("helm-charts", "support")

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -7,20 +7,20 @@ dependencies:
   # Prometheus for collection of metrics.
   # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
   - name: prometheus
-    version: 15.16.1
+    version: 19.3.1
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 6.42.2
+    version: 6.50.1
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from
   # a single IP entrypoint to various services exposed via k8s Ingress resources
   # that references this controller.
   - name: ingress-nginx
-    version: 4.1.4
+    version: 4.4.2
     repository: https://kubernetes.github.io/ingress-nginx
 
   # cluster-autoscaler for k8s clusters where it doesn't come out of the box (EKS)

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -24,7 +24,7 @@ prometheus:
     # Grafana also has alerts, and the UI of grafana is much better than that of alertmanager
     # We also expose Grafana publicly behind auth anyway, so we can consolidate alerting with Grafana too
     enabled: false
-  nodeExporter:
+  prometheus-node-exporter:
     tolerations:
       # Tolerate tainted jupyterhub user nodes
       - key: hub.jupyter.org_dedicated
@@ -42,7 +42,7 @@ prometheus:
         effect: NoSchedule
     updateStrategy:
       type: RollingUpdate
-  pushgateway:
+  prometheus-pushgateway:
     enabled: false
   server:
     ingress:


### PR DESCRIPTION
- In short, this PR is a new attempt of #2067 which is reasonable to make now that carbonplan's k8s version is upgraded from 1.19 to 1.24, which makes all of our k8s clusters be versioned 1.21 or higher - where the only cluster stuck at 1.21 is openscapes.
- "In long", this reverts commit d680896f1ba32a80643861a72650fffc6c1dc400, that was the merge commit for #2079, that in turn reverted #2067 after the incident in carbonplan #2080.

### Related action points

- [x] Review #2074 which I'd like to merge before this
- [ ] Review this PR
- [ ] Review a subsequent PR I'll open removing the patch to the deployer script in this PR