### PR TITLE
terraform: relax pins of providers by pinning to major versions only

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,13 +1,15 @@
 terraform {
   required_providers {
     aws = {
+      # ref: https://registry.terraform.io/providers/hashicorp/aws/latest
       source  = "hashicorp/aws"
-      version = "~> 4.15"
+      version = "~> 4.52"
     }
 
     mysql = {
+      # ref: https://registry.terraform.io/providers/petoju/mysql/latest
       source  = "petoju/mysql"
-      version = "3.0.20"
+      version = "~> 3.0"
     }
 
   }

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -2,13 +2,19 @@
 terraform {
   required_providers {
     azurerm = {
+      # ref: https://registry.terraform.io/providers/hashicorp/azurerm/latest
+      #
+      # FIXME: v3 has been released and we are still at v2, see release notes:
+      #        https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.0.0
+      #
       source = "hashicorp/azurerm"
-      version = "2.87.0"
+      version = "~> 2.99"
     }
 
     azuread = {
+      # ref: https://registry.terraform.io/providers/hashicorp/azuread/latest
       source = "hashicorp/azuread"
-      version = "2.10.0"
+      version = "~> 2.35"
     }
   }
   backend "gcs" {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -2,15 +2,18 @@ terraform {
   backend "gcs" {}
   required_providers {
     google = {
+      # ref: https://registry.terraform.io/providers/hashicorp/google/latest
       source  = "google"
-      version = "4.51.0"
+      version = "~> 4.55"
     }
     google-beta = {
+      # ref: https://registry.terraform.io/providers/hashicorp/google-beta/latest
       source  = "google-beta"
-      version = "4.51.0"
+      version = "~> 4.55"
     }
     kubernetes = {
-      version = "2.8.0"
+      # ref: https://registry.terraform.io/providers/hashicorp/kubernetes/latest
+      version = "~> 2.18"
     }
   }
 }

--- a/terraform/uptime-checks/main.tf
+++ b/terraform/uptime-checks/main.tf
@@ -7,14 +7,16 @@ terraform {
   }
   required_providers {
     google = {
+      # ref: https://registry.terraform.io/providers/hashicorp/google/latest
       source  = "google"
-      version = "4.40.0"
+      version = "~> 4.55"
     }
 
     # Used to decrypt sops encrypted secrets containing PagerDuty keys
     sops = {
+      # ref: https://registry.terraform.io/providers/carlpett/sops/latest
       source  = "carlpett/sops"
-      version = "0.7.1"
+      version = "~> 0.7.2"
     }
   }
 }


### PR DESCRIPTION
By pinning to the patch or minor versions, we may miss out on bugfixes and additions of relevance.

In this commit, I've made use of the `~>` version specifier, which means that the last provided version specifier is a lower bound. So, `~> 3.0` means `>= 3.0, < 4.0` and `~> 0.7.2` means `>= 0.7.2, < 0.8`.

I see this as a good trade off between pinning tightly and not pinning at all. Like this we can avoid bugs, rely on up-to-date documentation, without checking when something is introduced, and avoid breaking changes quite well.

In this commit, I've also updated the lower bound to the most recent version to help us narrow the range of actively used versions.