### PR TITLE
Add a separate nodepool for notebook and dask pods before ohw event

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,3 +1,14 @@
+dask-gateway:
+  gateway:
+    backend:
+      scheduler:
+        extraPodConfig:
+          nodeSelector:
+            2i2c.org/community: ohw
+      worker:
+        extraPodConfig:
+          nodeSelector:
+            2i2c.org/community: ohw
 basehub:
   userServiceAccount:
     annotations:
@@ -50,6 +61,8 @@ basehub:
             mem_guarantee: 4G
             cpu_limit: 2
             cpu_guarantee: 0.5
+      nodeSelector:
+        2i2c.org/community: ohw
     custom:
       cloudResources:
         provider: gcp

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,6 +23,19 @@ notebook_nodes = {
       count: 0
     }
   },
+  "ohw": {
+    min: 1,
+    max: 100,
+    machine_type: "n1-highmem-8",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  }
 }
 
 dask_nodes = {
@@ -31,6 +44,19 @@ dask_nodes = {
     max : 100,
     machine_type : "n1-highmem-4",
     labels: { },
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    }
+  },
+  "ohw": {
+    min: 0,
+    max: 100,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
     gpu: {
       enabled: false,
       type: "",


### PR DESCRIPTION
Same resources as for last year's event