### PR TITLE
Prevent validate clusters workflow failing if there's nothing to validate

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -100,6 +100,18 @@ jobs:
             cluster_specific:
               - added|modified: config/clusters/**
 
+      - name: Test outputs
+        run: |
+          echo "event name"
+          echo ${{ github.event_name == 'workflow_dispatch' }}
+          echo "common file changes"
+          echo "${{ steps.file_changes.outputs.common == 'true' }}"
+          echo "specific file changes"
+          echo "${{ steps.file_changes.outputs.cluster_specific == 'true' }}"
+          echo "whole statement"
+          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
+          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }} == 'true'
+
       # Only run this step if there *ARE* changes under the common filter, *OR*
       # we have manually triggered the workflow
       - name: Generate a matrix containing all clusters

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -110,7 +110,7 @@ jobs:
           echo "${{ steps.file_changes.outputs.cluster_specific == 'true' }}"
           echo "whole statement"
           echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
-          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }} == 'true'
+          echo ${{ (github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true')) == 'true' }} 
 
       # Only run this step if there *ARE* changes under the common filter, *OR*
       # we have manually triggered the workflow
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
     if: |
-      needs.generate-clusters-to-validate.outputs.continue_workflow == 'true' &&
+      needs.generate-clusters-to-validate.outputs.continue_workflow == true &&
       needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -96,7 +96,6 @@ jobs:
               - added|modified: helm-charts/daskhub/**
               - added|modified: helm-charts/support/**
               - added|modified: requirements.txt
-              - added|modified: .github/workflows/validate-clusters.yaml
             cluster_specific:
               - added|modified: config/clusters/**
 

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
     if: |
-      needs.generate-clusters-to-validate.outputs.continue_workflow &&
+      needs.generate-clusters-to-validate.outputs.continue_workflow == 'true' &&
       needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -96,6 +96,7 @@ jobs:
               - added|modified: helm-charts/daskhub/**
               - added|modified: helm-charts/support/**
               - added|modified: requirements.txt
+              - added|modified: .github/workflows/validate-clusters.yaml
             cluster_specific:
               - added|modified: config/clusters/**
 

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -110,7 +110,7 @@ jobs:
           echo "${{ steps.file_changes.outputs.cluster_specific == 'true' }}"
           echo "whole statement"
           echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
-          echo ${{ (github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true')) == 'true' }} 
+          echo ${{ (github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true')) == true }} 
 
       # Only run this step if there *ARE* changes under the common filter, *OR*
       # we have manually triggered the workflow
@@ -185,6 +185,10 @@ jobs:
               # General python object syntax sometimes works but sometimes does
               # not - for example, single quotes are not valid in JSON.
               f.write(f"MATRIX={json.dumps(matrix)}")
+
+      - name: Echo matrix env var
+        run: |
+          echo "${{ env.MATRIX }}"
 
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -100,18 +100,6 @@ jobs:
             cluster_specific:
               - added|modified: config/clusters/**
 
-      - name: Test outputs
-        run: |
-          echo "event name"
-          echo ${{ github.event_name == 'workflow_dispatch' }}
-          echo "common file changes"
-          echo "${{ steps.file_changes.outputs.common == 'true' }}"
-          echo "specific file changes"
-          echo "${{ steps.file_changes.outputs.cluster_specific == 'true' }}"
-          echo "whole statement"
-          echo ${{ github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true') }}
-          echo ${{ (github.event_name == 'workflow_dispatch' || (steps.file_changes.outputs.common == 'true' || steps.file_changes.outputs.cluster_specific == 'true')) == true }} 
-
       # Only run this step if there *ARE* changes under the common filter, *OR*
       # we have manually triggered the workflow
       - name: Generate a matrix containing all clusters

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -206,8 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
     if: |
-      needs.generate-clusters-to-validate.outputs.continue_workflow == true &&
-      needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]'
+      needs.generate-clusters-to-validate.outputs.continue_workflow &&
+      (needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -64,7 +64,7 @@ jobs:
         ${{ github.event_name == 'workflow_dispatch' ||
         (steps.file_changes.outputs.common == 'true' ||
         steps.file_changes.outputs.cluster_specific == 'true') }}
-      cluster_matrix: ${{ env.MATRIX }}
+      cluster_matrix: ${{ env.MATRIX || '[]' }}
     # Only run this job if one of the following conditions is true:
     # - The workflow was manually triggered
     # - The event is a push to the master branch

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -186,10 +186,6 @@ jobs:
               # not - for example, single quotes are not valid in JSON.
               f.write(f"MATRIX={json.dumps(matrix)}")
 
-      - name: Echo matrix env var
-        run: |
-          echo "${{ env.MATRIX }}"
-
   # This job runs the 'deployer validate' subcommand across a matrix of
   # cluster names.
   #


### PR DESCRIPTION
I noticed that on occasion the validate clusters workflow would fail with an error message that valid JSON was not provided to the `strategy` field of the `validate-helm-charts-values-files` job. Example here: https://github.com/2i2c-org/infrastructure/actions/runs/4372364264

It turned out, these failures happen in cases when the paths filter return false for BOTH common paths, and cluster specific paths. In this case, we would skip the step(s) that would generate a matrix and set the `MATRIX` environment variable. While we should also then skip the `validate-helm-charts-values-files` job, it fails to properly initialise because the `MATRIX` env var, which is passed to its `strategy` field, has not been set at all.

By simply forcing the `MATRIX` env var to be set to an empty list, we achieve the desired effect of the second job in the workflow being skipped, instead of registering as failed.