### PR TITLE
Increase number of node placeholders for UToronto

### DIFF
--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       # Keep at least one spare node around
-      replicas: 1
+      replicas: 2
       resources:
         requests:
           # Each node on the UToronto cluster has 59350076Ki of RAM


### PR DESCRIPTION
We have thrice had issues now where new node spinup on UToronto is taking too long, causing timeouts and users unable to start their server. We always keep one spare node around - with this change, we keep *two* spare nodes around. New node spinup times can be a bit chaotic, so this helps smooth that out.

Graph showing number of users 'waiting' for a new node:
<img width="1660" alt="image" src="https://user-images.githubusercontent.com/30430/219499517-a534f908-6d7d-4ff5-b7db-6eae3a4c1ac7.png">

I don't expect an additional ever-present node to increase costs too much, given the existing node usage:

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/30430/219499664-d44d44bd-e366-42fb-9141-d9059f62feef.png">

You can also see the startup failures that happened (based on this newly added graph https://github.com/jupyterhub/grafana-dashboards/pull/60):

<img width="849" alt="image" src="https://user-images.githubusercontent.com/30430/219501586-c0189228-4df4-4ab6-a6d6-aafc4a75b6a4.png">


Ref https://2i2c.freshdesk.com/a/tickets/449