### PR TITLE
openscapes: update EKS cluster config templates from k8s 1.21 to 1.24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ docs/reference/terraform.md
 
 # Don't check-in YAML files for eksctl config generated from jsonnet files
 **.eksctl.yaml
+eksctl-config.yaml
 
 # Don't version control any terraform state
 **.terraform.lock.hcl

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for carbonplan cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet openscapes.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -21,19 +35,19 @@ local notebookNodes = [
     { instanceType: "m5.2xlarge" },
     { instanceType: "m5.8xlarge" },
 ];
-
-// Node definitions for dask worker nodes. Config here is merged
-// with our dask worker node definition, which uses spot instances.
-// A `node.kubernetes.io/instance-type label is set to the name of the
-// *first* item in instanceDistribution.instanceTypes, to match
-// what we do with notebook nodes. Pods can request a particular
-// kind of node with a nodeSelector
 local daskNodes = [
+    // Node definitions for dask worker nodes. Config here is merged
+    // with our dask worker node definition, which uses spot instances.
+    // A `node.kubernetes.io/instance-type label is set to the name of the
+    // *first* item in instanceDistribution.instanceTypes, to match
+    // what we do with notebook nodes. Pods can request a particular
+    // kind of node with a nodeSelector
     { instancesDistribution+: { instanceTypes: ["m5.large"] }},
     { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
 ];
+
 
 {
     apiVersion: 'eksctl.io/v1alpha5',
@@ -41,7 +55,7 @@ local daskNodes = [
     metadata+: {
         name: "openscapeshub",
         region: clusterRegion,
-        version: '1.21'
+        version: '1.24'
     },
     availabilityZones: masterAzs,
     iam: {
@@ -57,9 +71,28 @@ local daskNodes = [
             ],
         } for namespace in namespaces],
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
+    addons: [
+        {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
+            name: 'aws-ebs-csi-driver',
+            wellKnownPolicies: {
+                ebsCSIController: true,
+            },
+        },
+    ],
     nodeGroups: [n + {clusterName:: $.metadata.name} for n in [
         ng {
-            name: 'core-b',
+            name: 'core-a',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/openscapes.key.pub'

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -1,14 +1,29 @@
-// This file is a jinja2 template of a jsonnet template of a eksctl's cluster
-// configuration file, which is in turn can be used with the `eksctl` CLI to both
-// update and initialize a AWS EKS based cluster.
-//
-// This jinja2 template is only used by the deployer script as part of creating
-// new clusters. If a relevant change is made here or the dependent file
-// libsonnet/nodegroup.jsonnet, one may consider if we should manually update
-// already generated jsonnet files in this folder.
-//
-// Configuration reference: https://eksctl.io/usage/schema/
-//
+{#-
+    This file is a jinja2 template of a jsonnet template of a eksctl's cluster
+    configuration file, which in turn is to be used with the eksctl CLI to both
+    update and initialize an AWS EKS based cluster.
+
+    This jinja2 template is used by the deployer script's generate-aws-cluster
+    command as part of creating new clusters.
+
+    References:
+    - https://infrastructure.2i2c.org/en/latest/hub-deployment-guide/new-cluster/aws.html#generate-cluster-files
+-#}
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet << cluster_name >>.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -56,6 +71,10 @@ local daskNodes = [];
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
     addons: [
         {
             // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that


### PR DESCRIPTION
This updates the eksctl configuration template files for the openscapes cluster that I've migrated from k8s 1.21 to k8s 1.24 now.

- Closes #2125
- Upgrade docs added in #2142

If you want me to re-formulate something, I'd like to do it in a standalone PR after this and #2149 is merged which also includes the same comments copied to many files.