### PR TITLE
Rewrite the "documentation structure" page to better reflect how our docs are currently organised

### DIFF
--- a/docs/hub-deployment-guide/cloud-accounts/new-aws-account.md
+++ b/docs/hub-deployment-guide/cloud-accounts/new-aws-account.md
@@ -48,7 +48,7 @@ More information on these terms can be found in [](cloud-access:aws).
    * On the "Review and submit assignments" page, click "Submit".
 
 You have successfully created a new AWS account and connected it to our SSO Management Account!
-Now, [setup a new cluster](new-cluster:new-cluster-aws) inside it via Terraform.
+Now, [setup a new cluster](new-cluster:aws) inside it via Terraform.
 
 ## Checking quotas and requesting increases
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,102 +1,53 @@
 # Documentation structure
 
-We primarily offer documentation, peace of mind and expertise to
-our users - and code/configuration is simply an implementation
-detail. Well structured documentation aimed at different audiences is
-essential to 2i2c's long term health. This document lists the audiencs
-we serve, what kinda docs they might expect, and where we provide them.
+This page describes how the documentation we maintain at
+<https://infrastructure.2i2c.org> is structured.
 
-## Audiences
+## Audience
 
-For each feature we add or change we make, we should create & update
-documentation for all of these audiences, as applicable. There are a
-few key audiences that are outlined below.
+The primary audience of this documentation is
+[**2i2c Engineers**](https://compass.2i2c.org/en/latest/engineering/structure.html#open-source-infrastructure-engineer),
+though anyone is welcome to peruse them for their own understanding if they wish.
 
-## The general public
-
-People visit our website to learn about us, and investigate if we could
-be of use to them. Communicating what value we can add to them is
-extremely important, so any feature we write should be integrated into
-[our website](https://2i2c.org/). The focus should
-be on the value we can add to potential users, and should link to
-other kinda documentation for more detail if needed.
-
-## Hub users
-
-Ultimately, our hubs are built to serve researchers, students and instructors.
-These are our *end users*, and they need to be able to
-get their work done.
-
-The infrastructure we provide is primarily opinionated bundles of
-upstream software, so we don't *need* to rewrite documentation for all
-the software they might use. However, since we make opinionated choices
-about JupyterHub deployments, some repetition of upstream documentation
-that assumes the specific choices we already make is helpful.
-
-We should provide at least the following kinds of documentation:
-
-1. **Tutorials** for common workflows on our infrastructure, since this is
-   heavily driven by the opinionated choices we have made while building it.
-2. **How-to guides** to help users accomplish a specific well defined task,
-   especially if it is something they know how to do in a different system.
-   The documentation titles should always be of the form **How do I `<title>`?**
-3. **Component reference** to inform users where to find documentation for
-   the component they might be having issues with. Most users are unfamiliar
-   with the intricate details of what component does what, so might not be
-   able to find the appropriate place to look at.
-
-This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
-repository, available at [docs.2i2c.org](https://docs.2i2c.org)
-
-## Hub administrators
-
-Hub administrators are the interface between the 2i2c engineers running
-the hub and the actual users of the hub. They are usually a part of the
-community using the hub, and are interested in the *configuration* of
-the hub infrastructure as well. They should be aware of possible
-configuration options they can choose to serve their community best, and
-be empowered to make those choices without interaction with 2i2c
-engineers wherever possible.
-
-They help make decisions about the configuration of the hub that benefits
-its users most, and hence we should provide at least the following kinds
-of documentaiton.
-
-1. **Configuration guides** to help them *pick* the configuration that
-   will be best fit for each of our major features - such as
-   authentication, kind of user interface, etc. Their hubs are then
-   configured with these choices in collaboration with 2i2c staff. Each
-   guide should mention *how* this implementation can occur - possibly
-   with a link to documentation for 2i2c engineers  .
-2. **How-to guides** to help admins accomplish very specific tasks during
-   the course of hub usage. Their titles should always be of the form
-   **How do I `<title>`?**.
-
-This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
-repository, available at [docs.2i2c.org](https://docs.2i2c.org/)
-
-## 2i2c engineers
-
-These are folks tasked with building, maintaining, debugging and fixing
-2i2c infrastructure. Documentation targetting them should be in
-[2i2c-org/infrastructure](https://github.com/2i2c-org/infrastructure)
-repository, regardless of the kind of hub it
-relates to. Since we run our hubs openly, with best practices that can
+Engineers are folks tasked with building, maintaining, debugging and fixing
+2i2c infrastructure. Since we run our hubs openly, with best practices that can
 be adopted by anyone, we should try write these to be as accessible to
 non 2i2c staff as possible - no secret sauce, minimal 2i2c specific
 process.
 
-Here are some contexts where they would need documentation.
+## Structure
 
-1. **Tutorials**, to help orient folks who might be working on areas
-   they aren't already familiar with. This should have clear links to
-   pre-requisite knowledge and how it can be acquired.
-2. **How-to guides** for performing common tasks that have not been
-   automated yet. Their titles should always be of the form
-   **How do I `<title>`?**
-3. **Topic guides**
-4. **References**, describing in detail parts of our infrastructure and
-   its configuration. This should ideally be kept in the code describing
-   our infrastructure - for example, [terraform-docs](https://github.com/terraform-docs/terraform-docs)
-   for terraform code, JSON Schema based document generator for YAML,
-   etc. This helps them be in sync with what we are actually doing.
+Infrastructure documentation is broken down into these main guides:
+
+- [**Site Reliability Guide.**](sre-guide) This guide covers day-to-day tasks
+  undertaken by engineers as well as tasks that may need to be completed as part
+  of the
+  [support process](https://team-compass.2i2c.org/en/latest/projects/managed-hubs/support.html).
+  It is also a place to document common problems and their solutions for future
+  reference.
+- [**Hub Deployment Guide.**](hub-deployment-guide) This guide walks an engineer
+  through the process of deploying a hub, step-by-step. It should document how
+  to enable all the features we typically enable during a standard hub deployment.
+
+The remainder of our documentation is organised as such:
+
+- **"Get Started"** tutorials help orient folks who might be working on areas
+  they aren't already familiar with and help them achieve a specific goal. These
+  articles should have clear links to pre-requisite knowledge and how it can be
+  acquired.
+- **How-to guides** demonstrate how to perform tasks that have not been automated
+  yet, or enable extra features that are not part of a standard hub deployment.
+  The titles of these guides should be of the form **How do I `<title>`?**
+- **Topic guides** go into greater depth of conceptual ideas around our
+  infrastructure, why we deploy things the way we do, and what steps we have
+  taken to automate some tasks. These articles are grouped together by a broad
+  topic, such as "monitoring and alerting". If the topic guide you are writing
+  doesn't belong to one of the pre-existing groups, feel free to create a new
+  group if you suspect we will generate more documentation for that topic, or
+  create it as a standalone article, such as the [](hub-features) article.
+- **References** describe in detail parts of our infrastructure and its
+  configuration. This should ideally be kept in the code describing our
+  infrastructure - for example,
+  [terraform-docs](https://github.com/terraform-docs/terraform-docs) for
+  terraform code, JSON Schema based document generator for YAML, etc. This helps
+  them keep in sync with what we are actually doing.

--- a/docs/topic/features.md
+++ b/docs/topic/features.md
@@ -1,3 +1,4 @@
+(hub-features)=
 # Features available on the hubs
 
 This document is a concise description of various features we can


### PR DESCRIPTION
This mostly reduces the complexity of this page by only focussing on 2i2c engineers as the audience, and the structure of the infrastructure.2i2c.org site only. It documents the SRE and Hub Deployment guides as well as the breakdown of our other docs that don't fall into those guides.

**Note:** I have kept a local copy of the original file contents because I do really like the idea of thinking about audiences and breaking down docs accordingly, and how we split that between infrastructure repo and the docs repo. But I think that discussion would be better placed into the team compass than in the infrastructure repo itself. So I will follow up with a PR over there bringing back some of the nuance and different audiences that this PR removes.

Link to rendered page: https://2i2c-pilot-hubs--2091.org.readthedocs.build/en/2091/structure.html

fixes #2055 