### PR TITLE
deployer: unfreeze requirements.txt so we pin to major version only

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,10 +4,10 @@
 
 # chartpress is relevant to build and push helm-charts/images/hub/Dockerfile and
 # update basehub's default values to reference the new image.
-chartpress
+chartpress==2.*
 
 # requests is used by extra_scripts/rsync-active-users.py
-requests
+requests==2.*
 
 # rich is used by extra_scripts/count-auth0-apps.py
 rich==13.*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,10 +4,10 @@
 
 # chartpress is relevant to build and push helm-charts/images/hub/Dockerfile and
 # update basehub's default values to reference the new image.
-chartpress==2.1.0
+chartpress
 
 # requests is used by extra_scripts/rsync-active-users.py
-requests==2.28.1
+requests
 
 # rich is used by extra_scripts/count-auth0-apps.py
-rich==13.3.1
+rich==13.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,28 +3,28 @@
 #
 
 # ruamel.yaml is used to read and write .yaml files.
-ruamel.yaml==0.17.21
+ruamel.yaml==0.17.*
 
 # auth0 is used to communicate with Auth0's REST API that we integrate with in
 # various ways.
-auth0-python==3.24.0
+auth0-python==3.*
 
 # jsonschema is used for validating cluster.yaml configurations
-jsonschema==4.17.0
+jsonschema==4.*
 
 # rich and py-markdown-table are used for pretty printing outputs that would otherwise
 # be difficult to parse by a human
-rich==13.3.1
-py-markdown-table==0.3.1
+rich==13.*
+py-markdown-table==0.3.*
 
 # jhub_client, pytest, and pytest-asyncio are used for our health checks
-jhub-client==0.1.6
-pytest==7.2.0
-pytest-asyncio>=0.17
+jhub-client==0.1.*
+pytest
+pytest-asyncio
 
 # Used to generate templates
-jinja2==3.1.2
+jinja2==3.*
 
 # Used for the debug CLI
-typer==0.7.0
-escapism==1.0.1
+typer==0.7.*
+escapism==1.*


### PR DESCRIPTION
While a frozen environment can help with reproducibility, I think we now have a very bad in-between in our deployer's requirements.txt file. I think its acceptable that we would have either:

- a requirements.in outlining the actual dependencies, and a requirements.txt representing a frozen snapshot that together with automation to update that regularly
- just a requirements.txt representing the actual dependencies, perhaps pinned to the major version also

Right now, we have pinned the direct dependencies, but not the full environment - only the direct dependencies, not the indirect ones. That I think is bound to cause issues down the line.

I open this PR now as when I was debugging #2288, I saw an error from `jhub_client`. That led me to looking at version we used, which wasn't the latest. We used 0.1.6 and there was 0.1.7 out with a bugfix - was that relevant? In this case, it wasn't, but I was side-tracked to investiate that as the cause of the issue. Of course, things can go both ways. We can end up investigating if there is a regression in some dependency by not pinning.

Overall, I think this approach is what is best for us right now, and the main option considered would be to use a `requirements.in` file and [automation as found in z2jh / binderhub](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/29b041ced53678357d062c188f52e8983bfb1f03/.github/workflows/watch-dependencies.yaml#L199-L230) to update a frozen `requirements.txt` file.