### PR TITLE
meom-ige, drakkar-demo: only show the 16 CPU server option

### DIFF
--- a/config/clusters/meom-ige/drakkar-demo.values.yaml
+++ b/config/clusters/meom-ige/drakkar-demo.values.yaml
@@ -48,42 +48,14 @@ jupyterhub:
       # The mem-guarantees are here so k8s doesn't schedule other pods
       # on these nodes. They need to be just under total allocatable
       # RAM on a node, not total node capacity
-      - display_name: "Small"
-        default: true
-        description: "~2 CPU, ~8G RAM"
-        kubespawner_override:
-          mem_limit: 8G
-          mem_guarantee: 5G
-          node_selector:
-            node.kubernetes.io/instance-type: n1-standard-2
-      - display_name: "Medium"
-        description: "~8 CPU, ~32G RAM"
-        kubespawner_override:
-          mem_limit: 32G
-          mem_guarantee: 25G
-          node_selector:
-            node.kubernetes.io/instance-type: n1-standard-8
       - display_name: "Large"
+        default: true
         description: "~16 CPU, ~64G RAM"
         kubespawner_override:
           mem_limit: 64G
           mem_guarantee: 50G
           node_selector:
             node.kubernetes.io/instance-type: n1-standard-16
-      - display_name: "Very Large"
-        description: "~32 CPU, ~128G RAM"
-        kubespawner_override:
-          mem_limit: 128G
-          mem_guarantee: 100G
-          node_selector:
-            node.kubernetes.io/instance-type: n1-standard-32
-      - display_name: "Huge"
-        description: "~64 CPU, ~256G RAM"
-        kubespawner_override:
-          mem_limit: 256G
-          mem_guarantee: 220G
-          node_selector:
-            node.kubernetes.io/instance-type: n1-standard-64
     defaultUrl: /lab
   scheduling:
     userPlaceholder:


### PR DESCRIPTION
- Changes made on request from https://github.com/2i2c-org/infrastructure/issues/2049#issuecomment-1406323704