### PR TITLE
terraform, gcp: remove redundant opt-out of using config-connector

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -11,9 +11,6 @@ enable_network_policy  = true
 enable_filestore       = true
 filestore_capacity_gb  = 1024
 
-# No plans to provide storage buckets to users on this hub, so no need to deploy config connector
-config_connector_enabled = false
-
 notebook_nodes = {
   "user" : {
     min : 0,

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -11,9 +11,6 @@ enable_network_policy  = true
 enable_filestore       = true
 filestore_capacity_gb  = 1024
 
-# No plans to provide storage buckets to users on this hub, so no need to deploy config connector
-config_connector_enabled = false
-
 notebook_nodes = {
   "user" : {
     min : 0,

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -8,10 +8,6 @@ enable_network_policy    = true
 
 regional_cluster = false
 
-# No plans to provide storage buckets to users on this hub, so no need to deploy
-# config connector
-config_connector_enabled = false
-
 notebook_nodes = {
   "user" : {
     min : 0,

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -6,9 +6,6 @@ enable_private_cluster = true
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy  = true
 
-# Some hubs want a storage bucket, so we need to have config connector enabled
-config_connector_enabled = false
-
 # Setup a filestore for in-cluster NFS
 enable_filestore = true
 filestore_capacity_gb = 4096


### PR DESCRIPTION
I understand it as we want to avoid using config-connector, so I've removed some comments and config explicitly opting out from it, while in practice we have an opt-in system atm.

### Related
- #2186