### PR TITLE
gridsst: default to start on smallest node pool with min_nodes set to 1

### DIFF
--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -54,6 +54,9 @@ basehub:
         # on these nodes.
         - display_name: "Small: m5.large"
           description: "~2 CPU, ~8G RAM"
+          # default set to small because that node pool is configured with
+          # min_nodes 1, so we should make use of it.
+          default: true
           kubespawner_override:
             # Expllicitly unset mem_limit, so it overrides the default memory limit we set in
             # basehub/values.yaml
@@ -63,7 +66,6 @@ basehub:
               node.kubernetes.io/instance-type: m5.large
         - display_name: "Medium: m5.xlarge"
           description: "~4 CPU, ~15G RAM"
-          default: true
           kubespawner_override:
             mem_limit: null
             mem_guarantee: 12G


### PR DESCRIPTION
I happened to see that the smallest node pool was configured with `min_nodes` set to 1 - so one is always running. Due to that, it didn't make much sense to let the profile list options default to the medium node pool that needed to be started first.

I've not checked in with the gridsst community representative about this, but I consider it a bugfix that should be fine to just go for.