### PR TITLE
linked-earth: fix memory requests, cleanup old workaround

### DIFF
--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -88,32 +88,32 @@ basehub:
                   default: true
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.875
+                    mem_guarantee: 0.875G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.75
+                    mem_guarantee: 1.75G
                     cpu_guarantee: 0.025
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.5
+                    mem_guarantee: 3.5G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.0
+                    mem_guarantee: 7.0G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 14.0
+                    mem_guarantee: 14.0G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 28.0
+                    mem_guarantee: 28.0G
                     cpu_guarantee: 0.4
           kubespawner_override:
             cpu_limit: null
@@ -131,43 +131,43 @@ basehub:
                 mem_1:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.969
+                    mem_guarantee: 0.969G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.938
+                    mem_guarantee: 1.938G
                     cpu_guarantee: 0.025
                 mem_4:
                   default: true
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.875
+                    mem_guarantee: 3.875G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.75
+                    mem_guarantee: 7.75G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.5
+                    mem_guarantee: 15.5G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.0
+                    mem_guarantee: 31.0G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 62.0
+                    mem_guarantee: 62.0G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 124.0
+                    mem_guarantee: 124.0G
                     cpu_guarantee: 1.6
           kubespawner_override:
             cpu_limit: null

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -54,28 +54,6 @@ basehub:
         name: quay.io/linkedearth/pyleoclim
         tag: "latest"
 
-      # FIXME: extraFiles and extraEnv has been updated since the combination of
-      #        jupyter_server 2 and jupyterlab doesn't work with a classical
-      #        notebook server.
-      #
-      #        This can probably be removed with this PR that is meant to transition
-      #        the default to jupyter_server from notebook:
-      #        https://github.com/2i2c-org/infrastructure/pull/2160
-      #
-      extraFiles:
-        jupyter_server_config.json:
-          mountPath: /usr/local/etc/jupyter/jupyter_server_config.json
-          data:
-            MappingKernelManager:
-              cull_idle_timeout: 3600
-              cull_interval: 300
-              cull_connected: true
-            ServerApp:
-              extra_template_paths:
-                - /usr/local/share/jupyter/custom_template
-      extraEnv:
-        JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
-
       profileList:
         - display_name: "Small: up to 4 CPU / 32 GB RAM"
           description: &profile_list_description "Start a container with at least a chosen share of capacity on a node of this type"


### PR DESCRIPTION
This PR includes:
- A memory typo fix like in #2225
- A workaround is cleaned up, no longer needed following #2160 -> #2210 -> #2210.

### Related

- #2121 