### PR TITLE
docs: use env vars in docs bash cmd

### DIFF
--- a/docs/howto/features/gpu.md
+++ b/docs/howto/features/gpu.md
@@ -61,13 +61,17 @@ AWS, and we can configure a node group there to provide us GPUs.
 2. Render the `.jsonnet` file into a `.yaml` file that `eksctl` can use
 
    ```bash
-   jsonnet <your-cluster>.jsonnet > <your-cluster>.eksctl.yaml
+   export CLUSTER_NAME=<your_cluster>
+   ```
+
+   ```bash
+   jsonnet $CLUSTER_NAME.jsonnet > $CLUSTER_NAME.eksctl.yaml
    ```
 
 3. Create the nodegroup
 
    ```bash
-   eksctl create nodegroup -f <your-cluster>.eksctl.yaml
+   eksctl create nodegroup -f $CLUSTER_NAME.eksctl.yaml
    ```
 
    This should create the nodegroup with 0 nodes in it, and the

--- a/docs/howto/manage-domains/override-domain.md
+++ b/docs/howto/manage-domains/override-domain.md
@@ -16,7 +16,7 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
 
 ## How-to guide
 
-1. Create a new file with the path `config/clusters/<cluster_name>/<hub_name>.domain_override.secret.yaml` where `<hub_name>` is the name of the hub we are targeting, and `<cluster_name>` is the name of the cluster upon which the hub is running.
+1. Create a new file with the path `config/clusters/$CLUSTER_NAME/<hub_name>.domain_override.secret.yaml` where `<hub_name>` is the name of the hub we are targeting, and `$CLUSTER_NAME` is the name of the cluster upon which the hub is running.
    ```{note}
    We have included `secret` in the filename since we will be encrypting this file with `sops` so that the new domain name cannot be discovered by someone checking the GitHub repository.
    However, it is worth noting that our deployment infrastructure does not _enforce_ the domain override file to be encrypted and an unencrypted file can be provided, if necessary.
@@ -28,13 +28,18 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
    ```
 
    ```{note}
-   The new domain still still follow the convention `foo.<cluster_name>.2i2c.cloud`, but `foo` can be replaced with anything that is not the current top-level domain of the hub.
+   The new domain still still follow the convention `foo.$CLUSTER_NAME.2i2c.cloud`, but `foo` can be replaced with anything that is not the current top-level domain of the hub.
    A randomly generated string is probably best to avoid the new domain being guessable.
    ```
 3. (Optional) Encrypt the file with `sops`.
 
    ```bash
-   sops --output config/clusters/<cluster_name>/enc-<hub_name>.domain_override.secret.yaml --encrypt config/clusters/<cluster_name>/<hub_name>.domain_override.secret.yaml
+   export CLUSTER_NAME=<cluster-name>
+   export HUB_NAME=<hub-name>
+   ```
+
+   ```bash
+   sops --output config/clusters/$CLUSTER_NAME/enc-$HUB_NAME.domain_override.secret.yaml --encrypt config/clusters/$CLUSTER_NAME/$HUB_NAME.domain_override.secret.yaml
    ```
 
    The file can now be safely committed to the repository.
@@ -43,9 +48,9 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
    ```yaml
    hubs:
      ...
-     - name: <hub_name>
+     - name: <hub-name>
        domain: original.domain.2i2c.cloud
-       domain_override_file: enc-<hub_name>.domain-override.secret.yaml
+       domain_override_file: enc-<hub-name>.domain-override.secret.yaml
    ```
 
    ```{note}
@@ -55,5 +60,5 @@ This is generally a temporary fix to rapidly make a hub undiscoverable and shoul
 5. Run the deployer for the hub!
 
    ```bash
-   deployer deploy <cluster_name> <hub_name>
+   deployer deploy $CLUSTER_NAME $HUB_NAME
    ```

--- a/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
+++ b/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
@@ -23,7 +23,11 @@ installed by default in many operating systems, to generate the password.
 Once you create the file, encrypt it with `sops`.
 
 ```bash
-sops --output config/clusters/<cluster-name>/enc-support.secret.values.yaml --encrypt config/clusters/<cluster-name>/support.secret.values.yaml
+export CLUSTER_NAME=<cluster-name>
+```
+
+```bash
+sops --output config/clusters/$CLUSTER_NAME/enc-support.secret.values.yaml --encrypt config/clusters/$CLUSTER_NAME/support.secret.values.yaml
 ```
 
 ## Update your `cluster.yaml` file
@@ -40,7 +44,7 @@ support:
 Then redeploy the `support chart`.
 
 ```bash
-deployer deploy-support <cluster-name>
+deployer deploy-support $CLUSTER_NAME
 ```
 
 ## Link the cluster's Prometheus server to the central Grafana

--- a/docs/hub-deployment-guide/deploy-support/setup-grafana-dashboards.md
+++ b/docs/hub-deployment-guide/deploy-support/setup-grafana-dashboards.md
@@ -29,7 +29,11 @@ admin user, you can generate an API key.
 You can do this by running a deployer command:
 
 ```bash
-deployer new-grafana-token <cluster_name>
+export CLUSTER_NAME=<cluster-name>
+```
+
+```bash
+deployer new-grafana-token $CLUSTER_NAME
 ```
 
 If the command succeeded, it should have created:
@@ -54,7 +58,7 @@ This key will be used by the [`deploy-grafana-dashboards` workflow](https://gith
 You can deploy the dashboards locally using the deployer:
 
 ```bash
-deployer deploy-grafana-dashboards <CLUSTER_NAME>
+deployer deploy-grafana-dashboards $CLUSTER_NAME
 ```
 
 ## Deploying the Grafana Dashboards from CI/CD

--- a/docs/hub-deployment-guide/hubs/other-hub-ops/delete-hub.md
+++ b/docs/hub-deployment-guide/hubs/other-hub-ops/delete-hub.md
@@ -25,8 +25,8 @@ Especially if we think that users will want this information in the future (or i
 Delete user home directories using the [deployer `exec-homes-shell`](https://github.com/2i2c-org/infrastructure/blob/master/deployer/README.md#exec-homes-shell) option.
 
 ```bash
-export CLUSTER_NAME=$CLUSTER_NAME
-export HUB_NAME=$HUB_NAME
+export CLUSTER_NAME=<cluster-name>
+export HUB_NAME=<hub-name>
 ```
 
 ```bash

--- a/docs/hub-deployment-guide/hubs/other-hub-ops/delete-hub.md
+++ b/docs/hub-deployment-guide/hubs/other-hub-ops/delete-hub.md
@@ -25,7 +25,12 @@ Especially if we think that users will want this information in the future (or i
 Delete user home directories using the [deployer `exec-homes-shell`](https://github.com/2i2c-org/infrastructure/blob/master/deployer/README.md#exec-homes-shell) option.
 
 ```bash
-deployer exec-homes-shell <cluster_name> <hub_name>
+export CLUSTER_NAME=$CLUSTER_NAME
+export HUB_NAME=$HUB_NAME
+```
+
+```bash
+deployer exec-homes-shell $CLUSTER_NAME $HUB_NAME
 ```
 
 This should get you a shell with the home directories of all the users on the given hub. Delete all user home directories with:
@@ -44,7 +49,7 @@ If the hub remains listed in its cluster's `cluster.yaml` file, the hub could be
 redeployed by any merged PR triggering our CI/CD pipeline.
 
 Open a decomissioning PR that removes the appropriate hub entry from the
-`config/clusters/<cluster_name>/cluster.yaml` file and associated
+`config/clusters/$CLUSTER_NAME/cluster.yaml` file and associated
 `*.values.yaml` files no longer referenced in the `cluster.yaml` file.
 
 You can continue with the steps below before the PR is merged, but be ready to
@@ -56,10 +61,10 @@ merged.
 In the appropriate cluster, run:
 
 ```bash
-deployer use-cluster-credentials <cluster-name>
+deployer use-cluster-credentials $CLUSTER_NAME
 
-helm --namespace=<hub-name> delete <hub-name>
-kubectl delete namespace <hub-name>
+helm --namespace=$HUB_NAME delete $HUB_NAME
+kubectl delete namespace $HUB_NAME
 ```
 
 ## 4. Delete the OAuth application
@@ -72,7 +77,7 @@ For each hub that uses Auth0, we create an [Application](https://auth0.com/docs/
 
 For each hub that uses the JupyterHub GitHubOAuthenticator, we create a GitHub [OAuth Application](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app). You should be able to see the [list of applications created under the `2i2c` GitHub org](https://github.com/organizations/2i2c-org/settings/applications) and delete the one created for the hub that's being decommissioned.
 
-The naming convention followed when creating these apps is: `<cluster_name>-<hub_name>`.
+The naming convention followed when creating these apps is: `$CLUSTER_NAME-$HUB_NAME`.
 
 ### CILogon OAuth application
 

--- a/docs/hub-deployment-guide/hubs/other-hub-ops/manual-deploy.md
+++ b/docs/hub-deployment-guide/hubs/other-hub-ops/manual-deploy.md
@@ -19,16 +19,21 @@ of this repository, and can deploy one or more hubs to our clusters.
 3. Deploy just a single hub:
 
    ```bash
-   deployer deploy <cluster-name> <hub-name>
+   export CLUSTER_NAME=<cluster-name>
+   export HUB_NAME=<hub-name>
    ```
 
-   The script will look for a hub named `<hub-name>` in the cluster config
-   defined at `config/clusters/<cluster-name>/cluster.yaml` and read in the `*.values.yaml` files associated with that hub.
+   ```bash
+   deployer deploy $CLUSTER_NAME $HUB_NAME
+   ```
+
+   The script will look for a hub named `$HUB_NAME` in the cluster config
+   defined at `config/clusters/$CLUSTER_NAME/cluster.yaml` and read in the `*.values.yaml` files associated with that hub.
 
 4. You can deploy to *all* hubs on a given cluster by omitting the hub name.
 
    ```bash
-   deployer deploy <cluster-name>
+   deployer deploy $CLUSTER_NAME
    ```
 
 ```{note}
@@ -53,14 +58,14 @@ runs to completion and the output cells have the expected value.
 To run the automated health check on a hub, run
 
 ```bash
-deployer run-hub-health-check <cluster-name> <hub-name>
+deployer run-hub-health-check $CLUSTER_NAME $HUB_NAME
 ```
 
 This will test a simple notebook, but not any dask functionality. To test dask
 functionality as well, run
 
 ```bash
-deployer run-hub-health-check --check-dask-scaling <cluster-name> <hub-name>
+deployer run-hub-health-check --check-dask-scaling $CLUSTER_NAME $HUB_NAME
 ```
 
 These tests are automatically run when you deploy via CI.

--- a/docs/hub-deployment-guide/new-cluster/aws.md
+++ b/docs/hub-deployment-guide/new-cluster/aws.md
@@ -40,17 +40,23 @@ We automatically generate the files required to setup a new cluster:
 You can generate these with:
 
 ```bash
-deployer generate-aws-cluster --cluster-name=<...> --cluster-region=<like ca-central-1> --hub-type=<like basehub>
+export CLUSTER_NAME=<cluster-name>
+export CLUSTER_REGION=<cluster-region-like ca-central-1>
+export HUB_TYPE=<hub-type-like-basehub>
+```
+
+```bash
+deployer generate-aws-cluster --cluster-name=$CLUSTER_NAME --cluster-region=$CLUSTER_REGION --hub-type=$HUB_TYPE
 ```
 
 This will generate the following files:
 
-1. `eksctl/<cluster-name>.jsonnet` with a default cluster configuration, deployed to `us-west-2`
-2. `eksctl/ssh-keys/secret/<cluster-name>.key`, a `sops` encrypted ssh private key that can be
+1. `eksctl/$CLUSTER_NAME.jsonnet` with a default cluster configuration, deployed to `us-west-2`
+2. `eksctl/ssh-keys/secret/$CLUSTER_NAME.key`, a `sops` encrypted ssh private key that can be
    used to ssh into the kubernetes nodes.
-3. `eksctl/ssh-keys/<cluster-name>.pub`, an ssh public key used by `eksctl` to grant access to
+3. `eksctl/ssh-keys/$CLUSTER_NAME.pub`, an ssh public key used by `eksctl` to grant access to
    the private key.
-4. `terraform/aws/projects/<cluster-name>.tfvars`, a terraform variables file that will setup
+4. `terraform/aws/projects/$CLUSTER_NAME.tfvars`, a terraform variables file that will setup
    most of the non EKS infrastructure.
 
 ### Create and render an eksctl config file
@@ -110,7 +116,7 @@ Once it is done, you can test access to the new cluster with `kubectl`, after
 getting credentials via:
 
 ```bash
-aws eks update-kubeconfig --name=<your-cluster-name> --region=<your-cluster-region>
+aws eks update-kubeconfig --name=$CLUSTER_NAME --region=$CLUSTER_REGION
 ```
 
 `kubectl` should be able to find your cluster now! `kubectl get node` should show
@@ -141,19 +147,19 @@ in GCP, so you also need to have `gcloud` set up and authenticated already.
 3. Create a new [terraform workspace](topic:terraform:workspaces)
 
    ```bash
-   terraform workspace new <your-cluster-name>
+   terraform workspace new $CLUSTER_NAMEF
    ```
 
 4. Deploy the terraform-managed infrastructure
 
    ```bash
-   terraform plan -var-file projects/<your-cluster-name>.tfvars
+   terraform plan -var-file projects/$CLUSTER_NAME.tfvars
    ```
 
    Observe the plan carefully, and accept it.
 
    ```bash
-   terraform apply -var-file projects/<your-cluster-name>.tfvars
+   terraform apply -var-file projects/$CLUSTER_NAME.tfvars
    ```
 
 (new-cluster:aws:terraform:cicd)=
@@ -173,20 +179,20 @@ have least amount of permissions possible.
 1. Fetch credentials for automatic deployment
 
    ```bash
-   terraform output -raw continuous_deployer_creds > ../../config/clusters/<your-cluster-name>/deployer-credentials.secret.json
+   terraform output -raw continuous_deployer_creds > ../../config/clusters/$CLUSTER_NAME/deployer-credentials.secret.json
    ```
 
 1. Encrypt the file storing the credentials
 
    ```bash
-   sops --output ../../config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json --encrypt ../../config/clusters/<your-cluster-name>/deployer-credentials.secret.json
+   sops --output ../../config/clusters/$CLUSTER_NAME/enc-deployer-credentials.secret.json --encrypt ../../config/clusters/$CLUSTER_NAME/deployer-credentials.secret.json
    ```
 
-1. Double check to make sure that the `config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json` file is
+1. Double check to make sure that the `config/clusters/$CLUSTER_NAME/enc-deployer-credentials.secret.json` file is
    actually encrypted by `sops` before checking it in to the git repo. Otherwise this can be a serious security leak!
 
     ```bash
-   cat ../../config/clusters/<your-cluster-name>/enc-deployer-credentials.secret.json
+   cat ../../config/clusters/$CLUSTER_NAME/enc-deployer-credentials.secret.json
    ```
 
 1. Grant the freshly created IAM user access to the kubernetes cluster.
@@ -204,14 +210,14 @@ have least amount of permissions possible.
 
       ```bash
       eksctl create iamidentitymapping \
-         --cluster <your-cluster-name> \
-         --region <your-cluster-region> \
+         --cluster $CLUSTER_NAME \
+         --region $CLUSTER_REGION \
          --arn arn:aws:iam::<aws-accout-id>:user/hub-continuous-deployer \
          --username hub-continuous-deployer \
          --group system:masters
       ```
 
-1. Create a minimal `cluster.yaml` file (`config/clusters/<your-cluster-name>/cluster.yaml`),
+1. Create a minimal `cluster.yaml` file (`config/clusters/$CLUSTER_NAME/cluster.yaml`),
    and provide enough information for the deployer to find the correct credentials.
 
    ```yaml
@@ -229,15 +235,24 @@ have least amount of permissions possible.
    The `aws.key` file is defined _relative_ to the location of the `cluster.yaml` file.
    ```
 
-1. Test the access by running `deployer use-cluster-credentials <cluster-name>` and
-   running `kubectl get node`. It should show you the provisioned node on the cluster if
-   everything works out ok.
+1. Test the access by running:
+
+   ```bash
+   deployer use-cluster-credentials $CLUSTER_NAME
+   ```
+
+   and running:
+
+   ```bash
+   kubectl get node
+   ```
+   It should show you the provisioned node on the cluster if everything works out ok.
 
 ## Grant `eksctl` access to other users
 
 ```{note}
 This section is still required even if the account is managed by SSO.
-Though a user could run `deployer use-cluster-credentials <cluster-name>` to gain access as well.
+Though a user could run `deployer use-cluster-credentials $CLUSTER_NAME` to gain access as well.
 ```
 
 AWS EKS has a strange access control problem, where the IAM user who creates
@@ -253,16 +268,19 @@ You can modify the command output by running `terraform output -raw eksctl_iam_c
 
 ```bash
 eksctl create iamidentitymapping \
-   --cluster <your-cluster-name> \
-   --region <your-cluster-region> \
+   --cluster $CLUSTER_NAME \
+   --region $CLUSTER_REGION \
    --arn arn:aws:iam::<your-org-id>:user/<iam-user-name> \
    --username <iam-user-name> \
    --group system:masters
 ```
 
-This gives all the users full access to the entire kubernetes cluster. They can
-fetch local config with `aws eks update-kubeconfig --name=<your-cluster-name> --region=<your-cluster-region>`
-after this step is done.
+This gives all the users full access to the entire kubernetes cluster.
+After this step is done, they can fetch local config with:
+
+```bash
+aws eks update-kubeconfig --name=$CLUSTER_NAME --region=$CLUSTER_REGION
+```
 
 This should eventually be converted to use an [IAM Role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)
 instead, so we need not give each individual user access, but just grant access to the

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -223,13 +223,17 @@ terraform workspace list  # List all available workspaces
 terraform workspace select WORKSPACE_NAME
 ```
 
-Then, output the credentials created by terraform to a file under the appropriate cluster directory: `/config/clusters/<cluster-name>`.
+Then, output the credentials created by terraform to a file under the appropriate cluster directory: `/config/clusters/$CLUSTER_NAME`.
 
 ````{note}
 Create the cluster directory if it doesn't already exist with:
 
 ```bash
-mkdir -p ../../config/clusters/<cluster-name>
+export CLUSTER_NAME=<cluster-name>
+```
+
+```bash
+mkdir -p ../../config/clusters/$CLUSTER_NAME
 ```
 ````
 
@@ -269,13 +273,13 @@ We use `cluster.yaml` files to describe a specific cluster and all the hubs depl
 See [](config:structure) for more information.
 ```
 
-Create a `cluster.yaml` file under the `config/cluster/<cluster-name>` folder and populate it with the following info:
+Create a `cluster.yaml` file under the `config/cluster/$CLUSTER_NAME>` folder and populate it with the following info:
 
 `````{tab-set}
 ````{tab-item} Google Cloud
 :sync: gcp-key
 ```yaml
-name: <cluster-name>  # This should also match the name of the folder: config/clusters/<cluster-name>
+name: <cluster-name>  # This should also match the name of the folder: config/clusters/$CLUSTER_NAME>
 provider: gcp
 gcp:
   # The location of the *encrypted* key we exported from terraform
@@ -298,7 +302,7 @@ to create a [Service Principal](https://learn.microsoft.com/en-us/azure/active-d
 with terraform.
 ```
 ```yaml
-name: <cluster-name>  # This should also match the name of the folder: config/clusters/<cluster-name>
+name: <cluster-name>  # This should also match the name of the folder: config/clusters/$CLUSTER_NAME
 provider: kubeconfig
 kubeconfig:
   # The location of the *encrypted* key we exported from terraform
@@ -307,7 +311,7 @@ kubeconfig:
 ````
 ````{tab-item} Azure (Service Principal)
 ```yaml
-name: <cluster-name>  # This should also match the name of the folder: config/clusters/<cluster-name>
+name: <cluster-name>  # This should also match the name of the folder: config/clusters/$CLUSTER_NAME
 provider: azure
 azure:
   # The location of the *encrypted* key we exported from terraform

--- a/docs/sre-guide/node-scale-up/aws.md
+++ b/docs/sre-guide/node-scale-up/aws.md
@@ -19,15 +19,18 @@ server startup faster.
    ```
 
 2. Render the `.jsonnet` file into a YAML file with:
+   ```bash
+   export CLUSTER_NAME=<your_cluster>
+   ```
 
    ```bash
-   jsonnet <your-cluster>.jsonnet > <your-cluster>.eksctl.yaml
+   jsonnet $CLUSTER_NAME.jsonnet > $CLUSTER_NAME.eksctl.yaml
    ```
 
 3. Use `eksctl` to scale the cluster.
 
    ```bash
-   eksctl scale nodegroup --config-file=<your-cluster>.eksctl.yaml
+   eksctl scale nodegroup --config-file=$CLUSTER_NAME.eksctl.yaml
    ```
 
    ```{note}

--- a/docs/sre-guide/support/home-dir.md
+++ b/docs/sre-guide/support/home-dir.md
@@ -9,11 +9,16 @@ The
 subcommand of the deployer can help us here.
 
 ```bash
-deployer exec-homes-shell <cluster-name> <hub-name>
+export CLUSTER_NAME=<cluster-name>
+export HUB_NAME=<hub-name>
 ```
 
-Will open a bash shell with all the home directories of all the users of `<hub-name>`
-in `<cluster-name>` mounted in read-write fashion under `/home/`.
+```bash
+deployer exec-homes-shell $CLUSTER_NAME $HUB_NAME
+```
+
+Will open a bash shell with all the home directories of all the users of `$HUB_NAME`
+in `$CLUSTER_NAME  ` mounted in read-write fashion under `/home/`.
 
 ```{warning}
 BE CAREFUL! DO NOT DELETE THINGS HERE WITHOUT BEING SURE YOU WANT THEM GONE.


### PR DESCRIPTION
This should make copying commands from the docs more straightforward, by removing the need to edit them before.