### PR TITLE
Stop forcing use of NotebookApp, take 2

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -186,11 +186,6 @@ jupyterhub:
       # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
       - jupyterhub-singleuser
     extraEnv:
-      # until https://github.com/jupyterhub/jupyterhub/pull/3918 or equivalent lands,
-      # and we upgrade to jupyterhub >= 2.3.1 on all images.
-      # Note: please checkout all occurences of `NotebookApp` configurations
-      # when moving away from it.
-      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
       # notebook writes secure files that don't need to survive a
       # restart here. Writing 'secure' files on some file systems (like
       # Azure Files with SMB) seems buggy, so we just put runtime dir on
@@ -210,28 +205,42 @@ jupyterhub:
           # by this unholy sqlite + NFS mixture.
           HistoryManager:
             enabled: false
-      jupyter_notebook_config.json:
-        mountPath: /usr/local/etc/jupyter/jupyter_notebook_config.json
+      # jupyter_server and notebook are different jupyter servers providing
+      # similar configuration options. Since we have user images that may
+      # provide either, we provide the same configuration for both via
+      # jupyter_server_config.json and jupyter_notebook_config.json.
+      #
+      # A hub can force a choice with singleuser.extraEnv via:
+      #
+      #     JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
+      #     JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+      #
+      jupyter_server_config.json:
+        mountPath: /usr/local/etc/jupyter/jupyter_server_config.json
         # if a user leaves a notebook with a running kernel,
         # the effective idle timeout will typically be cull idle timeout
         # of the server + the cull idle timeout of the kernel,
         # as culling the kernel will register activity,
         # resetting the no_activity timer for the server as a whole
         data:
-          MappingKernelManager:
-            # shutdown kernels after no activity
+          # MappingKernelManager configuration reference:
+          # https://jupyter-server.readthedocs.io/en/latest/api/jupyter_server.services.kernels.html#jupyter_server.services.kernels.kernelmanager.MappingKernelManager
+          #
+          MappingKernelManager: &server_config_mapping_kernel_manager
             cull_idle_timeout: 3600
-            # check for idle kernels this often
             cull_interval: 300
-            # a kernel with open connections but no activity still counts as idle
-            # this is what allows us to shutdown servers
-            # when people leave a notebook open and wander off
             cull_connected: true
-          # If we switch from setting `JUPYTERHUB_SINGLEUSER_APP` to be the NotebookApp
-          # this config kere might need to go under ServerApp instead
-          NotebookApp:
+          # ServerApp configuration reference:
+          # https://jupyter-server.readthedocs.io/en/latest/api/jupyter_server.html#jupyter_server.serverapp.ServerApp
+          #
+          ServerApp: &server_config_server_app
             extra_template_paths:
               - /usr/local/share/jupyter/custom_template
+      jupyter_notebook_config.json:
+        mountPath: /usr/local/etc/jupyter/jupyter_notebook_config.json
+        data:
+          MappingKernelManager: *server_config_mapping_kernel_manager
+          NotebookApp: *server_config_server_app
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     image:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -245,7 +245,7 @@ jupyterhub:
     defaultUrl: /tree
     image:
       name: quay.io/2i2c/2i2c-hubs-image
-      tag: 69b1f9dff7c7
+      tag: "05c6a27dc942"
     storage:
       type: static
       static:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2203

We had to revert it because nbgitpuller on cloudbank hubs failed when we started using jupyter
server everywhere - I am not entirely sure why, as it had worked before! We then upgraded just the
version of jupyterhub and nbgitpuller (https://github.com/2i2c-org/2i2c-hubs-image/pull/3), then tried
to do so without causing massive upgrades in middle of semester for all other packages (https://github.com/2i2c-org/2i2c-hubs-image/pull/4).
However, the image produced fails to even start now, with:

```
Traceback (most recent call last):
  File "/opt/conda/bin/jupyterhub-singleuser", line 5, in <module>
    from jupyterhub.singleuser import main
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/singleuser/__init__.py", line 5, in <module>
    from .app import SingleUserNotebookApp, main
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/singleuser/app.py", line 15, in <module>
    from .mixins import make_singleuser_app
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/singleuser/mixins.py", line 44, in <module>
    from ..log import log_request
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/log.py", line 14, in <module>
    from .handlers.pages import HealthCheckHandler
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/handlers/__init__.py", line 1, in <module>
    from . import base, login, metrics, pages
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/handlers/base.py", line 24, in <module>
    from .. import __version__, orm, roles, scopes
  File "/opt/conda/lib/python3.7/site-packages/jupyterhub/orm.py", line 31, in <module>
    from sqlalchemy.orm import (
  File "/opt/conda/lib/python3.7/site-packages/sqlalchemy/orm/__init__.py", line 56, in <module>
    from .decl_api import add_mapped_attribute as add_mapped_attribute
  File "/opt/conda/lib/python3.7/site-packages/sqlalchemy/orm/decl_api.py", line 164, in <module>
    query_expression,
TypeError: dataclass_transform() got an unexpected keyword argument 'field_specifiers'
```
in the user pod logs.

https://github.com/2i2c-org/2i2c-hubs-image/pull/5 is an attempt to fix this. Note that this is
the *default* image for all our 2i2c hubs as well, not just cloudbank! 

We need this PR to go in to support latest pangeo docker images and latest jupyterlab, but
it can't until we have upgraded our other images.