### PR TITLE
Bump z2jh to get new JupyterHub 3.1

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 2.0.1-0.dev.git.5850.he4dbf6c8
+    version: 2.0.1-0.dev.git.5987.h46a632f5
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -393,7 +393,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-n4497.haed80ebb"
+      tag: "0.0.1-0.dev.git.4978.h858bd17c"
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,7 +12,7 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:2.0.1-0.dev.git.5840.h71ad2287
+FROM jupyterhub/k8s-hub:2.0.1-0.dev.git.5984.h78a29217
 
 COPY requirements.txt /tmp/
 


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/jupyterhub/pull/4214,
which lets us graph active user metrics! It's a fairly small release
(see changelog: https://jupyterhub.readthedocs.io/en/stable/changelog.html#id1),
and I don't expect many changes.

Ref https://github.com/2i2c-org/infrastructure/issues/1888