### PR TITLE
Bump images for LEAP & m2lines hubs

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -17,7 +17,7 @@ basehub:
       extraImages:
         tensorflow-image:
           name: pangeo/ml-notebook
-          tag: "2023.02.08"
+          tag: "ebeb9dd"
     custom:
       # Extra mount point for admins to access to all users' home dirs
       # Ref https://github.com/2i2c-org/infrastructure/issues/2105
@@ -94,12 +94,13 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
+          profile_options: &profile_options
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           allowed_teams:
             - leap-stc:leap-pangeo-users
             - 2i2c-org:hub-access-for-2i2c-staff
-          profile_options:
+          profile_options: &profile_options
             image:
               display_name: Image
               choices:
@@ -108,17 +109,17 @@ basehub:
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2023.02.08"
+                    image: "pangeo/pangeo-notebook:ebeb9dd"
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.02.08"
+                    image: "pangeo/ml-notebook:ebeb9dd"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.02.08"
+                    image: "pangeo/pytorch-notebook:ebeb9dd"
                 leap-pangeo-edu:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
@@ -140,6 +141,7 @@ basehub:
             mem_guarantee: 24G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-8
+          profile_options: *profile_options
         - display_name: Huge
           description: 52GB RAM, 16 CPUs
           allowed_teams:
@@ -150,7 +152,7 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
-
+          profile_options: *profile_options
         - display_name: Large + GPU
           description: 24GB RAM, 8 CPUs
           allowed_teams:
@@ -165,12 +167,12 @@ basehub:
                   default: true
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.01.03"
+                    image: "pangeo/ml-notebook:ebeb9dd"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.01.03"
+                    image: "pangeo/pytorch-notebook:ebeb9dd"
           kubespawner_override:
             node_selector:
               cloud.google.com/gke-nodepool: nb-gpu-t4

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -95,12 +95,6 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
           profile_options: &profile_options
-        - display_name: Medium
-          description: 11GB RAM, 4 CPUs
-          allowed_teams:
-            - leap-stc:leap-pangeo-users
-            - 2i2c-org:hub-access-for-2i2c-staff
-          profile_options: &profile_options
             image:
               display_name: Image
               choices:
@@ -125,6 +119,12 @@ basehub:
                   slug: "leap_edu"
                   kubespawner_override:
                     image: "quay.io/jbusecke/leap-edu-image:fa442ab4851c"
+        - display_name: Medium
+          description: 11GB RAM, 4 CPUs
+          allowed_teams:
+            - leap-stc:leap-pangeo-users
+            - 2i2c-org:hub-access-for-2i2c-staff
+          profile_options: *profile_options
           kubespawner_override:
             mem_limit: 15G
             mem_guarantee: 11G

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -82,14 +82,6 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
-          profile_options: *profile_options
-        - display_name: Medium
-          description: 11GB RAM, 4 CPUs
-          kubespawner_override:
-            mem_limit: 15G
-            mem_guarantee: 11G
-            node_selector:
-              node.kubernetes.io/instance-type: n1-standard-4
           profile_options: &profile_options
             image:
               display_name: Image
@@ -110,6 +102,14 @@ basehub:
                   slug: "pytorch"
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:ebeb9dd"
+        - display_name: Medium
+          description: 11GB RAM, 4 CPUs
+          kubespawner_override:
+            mem_limit: 15G
+            mem_guarantee: 11G
+            node_selector:
+              node.kubernetes.io/instance-type: n1-standard-4
+          profile_options: *profile_options
         - display_name: Large
           description: 24GB RAM, 8 CPUs
           kubespawner_override:

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -68,7 +68,7 @@ basehub:
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
-        tag: "2023.01.03"
+        tag: "ebeb9dd"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
@@ -82,6 +82,7 @@ basehub:
             mem_guarantee: 4.5G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-2
+          profile_options: *profile_options
         - display_name: Medium
           description: 11GB RAM, 4 CPUs
           kubespawner_override:
@@ -89,7 +90,7 @@ basehub:
             mem_guarantee: 11G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-4
-          profile_options:
+          profile_options: &profile_options
             image:
               display_name: Image
               choices:
@@ -98,17 +99,17 @@ basehub:
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2023.01.03"
+                    image: "pangeo/pangeo-notebook:ebeb9dd"
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.01.03"
+                    image: "pangeo/ml-notebook:ebeb9dd"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.01.03"
+                    image: "pangeo/pytorch-notebook:ebeb9dd"
         - display_name: Large
           description: 24GB RAM, 8 CPUs
           kubespawner_override:
@@ -116,6 +117,7 @@ basehub:
             mem_guarantee: 24G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-8
+          profile_options: *profile_options
         - display_name: Huge
           description: 52GB RAM, 16 CPUs
           kubespawner_override:
@@ -123,6 +125,7 @@ basehub:
             mem_guarantee: 52G
             node_selector:
               node.kubernetes.io/instance-type: n1-standard-16
+          profile_options: *profile_options
         - display_name: Large + GPU
           description: 24GB RAM, 8 CPUs
           profile_options:
@@ -133,13 +136,13 @@ basehub:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.01.03"
+                    image: "pangeo/ml-notebook:ebeb9dd"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   default: true
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.01.03"
+                    image: "pangeo/pytorch-notebook:ebeb9dd"
           kubespawner_override:
             node_selector:
               cloud.google.com/gke-nodepool: nb-gpu-t4


### PR DESCRIPTION
Also consistently provide same image options for all node options.

Brings in https://github.com/pangeo-data/pangeo-docker-images/pull/443

Ref https://2i2c.freshdesk.com/a/tickets/458