### PR TITLE
openscapes/linked-earth: fix node sharing to fit on nodes perfectly

### DIFF
--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -61,8 +61,10 @@ basehub:
         #       profile list is setup to involve node sharing as considered in
         #       https://github.com/2i2c-org/infrastructure/issues/2121.
         #
-        #       - Memory requests are lower than the description, with a factor
-        #         of (node_max_mem - 4GB) / node_max_mem.
+        #       - Memory requests are different from the description, based on:
+        #         whats found to remain allocate in k8s, subtracting 1GiB
+        #         overhead for misc system pods, and transitioning from GB in
+        #         description to GiB in mem_guarantee.
         #       - CPU requests are lower than the description, with a factor of
         #         10%.
         #
@@ -79,32 +81,32 @@ basehub:
                   default: true
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.875G
+                    mem_guarantee: 0.836G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.75G
+                    mem_guarantee: 1.671G
                     cpu_guarantee: 0.025
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.5G
+                    mem_guarantee: 3.342G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.0G
+                    mem_guarantee: 6.684G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 14.0G
+                    mem_guarantee: 13.369G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 28.0G
+                    mem_guarantee: 26.738G
                     cpu_guarantee: 0.4
           kubespawner_override:
             cpu_limit: null
@@ -124,43 +126,43 @@ basehub:
                 mem_1:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.969G
+                    mem_guarantee: 0.903G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.938G
+                    mem_guarantee: 1.805G
                     cpu_guarantee: 0.025
                 mem_4:
                   default: true
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.875G
+                    mem_guarantee: 3.611G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.75G
+                    mem_guarantee: 7.222G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.5G
+                    mem_guarantee: 14.444G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.0G
+                    mem_guarantee: 28.887G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 62.0G
+                    mem_guarantee: 57.775G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 124.0G
+                    mem_guarantee: 115.549G
                     cpu_guarantee: 1.6
           kubespawner_override:
             cpu_limit: null

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -51,8 +51,10 @@ basehub:
         #       profile list is setup to involve node sharing as considered in
         #       https://github.com/2i2c-org/infrastructure/issues/2121.
         #
-        #       - Memory requests are lower than the description, with a factor
-        #         of (node_max_mem - 4GB) / node_max_mem.
+        #       - Memory requests are different from the description, based on:
+        #         whats found to remain allocate in k8s, subtracting 1GiB
+        #         overhead for misc system pods, and transitioning from GB in
+        #         description to GiB in mem_guarantee.
         #       - CPU requests are lower than the description, with a factor of
         #         10%.
         #
@@ -89,32 +91,32 @@ basehub:
                   default: true
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.875G
+                    mem_guarantee: 0.904G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.75G
+                    mem_guarantee: 1.809G
                     cpu_guarantee: 0.025
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.5G
+                    mem_guarantee: 3.617G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.0G
+                    mem_guarantee: 7.234G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 14.0G
+                    mem_guarantee: 14.469G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 28.0G
+                    mem_guarantee: 28.937G
                     cpu_guarantee: 0.4
           kubespawner_override:
             cpu_limit: null
@@ -134,43 +136,43 @@ basehub:
                 mem_1:
                   display_name: ~1 GB, ~0.125 CPU
                   kubespawner_override:
-                    mem_guarantee: 0.969G
+                    mem_guarantee: 0.942G
                     cpu_guarantee: 0.013
                 mem_2:
                   display_name: ~2 GB, ~0.25 CPU
                   kubespawner_override:
-                    mem_guarantee: 1.938G
+                    mem_guarantee: 1.883G
                     cpu_guarantee: 0.025
                 mem_4:
                   default: true
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.875G
+                    mem_guarantee: 3.766G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.75G
+                    mem_guarantee: 7.532G
                     cpu_guarantee: 0.1
                 mem_16:
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.5G
+                    mem_guarantee: 15.064G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.0G
+                    mem_guarantee: 30.128G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 62.0G
+                    mem_guarantee: 60.257G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 124.0G
+                    mem_guarantee: 120.513G
                     cpu_guarantee: 1.6
           kubespawner_override:
             cpu_limit: null
@@ -190,43 +192,43 @@ basehub:
                 mem_4:
                   display_name: ~4 GB, ~0.5 CPU
                   kubespawner_override:
-                    mem_guarantee: 3.969G
+                    mem_guarantee: 3.821G
                     cpu_guarantee: 0.05
                 mem_8:
                   display_name: ~8 GB, ~1.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 7.938G
+                    mem_guarantee: 7.643G
                     cpu_guarantee: 0.1
                 mem_16:
                   default: true
                   display_name: ~16 GB, ~2.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 15.875G
+                    mem_guarantee: 15.285G
                     cpu_guarantee: 0.2
                 mem_32:
                   display_name: ~32 GB, ~4.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 31.75G
+                    mem_guarantee: 30.571G
                     cpu_guarantee: 0.4
                 mem_64:
                   display_name: ~64 GB, ~8.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 63.5G
+                    mem_guarantee: 61.141G
                     cpu_guarantee: 0.8
                 mem_128:
                   display_name: ~128 GB, ~16.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 127.0G
+                    mem_guarantee: 122.282G
                     cpu_guarantee: 1.6
                 mem_256:
                   display_name: ~256 GB, ~32.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 254.0G
+                    mem_guarantee: 244.565G
                     cpu_guarantee: 3.2
                 mem_512:
                   display_name: ~512 GB, ~64.0 CPU
                   kubespawner_override:
-                    mem_guarantee: 508.0G
+                    mem_guarantee: 489.13G
                     cpu_guarantee: 6.4
           kubespawner_override:
             cpu_limit: null


### PR DESCRIPTION
This fixes a bug that hasn't been reported yet I think. Its a bug related to requesting 101% or similar when we should request <100% of the allocatable memory for a node.

Like this, we account for the allocatable memory as reported by k8s for specific node types and provide 1 GiB of headroom for system pods on the node like kube-proxy etc.

### Already deployed

I've tested this and it solves the issue of failing to start on the largest node share variant.

### Related
- https://github.com/2i2c-org/infrastructure/issues/2121#issuecomment-1465277039