### PR TITLE
leap, prometheus: reduce memory req/lim from 22Gi to 20Gi

### DIFF
--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -18,9 +18,9 @@ prometheus:
             - prometheus.leap.2i2c.cloud
     resources:
       requests:
-        memory: 22Gi
+        memory: 20Gi
       limits:
-        memory: 22Gi
+        memory: 20Gi
 
 grafana:
   grafana.ini:


### PR DESCRIPTION
Otherwise, we may fail to schedule on a node at all.
