### PR TITLE
Add public scratch buckets support and use it for m2lines

### DIFF
--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -8,7 +8,7 @@ basehub:
         SCRATCH_BUCKET: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://m2lines-persistent/$(JUPYTERHUB_USER)
-        PUBLIC_BUCKET: gs://m2lines-public/$(JUPYTERHUB_USER)
+        PERSISTENT_PUBLIC_BUCKET: gs://m2lines-persistent-public/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -8,7 +8,7 @@ basehub:
         SCRATCH_BUCKET: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://m2lines-persistent/$(JUPYTERHUB_USER)
-        PERSISTENT_PUBLIC_BUCKET: gs://m2lines-persistent-public/$(JUPYTERHUB_USER)
+        PUBLIC_PERSISTENT_BUCKET: gs://m2lines-public-persistent/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -8,6 +8,7 @@ basehub:
         SCRATCH_BUCKET: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://m2lines-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://m2lines-persistent/$(JUPYTERHUB_USER)
+        PUBLIC_BUCKET: gs://m2lines-public/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -56,7 +56,7 @@ on why users want this!
             # If we have a bucket that does not have a `delete_after`
             PERSISTENT_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
             # If we have a bucket defined in user_buckets that should be granted public read access.
-            PUBLIC_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            PERSISTENT_PUBLIC_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
 
    ```
 

--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -32,7 +32,16 @@ on why users want this!
    in the same `.tfvars` file. Follow all the steps listed there - this
    should create the storage buckets and provide all users access to them!
 
-3. You can set the `SCRATCH_BUCKET` (and the deprecated `PANGEO_SCRATCH`)
+3. (If requested) Enable public read access to these buckets by editing the
+   `bucket_public_access` list in the same `.tfvars`:
+
+   ```terraform
+   bucket_public_access = [
+      "persistent-public"
+   ]
+   ```
+
+4. You can set the `SCRATCH_BUCKET` (and the deprecated `PANGEO_SCRATCH`)
    env vars on all user pods so users can use the created bucket without
    having to hard-code the bucket name in their code. In the hub-specific
    `.values.yaml` file in `config/clusters/<cluster-name>`,
@@ -46,6 +55,9 @@ on why users want this!
             PANGEO_SCRATCH: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
             # If we have a bucket that does not have a `delete_after`
             PERSISTENT_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            # If we have a bucket defined in user_buckets that should be granted public read access.
+            PUBLIC_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+
    ```
 
    ```{note}
@@ -67,5 +79,5 @@ on why users want this!
 
    You can also add other env vars pointing to other buckets users requested.
 
-4. Get this change deployed, and users should now be able to use the buckets!
+5. Get this change deployed, and users should now be able to use the buckets!
    Currently running users might have to restart their pods for the change to take effect.

--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -37,7 +37,7 @@ on why users want this!
 
    ```terraform
    bucket_public_access = [
-      "persistent-public"
+      "public-persistent"
    ]
    ```
 
@@ -56,7 +56,7 @@ on why users want this!
             # If we have a bucket that does not have a `delete_after`
             PERSISTENT_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
             # If we have a bucket defined in user_buckets that should be granted public read access.
-            PERSISTENT_PUBLIC_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
+            PUBLIC_PERSISTENT_BUCKET: <s3 or gs>://<bucket-full-name>/$(JUPYTERHUB_USER)
 
    ```
 

--- a/terraform/gcp/buckets.tf
+++ b/terraform/gcp/buckets.tf
@@ -38,18 +38,6 @@ locals {
   ]))
 }
 
-locals {
-  # Get mapping of public buckets and their associated hub names
-  public_buckets = distinct(flatten([
-    for hub_name, permissions in var.hub_cloud_permissions : [
-      for bucket_name in permissions.public_buckets : {
-        hub_name    = hub_name
-        bucket_name = bucket_name
-      }
-    ]
-  ]))
-}
-
 resource "google_storage_bucket_iam_member" "member" {
   for_each = { for bp in local.bucket_permissions : "${bp.hub_name}.${bp.bucket_name}" => bp }
   bucket   = google_storage_bucket.user_buckets[each.value.bucket_name].name
@@ -58,8 +46,8 @@ resource "google_storage_bucket_iam_member" "member" {
 }
 
 resource "google_storage_default_object_access_control" "public_rule" {
-  for_each = { for bp in local.public_buckets : "${bp.hub_name}.${bp.bucket_name}" => bp }
-  bucket   = google_storage_bucket.user_buckets[each.value.bucket_name].name
+  for_each = toset(var.bucket_public_access)
+  bucket   = google_storage_bucket.user_buckets[each.key].name
   role   = "READER"
   entity = "allUsers"
 }

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -148,7 +148,7 @@ hub_cloud_permissions = {
   },
   "prod" : {
     requestor_pays : true,
-    bucket_admin_access: ["scratch", "persistent"],
+    bucket_admin_access: ["scratch", "persistent", "persistent-public"],
     public_buckets: ["persistent-public"],
     hub_namespace: "prod"
   },

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -26,7 +26,10 @@ user_buckets = {
   },
   "persistent-staging": {
     "delete_after": null
-  }
+  },
+  "persistent-public": {
+    "delete_after": null
+  },
 
 }
 
@@ -140,11 +143,13 @@ hub_cloud_permissions = {
   "staging" : {
     requestor_pays : true,
     bucket_admin_access: ["scratch-staging", "persistent-staging"],
+    public_buckets: [],
     hub_namespace: "staging"
   },
   "prod" : {
     requestor_pays : true,
     bucket_admin_access: ["scratch", "persistent"],
+    public_buckets: ["persistent-public"],
     hub_namespace: "prod"
   },
 }

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -27,7 +27,7 @@ user_buckets = {
   "persistent-staging": {
     "delete_after": null
   },
-  "persistent-public": {
+  "public-persistent": {
     "delete_after": null
   },
 
@@ -147,11 +147,11 @@ hub_cloud_permissions = {
   },
   "prod" : {
     requestor_pays : true,
-    bucket_admin_access: ["scratch", "persistent", "persistent-public"],
+    bucket_admin_access: ["scratch", "persistent", "public-persistent"],
     hub_namespace: "prod"
   },
 }
 
 bucket_public_access = [
-  "persistent-public"
+  "public-persistent"
 ]

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -143,13 +143,15 @@ hub_cloud_permissions = {
   "staging" : {
     requestor_pays : true,
     bucket_admin_access: ["scratch-staging", "persistent-staging"],
-    public_buckets: [],
     hub_namespace: "staging"
   },
   "prod" : {
     requestor_pays : true,
     bucket_admin_access: ["scratch", "persistent", "persistent-public"],
-    public_buckets: ["persistent-public"],
     hub_namespace: "prod"
   },
 }
+
+bucket_public_access = [
+  "persistent-public"
+]

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -282,7 +282,7 @@ variable "max_cpu" {
 }
 
 variable "hub_cloud_permissions" {
-  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string), public_buckets : set(string), hub_namespace : string }))
+  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string), hub_namespace : string }))
   default     = {}
   description = <<-EOT
   Map of cloud permissions given to a particular hub
@@ -295,6 +295,15 @@ variable "hub_cloud_permissions" {
      This *potentially* incurs cost for us, the originating project, so opt-in.
   2. bucket_admin_access: List of GCS storage buckets that users on this hub should have read
      and write permissions for.
+  EOT
+}
+
+variable "bucket_public_access" {
+  type        = list
+  default     = []
+  description = <<-EOT
+  A list of GCS storage buckets with public read access.
+
   EOT
 }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -282,7 +282,7 @@ variable "max_cpu" {
 }
 
 variable "hub_cloud_permissions" {
-  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string), hub_namespace : string }))
+  type        = map(object({ requestor_pays : bool, bucket_admin_access : set(string), public_buckets : set(string), hub_namespace : string }))
   default     = {}
   description = <<-EOT
   Map of cloud permissions given to a particular hub

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -302,7 +302,7 @@ variable "bucket_public_access" {
   type        = list
   default     = []
   description = <<-EOT
-  A list of GCS storage buckets with public read access.
+  A list of GCS storage buckets defined in user_buckets that should be granted public read access.
 
   EOT
 }


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/2123 and https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_default_object_access_control.html#role

Todo:
- [x] add docs
- [ ] 