### PR TITLE
deployer: refactor deploy_grafana_dashboards and related utilities

### DIFF
--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -24,6 +24,7 @@ from .config_validation import (
     validate_support_config,
 )
 from .file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
+from .grafana.grafana_utils import get_central_grafana_token, get_grafana_url
 from .helm_upgrade_decision import (
     assign_staging_jobs_for_missing_clusters,
     discover_modified_common_files,
@@ -96,95 +97,44 @@ def deploy_grafana_dashboards(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on")
 ):
     """
-    Deploy JupyterHub dashboards to grafana set up in the given cluster
+    Deploy the latest official JupyterHub dashboards to a cluster's grafana
+    instance. This is done via Grafana's REST API, authorized by using a
+    previously generated Grafana service account's access token.
 
-    Grafana dashboards and deployment mechanism are maintained at
-    https://github.com/jupyterhub/grafana-dashboards
+    The official JupyterHub dashboards are maintained in
+    https://github.com/jupyterhub/grafana-dashboards along with a python script
+    to deploy them to Grafana via a REST API.
     """
-    validate_cluster_config(cluster_name)
-    validate_support_config(cluster_name)
+    grafana_url = get_grafana_url(cluster_name)
+    grafana_token = get_central_grafana_token(cluster_name)
 
-    config_file_path = find_absolute_path_to_cluster_file(cluster_name)
-    with open(config_file_path) as f:
-        cluster = Cluster(yaml.load(f), config_file_path.parent)
-
-    # If grafana support chart is not deployed, then there's nothing to do
-    if not cluster.support:
-        print_colour(
-            "Support chart has not been deployed. Skipping Grafana dashboards deployment..."
-        )
-        return
-
-    grafana_token_file = (config_file_path.parent).joinpath(
-        "enc-grafana-token.secret.yaml"
-    )
-
-    # Read the cluster specific secret grafana token file
-    with get_decrypted_file(grafana_token_file) as decrypted_file_path:
-        with open(decrypted_file_path) as f:
-            config = yaml.load(f)
-
-    # Check GRAFANA_TOKEN exists in the secret config file before continuing
-    if "grafana_token" not in config.keys():
-        raise ValueError(
-            f"`grafana_token` not provided in secret file! Please add it and try again: {grafana_token_file}"
-        )
-
-    # FIXME: We assume grafana_url and uses_tls config will be defined in the first
-    #        file listed under support.helm_chart_values_files.
-    support_values_file = cluster.support.get("helm_chart_values_files", [])[0]
-    with open(config_file_path.parent.joinpath(support_values_file)) as f:
-        support_values_config = yaml.load(f)
-
-    # Get the url where grafana is running from the support values file
-    grafana_url = (
-        support_values_config.get("grafana", {}).get("ingress", {}).get("hosts", {})
-    )
-    uses_tls = (
-        support_values_config.get("grafana", {}).get("ingress", {}).get("tls", {})
-    )
-
-    if not grafana_url:
-        print_colour(
-            "Couldn't find `config.grafana.ingress.hosts`. Skipping Grafana dashboards deployment..."
-        )
-        return
-
-    grafana_url = (
-        f"https://{grafana_url[0]}" if uses_tls else f"http://{grafana_url[0]}"
-    )
-
-    # Use the jupyterhub/grafana-dashboards deployer to deploy the dashboards to this cluster's grafana
     print_colour("Cloning jupyterhub/grafana-dashboards...")
-
-    dashboards_dir = "grafana_dashboards"
-
     subprocess.check_call(
         [
             "git",
             "clone",
             "https://github.com/jupyterhub/grafana-dashboards",
-            dashboards_dir,
         ]
     )
 
-    # We need the existing env too for the deployer to be able to find jssonnet and grafonnet
-    deploy_env = os.environ.copy()
-    deploy_env.update({"GRAFANA_TOKEN": config["grafana_token"]})
-
+    # Add GRAFANA_TOKEN to the environment variables for
+    # jupyterhub/grafana-dashboards' deploy.py script
+    deploy_script_env = os.environ.copy()
+    deploy_script_env.update({"GRAFANA_TOKEN": grafana_token})
     try:
         print_colour(f"Deploying grafana dashboards to {cluster_name}...")
         subprocess.check_call(
-            ["./deploy.py", grafana_url], env=deploy_env, cwd=dashboards_dir
+            ["./deploy.py", grafana_url],
+            env=deploy_script_env,
+            cwd="grafana-dashboards",
         )
-
         print_colour(f"Done! Dashboards deployed to {grafana_url}.")
     finally:
         # Delete the directory where we cloned the repo.
         # The deployer cannot call jsonnet to deploy the dashboards if using a temp directory here.
         # Might be because opening more than once of a temp file is tried
         # (https://docs.python.org/3.8/library/tempfile.html#tempfile.NamedTemporaryFile)
-        shutil.rmtree(dashboards_dir)
+        shutil.rmtree("grafana-dashboards")
 
 
 @app.command()

--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -24,7 +24,7 @@ from .config_validation import (
     validate_support_config,
 )
 from .file_acquisition import find_absolute_path_to_cluster_file, get_decrypted_file
-from .grafana.grafana_utils import get_central_grafana_token, get_grafana_url
+from .grafana.grafana_utils import get_grafana_token, get_grafana_url
 from .helm_upgrade_decision import (
     assign_staging_jobs_for_missing_clusters,
     discover_modified_common_files,
@@ -106,7 +106,7 @@ def deploy_grafana_dashboards(
     to deploy them to Grafana via a REST API.
     """
     grafana_url = get_grafana_url(cluster_name)
-    grafana_token = get_central_grafana_token(cluster_name)
+    grafana_token = get_grafana_token(cluster_name)
 
     print_colour("Cloning jupyterhub/grafana-dashboards...")
     subprocess.check_call(
@@ -197,7 +197,7 @@ def generate_helm_upgrade_jobs(
     )
 ):
     """
-    Analyse added or modified files from a GitHub Pull Request and decide which
+    Analyze added or modified files from a GitHub Pull Request and decide which
     clusters and/or hubs require helm upgrades to be performed for their *hub helm
     charts or the support helm chart.
     """

--- a/deployer/grafana/central_grafana.py
+++ b/deployer/grafana/central_grafana.py
@@ -102,8 +102,8 @@ def update_central_grafana_datasources(
     """
     Update the central grafana with datasources for all clusters prometheus instances
     """
-    grafana_host = get_grafana_url(central_grafana_cluster)
-    datasource_endpoint = f"https://{grafana_host}/api/datasources"
+    grafana_url = get_grafana_url(central_grafana_cluster)
+    datasource_endpoint = f"{grafana_url}/api/datasources"
 
     # Get a list of the clusters that already have their prometheus instances used as datasources
     datasources = get_clusters_used_as_datasources(

--- a/deployer/grafana/central_grafana.py
+++ b/deployer/grafana/central_grafana.py
@@ -14,9 +14,9 @@ from ..cli_app import app
 from ..helm_upgrade_decision import get_all_cluster_yaml_files
 from ..utils import print_colour
 from .grafana_utils import (
-    get_central_grafana_token,
     get_cluster_prometheus_address,
     get_cluster_prometheus_creds,
+    get_grafana_token,
     get_grafana_url,
 )
 
@@ -58,7 +58,7 @@ def build_datasource_request_headers(cluster_name):
     Returns:
         dict: "Accept", "Content-Type", "Authorization" headers
     """
-    token = get_central_grafana_token(cluster_name)
+    token = get_grafana_token(cluster_name)
 
     headers = {
         "Accept": "application/json",

--- a/deployer/grafana/central_grafana.py
+++ b/deployer/grafana/central_grafana.py
@@ -1,7 +1,11 @@
 """
-Ensures that the central grafana at https://grafana.pilot.2i2c.cloud
-is configured to use as datasource the authenticated prometheus instances
-of all the clusters that we run.
+Each cluster deployed should have a Grafana and Prometheus instance running via
+the support chart, but the 2i2c cluster's Grafana instance is special, and we
+refer it as the central Grafana instance at https://grafana.pilot.2i2c.cloud.
+
+This code provides the deployer's update-central-grafana-datasources command,
+that ensures that the central grafana instance is able to access datasources the
+other clusters.
 """
 
 import json

--- a/deployer/grafana/grafana_tokens.py
+++ b/deployer/grafana/grafana_tokens.py
@@ -157,8 +157,8 @@ def new_grafana_token(
     Generate an API token for the cluster's Grafana `deployer` service account
     and store it encrypted inside a `enc-grafana-token.secret.yaml` file.
     """
-    grafana_host = get_grafana_url(cluster)
-    sa_endpoint = f"https://{grafana_host}/api/serviceaccounts"
+    grafana_url = get_grafana_url(cluster)
+    sa_endpoint = f"{grafana_url}/api/serviceaccounts"
     headers = build_service_account_request_headers()
 
     overwrite = False

--- a/deployer/grafana/grafana_tokens.py
+++ b/deployer/grafana/grafana_tokens.py
@@ -1,3 +1,13 @@
+"""
+This code is responsible for providing the deployer script's new-grafana-token
+command meant to be run once as part of setting up a new cluster.
+
+The new-grafana-token command makes use of a hardcoded admin password to create
+a grafana service account named "deployer" and an access token for it. This
+access token is written to a enc-grafana-token.secret.yaml file for use by the
+deployer command going forward.
+"""
+
 import json
 from base64 import b64encode
 from pathlib import Path

--- a/deployer/grafana/grafana_utils.py
+++ b/deployer/grafana/grafana_utils.py
@@ -113,7 +113,7 @@ def get_grafana_admin_password():
     return grafana_creds.get("grafana", {}).get("adminPassword", None)
 
 
-def get_central_grafana_token(cluster_name):
+def get_grafana_token(cluster_name):
     """
     Get the access token stored in the `enc-grafana-token.secret.yaml` file for
     the <cluster_name>'s Grafana.

--- a/deployer/grafana/grafana_utils.py
+++ b/deployer/grafana/grafana_utils.py
@@ -11,9 +11,9 @@ yaml = YAML(typ="safe")
 
 def get_grafana_url(cluster_name):
     """
-    Retrieve the URL of the Grafana running for <cluster_name> from the "support.values.yaml" file.
+    Return a Grafana instance URL using the cluster's "support.values.yaml"
+    file's grafana.ingress.tls[0].hosts[0] config.
     """
-
     cluster_config_dir_path = find_absolute_path_to_cluster_file(cluster_name).parent
 
     config_file = cluster_config_dir_path.joinpath("support.values.yaml")
@@ -23,14 +23,11 @@ def get_grafana_url(cluster_name):
     grafana_tls_config = (
         support_config.get("grafana", {}).get("ingress", {}).get("tls", [])
     )
-
     if not grafana_tls_config:
-        raise ValueError(
-            f"No tls config was found for the Grafana instance of {cluster_name}. Please consider enable it before using it as the central Grafana."
-        )
+        raise ValueError(f"grafana.ingress.tls config for {cluster_name} missing!")
 
     # We only have one tls host right now. Modify this when things change.
-    return grafana_tls_config[0]["hosts"][0]
+    return "https://" + grafana_tls_config[0]["hosts"][0]
 
 
 def get_cluster_prometheus_address(cluster_name):
@@ -118,8 +115,9 @@ def get_grafana_admin_password():
 
 def get_central_grafana_token(cluster_name):
     """
-    Get the access token stored in the `enc-grafana-token.secret.yaml`file
-    for the <cluster_name>'s Grafana.
+    Get the access token stored in the `enc-grafana-token.secret.yaml` file for
+    the <cluster_name>'s Grafana.
+
     This access token should have enough permissions to create datasources.
 
     Returns:
@@ -128,7 +126,7 @@ def get_central_grafana_token(cluster_name):
     # Get the location of the file that stores the central grafana token
     cluster_config_dir_path = find_absolute_path_to_cluster_file(cluster_name).parent
 
-    grafana_token_file = (cluster_config_dir_path).joinpath(
+    grafana_token_file = cluster_config_dir_path.joinpath(
         "enc-grafana-token.secret.yaml"
     )
 
@@ -136,6 +134,10 @@ def get_central_grafana_token(cluster_name):
     with get_decrypted_file(grafana_token_file) as decrypted_file_path:
         with open(decrypted_file_path) as f:
             config = yaml.load(f)
+    if "grafana_token" not in config.keys():
+        raise ValueError(
+            f"Grafana service account token not found, use `deployer new-grafana-token {cluster_name}`"
+        )
 
     return config["grafana_token"]
 

--- a/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
+++ b/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
@@ -49,4 +49,4 @@ deployer deploy-support $CLUSTER_NAME
 
 ## Link the cluster's Prometheus server to the central Grafana
 
-Run `deployer update-central-grafana-datasources` to register the new prometheus with the default central grafana.`
+Run `deployer update-central-grafana-datasources` to register the new prometheus with the default central grafana.


### PR DESCRIPTION
- removed duplicated logic by using existing helper functions from grafana_utils.py
- renamed `get_central_grafana_token` to `get_grafana_token` as it had nothing to do specifically with the "central grafana" instance in the `2i2c` cluster, but accepted a cluster name
- removed calls to validate functions as there was sufficient validation already via called utility functions for this to work