### PR TITLE
meom-ige: remove no longer needed workaround for dask-gateway 0.9.0

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -105,11 +105,6 @@ basehub:
           admin_users: *users
 
       allowNamedServers: true
-      networkPolicy:
-        # FIXME: For dask gateway
-        enabled: false
-      readinessProbe:
-        enabled: false
 dask-gateway:
   gateway:
     extraConfig:


### PR DESCRIPTION
This cleans up a no longer needed workaround, fixed in the release following 0.9.0 of dask-gateway.