### PR TITLE
daskhub: remove redundant nodeSelector

### DIFF
--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -101,12 +101,7 @@ dask-gateway:
   enabled: true # Enabling dask-gateway will install Dask Gateway as a dependency.
   # Futher Dask Gateway configuration goes here
   # See https://github.com/dask/dask-gateway/blob/master/resources/helm/dask-gateway/values.yaml
-  controller:
-    nodeSelector:
-      k8s.dask.org/node-purpose: core
   gateway:
-    nodeSelector:
-      k8s.dask.org/node-purpose: core
     backend:
       scheduler:
         extraPodConfig:


### PR DESCRIPTION
- Closes #1574

The nodes we have that isn't core nodes are dedicated nodes to dask workers and jupyterhub user servers. By removing this, we can stop needing to provide another set of labels to our node pools and use more similar config independent on basehub/daskhub setup etc.