### PR TITLE
Fix typo causing openscapes users to be under resourced

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -118,43 +118,43 @@ basehub:
                 mem_1:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.969
+                    mem_guarantee: 0.969G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.938
+                    mem_guarantee: 1.938G
                     cpu_guarantee: 0.025
                 mem_4:
                   default: true
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.875
+                    mem_guarantee: 3.875G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.75
+                    mem_guarantee: 7.75G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.5
+                    mem_guarantee: 15.5G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.0
+                    mem_guarantee: 31.0G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 62.0
+                    mem_guarantee: 62.0G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 124.0
+                    mem_guarantee: 124.0G
                     cpu_guarantee: 1.6
           kubespawner_override:
             cpu_limit: null
@@ -173,43 +173,43 @@ basehub:
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.969
+                    mem_guarantee: 3.969G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.938
+                    mem_guarantee: 7.938G
                     cpu_guarantee: 0.1
                 mem_16:
                   default: true
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.875
+                    mem_guarantee: 15.875G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.75
+                    mem_guarantee: 31.75G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 63.5
+                    mem_guarantee: 63.5G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 127.0
+                    mem_guarantee: 127.0G
                     cpu_guarantee: 1.6
                 mem_256:
                   display_name: ~256 GB, ~32.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 254.0
+                    mem_guarantee: 254.0G
                     cpu_guarantee: 3.2
                 mem_512:
                   display_name: ~512 GB, ~64.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 508.0
+                    mem_guarantee: 508.0G
                     cpu_guarantee: 6.4
           kubespawner_override:
             cpu_limit: null

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -76,32 +76,32 @@ basehub:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
                     mem_guarantee: 0.875
-                    cpu_guarantee: 0.013
+                    cpu_guarantee: 0.13
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
                     mem_guarantee: 1.75
-                    cpu_guarantee: 0.025
+                    cpu_guarantee: 0.25
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
                     mem_guarantee: 3.5
-                    cpu_guarantee: 0.05
+                    cpu_guarantee: 0.5
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
                     mem_guarantee: 7.0
-                    cpu_guarantee: 0.1
+                    cpu_guarantee: 1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
                     mem_guarantee: 14.0
-                    cpu_guarantee: 0.2
+                    cpu_guarantee: 2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
                     mem_guarantee: 28.0
-                    cpu_guarantee: 0.4
+                    cpu_guarantee: 4
           kubespawner_override:
             cpu_limit: null
             mem_limit: null
@@ -119,43 +119,43 @@ basehub:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
                     mem_guarantee: 0.969G
-                    cpu_guarantee: 0.013
+                    cpu_guarantee: 0.13
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
                     mem_guarantee: 1.938G
-                    cpu_guarantee: 0.025
+                    cpu_guarantee: 0.25
                 mem_4:
                   default: true
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
                     mem_guarantee: 3.875G
-                    cpu_guarantee: 0.05
+                    cpu_guarantee: 0.5
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
                     mem_guarantee: 7.75G
-                    cpu_guarantee: 0.1
+                    cpu_guarantee: 1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
                     mem_guarantee: 15.5G
-                    cpu_guarantee: 0.2
+                    cpu_guarantee: 2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
                     mem_guarantee: 31.0G
-                    cpu_guarantee: 0.4
+                    cpu_guarantee: 4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
                     mem_guarantee: 62.0G
-                    cpu_guarantee: 0.8
+                    cpu_guarantee: 8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
                     mem_guarantee: 124.0G
-                    cpu_guarantee: 1.6
+                    cpu_guarantee: 16
           kubespawner_override:
             cpu_limit: null
             mem_limit: null
@@ -174,43 +174,43 @@ basehub:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
                     mem_guarantee: 3.969G
-                    cpu_guarantee: 0.05
+                    cpu_guarantee: 0.5
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
                     mem_guarantee: 7.938G
-                    cpu_guarantee: 0.1
+                    cpu_guarantee: 1
                 mem_16:
                   default: true
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
                     mem_guarantee: 15.875G
-                    cpu_guarantee: 0.2
+                    cpu_guarantee: 2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
                     mem_guarantee: 31.75G
-                    cpu_guarantee: 0.4
+                    cpu_guarantee: 4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
                     mem_guarantee: 63.5G
-                    cpu_guarantee: 0.8
+                    cpu_guarantee: 8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
                     mem_guarantee: 127.0G
-                    cpu_guarantee: 1.6
+                    cpu_guarantee: 16
                 mem_256:
                   display_name: ~256 GB, ~32.0 CPU
                   kubespawner_override:
                     mem_guarantee: 254.0G
-                    cpu_guarantee: 3.2
+                    cpu_guarantee: 32
                 mem_512:
                   display_name: ~512 GB, ~64.0 CPU
                   kubespawner_override:
                     mem_guarantee: 508.0G
-                    cpu_guarantee: 6.4
+                    cpu_guarantee: 64
           kubespawner_override:
             cpu_limit: null
             mem_limit: null


### PR DESCRIPTION
Without the G, we were only guaranteeing them these values in bytes!
And all the CPU guarantees were off by one order of magnitude.