### PR TITLE
2i2c and cloudbank: fix priority of values.yaml files as a precaution

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -25,8 +25,8 @@ hubs:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
-      - enc-dask-staging.secret.values.yaml
       - dask-staging.values.yaml
+      - enc-dask-staging.secret.values.yaml
   - name: binder-staging
     display_name: "2i2c binder staging"
     domain: binder-staging.2i2c.cloud
@@ -42,8 +42,8 @@ hubs:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
-      - enc-demo.secret.values.yaml
       - demo.values.yaml
+      - enc-demo.secret.values.yaml
   - name: ohw
     display_name: "Ocean Hack Week"
     domain: oceanhackweek.2i2c.cloud
@@ -52,8 +52,8 @@ hubs:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
-      - enc-ohw.secret.values.yaml
       - ohw.values.yaml
+      - enc-ohw.secret.values.yaml
   - name: pfw
     display_name: "Purdue Fort Wayne"
     domain: pfw.pilot.2i2c.cloud

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -168,8 +168,8 @@ hubs:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
-      - enc-pasadena.secret.values.yaml
       - pasadena.values.yaml
+      - enc-pasadena.secret.values.yaml
   - name: sjcc
     display_name: "San Jose Community College"
     domain: sjcc.cloudbank.2i2c.cloud


### PR DESCRIPTION
I don't expect anything to change from this, but I wanted to get this done so that we don't risk running into due to this ordering where for example a `common.values.yaml` could define a blank string for `client_secret` that takes precedence over a `client_secret` defined in enc-prod.secret.values.yaml` or similar.