### PR TITLE
grafana, utoronto: update grafana serviceaccount token

### DIFF
--- a/config/clusters/utoronto/enc-grafana-token.secret.yaml
+++ b/config/clusters/utoronto/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:ijxaOETmUljjDfnl6hT3u9TpyzBJ5aXdEMQCHP4T4Gjsv6kaprIhkrkL4Hm8N7ET1/hXtgAFhfQy8xjJc1lSuxvGkrCyngzwiz90XNLEjLmA3WUDj14+Cxg/lM0=,iv:yNTTBKFfGluB0QSFah7ByevF88jBkkJBzmzY6uZaC18=,tag:VL0syaFNHMKZ7s7wYHASBQ==,type:str]
+grafana_token: ENC[AES256_GCM,data:QZahZIvf+EKQPolv9RFSEJy+OWqghBM+ejOWAFKdQVjLyklEukuwXJnDDoUWPw==,iv:PU+dsYOO6qEJE6zoCTjkpvY+fR5pQ9MJ1Nnhn318zAc=,tag:ffjtznQJNmDSHURcKwGjow==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2022-02-24T17:58:45Z"
-      enc: CiQA4OM7eA2DadN8OGAaD4DPWKoIMoZVC4OPTbwlD+9aPVUDnHsSSQDm5XgWOsXvcy2uNViQ3bh6jCFP/c74oDOBFFXxfJ81OippLpd2Sz+bd2YI2yLl1z4ST8M96rxnYurahryO1X5H9cpaXoQ937s=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: "2022-02-24T17:58:45Z"
-  mac: ENC[AES256_GCM,data:ALfPP6PToCt3kOmjTNlqykUerdiRa7ev26hAkfhsFgQpHJRwEQqJlvBpM7ixHUitNQro7rRerXRra5AHKdBpmB0k5jFPn1aABQGkkOXQE7EOmwQqRsERM7sZ7+GizfAsDghATE/du0lHA/dOYBRK2IssRXNuE9wfpWXlana1QAg=,iv:TWF3jEmrMQPe1qt4bszj82gk8civDEPv/fU1HUHfbMA=,tag:QfLN1MwEsinj6A2sPILUyA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-02-17T04:03:31Z"
+          enc: CiUA4OM7eLRUO7RuJad23ABqIeYgpsMJtvxdNz3E8T20IV2u8i3qEkgA+0T9hZhp8XKyUPxjUIXkEMhS5dbymfY+7HrCO9qh9HG/F5QIyL/QefFilBENh9liQt3b58DreDJH47C5Qsu5Un+gdt5vN9w=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-02-17T04:03:31Z"
+    mac: ENC[AES256_GCM,data:uIgLocKhcKWS9/jaWXQdJ5yp1PFwf87OnJZBnEQqO6TbBSmjQmo3PizX+My1csRJ6iSACJNq6218/7i689Vxt4YjvQSZ9VNfMl+6pUgwjV+Z+guYdcvFhIYvRvZV1vaSnFD2o8yVgtiRc8+l+HS/0vnXAcbZure2zgzWXALXG74=,iv:g47wnZK5R93XuJW9f7YD9WvvU/m6ICQ6dOvRM+xG6go=,tag:Edh9xXZLyFTyoqhRXyj8iA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.2


### PR DESCRIPTION
I'm not sure why this was invalid or didn't function, but it didn't. After re-using `deployer new-grafana-token utoronto` it worked.

- Closes #2152

I'm confused to not see `deployer` service accounts listed in all grafana instances, but at least they work. Maybe its related to utoronto being an older hub or similar setup before grafana service accounts was around? For now, this seem to work.

### From [grafana's docs](https://grafana.com/docs/grafana/latest/administration/service-accounts/org/serviceaccounts)

It seems that service accounts hasn't been around always, and previous there was a concept about standalone api keys.

![image](https://user-images.githubusercontent.com/3837114/219547490-1d2f1258-deb2-4c39-adab-f4afee85bf86.png)
