### PR TITLE
Make LEAP dask workers be not pre-emptible

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -358,7 +358,7 @@ resource "google_container_node_pool" "dask_worker" {
 
   node_config {
 
-    preemptible = true
+    preemptible = each.value.preemptible
 
     # Balanced disks are much faster than standard disks, and much cheaper
     # than SSD disks. It contributes heavily to how fast new nodes spin up,

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -84,6 +84,7 @@ dask_nodes = {
   "medium" : {
     min : 0,
     max : 200,
+    preemptible: false,
     machine_type : "n2-highmem-16",
     labels : {},
     gpu : {

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -84,6 +84,9 @@ dask_nodes = {
   "medium" : {
     min : 0,
     max : 200,
+    # Disable preemptive nodes for dask so we can remove possible complications
+    # on why some dask computations are dying off.
+    # See https://github.com/2i2c-org/infrastructure/issues/2396
     preemptible: false,
     machine_type : "n2-highmem-16",
     labels : {},

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -61,7 +61,14 @@ variable "notebook_nodes" {
 }
 
 variable "dask_nodes" {
-  type        = map(object({ min : number, max : number, machine_type : string, labels : map(string), gpu : object({ enabled : bool, type : string, count : number }) }))
+  type        = map(object({
+    min : number,
+    max : number,
+    preemptible: optional(bool, true),
+    machine_type : string,
+    labels : map(string),
+    gpu : object({ enabled : bool, type : string, count : number })
+  }))
   description = "Dask node pools to create. Defaults to notebook_nodes"
   default     = {}
 }


### PR DESCRIPTION
Possible way to reduce confounding factors for
https://github.com/2i2c-org/infrastructure/issues/2396