### PR TITLE
aws clusters: systematically add ebs-csi-driver addon before k8s 1.23+ upgrade

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for carbonplan cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet 2i2c-aws-us.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -23,19 +37,20 @@ local notebookNodes = [
     },
 ];
 
-local daskNodes =
-    if "daskhub" == "daskhub" then [
+local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged
     // with our dask worker node definition, which uses spot instances.
     // A `node.kubernetes.io/instance-type label is set to the name of the
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-        { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
-    ];
+    { instancesDistribution+: { instanceTypes: ["m5.large"] }},
+    { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
+];
+
+
 {
     apiVersion: 'eksctl.io/v1alpha5',
     kind: 'ClusterConfig',
@@ -51,6 +66,25 @@ local daskNodes =
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
+    addons: [
+        {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
+            name: 'aws-ebs-csi-driver',
+            wellKnownPolicies: {
+                ebsCSIController: true,
+            },
+        },
+    ],
     nodeGroups: [
         ng {
             name: 'core-a',

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -1,14 +1,18 @@
-// This file is a jinja2 template of a jsonnet template of a eksctl's cluster
-// configuration file, which is in turn can be used with the `eksctl` CLI to both
-// update and initialize a AWS EKS based cluster.
-//
-// This jinja2 template is only used by the deployer script as part of creating
-// new clusters. If a relevant change is made here or the dependent file
-// libsonnet/nodegroup.jsonnet, one may consider if we should manually update
-// already generated jsonnet files in this folder.
-//
-// Configuration reference: https://eksctl.io/usage/schema/
-//
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet carbonplan.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -69,6 +73,10 @@ local daskNodes = [
             ],
         } for namespace in namespaces],
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
     addons: [
         {
             // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for carbonplan cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet gridsst.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -23,18 +37,19 @@ local notebookNodes = [
     },
 ];
 
-// Node definitions for dask worker nodes. Config here is merged
-// with our dask worker node definition, which uses spot instances.
-// A `node.kubernetes.io/instance-type label is set to the name of the
-// *first* item in instanceDistribution.instanceTypes, to match
-// what we do with notebook nodes. Pods can request a particular
-// kind of node with a nodeSelector
 local daskNodes = [
+    // Node definitions for dask worker nodes. Config here is merged
+    // with our dask worker node definition, which uses spot instances.
+    // A `node.kubernetes.io/instance-type label is set to the name of the
+    // *first* item in instanceDistribution.instanceTypes, to match
+    // what we do with notebook nodes. Pods can request a particular
+    // kind of node with a nodeSelector
     { instancesDistribution+: { instanceTypes: ["m5.large"] }},
     { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
 ];
+
 
 {
     apiVersion: 'eksctl.io/v1alpha5',
@@ -48,6 +63,25 @@ local daskNodes = [
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
+    addons: [
+        {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
+            name: 'aws-ebs-csi-driver',
+            wellKnownPolicies: {
+                ebsCSIController: true,
+            },
+        },
+    ],
     nodeGroups: [
         ng {
             name: 'core-a',

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for carbonplan cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet nasa-cryo.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -17,18 +31,19 @@ local notebookNodes = [
     { instanceType: "m5.8xlarge" },
 ];
 
-// Node definitions for dask worker nodes. Config here is merged
-// with our dask worker node definition, which uses spot instances.
-// A `node.kubernetes.io/instance-type label is set to the name of the
-// *first* item in instanceDistribution.instanceTypes, to match
-// what we do with notebook nodes. Pods can request a particular
-// kind of node with a nodeSelector
 local daskNodes = [
+    // Node definitions for dask worker nodes. Config here is merged
+    // with our dask worker node definition, which uses spot instances.
+    // A `node.kubernetes.io/instance-type label is set to the name of the
+    // *first* item in instanceDistribution.instanceTypes, to match
+    // what we do with notebook nodes. Pods can request a particular
+    // kind of node with a nodeSelector
     { instancesDistribution+: { instanceTypes: ["m5.large"] }},
     { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
 ];
+
 
 {
     apiVersion: 'eksctl.io/v1alpha5',
@@ -42,6 +57,25 @@ local daskNodes = [
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
+    addons: [
+        {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
+            name: 'aws-ebs-csi-driver',
+            wellKnownPolicies: {
+                ebsCSIController: true,
+            },
+        },
+    ],
     nodeGroups: [
         ng {
             name: 'core-a',

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -1,14 +1,18 @@
-// This file is a jinja2 template of a jsonnet template of a eksctl's cluster
-// configuration file, which is in turn can be used with the `eksctl` CLI to both
-// update and initialize a AWS EKS based cluster.
-//
-// This jinja2 template is only used by the deployer script as part of creating
-// new clusters. If a relevant change is made here or the dependent file
-// libsonnet/nodegroup.jsonnet, one may consider if we should manually update
-// already generated jsonnet files in this folder.
-//
-// Configuration reference: https://eksctl.io/usage/schema/
-//
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet nasa-veda.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -26,6 +30,7 @@ local notebookNodes = [
     { instanceType: "m5.2xlarge" },
     { instanceType: "m5.8xlarge" },
 ];
+
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged
     // with our dask worker node definition, which uses spot instances.
@@ -38,9 +43,8 @@ local daskNodes = [
     { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
 ];
- 
 
-                       
+
 {
     apiVersion: 'eksctl.io/v1alpha5',
     kind: 'ClusterConfig',
@@ -53,6 +57,10 @@ local daskNodes = [
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
     addons: [
         {
             // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for carbonplan cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet ubc-eoas.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -17,19 +31,9 @@ local notebookNodes = [
     { instanceType: "m5.8xlarge" },
 ];
 
-local daskNodes =
-    if "basehub" == "daskhub" then [
-    // Node definitions for dask worker nodes. Config here is merged
-    // with our dask worker node definition, which uses spot instances.
-    // A `node.kubernetes.io/instance-type label is set to the name of the
-    // *first* item in instanceDistribution.instanceTypes, to match
-    // what we do with notebook nodes. Pods can request a particular
-    // kind of node with a nodeSelector
-        { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
-        { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
-    ];
+local daskNodes = []
+
+
 {
     apiVersion: 'eksctl.io/v1alpha5',
     kind: 'ClusterConfig',
@@ -42,8 +46,19 @@ local daskNodes =
     iam: {
         withOIDC: true,
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
     addons: [
         {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
             name: 'aws-ebs-csi-driver',
             wellKnownPolicies: {
                 ebsCSIController: true,

--- a/eksctl/uwhackweeks.jsonnet
+++ b/eksctl/uwhackweeks.jsonnet
@@ -1,4 +1,18 @@
-// Exports an eksctl config file for uwhackweeks cluster
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet uwhackweeks.jsonnet > eksctl-config.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import "./libsonnet/nodegroup.jsonnet";
 
 // place all cluster nodes here
@@ -28,18 +42,19 @@ local notebookNodes = [
     },
 ];
 
-// Node definitions for dask worker nodes. Config here is merged
-// with our dask worker node definition, which uses spot instances.
-// A `node.kubernetes.io/instance-type label is set to the name of the
-// *first* item in instanceDistribution.instanceTypes, to match
-// what we do with notebook nodes. Pods can request a particular
-// kind of node with a nodeSelector
 local daskNodes = [
+    // Node definitions for dask worker nodes. Config here is merged
+    // with our dask worker node definition, which uses spot instances.
+    // A `node.kubernetes.io/instance-type label is set to the name of the
+    // *first* item in instanceDistribution.instanceTypes, to match
+    // what we do with notebook nodes. Pods can request a particular
+    // kind of node with a nodeSelector
     { instancesDistribution+: { instanceTypes: ["m5.large"] }},
     { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
 ];
+
 
 {
     apiVersion: 'eksctl.io/v1alpha5',
@@ -63,6 +78,25 @@ local daskNodes = [
             ],
         } for namespace in namespaces],
     },
+    // If you add an addon to this config, run the create addon command.
+    //
+    //    eksctl create addon --config-file=eksctl-config.yaml
+    //
+    addons: [
+        {
+            // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+            // couple to AWS EBS based storage, without it expect to see pods
+            // mounting a PVC failing to schedule and PVC resources that are
+            // unbound.
+            //
+            // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+            //
+            name: 'aws-ebs-csi-driver',
+            wellKnownPolicies: {
+                ebsCSIController: true,
+            },
+        },
+    ],
     nodeGroups: [n + {clusterName:: $.metadata.name} for n in [
         ng {
             name: 'core-b',


### PR DESCRIPTION
- This is part of the work required for #2057.

There is an upgrade step that I've taken systematically in the infrastructure, and this PR reflects those changes. Adding a EKS cluster addon to ensure EBS storage can be handled in EKS k8s 1.23+.

No disruptions was experienced adding this addon, so it reduces the amount of work when we make a disruptive upgrade incrementing the k8s cluster version.

---

Note that the changes in the `<cluster>.jsonnet` files represents the changes in `template.jsonnet` made in #2139.