### PR TITLE
nasa-veda: upgrade to k8s 1.25, highmem nodes, profile list with node sharing

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,6 +60,176 @@ basehub:
       image:
         name: pangeo/pangeo-notebook
         tag: "2023.01.13"
+      profileList:
+        # NOTE: About node sharing
+        #
+        #       CPU/Memory requests/limits are actively considered still. This
+        #       profile list is setup to involve node sharing as considered in
+        #       https://github.com/2i2c-org/infrastructure/issues/2121.
+        #
+        #       - Memory requests are different from the description, based on:
+        #         whats found to remain allocate in k8s, subtracting 1GiB
+        #         overhead for misc system pods, and transitioning from GB in
+        #         description to GiB in mem_guarantee.
+        #       - CPU requests are lower than the description, with a factor of
+        #         10%.
+        #
+        - display_name: "Small: up to 4 CPU / 32 GB RAM"
+          description: &profile_list_description "Start a container with at least a chosen share of capacity on a node of this type"
+          slug: small
+          default: true
+          profile_options:
+            requests:
+              # NOTE: Node share choices are in active development, see comment
+              #       next to profileList: above.
+              display_name: Node share
+              choices:
+                mem_1:
+                  default: true
+                  display_name: ~1 GB, ~0.125 CPU
+                  kubespawner_override:
+                    mem_guarantee: 0.904G
+                    cpu_guarantee: 0.013
+                mem_2:
+                  display_name: ~2 GB, ~0.25 CPU
+                  kubespawner_override:
+                    mem_guarantee: 1.809G
+                    cpu_guarantee: 0.025
+                mem_4:
+                  display_name: ~4 GB, ~0.5 CPU
+                  kubespawner_override:
+                    mem_guarantee: 3.617G
+                    cpu_guarantee: 0.05
+                mem_8:
+                  display_name: ~8 GB, ~1.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 7.234G
+                    cpu_guarantee: 0.1
+                mem_16:
+                  display_name: ~16 GB, ~2.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 14.469G
+                    cpu_guarantee: 0.2
+                mem_32:
+                  display_name: ~32 GB, ~4.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 28.937G
+                    cpu_guarantee: 0.4
+          kubespawner_override:
+            cpu_limit: null
+            mem_limit: null
+            node_selector:
+              node.kubernetes.io/instance-type: r5.xlarge
+        - display_name: "Medium: up to 16 CPU / 128 GB RAM"
+          description: *profile_list_description
+          slug: medium
+          profile_options:
+            requests:
+              # NOTE: Node share choices are in active development, see comment
+              #       next to profileList: above.
+              display_name: Node share
+              choices:
+                mem_1:
+                  display_name: ~1 GB, ~0.125 CPU
+                  kubespawner_override:
+                    mem_guarantee: 0.942G
+                    cpu_guarantee: 0.013
+                mem_2:
+                  display_name: ~2 GB, ~0.25 CPU
+                  kubespawner_override:
+                    mem_guarantee: 1.883G
+                    cpu_guarantee: 0.025
+                mem_4:
+                  default: true
+                  display_name: ~4 GB, ~0.5 CPU
+                  kubespawner_override:
+                    mem_guarantee: 3.766G
+                    cpu_guarantee: 0.05
+                mem_8:
+                  display_name: ~8 GB, ~1.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 7.532G
+                    cpu_guarantee: 0.1
+                mem_16:
+                  display_name: ~16 GB, ~2.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 15.064G
+                    cpu_guarantee: 0.2
+                mem_32:
+                  display_name: ~32 GB, ~4.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 30.128G
+                    cpu_guarantee: 0.4
+                mem_64:
+                  display_name: ~64 GB, ~8.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 60.257G
+                    cpu_guarantee: 0.8
+                mem_128:
+                  display_name: ~128 GB, ~16.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 120.513G
+                    cpu_guarantee: 1.6
+          kubespawner_override:
+            cpu_limit: null
+            mem_limit: null
+            node_selector:
+              node.kubernetes.io/instance-type: r5.4xlarge
+        - display_name: "Large: up to 64 CPU / 512 GB RAM"
+          description: *profile_list_description
+          slug: large
+          profile_options:
+            requests:
+              # NOTE: Node share choices are in active development, see comment
+              #       next to profileList: above.
+              display_name: Node share
+              choices:
+                mem_4:
+                  display_name: ~4 GB, ~0.5 CPU
+                  kubespawner_override:
+                    mem_guarantee: 3.821G
+                    cpu_guarantee: 0.05
+                mem_8:
+                  display_name: ~8 GB, ~1.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 7.643G
+                    cpu_guarantee: 0.1
+                mem_16:
+                  default: true
+                  display_name: ~16 GB, ~2.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 15.285G
+                    cpu_guarantee: 0.2
+                mem_32:
+                  display_name: ~32 GB, ~4.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 30.571G
+                    cpu_guarantee: 0.4
+                mem_64:
+                  display_name: ~64 GB, ~8.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 61.141G
+                    cpu_guarantee: 0.8
+                mem_128:
+                  display_name: ~128 GB, ~16.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 122.282G
+                    cpu_guarantee: 1.6
+                mem_256:
+                  display_name: ~256 GB, ~32.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 244.565G
+                    cpu_guarantee: 3.2
+                mem_512:
+                  display_name: ~512 GB, ~64.0 CPU
+                  kubespawner_override:
+                    mem_guarantee: 489.13G
+                    cpu_guarantee: 6.4
+          kubespawner_override:
+            cpu_limit: null
+            mem_limit: null
+            node_selector:
+              node.kubernetes.io/instance-type: r5.16xlarge
     scheduling:
       userScheduler:
         enabled: true

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -51,6 +51,12 @@ basehub:
           scope:
             - read:org
     prePuller:
+      # NOTE: To have prePuller enabled makes sense as long as we stick with a
+      #       single image option configured. Disable prePuller if the
+      #       configurator is used or a list of images is chosen from in the
+      #       profileList. Otherwise its likely to delay delay startup of a user
+      #       pod wanting to getting to wait for the pulling of another image.
+      #
       continuous:
         enabled: true
       hook:
@@ -58,12 +64,6 @@ basehub:
     singleuser:
       defaultUrl: /lab
       image:
-        # NOTE: To have prePuller enabled makes sense as long as we stick with a
-        #       single image option configured from here. If the configurator is
-        #       used, or a list of images is chosen from, then prePuller should
-        #       be disabled to avoid pulling images not to be used, which could
-        #       potentially delay startup of a user pod wanting to pull another
-        #       image.
         name: pangeo/pangeo-notebook
         tag: "2023.01.13"
       profileList:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -12,11 +12,6 @@ basehub:
       serverIP: fs-029a8973da2b1ef5f.efs.us-west-2.amazonaws.com
       baseShareName: /
   jupyterhub:
-    prePuller:
-      continuous:
-        enabled: true
-      hook:
-        enabled: true
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true
@@ -55,9 +50,20 @@ basehub:
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
+    prePuller:
+      continuous:
+        enabled: true
+      hook:
+        enabled: true
     singleuser:
       defaultUrl: /lab
       image:
+        # NOTE: To have prePuller enabled makes sense as long as we stick with a
+        #       single image option configured from here. If the configurator is
+        #       used, or a list of images is chosen from, then prePuller should
+        #       be disabled to avoid pulling images not to be used, which could
+        #       potentially delay startup of a user pod wanting to pull another
+        #       image.
         name: pangeo/pangeo-notebook
         tag: "2023.01.13"
       profileList:

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -25,10 +25,9 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "m5.large" },
-    { instanceType: "m5.xlarge" },
-    { instanceType: "m5.2xlarge" },
-    { instanceType: "m5.8xlarge" },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
 ];
 
 local daskNodes = [
@@ -38,10 +37,7 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-    { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 
 
@@ -51,7 +47,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-veda",
         region: clusterRegion,
-        version: '1.24'
+        version: '1.25'
     },
     availabilityZones: masterAzs,
     iam: {
@@ -78,12 +74,12 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-veda.key.pub'
             },
-            instanceType: "m5.xlarge",
+            instanceType: "r5.xlarge",
             minSize: 1,
             maxSize: 6,
             labels+: {


### PR DESCRIPTION
The nasa-veda cluster didn't have a profile list and they had run into 1GB memory limitations as noted in https://2i2c.slack.com/archives/C04R9B69T5W/p1678479120570969. I took initiative and did some disruptive maintenance now that people wasn't using it, setting up small / medium / large node options with an ability to pick a node share as well.

### Already deployed

This is already deployed, and if someone deploys the default branchs configuration to nasa-veda before this is merged, it will make it break.