### PR TITLE
meom-ige: fix missing github grafana auth

### DIFF
--- a/config/clusters/meom-ige/support.values.yaml
+++ b/config/clusters/meom-ige/support.values.yaml
@@ -13,6 +13,12 @@ prometheus:
             - prometheus.meom-ige.2i2c.cloud
 
 grafana:
+  grafana.ini:
+    server:
+      root_url: https://grafana.meom-ige.2i2c.cloud/
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org
   ingress:
     hosts:
       - grafana.meom-ige.2i2c.cloud


### PR DESCRIPTION
- I must have missed to add this config while trying to setup github auth for all grafana instances systematically in #2175.