### PR TITLE
terraform, gcp: configure user_project_override to avoid error

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -15,6 +15,18 @@ terraform {
   }
 }
 
+provider "google" {
+  # This was configured without full understanding of the implications to
+  # resolve the following error:
+  #
+  # Error: Error when reading or editing BillingBudget "...": googleapi: Error 403: Your application has authenticated using end user credentials from the Google Cloud SDK or Google Cloud Shell which are not supported by the billingbudgets.googleapis.com. We recommend configuring the billing/quota_project setting in gcloud or using a service account through the auth/impersonate_service_account setting. For more information about service accounts and how to use them in your application, see https://cloud.google.com/docs/authentication/. If you are getting this error with curl or similar tools, you may need to specify 'X-Goog-User-Project' HTTP header for quota and billing purposes. For more information regarding 'X-Goog-User-Project' header, please check https://cloud.google.com/apis/docs/system-parameters.
+  #
+  # Configuration reference:
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override
+  #
+  user_project_override = true
+}
+
 data "google_client_config" "default" {}
 
 provider "kubernetes" {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -25,6 +25,7 @@ provider "google" {
   # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override
   #
   user_project_override = true
+  billing_project = "two-eye-two-see"
 }
 
 data "google_client_config" "default" {}


### PR DESCRIPTION
When @GeorgianaElena planned terraform work, there was an issue as outlined below when trying `terraform plan -var-file=projects/pilot-hubs.tfvars` from `terraform/gcp`. We couldn't understand why well, but this did the trick. But - maybe it has negative sideeffects? I can't say I understand this very well at all.

```
...
google_container_node_pool.dask_worker["worker"]: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/dask-worker]
google_container_node_pool.notebook["user"]: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-user]
google_container_node_pool.core: Refreshing state... [id=projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/core-pool]
╷
│ Error: Error when reading or editing BillingBudget "billingAccounts/censored/budgets/censored": googleapi: Error 403: Your application has authenticated using end user credentials from the Google Cloud SDK or Google Cloud Shell which are not supported by the billingbudgets.googleapis.com. We recommend configuring the billing/quota_project setting in gcloud or using a service account through the auth/impersonate_service_account setting. For more information about service accounts and how to use them in your application, see https://cloud.google.com/docs/authentication/. If you are getting this error with curl or similar tools, you may need to specify 'X-Goog-User-Project' HTTP header for quota and billing purposes. For more information regarding 'X-Goog-User-Project' header, please check https://cloud.google.com/apis/docs/system-parameters.
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.ErrorInfo",
│     "domain": "googleapis.com",
│     "metadata": {
│       "consumer": "projects/32555940559",
│       "service": "billingbudgets.googleapis.com"
│     },
│     "reason": "SERVICE_DISABLED"
│   }
│ ]
```

I think the issue may relate to making a change to the node pools, which somehow couples with billing alerts that has been handled outside of terraform. In practice, when applying the addition of node pools the following showed up as resources to be destroyed.

```terraform
  # google_billing_budget.budget[0] will be destroyed
  # (because google_billing_budget.budget is not in configuration)
  - resource "google_billing_budget" "budget" {
      - billing_account = "0157F7-E3EA8C-25AC3C" -> null
      - display_name    = "Billing alert" -> null
      - id              = "billingAccounts/0157F7-E3EA8C-25AC3C/budgets/1bf2106a-0b81-4a70-ab09-bcd568d80e13" -> null
      - name            = "1bf2106a-0b81-4a70-ab09-bcd568d80e13" -> null

      - all_updates_rule {
          - disable_default_iam_recipients   = true -> null
          - monitoring_notification_channels = [
              - "projects/two-eye-two-see/notificationChannels/10693994760737431897",
            ] -> null
          - schema_version                   = "1.0" -> null
        }

      - amount {
          - last_period_amount = false -> null

          - specified_amount {
              - currency_code = "USD" -> null
              - nanos         = 0 -> null
              - units         = "2500" -> null
            }
        }

      - budget_filter {
          - calendar_period        = "MONTH" -> null
          - credit_types           = [] -> null
          - credit_types_treatment = "INCLUDE_ALL_CREDITS" -> null
          - labels                 = {} -> null
          - projects               = [
              - "projects/350668521154",
            ] -> null
          - services               = [] -> null
          - subaccounts            = [] -> null
        }

      - threshold_rules {
          - spend_basis       = "CURRENT_SPEND" -> null
          - threshold_percent = 1 -> null
        }
      - threshold_rules {
          - spend_basis       = "FORECASTED_SPEND" -> null
          - threshold_percent = 1.01 -> null
        }
    }
    
  # google_monitoring_notification_channel.support_email[0] will be destroyed
  # (because google_monitoring_notification_channel.support_email is not in configuration)
  - resource "google_monitoring_notification_channel" "support_email" {
      - display_name = "support@2i2c.org email" -> null
      - enabled      = true -> null
      - force_delete = false -> null
      - id           = "projects/two-eye-two-see/notificationChannels/10693994760737431897" -> null
      - labels       = {
          - "email_address" = "support@2i2c.org"
        } -> null
      - name         = "projects/two-eye-two-see/notificationChannels/10693994760737431897" -> null
      - project      = "two-eye-two-see" -> null
      - type         = "email" -> null
      - user_labels  = {} -> null
    }
```