### PR TITLE
New R image build to fix deployment error

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -44,7 +44,7 @@ basehub:
         - display_name: "R en RStudio"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/r:cf019b7"
+            image: "ghcr.io/oceanhackweek/r:8387ef3"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
Added `jsonschema-with-format-nongpl` to the conda environment.

See discussions in https://github.com/2i2c-org/infrastructure/pull/2252#issuecomment-1444887522

cc @yuvipanda 