### PR TITLE
Take into account all possible states of c.Authenticator.admin_users …

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -517,7 +517,11 @@ jupyterhub:
         if add_staff_user_ids_to_admin_users:
             user_id_type = get_config("custom.2i2c.add_staff_user_ids_of_type")
             staff_user_ids = get_config(f"custom.2i2c.staff_{user_id_type}_ids", [])
-            c.Authenticator.admin_users.extend(staff_user_ids)
+            # `c.Authenticator.admin_users` can contain additional admins, can be an empty list,
+            # or it cannot be defined at all.
+            # This should cover all these cases.
+            staff_user_ids.extend(get_config("hub.config.Authenticator.admin_users", []))
+            c.Authenticator.admin_users = staff_user_ids
 
       05-per-user-disk: |
         # Optionally, create a PVC per user - useful for per-user databases


### PR DESCRIPTION
…list in a hub config

Fixes https://github.com/2i2c-org/infrastructure/issues/1671 based on @sgibson91 's awesome detective work ✨ 

With this, we can remove redundant config that specifies `"admin_users = []"` in the config, but won't do it in this PR yet, because it might cause conflicts for https://github.com/2i2c-org/infrastructure/pull/2277
Will do all necersary simplification of the auth config in that big PR instead.

This came up when playing with CILogon on the staging hubs, when I realized that the `2i2c dask-staging` hub had no admin users.
