### PR TITLE
Specify funding source and add admin users

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -34,8 +34,8 @@ basehub:
             name: "2i2c"
             url: https://2i2c.org
           funded_by:
-            name: "TODO"
-            url: https://www.earthdata.nasa.gov/esds/veda
+            name: "NASA"
+            url: https://www.earthdata.nasa.gov/esds
     hub:
       allowNamedServers: true
       config:
@@ -45,6 +45,8 @@ basehub:
             - freitagb
             - j08lue
             - rezuma
+            - ranchodeluxe
+            - jsignell
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:


### PR DESCRIPTION
Providing a missing piece of information from https://github.com/2i2c-org/infrastructure/issues/2017#issuecomment-1405190865

And using the chance to add two admin users - I realize I can probably also do that through the JupyterHub admin interface.