### PR TITLE
binderhub: stop bumping repo2docker image, use binderhub default

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -27,14 +27,6 @@ jobs:
           # For each new config_path to monitor, add a new item in this matrix.
           # The Action can read multiple paths to images, but not multiple config files.
           #
-          # Bump repo2docker image in BinderHub helm chart
-          - name: "BinderHub/repo2docker bump"
-            config_path: "helm-charts/binderhub/values.yaml"
-            # We use regex to select any image tag that begins with a number since
-            # repo2docker is tagged something like YYYY.MM.N-NN.hash. This will
-            # explicitly ignore the 'main' tag.
-            images_info: '[{"values_path": ".binderhub.config.BinderHub.build_image", "regexpr": "^[0-9].*"}]'
-
           # Bump images in openscapes cluster
           - name: "OpenScapes profiles"
             config_path: "config/clusters/openscapes/common.values.yaml"

--- a/helm-charts/binderhub/values.yaml
+++ b/helm-charts/binderhub/values.yaml
@@ -4,7 +4,6 @@ binderhub:
   config:
     BinderHub:
       use_registry: true
-      build_image: "quay.io/jupyterhub/repo2docker:2022.10.0-91.g326dc92"
       per_repo_quota: 150
       build_node_selector:
         # Build user images only on user nodes, not dask or core nodes


### PR DESCRIPTION
#2180 is a PR bumping the version of binderhub the helm chart, which in turn bumps the build image tied to the software repo2docker. Since we have that, I don't think there is a need for us to manage a manually handled image ourselves, but rely on binderhub chart being updated with a tested repo2docker version.

### Related
- #2180
- #1427