### PR TITLE
Rely on the sops pin in the action setting up sops for us

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -85,8 +85,6 @@ runs:
     # This action use the github official cache mechanism internally
     - name: Install sops
       uses: mdgreenwald/mozilla-sops-action@v1.4.1
-      with:
-        version: v3.7.2
 
     # Install pre-requisite for "gcloud container clusters get-credentials"
     # command with a modern k8s client.

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Install sops
         uses: mdgreenwald/mozilla-sops-action@v1.4.1
-        with:
-          version: v3.7.1
 
       - name: Setup sops credentials to decrypt repo secrets
         uses: google-github-actions/auth@v1


### PR DESCRIPTION
I got an error in one of our github workflows (grafana dashboard deployment) related to setting up sops. Apparently the action setting sops up failed to fetch the right [release artifact](https://github.com/mozilla/sops/releases) for version v3.7.1 of sops as we specifically requested as seen in from this error message.

![image](https://user-images.githubusercontent.com/3837114/216348970-0a2d3c3c-4c3b-488e-bb89-35411dae71e2.png)

The action we use to install sops [itself pins a default version of sops though](https://github.com/mdgreenwald/mozilla-sops-action/pull/165), so if we don't bump the action version, we stay put with a given sops version.

I'd like for us to not provide an explicit pin of sops ourselves, and instead get help from dependabot to get new versions from time to time as part of updating the action setting up sops.