### PR TITLE
deployer: cleanup no longer needed patch for prometheus upgrade

### DIFF
--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -61,19 +61,6 @@ class Cluster:
         )
         print_colour("Done!")
 
-        # FIXME: Revert this addition after one upgrade is made
-        print_colour("Preparing for prometheus v16 v19 migration...")
-        subprocess.check_call(
-            [
-                "kubectl",
-                "delete",
-                "daemonset",
-                "--namespace=support",
-                "support-prometheus-node-exporter",
-            ]
-        )
-        print_colour("Done!")
-
         print_colour("Provisioning support charts...")
 
         support_dir = (Path(__file__).parent.parent).joinpath("helm-charts", "support")


### PR DESCRIPTION
- This cleans up the patch to the deployer script that was added in #2086 to handle upgrading prometheus from v16 to v19