### PR TITLE
meom-ige, drakkar-demo: declare serviceAccountName for a basehub

### DIFF
--- a/config/clusters/meom-ige/drakkar-demo.values.yaml
+++ b/config/clusters/meom-ige/drakkar-demo.values.yaml
@@ -34,6 +34,7 @@ jupyterhub:
           name: SWOT Ocean Pangeo Team
           url: https://meom-group.github.io/
   singleuser:
+    serviceAccountName: user-sa
     extraEnv:
       SCRATCH_BUCKET: "gs://meom-ige-scratch-drakkar-demo/$(JUPYTERHUB_USER)"
     profileList:


### PR DESCRIPTION
This follows up #2101, because while all daskhub has `jupyterhub.singleuser.serviceAccountName` pre-defined, the basehub helm chart doesn't.

Maybe I'm one of the first to run into a situation where a dedicated cluster has a daskhub setup, but a temporary basehub is then used.