### PR TITLE
victor: k8s 1.22 to 1.25, core node from m5 to r5, dask nodes from 4 different m5 to one r5.4xlarge 

### DIFF
--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -38,10 +38,7 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-    { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 
 
@@ -54,7 +51,7 @@ local daskNodes = [
         // Warning: version 1.23 introduces some breaking changes
         // Checkout the docs before upgrading
         // ref: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html
-        version: '1.22'
+        version: '1.25'
     },
     availabilityZones: masterAzs,
     iam: {
@@ -81,12 +78,12 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/victor.key.pub'
             },
-            instanceType: "m5.xlarge",
+            instanceType: "r5.xlarge",
             minSize: 1,
             maxSize: 6,
             labels+: {
@@ -141,6 +138,4 @@ local daskNodes = [
             },
         } + n for n in daskNodes
     ]
-
-
 }

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -48,9 +48,6 @@ local daskNodes = [
     metadata+: {
         name: "victor",
         region: clusterRegion,
-        // Warning: version 1.23 introduces some breaking changes
-        // Checkout the docs before upgrading
-        // ref: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html
         version: '1.25'
     },
     availabilityZones: masterAzs,


### PR DESCRIPTION
**k8s upgrade**

I saw that the victor cluster wasn't actively used, to I took the opportunity to perform an upgrade from k8s 1.22 to 1.25.

**core node from m5.xlarge to r5.xlarge**

I also transitioned the core node pool from a m5.xlarge (4CPU/16GB) to a r5.xlarge (4CPU/32GB) machine for more RAM without too much additional cost. I think all daskhub clusters ought to have at least 32 GB of memory as prometheus-server is likeley to need a memory request bump if dask-gateway is used, and the m5.xlarge just provides 16GB of memory.

**dask nodes provided reduced from 4 m5 types to one r5.4xlarge (16CPU/128GB)**

These are meant to perform heavier computations not possible on a single machine, and the users are not specifying what machine to startup on. Due to that, it doesn't make sense to provide four kinds of nodes matching those provided as user nodes. So, I'm fixing it in this PR just in case.