### PR TITLE
leap: make allusers mount read only

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -34,6 +34,7 @@ jupyterhub:
       extraVolumeMounts:
         - name: home
           mountPath: /home/jovyan/allusers
+          readOnly: true
   singleuser:
     image:
       # https://hub.docker.com/r/lisacuk/lishub-base


### PR DESCRIPTION
As requested in https://2i2c.freshdesk.com/a/tickets/387 by @jbusecke, following #2135.