### PR TITLE
callysto: add maintenance notice and erik as admin

### DIFF
--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -107,6 +107,26 @@ jupyterhub:
 
         c.JupyterHub.authenticator_class = EmailAuthenticatingCILogonOAuthenticator
     config:
+      JupyterHub:
+        # Announcement is a JupyterHub feature to present messages to users in
+        # web pages under the /hub path (JupyterHub responds), but not via the
+        # /user path (single-user server responds).
+        #
+        # ref: https://github.com/2i2c-org/infrastructure/issues/1501
+        # ref: https://jupyterhub.readthedocs.io/en/stable/reference/templates.html#announcement-configuration-variables
+        #
+        # This maintenance was planned with Ian in
+        # https://2i2c.freshdesk.com/a/tickets/562.
+        #
+        template_vars:
+          announcement: >-
+            <strong>
+            Service maintenance is scheduled Wednesday March 22 between 0 AM and
+            4 AM PDT.
+            </strong>
+            <br/>
+            Running servers may be forcefully stopped and service disruption is
+            expected.
       EmailAuthenticatingCILogonOAuthenticator:
         allowed_domains:
           - 2i2c.org

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -148,8 +148,9 @@ jupyterhub:
       CILogonOAuthenticator:
         # We set up admin_users, but *not* allowed users. Those are set up via the extraConfig
         admin_users: &callysto_users
-          - "117859169473992122769" # Georgiana
-          - "115722756968212778437" # Sarah
+          - "117859169473992122769" # Georgiana (2i2c)
+          - "115722756968212778437" # Sarah (2i2c)
+          - "103849660365364958119" # Erik (2i2c)
           - "115240156849150087300" # Ian Allison (PIMS)
           - "102749090965437723445" # Byron Chu (Cybera)
           - "115909958579864751636" # Michael Jones (Cybera)


### PR DESCRIPTION
Ian at Callysto confirmed a maintenance plan in https://2i2c.freshdesk.com/a/tickets/562.