### PR TITLE
drakkar-demo: setup GCP/k8s SA to work against buckets, and scratch bucket

### DIFF
--- a/config/clusters/meom-ige/drakkar-demo.values.yaml
+++ b/config/clusters/meom-ige/drakkar-demo.values.yaml
@@ -1,3 +1,6 @@
+userServiceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: meom-ige-drakkar-demo@meom-ige-cnrs.iam.gserviceaccount.com
 nfs:
   pv:
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
@@ -31,6 +34,8 @@ jupyterhub:
           name: SWOT Ocean Pangeo Team
           url: https://meom-group.github.io/
   singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: "gs://meom-ige-scratch-drakkar-demo/$(JUPYTERHUB_USER)"
     profileList:
       # The mem-guarantees are here so k8s doesn't schedule other pods
       # on these nodes. They need to be just under total allocatable

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -130,6 +130,9 @@ user_buckets = {
   "scratch": {
     "delete_after": null
   },
+  "scratch-drakkar-demo": {
+    "delete_after" : 7
+  },
   "data": {
     "delete_after": null
   }
@@ -145,5 +148,10 @@ hub_cloud_permissions = {
     requestor_pays : true,
     bucket_admin_access: ["scratch", "data"],
     hub_namespace: "prod"
+  },
+  "drakkar-demo" : {
+    requestor_pays : true,
+    bucket_admin_access: ["scratch-drakkar-demo"],
+    hub_namespace: "drakkar-demo"
   }
 }


### PR DESCRIPTION
This complements https://github.com/2i2c-org/infrastructure/pull/2074 thanks to a crisp analysis by @auraoupa  in https://github.com/2i2c-org/infrastructure/issues/2049#issuecomment-1405425580 that the meom-ige and this hub differed even when the image used was the same.

I understand it as the issue was that we didn't provide drakkar-demo with credentials to work against remote object storage buckets where we need to pay to fetch data from them.

---

I've deployed the terraform plan already, and will go for a self-merge because drakkar-demo is a temporary hub meant to be used very soon!