### PR TITLE
leap: maintenance notice (basehub: fix override of template_vars)

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -57,6 +57,24 @@ basehub:
             - jbusecke
         JupyterHub:
           authenticator_class: github
+          # Announcement is a JupyterHub feature to present messages to users in
+          # pages under the /hub path, but not via the /user.
+          #
+          # This specific maintenance announcement was requested via
+          # https://2i2c.freshdesk.com/a/tickets/525.
+          #
+          # ref: https://github.com/2i2c-org/infrastructure/issues/1501
+          # ref: https://jupyterhub.readthedocs.io/en/stable/reference/templates.html#announcement-configuration-variables
+          #
+          template_vars:
+            announcement: >-
+              <strong>
+              Service maintenance is scheduled Sunday March 12, to Monday 8AM
+              EST.
+              </strong>
+              <br/>
+              Running servers may be forcefully stopped and service disruption
+              is expected.
         GitHubOAuthenticator:
           populate_teams_in_auth_state: true
           allowed_organizations:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -460,7 +460,7 @@ jupyterhub:
     extraConfig:
       01-custom-theme: |
         from z2jh import get_config
-        c.JupyterHub.template_paths.extend(['/usr/local/share/jupyterhub/custom_templates/'])
+        c.JupyterHub.template_paths.insert(0,'/usr/local/share/jupyterhub/custom_templates')
         c.JupyterHub.template_vars.update({
             'custom': get_config('custom.homepage.templateVars')
         })

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -460,11 +460,10 @@ jupyterhub:
     extraConfig:
       01-custom-theme: |
         from z2jh import get_config
-        c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/']
-
-        c.JupyterHub.template_vars = {
+        c.JupyterHub.template_paths.extend(['/usr/local/share/jupyterhub/custom_templates/'])
+        c.JupyterHub.template_vars.update({
             'custom': get_config('custom.homepage.templateVars')
-        }
+        })
       02-custom-admin: |
         from z2jh import get_config
         from kubespawner import KubeSpawner


### PR DESCRIPTION
I wanted to provide a maintenance notice for LEAP as planned with @jbusecke for work in #2209.

As part of this, I also needed to fix a forceful override of `c.JupyterHub.template_vars` so that it didn't make changes to `template_vars` elsewhere be overridden. Due to that, we will redeploy across all hubs.

![maintenance-scheduled](https://user-images.githubusercontent.com/3837114/223574189-3204c04b-04ed-4999-93e8-7d3d4998077c.gif)

### Related

- #1501 