### PR TITLE
pangeo-hubs, support: increase prometheus memory limit from 8->12 GB

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -41,4 +41,4 @@ prometheus:
         # WAL after a restart (https://github.com/prometheus/prometheus/issues/6934). This was
         # causing prometheus to crash forever, as the memory spike would get it killed. The
         # higher limit helps with this
-        memory: 8Gi
+        memory: 12Gi


### PR DESCRIPTION
Following instructions in https://infrastructure.2i2c.org/en/latest/sre-guide/common-problems-solutions.html#prometheus-server-is-out-of-memory-oom as suggested by @GeorgianaElena this is what I ended up with.

This is now deployed successfully!

I did not try increase 8GB to 9GB etc, and went straight to 12GB, thinking it will cause us more trouble than its worth to get this tuned perfectly. I've seen a need for more than 16GB in memory as well for prometheus-server, so nudging it just slightly didn't seem like the right call.