### PR TITLE
support chart / grafana setup: systematic use of github auth for 2i2c-org

### DIFF
--- a/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:4DPd7lTWaJ8ND8GceLh6wNzHAY1LeqMIokEHBqObThtXtnfpmE11z7FIMb1Vant+di7SbbCAPcoGgUdvUOsXLQ==,iv:kj0DnH2cCzw7iBraX/dfjENXOIgk/ZC/qCjseisno/c=,tag:AgGZJfGRBsqaYlzqpvSpbg==,type:str]
     password: ENC[AES256_GCM,data:Yt6DejIrACYstASWXxBPshCm6/n4vsSw7NK1RxH9fKMxjn+Bs1x6+MKD7Im2IRxWzSoP3XtURJjmaYdio98U/Q==,iv:HGnhJhRX7O/nn4y4HujGT18nJoB3kPMD0x+x/PSbjps=,tag:hCnTt0eWn57EH/3k5HXexQ==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:fhBw8hcujgJxzM6mdtPYDTr7KRg=,iv:89ceeLKHYSinwbDfbWXqCjtX5YGjlbLtWATzEtqQTM0=,tag:1zbDCjtnsByQHwqvTlI/pw==,type:str]
+            client_secret: ENC[AES256_GCM,data:95aqu0+jMHj+X7zfXTK2W2p2gUWu4CIl6iODEzI+CGYCI62xFYwGVw==,iv:M+eUxU6v1RdF6JqoUvW3Mj3lIX3RW/loAOQu369+LpI=,tag:BRwyzQWwdLSf+IQwIqwf7w==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-12-02T16:48:55Z"
-    mac: ENC[AES256_GCM,data:0jbzDZ/5aY022XU6u3ftcafKdnujPZNOowH4zyafVDSkDAZJAKQE4GnJpW9s32NVSkptmnCA6Xr2u0dm7UAuWBFrepnHt0PLTJaUr33DtgAO8QfwXbDAD2MdrAPoH1Lvd43XwTqCY4ujX8Of/Vd6FsfIToHdKrDv3znI+6g6UTs=,iv:56pLW3wQ7AenXVl9GaI/A/e09co9F2gLdVznX57w66E=,tag:QWr3kQuOuGRaCWXIYE7Xtg==,type:str]
+    lastmodified: "2023-02-08T13:54:33Z"
+    mac: ENC[AES256_GCM,data:lyVhSyZ8YWBc/XKasEl8ITed9lZvPaunNCryUtY1+/HXr8SFz1v8gTFQtClXyoahw27iJX3BsfqdLpGM4nktjGDXqukbLT6OLmFmHQo0F/lxTXqt6ZdUtOLfxmallXKi68/8o58GpXC0oY9pnozvcOL4VXD0sQqopMMFw9tLh2k=,iv:Qw3rQ9Eb00uSzDMupa1St8ZhF9u9KAln3hZ7CiLw2LU=,tag:tNi8mkFT84x9WeM0x5OHXg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -5,6 +5,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.aws.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.aws.2i2c.cloud

--- a/config/clusters/2i2c-uk/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-uk/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:Qkfs/MqhEIEQ0uGl6sbSXJIPRi8k/TGNFgCtI0VIU0mYr4Lff+kAK2Zd5FG8rR91Q2xsNYMojCv3GV/YZfa8Vg==,iv:c3pPdTYivRYtgsi32nwHiKKDnDM71ZSA9WI4frdkqd8=,tag:sx++V6n6Zkq188AZJJhHlA==,type:str]
     password: ENC[AES256_GCM,data:BB1KIaJvWApPBtjIoS3brcg2ZIYeNJYvDcN41Cg14tPSY1bg6m43VLV4BfEo7DeCPxNF5c+W5NwaQXqDrx3raw==,iv:P2kztAXT+AMzPTcyoGZYxV/Qgw+4WdKvEF6gV56nhks=,tag:VS/MGouTH7zLLxlBLPX9YA==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:eGH4zTJtiJb8ixWcJjfjHRfUH+A=,iv:XkIfVP1M8sOazLVc0hTHmRHdonExh5M5RnluRW6xRZQ=,tag:Tdd87ubFQaVGYB23VmofrQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:pkC7g7U6wAJDTXjMv1doJTAC2MmQDSJDLve4EWjx2WzF9PHih1LVdg==,iv:fqZ30SKh367SlUji0USUI54QG0LRpfqtSn8TTp6HFTo=,tag:eNNEAWc4YNtwkS+oECBoyQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-09-22T08:38:18Z"
-    mac: ENC[AES256_GCM,data:reL3wgqIrHTJGgluNwEJni0nuxQ72ojIN7RffCQ5pFbutu0pHdDsDUccrKjViKmWhJIEY7BYKoRHy+YrJhNdYcprZSXKuMtvHW+b/sG8Hb5qUc+WN10xx/G1zt82vi8Djd41MnGVhqNwJmaLRpkV2UNiQWfd7uy26AClMagAuSg=,iv:sXcS/v4/wS6KsP3N1GwPUxEDG5FUTdV0lQBGTf/42Dg=,tag:zvL/ipNXifxCUXq3JKZuVg==,type:str]
+    lastmodified: "2023-02-08T13:57:25Z"
+    mac: ENC[AES256_GCM,data:RzK1JdpUrIqp0whfGJytF7STvM3qkLB8rTnHgZmh3L18/JHrP9POztuPSkL50kmZVwrh20kRV7g+1kIXeYDKMbYxSfabT+xXNWuY2SawUxjPyR0vPyiv7ce4WqoH8bKNnbEBQxkU7wh2BqKk63cS8c7qK6fp5OZmSQeul5kadwU=,iv:21mFZxBGdxnJbmgdCkfffg0bucNRn71SCK8Sr54iXxw=,tag:n6RxsjLgRYw6TexwEd6QNw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c-uk/support.values.yaml
+++ b/config/clusters/2i2c-uk/support.values.yaml
@@ -11,10 +11,14 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.uk.2i2c.cloud
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.uk.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.uk.2i2c.cloud

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -18,7 +18,14 @@ prometheus:
       limits:
         cpu: 2
         memory: 4Gi
+
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.pilot.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.pilot.2i2c.cloud
@@ -26,14 +33,3 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.pilot.2i2c.cloud
-  grafana.ini:
-    server:
-      root_url: https://grafana.pilot.2i2c.cloud/
-    auth.github:
-      enabled: true
-      allow_sign_up: true
-      scopes: user:email,read:org
-      auth_url: https://github.com/login/oauth/authorize
-      token_url: https://github.com/login/oauth/access_token
-      api_url: https://api.github.com/user
-      allowed_organizations: 2i2c-org

--- a/config/clusters/awi-ciroh/enc-support.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:VdgjxTemXfrrWoSAbpJGuKQPnTKj2TRB+SMfdpc0UaCN4iW5ikJfp2ekoQGkSUoSMGOuGLXfr1Fzo6RSi3GRDw==,iv:bVhIOxIKCo9LWixZUarHkSKbr01N2j+S4uSGX9IDm3Y=,tag:Ys1JM7L30mjeDQCWZaPKVQ==,type:str]
     password: ENC[AES256_GCM,data:D8/XRBacGtcKhd5BnzrLxV+IEXEvgo0c5KzrKR+BC/HEl5qUk8yPs7uZ0x2pAkZzgvkLz/FeqEej74X4ZW8Z1w==,iv:yC1uoNwmlu3FoVThfGQnSCICpuYxiPCzlc564Fe+/Tw=,tag:mgTCOfAqibEWXnjMFsa12Q==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:Dl8d7l4U13d4+ZgEkZbdyZ/gc/s=,iv:4FYffWWrT4I/vfplptjG52h39kwIzjltsniwz5Ej69Q=,tag:Hn6Czq6lhFTeGnuOkAv0UQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:qGnNIOIR9yqNSRYK6rIRoZGWcmQOPbxQMXmVg24nJrmjfPhJhEL5/w==,iv:rcSdsWsZB7qwX6zxqskRy2/CNe+hZcsFTUKQc39NwEA=,tag:gtVUDju1aQiQsN1nqfYdlA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-07-22T12:53:23Z"
-    mac: ENC[AES256_GCM,data:b7BvuPil5HrCcwJxc84x/Jqyj8aDEwGMIsYH4AAYwuU2BmheYHQYnJUISPzPz6EE5vHITtsU+5bkJozgNOfYQaOz4lbyWr2+nGyneHp2ugksd4MlmJzdWqmBhI7gMQmbRqMW+vTssNJ24c7jDnPmARtnLicqvEwOTfvSdiQVr44=,iv:XYIxoLpU3yGoO7f3RXbfZkDn/b2sS1rUwMerIxC+NY4=,tag:9+DVaMXNhQ+tmAuWfAmETA==,type:str]
+    lastmodified: "2023-02-08T13:58:32Z"
+    mac: ENC[AES256_GCM,data:1ha6X1G7fmjVtLlxzm/0Ok6i2IGpiKshMSHo8PpQWHk4NESCVscVpzKUA5QF37ubOv/iEWkLPc4NASIsozA2rAb0jFD81KWJOT4DkMUzGeuChr2MuMhTwifDGCZmgO6//0HweCgalxd1RL/L+fEFQf54TLOZarbdgm9NvInTYb8=,iv:K7aPfOVLE1l18SMImO5qGU5IaNbuZaHeBkRWZBNu3UY=,tag:/vX/8d31suwuoQa3lkIpAw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/awi-ciroh/support.values.yaml
+++ b/config/clusters/awi-ciroh/support.values.yaml
@@ -5,6 +5,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.ciroh.awi.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.ciroh.awi.2i2c.cloud

--- a/config/clusters/callysto/enc-support.secret.values.yaml
+++ b/config/clusters/callysto/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:PRxijXnlvkmjCkQyK/I+l2wWbaDkaJP94EmX7URKnBwZgokrPVG8azrHDJt5lEGo5PhX6waXTLHVgpK+ocP3Kg==,iv:HOVnan28Mpfg0X8jo284ZVdHUtV1CmgW3fR3hd+Vah8=,tag:vc2rLFUvs/p6JpoaIvQp5Q==,type:str]
     password: ENC[AES256_GCM,data:mKNG8ASGy/G0fR3i6iOumvofaecFsT/lgZgKf3EitAz/bjqZ1MS4ofV73TQDdfxPx8/xYXjg1xH37mWd9s19aw==,iv:2AWZ1wnbBY+MFxtfu9SKPykIU6zih+7a+VhvTxWKM3A=,tag:uEH9uCPrIjywqcC53CZZTQ==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:KuO3irah/twI6TQucSyppd9oLg8=,iv:D4Z9iipzgb3J9nZ8hv+Jv66R0Mi0iEFbMKambqTalRY=,tag:E9Ml95cTLk8PtwgWjS0TjQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:Gn6XVtOQlRGw7qS6ctFWUwPDV8dsH87Epx1V6DIDuCylssZBq+W0Yw==,iv:3hF7N7QMzYQL1BAg/zwsofCZ4Wz3ulhLqiJ1BZzqlC8=,tag:dr5ryYXOJ6fr4/G/e+mMRw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-25T11:13:09Z"
-    mac: ENC[AES256_GCM,data:CUb2/JqU7OnlIzdiSDwhYP6YurH26B1nQi+n2TSwOb4kTapWeMnx8qxvl1LIW4WkXHsBdKtZ7CPXp0gKuD+vlsLafWNLACl+R6bRF5YqHqBU+VvapcITnwiDOF809MrpR1Rj0x4iDmICrzjOGGBCdLitCcIe9X8P8FHZc2ocr3k=,iv:4OXNg885TP4FVNRitthgUOaPHfHuwuQ8kWq1W12E98U=,tag:ocMeOFCY56gnb6zC0EaYpw==,type:str]
+    lastmodified: "2023-02-08T14:00:05Z"
+    mac: ENC[AES256_GCM,data:E/VDvnHvE1CjjR4uYo0LS3dNo8uEG3Cp4IEp/WIWPDSAYWfCiMMGQSwXQCmFtZyjhQ+0Ve+nbfzsmXTNfCobzadStzA938uvT3L1i/hGpUne0CBCninyRERd0h8jkzbs2l9kDFMDIQEEkSet0OfRVg3yl0956o06ocQzcdd9jWY=,iv:iq44FBwxVud/1KYkWodQEdrXjHnn0VBnMlAlbfdkIl0=,tag:6n/kYOqwtgExIdLtD7MCiQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/callysto/support.values.yaml
+++ b/config/clusters/callysto/support.values.yaml
@@ -11,10 +11,14 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.callysto.2i2c.cloud
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.callysto.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.callysto.2i2c.cloud

--- a/config/clusters/carbonplan/enc-support.secret.values.yaml
+++ b/config/clusters/carbonplan/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:TSCjdYydQsYNp5otbeAzcDi/H1TdjbilhNfzd31FJ+mGIl+LE6DwHN+04NTcEqIKGprWWSqesPCKWcsGw++jQA==,iv:mlN6ku7DKTckZeOU3PXCuAPGbrhNF06N5M04NIBmOEo=,tag:0Ze7D7IoK/F3V5FjcbLUDA==,type:str]
     password: ENC[AES256_GCM,data:yXZqIHPziZLUN2WG/yWotx72kbESAAx5zwNIgPzlDFmqegP62hUIWY8uwFSjpVl8PIQ4MSLgorrbm6Pq7eHu3w==,iv:w9MghOkbt5RoTXlh9jyemGalyB0COWpP/lzdgWm3ehI=,tag:k5f1Nq4yZzS8bTN2Lcl6Iw==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:nxrFL8XmiKnYa5YPrinCNW6rOqw=,iv:c/W9a0TM29vLD3DxdsNaxW7u84/umHNhqdHkhvXfBUI=,tag:YzErxTXHMCxoxHyN8MgxwA==,type:str]
+            client_secret: ENC[AES256_GCM,data:Ycqb/J+LpIqulB5+Ez3M1L82o6pokuXUS1dnmVI2/sYFAianMza3YQ==,iv:0RRD0G3t+gjFY+y3k8CrcaSKSHcxyYxoT24TOVGNIUQ=,tag:aF6yp5U6bCZv5WbDxUkaJA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:45Z"
-    mac: ENC[AES256_GCM,data:/qGFeUCA9zU9oz4d9OobQ/oZHJtC7uoqDjxYIy3vnxC9w4HEktde1lCBOc/YdWWFiKxjKU31d2hceb6+tvB/IUmybcERxeVCQVMAqXXSmtTm78irppJjrNIrifQMBG4dOtXyaHSp4TZsLEWQmiC1pq1i1sXHcPcAf+jBcyJbFfs=,iv:oKelZoxcF6em7TsG6Q949X9AdfTfx+RB2PJPg34Bc58=,tag:gIZojWD7T7gpMYfvD0Hp/w==,type:str]
+    lastmodified: "2023-02-08T14:00:59Z"
+    mac: ENC[AES256_GCM,data:bXDsN9d54w4IgLpMbhYgqR7JN8ApuQJs8lAC1XgAf4UtH6OSZlBAgE29oVj90tZ5ttPwKgMBHByMCp1i3wEVgaRf0yPV778j9abUR02tY3vfgT+KGESOMsIIMiMldQIj9ut0/jY6dziboe8T1bn4BoFBAtuP2IvDpwTVdA/Snn0=,iv:HUOjJEXKE4bPGyVMvxAL/6zhWTF7MdsCfk8AQzpa3vE=,tag:mTszwRrT8JI/uXFc28FsGg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2

--- a/config/clusters/carbonplan/support.values.yaml
+++ b/config/clusters/carbonplan/support.values.yaml
@@ -18,15 +18,20 @@ prometheus:
       limits:
         cpu: 4
         memory: 8Gi
+
 cluster-autoscaler:
   enabled: true
   autoDiscovery:
     clusterName: carbonplanhub
   awsRegion: us-west-2
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.carbonplan.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.carbonplan.2i2c.cloud

--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -11,10 +11,14 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.cloudbank.2i2c.cloud
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.cloudbank.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.cloudbank.2i2c.cloud

--- a/config/clusters/gridsst/enc-support.secret.values.yaml
+++ b/config/clusters/gridsst/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:RgttnPfuHqciM3qaxAwUgmvZjm3AkYvMveK9X5QqQLcwPjDOtpsFo98iqXs/IgJSrfDFs7vNM3F/U5iYjP77Rg==,iv:R7tmVYIh+1YDdQ1qTchaYNJ5OD727s9H0E/7R0kzU7w=,tag:zp+ctVogJG7jyEhu6xRcuA==,type:str]
     password: ENC[AES256_GCM,data:M/AswbGMmcNN6bIwMKyRDsW6sdaQvcP3DQbL2f7Wn1yOcY59cVE8avSEqpJAg+d52XzkPMG6Z/RmYDMN4LQi7g==,iv:FK64RqgZUJRpkInbqdIJtwL4rol5MXGHN6Y+7B4XTPw=,tag:7d98TTIiTaXc/Ssiy0vvuA==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:R72hgUbGv5yycxUbvq3kfU9dZk8=,iv:WIVPG1dP1IEWoTAdwJcgonRA7tJhvMhX+JgiPHA+zNw=,tag:K5uvA+YXLCPGIkbxURLT2A==,type:str]
+            client_secret: ENC[AES256_GCM,data:W4U5P9QoEHOsLKyg3RIEPie40hBXR6dubhF3JLIiC3UyUfbonVWVrQ==,iv:f5tNG0m7auKQMMY0GqHtqCuFzvTAhQlvmuWGpa3nhgw=,tag:WbtHXKAkxWFdjBwQ5VTFhA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-10-27T14:20:54Z"
-    mac: ENC[AES256_GCM,data:uzg3XNJ/lawV4P7R5xV1IupvCrZPT8Z0/3C0coVZzdEyEXHZmsTFRJElp8o1DcsxC/8nyJnooC68zF5acuTSeFR1rVndD0M7umxIB4X5fJ1gXl29fhRYfLpRpvc8y5aX/OnCxmAROGbes9/KIyaOiq9H94gFh8OtdZABgHh5Wn8=,iv:pwI8iXG5dUT2n0YX2JX9udYtfK5ysevG5MNwVh8XZmU=,tag:ijemxgU2fMooiyXRFhhNBg==,type:str]
+    lastmodified: "2023-02-08T14:02:02Z"
+    mac: ENC[AES256_GCM,data:VHw69wu12NEi1Nke67jsF2IYoycuVWJLpenkEaBOPE8z2QZSDL+JMniLpT9RSpNlQgVFWinfQU4pPEv66BfJDm7yzVLkMDjPX62R2M/mP0Gtuc7JjcS71KHcTR0tELvF0zpzny6FHbaeYUpzwy3z0i/HaBFMIzAicp8nEbCG7NM=,iv:vUlhDDs8IL9QMaCeP6Bogz7Rle90ZlWU/JbSo0MoPC8=,tag:cckV05WOGEYsNuWu1hK4nw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/gridsst/support.values.yaml
+++ b/config/clusters/gridsst/support.values.yaml
@@ -11,6 +11,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.gridsst.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.gridsst.2i2c.cloud

--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -25,6 +25,12 @@ prometheus:
         memory: 22Gi
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.leap.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.leap.2i2c.cloud
@@ -32,14 +38,3 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.leap.2i2c.cloud
-  grafana.ini:
-    server:
-      root_url: https://grafana.leap.2i2c.cloud/
-    auth.github:
-      enabled: true
-      allow_sign_up: true
-      scopes: user:email,read:org
-      auth_url: https://github.com/login/oauth/authorize
-      token_url: https://github.com/login/oauth/access_token
-      api_url: https://api.github.com/user
-      allowed_organizations: 2i2c-org

--- a/config/clusters/linked-earth/enc-support.secret.values.yaml
+++ b/config/clusters/linked-earth/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:KvJa9NuUXutQ4ZkCP56KbfyD+Si+TMTb6iplc1i3FJ9u9q6qfB5gtL6g52CzNwttegicb7fuD//Fn9IhdfiyBg==,iv:Zbt/i1rHXTNMVXrrqTbLqjE2sdMG5zzIOHgJrHIVH+I=,tag:IwhOr90toCsjbjWsQbpQzw==,type:str]
     password: ENC[AES256_GCM,data:58zXLP3t6nSj7vwE1teMkZNbC3N9BhVDuJ70nZ838ZjJpgUkfnOU7pS/QyAvae4QIzqloCpNosev4gANmj+ylw==,iv:PJA1/2OEEY0OrQaUVRBffIKSzNTY/j8vTtN/SXFAnG4=,tag:oP7nz0PFC0VhLPK2WmWm7Q==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:sHHDZo9zySW+qgpXlELt7vSEe/A=,iv:65Hf1AuTTT/NceeTZjhxG97RWDpe+eKle5MJwwLrJFI=,tag:gIw51rQambcqfeUV1UWnxQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:QFLasNiwqX3dVnLWwViQHwM6MMhdNspOMxY+hV+TuF9dlaQLwDEqng==,iv:r/aLpr+2+LA9GCyayOe2+yDWk6ZoajSZKzUc2A9kMmo=,tag:hAlGz1RDWyJ34HeLbpkNZw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-28T10:36:15Z"
-    mac: ENC[AES256_GCM,data:5EecXQhmTHpMkXcnLyzUTyH6/B3x80h3kNrUcyk/YhihCf2kS/LnWgtnhyKcDoo6ExgURQEAXxaat3vEDUaNSz0JnmLvcYqnKjbwlbI/QXt0YSKzUhCDAf6NGM+ZULdXVZ+v6BjOwBwGdH5QAELdgr4SppvTlzaIsn5oxl6Zrho=,iv:ezvmKIcp3zMPbGPxikfQqtjE/Kg7Wf2TAkmSXYKWfyc=,tag:RaO1SF+sg+pFmiuiRdzPaQ==,type:str]
+    lastmodified: "2023-02-08T14:03:38Z"
+    mac: ENC[AES256_GCM,data:zcYg/gNHre+kftU9sk0aAkaaPmaCxG/SWiv9Rbq8V/LIThxMRf5trD42EFwssFkvavWnxAc3+6pNKdZgGvuz5C2r8woBhfN+HChjpKNn48SygchOcWs+Hv2yG7ygAHZRe08RkabQDVYMDVL6Sagem+NaHM5se3qFIJ9xB/HPR4I=,iv:aZDX15aKvYtW3z96baS7QY4QVYJxAI5Q8WhRipK4kYA=,tag:26mnsGGgpLlr/xH+B5a2yA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2

--- a/config/clusters/linked-earth/support.values.yaml
+++ b/config/clusters/linked-earth/support.values.yaml
@@ -16,6 +16,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.linkedearth.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.linkedearth.2i2c.cloud

--- a/config/clusters/m2lines/support.values.yaml
+++ b/config/clusters/m2lines/support.values.yaml
@@ -4,6 +4,12 @@ nvidiaDevicePlugin:
     version: "latest"
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.m2lines.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.m2lines.2i2c.cloud
@@ -11,17 +17,6 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.m2lines.2i2c.cloud
-  grafana.ini:
-    server:
-      root_url: https://grafana.m2lines.2i2c.cloud
-    auth.github:
-      enabled: true
-      allow_sign_up: true
-      scopes: "user:email,read:org"
-      auth_url: https://github.com/login/oauth/authorize
-      token_url: https://github.com/login/oauth/access_token
-      api_url: https://api.github.com/user
-      allowed_organizations: 2i2c-org
 
 prometheusIngressAuthSecret:
   enabled: true

--- a/config/clusters/meom-ige/enc-support.secret.values.yaml
+++ b/config/clusters/meom-ige/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:UgQfeU/OUU3z+8ylT3OQTvWh6R7QevM5lPd/XkJ+AltY7Po6INJxSluH/esJLC2V8q7jZF2mCejGNKy7dt8Xjw==,iv:rh1VPMfvXlqgrVgLzqj8eL+PA+lqZ0Esa+Aklswn24Y=,tag:uTIm1HBAQjTLJDQBfyJKjg==,type:str]
     password: ENC[AES256_GCM,data:caUmNT2gG5MFm2PpLjazqHLWZkI7GXRdqdeK7wxhI15FMO+8led5dW3Bd8pm0aLkIhgs0v4wCxL69oBw80qaKw==,iv:A/26GE1/R9S4mCBvknNvFtWyxI+PCBoXUVRbYZLAmzU=,tag:3ajE+3UUKKaev87P+afcOA==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:t3qbhHOugDCX92DSZW8b64jA8zI=,iv:Q5uFboxxAn3zfSj0f6V2E7IiSfbcajXIw+jpuz363DQ=,tag:KnwAlvNmXulaMXOLdDyGJA==,type:str]
+            client_secret: ENC[AES256_GCM,data:xdLGBSiGYIhaWIYWklRKCSCoxz6CRbklDZas0zw2ZrcrZF/QP7tBYg==,iv:TK9YV+qbaBrZnoIiR6R1H7EkdEip2YOg5pcJ+L4A3xc=,tag:gXUgcoCOKnjGAVa4qcCISg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-05-19T11:58:54Z"
-    mac: ENC[AES256_GCM,data:tRu30bx2qkFQ2T+QOtR3pFa4dhrgXhdaFuKfFOvuPQkUzCyW+aSRolPkgiBcmON6rWOvVHf2EpyMZbTEqE5JAdZV2mz0z+yIBnqlhxh0Vsorl1cP7fjSguHdjYYI5uzxj96OSt4GW4gdXr8nPSzzmByLTswPdsIBa1Q4hIF6JLg=,iv:6phRu509nLWPuVVXiBc/zHq1ZQ13vZDKd0NKUZopAho=,tag:1uOZzo7p79dKxhxH/i2IVw==,type:str]
+    lastmodified: "2023-02-08T14:04:32Z"
+    mac: ENC[AES256_GCM,data:/uUXimr/7fhBZwJ301GfI0J92pREWp8l5VgVZwC5d1sWwXhGf7BPz4Taftqe80/4vkY8HJPCmV47oSHxGOYuMYU6kuI1NNmoabT3O866vxFIsE+keurUzVC0x5KfCbCCIr6AOtW8HMbKBkFc8I0x59KBMH+XR6GgYeKzc6xxXsQ=,iv:7TI/zCMoSCavyv71tyjRMUYKRJzNKLE5Hq+tQ62ZUB4=,tag:5MOATCS9HixUQxnW+wcQvA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/nasa-cryo/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-cryo/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:ebPGMvUPCEaDzGY144yJZkI/+0FJuvFxcs0+lxKt1o1s6wMzkL5di+HB3NY98VIOFtbHro0cOBjtFyes3UkgSA==,iv:j4SXSqWNJjXhPcnDep2tRPsdF+9vUG+d9QW0ZRqNxGM=,tag:lAG+hK1dLSwJHVy5tT1kjA==,type:str]
     password: ENC[AES256_GCM,data:zHPuOyaT5+HC+3IKin54as4YI1nJrxCa7huIP85MEKWaHa11lyQLjAW4bQsQY1hBH/0kgW+kzVtkDlcIghtjGA==,iv:8nHsm5KipEKs7o4KV7mBQ31a6xCXMp8oBL7Ip1IWpy4=,tag:tuKlTIAiMCWnuME0EpJJKQ==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:KdqfRXbeUfvgp2wIj0fvTKo8szs=,iv:3qiK9UBU/6fRX8gMW34M18MXwlQEKe1GIIMqTdpAPEw=,tag:nxhsk7ezqxv3aumC7XHXxw==,type:str]
+            client_secret: ENC[AES256_GCM,data:YxiY+bITNQ0wajPP5HxT97B4tUOGuSFcZlIBAATlcspykh+cUczp1A==,iv:ZPFmT5UMvCr/avX3fYAHxY6kBfjnvUcpFCDwUjENOi0=,tag:o3OzRoxktHitIzdWWneSDg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-10-14T10:37:09Z"
-    mac: ENC[AES256_GCM,data:rIOhzKLT0i55m9Ro+1DZ56DFnM5/uyMoGgaKWsgFCCxlIXcbSjwY3opyKjI8yn2JTZjxh1/8aScxHiLfI3tVsa1hYQqnI7HVtmbqR8PYLxi4W7OTWmoc8xoaYGuSD2SWRM7s/JXcZqcBLA3JqqZUiAmfnHfqo6bcU5WclItI6I0=,iv:o+c+SeWnt9E+b9zoDnUr3lxfrDVD7aUNl7fyvK8QVm4=,tag:g01sgSXHjlZEIy3DSrKH5g==,type:str]
+    lastmodified: "2023-02-08T14:06:48Z"
+    mac: ENC[AES256_GCM,data:6dt9GAXp1cZDaLqzujOqnaCaeYe9u+FBhcL6HUlBVoCqXzH65+o0NW0g2FJt8/Yu2j1G0Puqwio9YQTsTOwOg2aW2yvb7BC6zA2cNd3XqGxeOKH7zeRi7smBT2WGt94eg9s6wcqL4AXBTCiy7Rj0rXg+44XQEOLKlZ6xGJVd9XQ=,iv:bXAZkUPqQYji0lJwkmvU9LhAlpiLZTdYMaOQYCITc8k=,tag:yt3Xp8iJ0+VVl+BQdjscCA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/nasa-cryo/support.values.yaml
+++ b/config/clusters/nasa-cryo/support.values.yaml
@@ -8,6 +8,12 @@ cluster-autoscaler:
   awsRegion: us-west-2
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.cryointhecloud.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.cryointhecloud.2i2c.cloud

--- a/config/clusters/nasa-veda/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-veda/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:LLY0rZP1sw+xO/D9Kjddh5UyO2M/bwQAmkSm6NJmZX+Gew19diIC0Pygu2qHseQM7aAHks5GQhUXbwCubkXjSA==,iv:cWCxydhWlPY6n394pb6VXqTwqmA1xNYOYoZ96OrH8cw=,tag:uaBVVQmAoTn0L7LV2Zq39Q==,type:str]
     password: ENC[AES256_GCM,data:vK/L2heF+tpPD4p6QAOK42POuYeFbR5d+wnYdv+MEqQ24W2Xjgel9fxm/UW+ZIvtjTpMfcRjdJAkQdcmjb1Vnw==,iv:d9KEfBlNdlFf/ekGtQnwObMtvVkVJhRvBfC6QMtBKHE=,tag:Q4zbJD5cUn5XfbG+xGny0g==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:HXvVYhg+nvVl6yA/zwNZZblDqRs=,iv:cXRUeXB+ZdnFPFr+IbUyrheIq+7q5MiF8X66F8TNv/I=,tag:pukQh4DoHvwc1kqgu46QSQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:r8EaICBCNsAZQ4xNX4zzMq9u733/nejDMUtH5qVmBa8OzdpFhTjftg==,iv:l52ck0g4hrE9Ah5bPHi2nZDPMND3NN/Mfs+myRy7Tks=,tag:9PPUspkMIZQicAMlOg3mvg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-26T13:10:34Z"
-    mac: ENC[AES256_GCM,data:dvOc33v8HCWt5cCF4P/aixW7SUdzILPw112FmA8FWDRUppaYhTmJto3QqVCdJrBDMLQjzrBv0LEFHbi4mG4cDjlwTGfuezCd5YrKwX09DCextMYQwGE4AhFoW8I6o2vW1AQonCx1GZiJq0q3Wx+3wfWV9kezwrQT5EFTvsmlAtM=,iv:JnW7NmpEAgPHj3vSrzjaIvPTyOaJCys/1LTIkELDn7A=,tag:cBWvRHV0mSfGsBqqZ/bPew==,type:str]
+    lastmodified: "2023-02-08T14:07:56Z"
+    mac: ENC[AES256_GCM,data:W7CLTcluOLbLjVFIG5OshwMyrcXxxH/FfAeJ8Hg65VhcDjc324ZS5HPzJl6XbEySRmUtEBdHIZeFN8+izRf6AA62ZHbwtVjx2FPEhRCBDpvpo52WxzMhffG/CoYXNXnjg3XzCTQhKzPaRxAL9MNXPxV0PdDPnF28Dc/r1PeRsTk=,iv:8GPEQ/mb5EmtNgoANH+1XV9YwTO1cKY2bDWR5Os5770=,tag:ukm9Bo/jZ012LxNfZgym+Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -10,7 +10,10 @@ cluster-autoscaler:
 grafana:
   grafana.ini:
     server:
-      root_url: https://grafana.nasa-veda.2i2c.cloud
+      root_url: https://grafana.nasa-veda.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.nasa-veda.2i2c.cloud

--- a/config/clusters/openscapes/enc-support.secret.values.yaml
+++ b/config/clusters/openscapes/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:FrWs9Ubya7M/ri55ZFiirAB4x71D2P3AvGUZsXWg0/AMnTTOeD+oDijWch9DxBzAPSGLMltgi2G3/GhldJqjvw==,iv:dBpn3Pd85R1lfwXfVPBIWBV139v+FbNFhbSoWHVzqiM=,tag:czBdVEHUG5A8Ah7/8gv6uQ==,type:str]
     password: ENC[AES256_GCM,data:Rjq39W38GVkd1zaq9qWLjvhsnrgi6HkoKtSSRuxFYUZM/b+ax7ZD57x/Thni6Lz4anVPhVSCaPRtjttQbTpKNQ==,iv:5Z7kPVZ3CxT69i3fkzP9QRgtog542ATWXFJpUkFLpPU=,tag:5zH0e66qse9OSVrZ2kNNVA==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:gEHcTv5tBxTiKShysWAv/OpAIy4=,iv:J7LVSXC4pA2rNcmSU77x6UnYIGDp/ENnD0WU+nCsEHo=,tag:KNcWmeKKFNUfGLbfony+yw==,type:str]
+            client_secret: ENC[AES256_GCM,data:CH/15K14SgpFMtkIzA7HNvRtLCCsAPMgqRcr7GHC7VjRckX28H9afQ==,iv:IQWWgFCsLD1VQ8WdDTWJDMLKUa8O0Pmx2mOk8Z1PvEA=,tag:Va6q0TUFqPvvjbdu0x81PA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:47Z"
-    mac: ENC[AES256_GCM,data:KZEVVWFz34Tx6NM1NoKuSYQRKM35qg0Q3wqUC9/Lg46wD4BPmD2n/wh05Yxct33qDmbi2M8wS1jzDFqhaOdLe+tdQVd0NNLceINHRv2YNaJG680GG9aRZZTNfZ152Tai4wAgtXQqwhHVuia0gfbvmMCmisYqYOaDKP1upp58/U8=,iv:1Bcl2D2fEtNAVv4giUw3bA3hQlEk20tHLoNkbnWnoP8=,tag:cQA0OXSa6Tj1WCbbuueZMg==,type:str]
+    lastmodified: "2023-02-08T09:31:47Z"
+    mac: ENC[AES256_GCM,data:pS0Q0HufeHhEk+n+1R5Woe4ZzPFM+xQafC9T3QEWPqMdyydrGIXgzPtV+sn+yf9+kMgxrADWY5GncLDLf9ICstnyjaFM1bXDA6kWfgljnI0/m4X5rD6w4XkZZJqzxDsIdiOS0u/YrTAQV+4nUlWDAjz/NyHkournuw/1PlSjc58=,iv:Ssg7aCPhPLvG5uwA3Q0uVpifLNG3WUIrlyMJAfp1MxI=,tag:lMWCdGcwnEpMiH5NRZpQVA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2

--- a/config/clusters/openscapes/support.values.yaml
+++ b/config/clusters/openscapes/support.values.yaml
@@ -18,11 +18,13 @@ prometheus:
       limits:
         cpu: 4
         memory: 8Gi
+
 cluster-autoscaler:
   enabled: true
   autoDiscovery:
     clusterName: openscapeshub
   awsRegion: us-west-2
+
 grafana:
   ingress:
     hosts:
@@ -31,3 +33,9 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.openscapes.2i2c.cloud
+  grafana.ini:
+    server:
+      root_url: https://grafana.openscapes.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org NASA-Openscapes

--- a/config/clusters/pangeo-hubs/enc-support.secret.values.yaml
+++ b/config/clusters/pangeo-hubs/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:Qq5cEmsWnutE+HvCvRcg/A+SdK1Thr+R6dRT6+b+qCEBYKpYG2Xrdcb2es65z5xZAx7tzTN6MhIWytrewYrbxQ==,iv:DEcYIRPizwe5Z6rz7tEqTiYJ/oiWDKErV17/Dsu4QNg=,tag:K+8QvYKysgUrzjy1dkhFJA==,type:str]
     password: ENC[AES256_GCM,data:zVs5aFx9GmcbvwNxRXOy1OQGxvYiEkicKdV7p5SA1na795oIJP3ysCaWYPwVL+yNXy4kN6IJ2Ja2aFdcacjgcg==,iv:/d2WgJkinDTLMimGDMYsVZ6AsoGSKtIuhM8Y+rMf6YQ=,tag:0Rv/hEtnofkW3XdzagP4zA==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:hovv82ysQi5EEx7dSzCKnpbZ/ys=,iv:In6DqW9UmX5diPRbAJ+79CT8iLtFKZdtoZXlNyeWqZA=,tag:SHFkGMT67aUAxqNrYUfN3Q==,type:str]
+            client_secret: ENC[AES256_GCM,data:BnpkCV+vIFKzXyq0ggbzTyS7RZyb7Ty8koYVsWkMwdrjXuvJuONGYQ==,iv:Lo8yOyNBB1HFwTlmaFhrQa4xzqy6fps9mMwE4wyIGUM=,tag:UPNVrq8K71Mh+qPFNN927Q==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:45Z"
-    mac: ENC[AES256_GCM,data:Q6bz2HY7t8fvwZt84PtXCVYrjMd5HAs0NT4L6h1bfDw1LmfrGULY+/DUkop6pmvhFRX+oavnPxz4njboKMk4gcyCktgdw5gr/pEMaAWdzNe3EH5M7PtfCU91sxfpJsVxWwM+LXqHZ8lP9d7fu2UOpWVk/+IWEu0uWEVBbP4TNRI=,iv:2DBZoKfjOx2ciT30kS0qKFhaXfyYcoWYvuLYUHd+EL4=,tag:tTnjq/0CDkpIr0Zz2/q5Kg==,type:str]
+    lastmodified: "2023-02-08T14:09:30Z"
+    mac: ENC[AES256_GCM,data:EATjL6qOUjWvHUURy9zY1uspHFtXgZZEoxgCODNDbaBH0sLB/O4mvQRQI+LEEJnw0+kFI7KKTPhguqAjtoyhebSwTGH3t1YMkm2SzDBkKKFJCbA1foKXSDqat5dHIZbRJJDhHAOOU9s3DOOt0dxlbgVeeZk2laVBmsBy0+7SJqs=,iv:dtSKdm0YCOhgY8unlEjwlPXoLulXe2Bg1DfPMvDa3c4=,tag:F85IaKFSep7bw+aq4gnvTg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2

--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -1,4 +1,10 @@
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.gcp.pangeo.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.gcp.pangeo.2i2c.cloud
@@ -6,6 +12,7 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.gcp.pangeo.2i2c.cloud
+
 # Disable the Admissions Validation Webhook and the port is not
 # permitted on private GKE clusters
 ingress-nginx:

--- a/config/clusters/templates/gcp/support.values.yaml
+++ b/config/clusters/templates/gcp/support.values.yaml
@@ -1,25 +1,28 @@
 prometheusIngressAuthSecret:
-    enabled: true
+  enabled: true
   
-  prometheus:
-    server:
-      ingress:
-        enabled: true
-        hosts:
-          - prometheus.{{ cluster_name }}.2i2c.cloud
-        tls:
-          - secretName: prometheus-tls
-            hosts:
-              - prometheus.{{ cluster_name }}.2i2c.cloud
-  grafana:
-    grafana.ini:
-      server:
-        root_url: https://grafana.{{ cluster_name }}.2i2c.cloud/
+prometheus:
+  server:
     ingress:
+      enabled: true
       hosts:
-        - grafana.{{ cluster_name }}.2i2c.cloud
+        - prometheus.{{ cluster_name }}.2i2c.cloud
       tls:
-        - secretName: grafana-tls
+        - secretName: prometheus-tls
           hosts:
-            - grafana.{{ cluster_name }}.2i2c.cloud
-  
+            - prometheus.{{ cluster_name }}.2i2c.cloud
+
+grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.{{ cluster_name }}.2i2c.cloud/
+  auth.github:
+    enabled: true
+    allowed_organizations: 2i2c-org
+  ingress:
+    hosts:
+      - grafana.{{ cluster_name }}.2i2c.cloud
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.{{ cluster_name }}.2i2c.cloud

--- a/config/clusters/ubc-eoas/enc-support.secret.values.yaml
+++ b/config/clusters/ubc-eoas/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:sSX4NlMykmMUxjBcvdbbNe3aBepQ40qD/OIch9Llgl7tpY1HULGtoGHX8WgnXKgWGmICoDAdd2a5g4Ipu+J27A==,iv:jppfe4OvBpKviWIJxyr1IaIZ9YT01FFwaQtiJS61B/4=,tag:8oSUozI3CC1dScBN6LdBVg==,type:str]
     password: ENC[AES256_GCM,data:I2cyQ50eESqZP+Xc8mEu2IVUEfqtIgCqdXz4nxw6l5vR9UvUi4Uojs7r0NHnTCEQpTQb19UbScKGI5i3IwGNHg==,iv:YKeAF1CTwbSjysKw0VtSJfm44UTzviEPSmEmp9OjvJY=,tag:dQK6zItuaEYtTgDJONnpdQ==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:1bwtlPW4SoO6E20xKLTei9DXfE4=,iv:57gLGFqthkmkwLIka7uWXJKlCnvSncVE/sgbTZ2fo7w=,tag:C2TivYXWw7QzbM4T9N63Bg==,type:str]
+            client_secret: ENC[AES256_GCM,data:kH29ID3kFsby69gbIAWELhfsuOqIgu6HK+GTltpdmQkuqz74lwfKHg==,iv:IgYHnrVRclmSjMtaIbr3DIBRNk0o1LY9jq++ZomFI9Y=,tag:WufH5jVRR+WNrq5jriwOVA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-11T18:30:03Z"
-    mac: ENC[AES256_GCM,data:hgD02yRCz/vs98eewrWuI1U4R5IvKfZLw2TUmt49EWsikG7ZFvIRkrzObsve+phx7OLfY1mizUtEsz2c7S7aI1K/HmtJaI7TC2AJdun0fLIJ2K3dKbP77I1B5HA3qWUGH+R1S2JADJuk0UXS7ISDHFCr2KGQbZM843SLVdwXEgU=,iv:qXQAoXjcsGJsV9UBdkIceEnd5pVVWj53fMADovdAIWo=,tag:HmPtXxtsi5Uall3+zukoSA==,type:str]
+    lastmodified: "2023-02-08T14:10:42Z"
+    mac: ENC[AES256_GCM,data:MBenbXKFL0QJDUQVpH95XrrBrumrBoJLaI5r6/mLLoLz7Bq+IJYY91oCxj43c+/chkUxz854uI2KpSjtsHXolmAe8PaLcfJqJcx0HeFioVP/ohCeRiE/f7G5JUF0ufoLZjlgskh1gsNSPsZP7+yFfX8KXDmZ40C1bVA5dzFcLzc=,iv:RN2HJWbyz8hVjKTj3ByYd+nVlVZiCxWQRcgH7eKfS9U=,tag:YFjXl1TCKvyZL9DHZU3k9A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.2

--- a/config/clusters/ubc-eoas/support.values.yaml
+++ b/config/clusters/ubc-eoas/support.values.yaml
@@ -11,6 +11,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.ubc-eoas.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.ubc-eoas.2i2c.cloud

--- a/config/clusters/utoronto/enc-support.secret.values.yaml
+++ b/config/clusters/utoronto/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:2ub6n2kKYjWWSsng1V/0eVPm5mXdxazBhe3lWknfRweur+sX6gWimBwW9fj3w7lAH068PsEWWgjTG2ZoSDSFsA==,iv:Ark6kfCamRVIdxk8pemStIwalu0kgOb56rHBvnNb1/8=,tag:O/WVZv75QD9JluNlFPWflg==,type:str]
     password: ENC[AES256_GCM,data:KUwQV5C2vh4bQwg6AGD50prZJ+3/laR7k7mt61jQVG1LMlPtgCzU/pkvES55oklWJ7i4HSuLEpjApVjwfLFXWg==,iv:IQheCbGfPXLYiuKAJxgR0BUmXFYNawl6Ev58xBg/zXY=,tag:cS94tF1+ry2SsjTTzauk8w==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:pg9Y7t0yDYY6wffxat4wwRwC9+g=,iv:Pz6ig2wcVVoSN4m1srHaVUA3eUhZ69Tao1Vz0MMYaqY=,tag:PbL6xEJsZxTsaienW1fBgQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:YZeTMcHmKeI7ZtvsSA5ixaeaPnwby1KlP6D/sKfooAdwtD71rH1a/g==,iv:fc+sUhZlxxxxzA7eRjWPQ52AWE6ciE/S1vOjZmTjuEk=,tag:16FaLIqBREeEay9JXSqVdg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:46Z"
-    mac: ENC[AES256_GCM,data:xCCOx77k76jlQJCTlIsNInZNLlISC09MOTuq6hhMWLWhKHEzhRo60QjA2PxQ1ArtJC/TUf9OnoJ7zCMb/f/cIcsG6GGY0UfXyoNLah9x8EsITrR0vMLrc//RlyCXk6OqFd17hNATesxvByojwqyQSp3eLemFXmby5nathXn2jqc=,iv:YiPvrUzxMtB7ey1sfY7tnZKgFiLfl5QD8+LmTYCQzGg=,tag:e5RDhCF/TMkTfuRW0hMGWw==,type:str]
+    lastmodified: "2023-02-08T14:11:59Z"
+    mac: ENC[AES256_GCM,data:av4k45kvQJ9lkqQu86e2QHePXi2f3FGoriE7gSUH18SMj4O136P94llrWTEDttddDkw7cgaEjvB+eJQoDgZaSpOlVAf//apOqopt5A9CkXQ4AECLFBTXJKJi9mqltS8TUPbvdmEQEpL9U5zJuP7SfmaF2+pjPbyB0W1D3xdsEGM=,iv:t2Dam7qD2ZZQX2vwV5LY+Lepyr4M4+mxiWygbZixomI=,tag:BLGyhg/Dj9eEUBrobpAMPw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -29,10 +29,14 @@ prometheus:
       limits:
         cpu: 2
         memory: 16Gi
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.utoronto.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.utoronto.2i2c.cloud

--- a/config/clusters/uwhackweeks/support.values.yaml
+++ b/config/clusters/uwhackweeks/support.values.yaml
@@ -18,15 +18,20 @@ prometheus:
       limits:
         cpu: 4
         memory: 8Gi
+
 cluster-autoscaler:
   enabled: true
   autoDiscovery:
     clusterName: uwhackweeks
   awsRegion: us-west-2
+
 grafana:
   grafana.ini:
     server:
       root_url: https://grafana.uwhackweeks.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.uwhackweeks.2i2c.cloud

--- a/config/clusters/victor/support.values.yaml
+++ b/config/clusters/victor/support.values.yaml
@@ -11,6 +11,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.victor.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.victor.2i2c.cloud
@@ -18,14 +21,6 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.victor.2i2c.cloud
-    auth.github:
-      enabled: true
-      allow_sign_up: true
-      scopes: user:email,read:org
-      auth_url: https://github.com/login/oauth/authorize
-      token_url: https://github.com/login/oauth/access_token
-      api_url: https://api.github.com/user
-      allowed_organizations: 2i2c-org
 
 prometheus:
   server:

--- a/docs/howto/grafana-github-auth.md
+++ b/docs/howto/grafana-github-auth.md
@@ -31,11 +31,6 @@ To enable logging into Grafana using GitHub, follow these steps:
          root_url: https://<grafana.ingress.hosts[0]>
        auth.github:
          enabled: true
-         allow_sign_up: true
-         scopes: user:email,read:org
-         auth_url: https://github.com/login/oauth/authorize
-         token_url: https://github.com/login/oauth/access_token
-         api_url: https://api.github.com/user
          # allowed_organizations should be a space separated list
          allowed_organizations: 2i2c-org
    ```

--- a/docs/howto/grafana-github-auth.md
+++ b/docs/howto/grafana-github-auth.md
@@ -31,11 +31,12 @@ To enable logging into Grafana using GitHub, follow these steps:
          root_url: https://<grafana.ingress.hosts[0]>
        auth.github:
          enabled: true
-         allow_sign_up: false
+         allow_sign_up: true
          scopes: user:email,read:org
          auth_url: https://github.com/login/oauth/authorize
          token_url: https://github.com/login/oauth/access_token
          api_url: https://api.github.com/user
+         # allowed_organizations should be a space separated list
          allowed_organizations: 2i2c-org
    ```
 

--- a/docs/hub-deployment-guide/deploy-support/configure-support.md
+++ b/docs/hub-deployment-guide/deploy-support/configure-support.md
@@ -22,6 +22,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://<grafana-domain>/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - <grafana-domain>

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -158,6 +158,32 @@ grafana:
       kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
 
+  # grafana is partially configured for GitHub authentication here, but the
+  # following values need to be set as well, where client_secret should be kept
+  # secret:
+  #
+  #     server:
+  #       root_url: https://grafana.<cluster_name>.2i2c.cloud
+  #     auth.github:
+  #       enabled: true
+  #       allowed_organizations: "2i2c-org some-other-gh-org"
+  #       client_id: ""
+  #       client_secret: ""
+  #
+  grafana.ini:
+    server:
+      root_url: ""
+    auth.github:
+      enabled: false
+      allowed_organizations: ""
+      client_id: ""
+      client_secret: ""
+      allow_sign_up: true
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
This PR puts common github auth config into support charts default values.

- Closes #2175

### GitHub org is always relevant

Since GitHub as identity provider has setup for grafana systematically with this PR to allow 2i2c engineers access, we can benefit from this.

If the community representatives have github identities and a github organization related to them, that is relevant information to acquire together with consent to granting the entire organization access. Maybe a github team will be fine also, but [we haven't yet verified this](https://github.com/2i2c-org/infrastructure/issues/2179).

Ping @2i2c-org/team-leads 

### r2r consideration

**The support chart should not provide 2i2c permissions by default.**

By default, the support chart won't enable github auth (as it requires client id/secret config), and it doesn't by default grant 2i2c any permissions. This is to ensure use of the basehub chart for someone else doesn't without explicit configuration grant 2i2c any permissions.

### GitHub auth already setup

- [x] 2i2c
- [x] leap
- [x] m2lines
- [x] victor

### GitHub auth setup in this PR

- [x] openscapes (nasa-openscapes org has permissions also)
- [x] 2i2c-aws-us
- [x] 2i2c-uk
- [x] awi-ciroh
- [x] callysto
- [x] carbonplan
- [x] gridsst
- [x] linked-earth
- [x] meom-ige
- [x] nasa-cryo
- [x] nasa-veda
- [x] pangeo-hubs
- [x] ubc-eoas
- [x] utoronto

### GitHub auth not setup

- uwhackweeks, being decomissioned (#2173)