### PR TITLE
Disable dex / staticwebsite in staging hub

### DIFF
--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -1,9 +1,9 @@
 dex:
-  enabled: true
+  enabled: false
   hubHostName: staging.2i2c.cloud
 
 staticWebsite:
-  enabled: true
+  enabled: false
   source:
     git:
       repo: https://github.com/jupyter/try.jupyter.org


### PR DESCRIPTION
This seems broken, and is blocking deployment to anything on the 2i2c hub :( Disabling it to unblocko deployments.