### PR TITLE
Force user pods to schedule on user nodes, enable user-scheduler where needed

### DIFF
--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -1,5 +1,5 @@
 name: 2i2c-aws-us
-provider: aws
+provider: aws # https://2i2c.awsapps.com/start#/
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -26,6 +26,7 @@ hubs:
     auth0:
       enabled: false
     helm_chart_values_files:
+      - common.values.yaml
       - dask-staging.values.yaml
       - enc-dask-staging.secret.values.yaml
   - name: researchdelight
@@ -35,4 +36,5 @@ hubs:
     auth0:
       connection: github
     helm_chart_values_files:
+      - common.values.yaml
       - researchdelight.values.yaml

--- a/config/clusters/2i2c-aws-us/common.values.yaml
+++ b/config/clusters/2i2c-aws-us/common.values.yaml
@@ -1,0 +1,5 @@
+basehub:
+  jupyterhub:
+    scheduling:
+      userScheduler:
+        enabled: true

--- a/config/clusters/2i2c-uk/cluster.yaml
+++ b/config/clusters/2i2c-uk/cluster.yaml
@@ -1,5 +1,5 @@
 name: 2i2c-uk
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?authuser=3&project=two-eye-two-see-uk
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see-uk

--- a/config/clusters/2i2c-uk/cluster.yaml
+++ b/config/clusters/2i2c-uk/cluster.yaml
@@ -1,5 +1,5 @@
 name: 2i2c-uk
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?authuser=3&project=two-eye-two-see-uk
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?project=two-eye-two-see-uk
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see-uk

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -1,5 +1,5 @@
 name: 2i2c
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pilot-hubs-cluster/details?project=two-eye-two-see
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see

--- a/config/clusters/2i2c/paleohack2021.values.yaml
+++ b/config/clusters/2i2c/paleohack2021.values.yaml
@@ -1,10 +1,6 @@
 jupyterhub:
   scheduling:
-    userPlaceholder:
-      # Not needed anymore, hackathon is over
-      replicas: 0
     userScheduler:
-      # Each user gets almost 1 anyway
       enabled: true
   custom:
     2i2c:

--- a/config/clusters/awi-ciroh/cluster.yaml
+++ b/config/clusters/awi-ciroh/cluster.yaml
@@ -1,5 +1,5 @@
 name: awi-ciroh
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/awi-ciroh-cluster/details?project=awi-ciroh
 gcp:
   key: enc-deployer-credentials.secret.json
   project: awi-ciroh

--- a/config/clusters/callysto/cluster.yaml
+++ b/config/clusters/callysto/cluster.yaml
@@ -1,5 +1,5 @@
 name: callysto
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/northamerica-northeast1/callysto-cluster/details?project=callysto-202316
 gcp:
   key: enc-deployer-credentials.secret.json
   project: callysto-202316

--- a/config/clusters/carbonplan/cluster.yaml
+++ b/config/clusters/carbonplan/cluster.yaml
@@ -1,5 +1,5 @@
 name: carbonplan
-provider: aws
+provider: aws # https://631969445205.signin.aws.amazon.com/console
 account: "631969445205"
 aws:
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -118,7 +118,7 @@ basehub:
         enabled: false
         replicas: 0
       userScheduler:
-        enabled: false
+        enabled: true
     proxy:
       chp:
         resources:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -114,9 +114,6 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: x1.32xlarge
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: true
     proxy:

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -1,5 +1,5 @@
 name: cloudbank
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/cb-cluster/nodes?project=cb-1003-1696
 gcp:
   key: enc-deployer-credentials.secret.json
   project: cb-1003-1696

--- a/config/clusters/gridsst/cluster.yaml
+++ b/config/clusters/gridsst/cluster.yaml
@@ -1,5 +1,5 @@
 name: gridsst
-provider: aws
+provider: aws # https://2i2c.awsapps.com/start#/
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -121,4 +121,4 @@ basehub:
         enabled: false
         replicas: 0
       userScheduler:
-        enabled: false
+        enabled: true

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -117,8 +117,5 @@ basehub:
         name: quay.io/uwhackweek/snowex
         tag: "2022.07.07"
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: true

--- a/config/clusters/leap/cluster.yaml
+++ b/config/clusters/leap/cluster.yaml
@@ -1,5 +1,5 @@
 name: leap
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/leap-cluster/nodes?project=leap-pangeo
 gcp:
   key: enc-deployer-credentials.secret.json
   project: leap-pangeo

--- a/config/clusters/linked-earth/cluster.yaml
+++ b/config/clusters/linked-earth/cluster.yaml
@@ -1,5 +1,5 @@
 name: linked-earth
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/linked-earth-cluster/nodes?project=linked-earth-hubs
 gcp:
   key: enc-deployer-credentials.secret.json
   project: linked-earth-hubs

--- a/config/clusters/m2lines/cluster.yaml
+++ b/config/clusters/m2lines/cluster.yaml
@@ -1,5 +1,5 @@
 name: m2lines
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/m2lines-cluster/details?project=m2lines-hub
 gcp:
   key: enc-deployer-credentials.secret.json
   project: m2lines-hub

--- a/config/clusters/meom-ige/cluster.yaml
+++ b/config/clusters/meom-ige/cluster.yaml
@@ -1,5 +1,5 @@
 name: meom-ige
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pangeo-hubs-cluster/nodes?project=columbia
 gcp:
   key: enc-deployer-credentials.secret.json
   project: meom-ige-cnrs

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -79,9 +79,6 @@ basehub:
         name: pangeo/pangeo-notebook
         tag: "2022.06.13"
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: false
     proxy:

--- a/config/clusters/meom-ige/drakkar-demo.values.yaml
+++ b/config/clusters/meom-ige/drakkar-demo.values.yaml
@@ -58,9 +58,6 @@ jupyterhub:
             node.kubernetes.io/instance-type: n1-standard-16
     defaultUrl: /lab
   scheduling:
-    userPlaceholder:
-      enabled: false
-      replicas: 0
     userScheduler:
       enabled: false
   hub:

--- a/config/clusters/nasa-cryo/cluster.yaml
+++ b/config/clusters/nasa-cryo/cluster.yaml
@@ -1,5 +1,5 @@
 name: nasa-cryo
-provider: aws
+provider: aws # https://2i2c.awsapps.com/start#/
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -127,8 +127,5 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: m5.8xlarge
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: true

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -131,4 +131,4 @@ basehub:
         enabled: false
         replicas: 0
       userScheduler:
-        enabled: false
+        enabled: true

--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -1,5 +1,5 @@
 name: nasa-veda
-provider: aws
+provider: aws # https://smce-veda.signin.aws.amazon.com/console
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,3 +60,6 @@ basehub:
       image:
         name: pangeo/pangeo-notebook
         tag: "2023.01.13"
+    scheduling:
+      userScheduler:
+        enabled: true

--- a/config/clusters/openscapes/cluster.yaml
+++ b/config/clusters/openscapes/cluster.yaml
@@ -1,6 +1,6 @@
 name: openscapes
-provider: aws
-account: "783616723547" # https://783616723547.signin.aws.amazon.com/console
+provider: aws # https://783616723547.signin.aws.amazon.com/console
+account: "783616723547"
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -217,9 +217,6 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: r5.16xlarge
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: true
       userPods:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -221,7 +221,7 @@ basehub:
         enabled: false
         replicas: 0
       userScheduler:
-        enabled: false
+        enabled: true
       userPods:
         nodeAffinity:
           matchNodePurpose: require

--- a/config/clusters/pangeo-hubs/cluster.yaml
+++ b/config/clusters/pangeo-hubs/cluster.yaml
@@ -1,5 +1,5 @@
 name: pangeo-hubs
-provider: gcp
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pangeo-hubs-cluster/nodes?project=columbia
 account: columbia
 gcp:
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/ubc-eoas/cluster.yaml
+++ b/config/clusters/ubc-eoas/cluster.yaml
@@ -1,5 +1,5 @@
 name: ubc-eoas
-provider: aws
+provider: aws # https://2i2c.awsapps.com/start#/
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -87,3 +87,7 @@ jupyterhub:
           mem_guarantee: 50G
           node_selector:
             node.kubernetes.io/instance-type: m5.8xlarge
+
+  scheduling:
+    userScheduler:
+      enabled: true

--- a/config/clusters/uwhackweeks/common.values.yaml
+++ b/config/clusters/uwhackweeks/common.values.yaml
@@ -103,9 +103,6 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: g4dn.xlarge
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: false
     hub:

--- a/config/clusters/victor/cluster.yaml
+++ b/config/clusters/victor/cluster.yaml
@@ -1,5 +1,5 @@
 name: victor
-provider: aws
+provider: aws # https://2i2c.awsapps.com/start#/
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -88,8 +88,5 @@ basehub:
         name: pangeo/pangeo-notebook
         tag: "2022.09.21"
     scheduling:
-      userPlaceholder:
-        enabled: false
-        replicas: 0
       userScheduler:
         enabled: true

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -92,4 +92,4 @@ basehub:
         enabled: false
         replicas: 0
       userScheduler:
-        enabled: false
+        enabled: true

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -125,9 +125,6 @@ jupyterhub:
       replicas: 0
     podPriority:
       enabled: true
-      globalDefault: false
-      defaultPriority: 0
-      userPlaceholderPriority: -10
     userScheduler:
       enabled: false
       resources:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -106,6 +106,20 @@ jupyterhub:
       kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
   scheduling:
+    # We declare matchNodePurpose=require to get a nodeAffinity like a
+    # nodeSelector on all core pods and user pods. core pods like hub and proxy
+    # will schedule on nodes with hub.jupyter.org/node-purpose=core and user
+    # pods on nodes with hub.jupyter.org/node-purpose=user.
+    #
+    # Since this setting adds a nodeAffinity, its okay that we configure
+    # KubeSpawner's profile_list to override node_selector.
+    #
+    corePods:
+      nodeAffinity:
+        matchNodePurpose: require
+    userPods:
+      nodeAffinity:
+        matchNodePurpose: require
     userPlaceholder:
       enabled: true
       replicas: 0
@@ -116,8 +130,6 @@ jupyterhub:
       userPlaceholderPriority: -10
     userScheduler:
       enabled: false
-      nodeSelector:
-        hub.jupyter.org/node-purpose: core
       resources:
         requests:
           # FIXME: Just unset this?
@@ -134,8 +146,6 @@ jupyterhub:
     service:
       type: ClusterIP
     chp:
-      nodeSelector:
-        hub.jupyter.org/node-purpose: core
       resources:
         requests:
           # FIXME: We want no guarantees here!!!
@@ -145,8 +155,6 @@ jupyterhub:
         limits:
           memory: 1Gi
     traefik:
-      nodeSelector:
-        hub.jupyter.org/node-purpose: core
       resources:
         requests:
           memory: 64Mi
@@ -227,8 +235,6 @@ jupyterhub:
               - /usr/local/share/jupyter/custom_template
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
-    nodeSelector:
-      hub.jupyter.org/node-purpose: user
     image:
       name: quay.io/2i2c/2i2c-hubs-image
       tag: 69b1f9dff7c7
@@ -394,8 +400,6 @@ jupyterhub:
     image:
       name: quay.io/2i2c/pilot-hub
       tag: "0.0.1-0.dev.git.4978.h858bd17c"
-    nodeSelector:
-      hub.jupyter.org/node-purpose: core
     networkPolicy:
       enabled: true
       ingress:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -120,11 +120,11 @@ jupyterhub:
     userPods:
       nodeAffinity:
         matchNodePurpose: require
+    podPriority:
+      enabled: true
     userPlaceholder:
       enabled: true
       replicas: 0
-    podPriority:
-      enabled: true
     userScheduler:
       enabled: false
       resources:


### PR DESCRIPTION
Since this PR touches basehub and the jupyterhub helm chart, it means a lot of installations will have a hub pod that restarts I think. Due to that I've bundled a few changes to minimize disruption of our hubs.

- Closes #2163
- Closes #2190

## Changes by commit

1. **basehub: fix node selection using z2jh config option**
   This is a bugfix and complexity reduction by relying on the jupyterhub chart's functionality.
   
   Instead of specifying `nodeSelector` on various jupyterhub chart pods and user pods to schedule on "core" and "user" nodes, we let the jupyterhub chart apply a `nodeAffinity` that works the same way via [`scheduling.corePods.matchNodePurpose=require`](https://z2jh.jupyter.org/en/stable/resources/reference.html#scheduling-corepods-nodeaffinity-matchnodepurpose).
   
   This way, we avoid a bug where we override the user pods' `nodeSelector` via KubeSpawner's profile_list choices, which can make user nodes schedule on core nodes for example.
2. **basehub: avoid re-specification of z2jh default values**
   Just a cleanup to reduce complexity, and generally avoid issues by following z2jh defaults in case they change.
3. **Add link in cluster.yaml to reach cloud console**
   Makes it easier to find the clusters associated cloud console, which is a generally useful shortcut.
4. **Enable user-scheduler on all non-gcp hubs**
   This is a bugfix as I see it. We intend for this behavior overall, but it was disabled for all clusters when enabled out of the box on GKE clusters. Without this, we fail to scale down efficiently on AWS/Azure clusters and using shared nodes.

   The user-scheduler is a jupyterhub chart provided kubernetes pod scheduler to help get user pods scheduled on the most busy node. Like this, we improve scale down significantly when using shared nodes. This is enabled only for AWS/Azure hubs, and not on GCP hubs, as there we activate the same feature from GKE out of the box.
5. **Let user-placeholder's statefulset be around with 0 replicas**
   The user-placeholder resource with 0 replicas isn't harmful to have around, but ensures it becomes an option if we want to use it.