### PR TITLE
reverting to Python 3.9

### DIFF
--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -18,7 +18,7 @@ basehub:
                   default: true
                   slug: "python"
                   kubespawner_override:
-                    image: openscapes/python:7bc507a
+                    image: openscapes/python:7a02c71
                 rocker:
                   display_name: R
                   slug: "rocker"


### PR DESCRIPTION
Datashader and friends are not totally compatible with Python 3.11, until they are we'll keep using 3.9 :( 