### PR TITLE
Increase memory limit & guarantee for CCSF

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -1,4 +1,10 @@
 jupyterhub:
+  singleuser:
+    memory:
+      # Increased to help deal with possible kernel restarts
+      # https://2i2c.freshdesk.com/a/tickets/567
+      guarantee: 384M
+      limit: 1.5G
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
A 1.5x increase for both guarantee and limits, based on https://2i2c.freshdesk.com/a/tickets/567.

Cloudbank should have enough credits to cover this.