### PR TITLE
Undo Jupyter ServerApp usage to fix jupyter-nbcontrib-extensions

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -3,6 +3,7 @@ jupyterhub:
     extraEnv:
       # Required to get jupyter-contrib-nbextensions to work
       # See https://github.com/2i2c-org/infrastructure/issues/2380
+      # Upstream issue at https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/153
       JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
     image:
       name: quay.io/2i2c/utoronto-image

--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -1,8 +1,12 @@
 jupyterhub:
   singleuser:
+    extraEnv:
+      # Required to get jupyter-contrib-nbextensions to work
+      # See https://github.com/2i2c-org/infrastructure/issues/2380
+      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "dfd2313d2617"
+      tag: "c68f2eb785f9"
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
jupyter-nbcontrib-extensions required the following fixes to work:

1. Pin nbclassic<0.5 (done in https://github.com/2i2c-org/utoronto-image/pull/49, until https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/pull/152 is merged and released)
2. Upgrade jupyter-nbcontrib-extensions to latest released version (done in https://github.com/2i2c-org/utoronto-image/pull/48)
3. Stop using ServerApp, and use NotebookApp (https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/153)

Ref https://github.com/2i2c-org/utoronto-image/pull/48