### PR TITLE
Bump utoronto image version to 351aa3042464

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "546288fe0911"
+      tag: "351aa3042464"
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
Includes https://github.com/2i2c-org/utoronto-image/pull/45.

Ref #2244.