### PR TITLE
Revert 2i2c-org/carbonplan-increase-kubespawner-timout changes

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -32,9 +32,6 @@ basehub:
             name: Carbon Plan
             url: https://carbonplan.org
     singleuser:
-      # Temporarily override startTimeout to see if can diagnose scheduling error
-      # https://github.com/2i2c-org/infrastructure/issues/2271
-      startTimeout: 600
       serviceAccountName: cloud-user-sa
       image:
         name: carbonplan/trace-python-notebook
@@ -149,10 +146,6 @@ basehub:
           allowed_users: &users
             - jhamman
           admin_users: *users
-        # Temporarily increase timeout to debug #2271
-        # TODO(pnasrat): remove
-        KubeSpawner:
-          http_timeout: 600
 
 dask-gateway:
   traefik:


### PR DESCRIPTION

This reverts commit a87222b3fed92805fe12d037a7c3f43760093de1, reversing changes made to cedc5827e347bd82b579c29b162525373e67f1a3.

Roll back temporary timeout increase in carbonplan cluster for #2271