### PR TITLE
cd: upgrade helm 3.8 -> 3.11 and kubectl 1.23 -> 1.24

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -71,16 +71,41 @@ runs:
     # This action use the github official cache mechanism internally
     - uses: azure/setup-helm@v3
       with:
-        # version is pinned for helm to avoid an automatic update of its version
-        # which would cause something unexpected without an action on our
-        # behalf.
-        version: v3.8.2
+        # Manually update a pinning of helm to a minor version based on:
+        #
+        # - it seems to work
+        # - to avoid falling behind
+        #
+        # Related:
+        #
+        # - helm versions: https://github.com/helm/helm/releases
+        #
+        version: v3.11.1
 
-    # Pin kubectl version to 1.23 otherwise interactions with k8s clusters versioned <=1.21 won't work.
-    # See https://github.com/2i2c-org/infrastructure/issues/1271.
+    # Manually update a pinning of kubectl to a minor version based on:
+    #
+    # - the current range of k8s version in our k8s clusters, as of 2023-03-07,
+    #   this is k8s 1.22 - 1.24
+    # - the expected change in this range, as of 2023-03-07, is to expand to
+    #   1.22 - 1.25
+    # - the kubectl <-> k8s api-server skew policy of +/- one minor version
+    # - the policy of attempting to update our kubectl version here to be +/-
+    #   one minor versions of future k8s clusters additions or upgrades, so that
+    #   additions or upgrades of k8s clusters aren't unexpectedly held back
+    #
+    # As an example, we upgraded to kubectl to version 1.24 before we
+    # added/upgraded a k8s cluster to version 1.25.
+    #
+    # Related:
+    #
+    # - k8s versions: https://kubernetes.io/releases/
+    # - Kubectl version skew policy: https://kubernetes.io/releases/version-skew-policy/#kubectl
+    # - 2i2c, k8s upgrades tracked: https://github.com/2i2c-org/infrastructure/issues/2293
+    # - 2i2c, historical issue: https://github.com/2i2c-org/infrastructure/issues/1271
+    #
     - uses: azure/setup-kubectl@v3
       with:
-        version: "v1.23.16"
+        version: "v1.24.10"
 
     # This action use the github official cache mechanism internally
     - name: Install sops


### PR DESCRIPTION
K8s 1.25 is out, and we may very well upgrade to it or create a new cluster with it very soon. That makes it relevant to ahead of time upgrade `kubectl` to version 1.24 so that we can assume based on a k8s official version skew poolicy that kubectl can work against the not yet deployed/upgaded k8s 1.25 cluster.

I think historically we have been held back by k8s clusters versioned 1.21 or older, but now we are at k8s 1.22 and above so we can probably make this upgrade.

I didn't find the reason why we were still using helm 3.8.2, but I recall issues of using something newer at some point. But with all Helm charts upgraded to modern versions and k8s clusters upgraded to 1.22+ I think we can also upgrade helm at this point.

### Related

- #2293