### PR TITLE
Bump up LEAP hub component resource requirements

### DIFF
--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -1,14 +1,33 @@
+dask-gateway:
+  gateway:
+    backend:
+      cores:
+        request: 1
+        limit: 2
+      memory:
+        request: 2G
+        limit: 4G
 basehub:
   userServiceAccount:
     annotations:
       iam.gke.io/gcp-service-account: leap-prod@leap-pangeo.iam.gserviceaccount.com
   jupyterhub:
+    proxy:
+      chp:
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://leap-persistent/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://leap-scratch/$(JUPYTERHUB_USER)
     hub:
+      resources:
+        requests:
+          cpu: 1
+          memory: 2Gi
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://leap.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -1,12 +1,13 @@
 dask-gateway:
   gateway:
     backend:
-      cores:
-        request: 1
-        limit: 2
-      memory:
-        request: 2G
-        limit: 4G
+      scheduler:
+        cores:
+          request: 1
+          limit: 2
+        memory:
+          request: 2G
+          limit: 4G
 basehub:
   userServiceAccount:
     annotations:


### PR DESCRIPTION
Ref https://2i2c.freshdesk.com/a/tickets/414

We should figure out better defaults in
https://github.com/2i2c-org/infrastructure/issues/2127, but as LEAP is getting close to publication on some stuff, this will help us with stabilizing the infrastructure.