### PR TITLE
Simplify display name

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -121,7 +121,7 @@ basehub:
         #          causes more frequent need to wait on startups, increased cost,
         #          wasted energy.
         #
-        - display_name: "Medium: up to 16 CPU / 128 GB RAM"
+        - display_name: "CPU only"
           description: &profile_list_description "Start a container limited to a chosen share of capacity on a node of this type"
           slug: medium-full
           default: true
@@ -223,7 +223,7 @@ basehub:
         #       share options for a different subset of users via the basehub
         #       specific allowed_teams configuration.
         #
-        - display_name: "Medium: up to 16 CPU / 128 GB RAM"
+        - display_name: "CPU only"
           description: *profile_list_description
           slug: medium-base
           default: true


### PR DESCRIPTION
Thanks so much for the work on the server options refactor @consideRatio et al.!  I just checked the server start up times and it was massively improved!

I got some feedback from users that the `display_name` was slightly confusing. Particularly for members of `leap-pangeo-base-access` the description does say up to 16cores/128GB, which they are not able to select. I would suggest to rename to a simpler description in line with the GPU option.