### PR TITLE
Add new image option for LEAP classes

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -112,7 +112,7 @@ basehub:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
                   kubespawner_override:
-                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
+                    image: "quay.io/jbusecke/leap-edu-image:9896814442a9"
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -83,6 +83,27 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
+         - display_name: Medium Admin Test
+          description: 11GB RAM, 4 CPUs
+          allowed_teams:
+            - leap-stc:webmasters # basically just julius and ryan for testing things. I could make a separate admin group?
+            - 2i2c-org:hub-access-for-2i2c-staff
+          profile_options:
+            image:
+              display_name: Image
+              choices:
+                pangeo:
+                  display_name: Base Pangeo Notebook
+                  default: true
+                  slug: "pangeo"
+                  kubespawner_override:
+                    image: "pangeo/pangeo-notebook:2023.01.03"
+                custom:
+                  display_name: Prototype Education Notebook
+                  slug: "leap_edu"
+                  kubespawner_override:
+                    image: "jbusecke/leap-edu-image:e8cf3f0ccb57"
+                  
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           allowed_teams:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -83,12 +83,12 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
-         - display_name: Medium Admin Test
-           description: 11GB RAM, 4 CPUs
-           allowed_teams:
+        - display_name: Medium Admin Test
+          description: 11GB RAM, 4 CPUs
+          allowed_teams:
             - leap-stc:webmasters # basically just julius and ryan for testing things. I could make a separate admin group?
             - 2i2c-org:hub-access-for-2i2c-staff
-           profile_options:
+          profile_options:
             image:
               display_name: Image
               choices:
@@ -102,8 +102,7 @@ basehub:
                   display_name: Prototype Education Notebook
                   slug: "leap_edu"
                   kubespawner_override:
-                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
-                  
+                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"    
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           allowed_teams:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -86,7 +86,7 @@ basehub:
         - display_name: Medium Admin Test
           description: 11GB RAM, 4 CPUs
           allowed_teams:
-            - leap-stc:webmasters # basically just julius and ryan for testing things. I could make a separate admin group?
+            - leap-stc:leap-pangeo-testers
             - 2i2c-org:hub-access-for-2i2c-staff
           profile_options:
             image:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -84,11 +84,11 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
          - display_name: Medium Admin Test
-          description: 11GB RAM, 4 CPUs
-          allowed_teams:
+           description: 11GB RAM, 4 CPUs
+           allowed_teams:
             - leap-stc:webmasters # basically just julius and ryan for testing things. I could make a separate admin group?
             - 2i2c-org:hub-access-for-2i2c-staff
-          profile_options:
+           profile_options:
             image:
               display_name: Image
               choices:
@@ -102,7 +102,7 @@ basehub:
                   display_name: Prototype Education Notebook
                   slug: "leap_edu"
                   kubespawner_override:
-                    image: "jbusecke/leap-edu-image:e8cf3f0ccb57"
+                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
                   
         - display_name: Medium
           description: 11GB RAM, 4 CPUs

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -102,7 +102,7 @@ basehub:
                   display_name: Prototype Education Notebook
                   slug: "leap_edu"
                   kubespawner_override:
-                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"    
+                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           allowed_teams:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -83,26 +83,6 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
-        - display_name: Medium Admin Test
-          description: 11GB RAM, 4 CPUs
-          allowed_teams:
-            - leap-stc:leap-pangeo-testers
-            - 2i2c-org:hub-access-for-2i2c-staff
-          profile_options:
-            image:
-              display_name: Image
-              choices:
-                pangeo:
-                  display_name: Base Pangeo Notebook
-                  default: true
-                  slug: "pangeo"
-                  kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2023.01.03"
-                custom:
-                  display_name: Prototype Education Notebook
-                  slug: "leap_edu"
-                  kubespawner_override:
-                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           allowed_teams:
@@ -128,6 +108,11 @@ basehub:
                   slug: "pytorch"
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2023.01.03"
+                leap-pangeo-edu:
+                  display_name: LEAP Education Notebook (Testing Prototype)
+                  slug: "leap_edu"
+                  kubespawner_override:
+                    image: "quay.io/jbusecke/leap-edu-image:e8cf3f0ccb57"
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G


### PR DESCRIPTION
I would like to test a custom image (details overe [here](https://github.com/jbusecke/leap_education_docker_image), made according to the instructions [here](https://docs.2i2c.org/en/latest/admin/howto/environment/hub-user-image-template-guide.html?highlight=image#create-a-custom-user-image-for-your-hub)). If I understand correctly using the ['configurator'](https://pilot.2i2c.org/en/latest/admin/howto/configurator.html) this will change the image for every user starting a new server (which I want to avoid at all cost rn, since this is very early testing 😬). 

Ultimately I would like to have an option to pull arbitrary images using tags (but I will send a separate email for that, also cc @jmunroe, who might have already raised this more general issue).