### PR TITLE
grafana: setup github auth for 2i2c-org in cloudbank

### DIFF
--- a/config/clusters/cloudbank/enc-support.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:CBRp+deGS8SK1Zd4dC1hm9F5t4x3kaUjUpYicBxg/EKuNYG+zKoMhr5nxMABY8szeEEz201rLTjbbXe7VC7+kg==,iv:R1V0h4M+UIdnVQv2I1gDcFcNKV2BMj9DPkJy5WXX08o=,tag:2A2P5UOU2oCRs0FZrx7z8Q==,type:str]
     password: ENC[AES256_GCM,data:j8wnzJIm1f67zCk1Vjs9ZTAby7ILv/yFq7N7+TAscLbtTj7XiYzl4FMmU4H1MY8Qm0Jup7EpZVI2En0Ml3nrvw==,iv:aZYQeRxnjbqq88Qmz04IXAeq9RVKp3BCkcsSaZh1/jY=,tag:HPonJ/ekaPN6VhxHHLj1gw==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:Npo50yTCsUxwiGFCpit/Gf+AGEs=,iv:IR/UEEl7Df3GTL4nFAInyQQ5RlrbbT5cZgKW+wedF2E=,tag:7XsPhfHHoVj6ewoBLODORQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:i44fpj9rgMtaiFoO9VMyikNkFdPc6CImDk375PgIm6kIMa0IrCAy1A==,iv:TbWvNMJ+X6aIf0CJ1CrSTBJ/TjPNUP3TnEcP1d6u0FM=,tag:RlNyC+/9Hsj9s16iB9rlCQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-03-14T20:52:48Z"
-    mac: ENC[AES256_GCM,data:BliNs0s+xjroyTtQZKN9ElwMO9h75e8gcQ0kKTPKVp7Solaa7NU24xs/I/obeKqCO6aUXDKQb32EuNK2ct4WD4LvtDxeC2QVQilTxZZZUjR2qfpPwbiRYvK6FBZob5s5XTNwUYQgKhb1cbM6fVVSoF845skzaBqNrEMP8WjgcGg=,iv:PIBVhtnt9Ir6i2B9eSv7RSZz1ejKf+nxBdXce9pelak=,tag:vx/nWgPIL3SIjSN97MNDgw==,type:str]
+    lastmodified: "2023-02-09T11:53:22Z"
+    mac: ENC[AES256_GCM,data:bpqm8FaHX7jy8I3v/xJTYOJi+zZVjuIRf4ZU120/ICXtynZ/Oq59rR6CUJhE0ZYApHn5SQBPwOSmjTBIMewNytHXQUWO3Y0kHaPXkISU61oU5rZw3X2XwSCaiE58sMMdwb+zcptrF9C2RhBJrxVdB5FItGQ0iRo3D0ncNdiuUEk=,iv:m+hFU7l0WlgQpm1AzqZwio6NBKfeWo0iBuAuJcAWjp4=,tag:9nsFgdj0XdRlDpLIqVORLQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.1
+    version: 3.7.2


### PR DESCRIPTION
This is a followup on #2178 where I missed to provide github auth for the grafana instance on the cloudbank cluster.