### PR TITLE
Revert "Bump utoronto image"

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "d4acd523a27a"
+      tag: "546288fe0911"
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2240

This seems to have broken the hub for loading notebooks