### PR TITLE
Disable managed prometheus collecting components on our clusters

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -137,6 +137,15 @@ resource "google_container_cluster" "cluster" {
     service_account = google_service_account.cluster_sa.email
   }
 
+  monitoring_config {
+    managed_prometheus {
+      # We do not use GCP managed Prometheus, but our own installation.
+      # So we do not install the managed prometheus collector on every node,
+      # saving some resources on each node.
+      enabled = false
+    }
+  }
+
   // Set these values explicitly so they don't "change outside terraform"
   resource_labels = {}
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "google"
-      version = "4.11.0"
+      version = "4.51.0"
     }
     google-beta = {
       source  = "google-beta"
-      version = "4.11.0"
+      version = "4.51.0"
     }
     kubernetes = {
       version = "2.8.0"


### PR DESCRIPTION
We got the following email from GCP (as reported by @sgibson91):

```
Dear Yuvi,

We’re writing to let you know that after March 15, 2023, all newly created Google Kubernetes Engine standard clusters will have Managed Service for Prometheus in-cluster components deployed by default.
What do I need to know?

Your overall cost to run a GKE cluster is not expected to change in most scenarios. If you are running below 100% utilization, there will be no additional infrastructure cost. If you are running at near 100% utilization, the cost per month is predicted to be USD $0.24/cluster plus $0.13/node.

This change only deploys in-cluster components for managed collection in new clusters. You will not pay for Prometheus samples ingested unless you take explicit action by installing a scrape configuration in your cluster.
```

This would run a couple additional components for each node, in support of [managed prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus). It's a service we don't currently use. We could decide to in the future, but we currently have no plans to. So to save on a little bit of resources, we turn it off here.

To do so, I've also had to:

1. Upgrade the version of Google Terraform Provider
2. Make sure that we don't destroy & recreate node pools unnecessarily