### PR TITLE
Add opencost to support

### DIFF
--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -1,22 +1,29 @@
 prometheusIngressAuthSecret:
-    username: ENC[AES256_GCM,data:JvYLxEOsbjfFCn+ZUwLQZ9KzrUFsUxxrHh/+66cWnD7H8ThGPtEPGwtZBDQXPZWiLkiI6Xp3tLTu/WGjMUnstw==,iv:eaElI1PK3Qnzd7/msM/14ws6a0WgAX69fQhyC/gMqdg=,tag:9TVlhr+4M3a2lZgFG9l12g==,type:str]
-    password: ENC[AES256_GCM,data:MelDCxj31MKwzYQazMFWOPaE8xF9dlesW1r7zl4njPftKLGyqjfvLSzrjoqc+3O1mZBH0a97L3eBb6S+NLBxzA==,iv:4mo8AhPHz5DQNs/w9fpoWmP1WA/HPj0u/T5IpR68x3o=,tag:gs4V+Db9g3uf/DKsCkIRjQ==,type:str]
+    username: ENC[AES256_GCM,data:3jCF2C9r86coRsyA08IjCwzJN1qlmCarCq48PKQuwdHTHRfuAEIC4GEfnqoE0kICqLx/Ial0qjN+iRHuN7MksA==,iv:Dvftu9C8NrzP734RDAhiyNGK4J+40xEBsgBWg6tzghY=,tag:TSat9zMlAq6bWxf+/QdYzQ==,type:str]
+    password: ENC[AES256_GCM,data:vW/q4XycDPPEQ9wEwAzR6Q5QMeNXPFyX+6rDmg4yLyPWGiVAsDNgX1QuQZp5DC0WoHIccQ8KetKEfVAOVUeFQg==,iv:+eMjRrcfFdrDamA5X6rTmYXbtClgFgLrHNOcOPMjHds=,tag:EOjW3TbvDTQk0WhLzkP0hg==,type:str]
 grafana:
     grafana.ini:
         auth.github:
-            client_id: ENC[AES256_GCM,data:8h2NTnOgi69C9r2rPhAsovA9j5w=,iv:ChibKvAdzbI3F8ew21Fy2TqAIdCgpf0J0A1wICsAuIo=,tag:6JAlaJ8H/6MvJwXS8gDAzQ==,type:str]
-            client_secret: ENC[AES256_GCM,data:/bm7OcoLM8f8kUbP/bSAi8iFO6mETEydjiqwqXd2qGzwl6D213Okdw==,iv:syKMxz6GIfH2CeN+pSekebcS2mQgrEizt56eJz1rZJs=,tag:9jzXPcnBbNL6SLNHJ859zg==,type:str]
+            client_id: ENC[AES256_GCM,data:VrlrhKsRZntii1S2fkrSmclE/F4=,iv:97teDRGrhr6s/I/hFVTHmgyMoP6a5cD0rOhSCYHseLw=,tag:wKq7UD4PU1nBIbw+H8qn/Q==,type:str]
+            client_secret: ENC[AES256_GCM,data:cTBoQnd31OhrU5Q1m8n1Ieg8PvE8/mqZEEGOZNRCyKi7vf4OU7YVkw==,iv:u3R9rHis17uPDSBVqU/CCAR3eQB4N1kcK/ks7aV+mCc=,tag:8i8JQGU7ybEKHi9d865Rjg==,type:str]
+#ENC[AES256_GCM,data:BI6MIXgAkb71EM8JSrsamUVrr0/EhRJv2VbOyA==,iv:9kftViYkNFCIoSdK0q+7HEVjDu/K81qRg/vTAnAeAAM=,tag:BJqsGgaaAcE9aoLq1sIqig==,type:comment]
+#ENC[AES256_GCM,data:TyzGF4l6uyLcoQZSZ/EeJWctRJlEEWHqSCyWqzjsPH11Jkff9YB2PD5BAyQ1NZ6vXS4lNYhsrQ==,iv:3V5vaq1wPXL1LI44Rm2HQ4TGAy9xG/RyRulxDD9qbAc=,tag:vF1egJ1wIquiRkyW1EZX9A==,type:comment]
+#ENC[AES256_GCM,data:vJ0HZUkrf8b1tw/omRvB6Lnx8GMvf2Xoczl44DUpZkik6X7hCmzwzRbZyIR62mAkGtVdcHF5Vw==,iv:ovE4BH2zdhQQRcvVHfxhsByHPOUOM+l4gq/ZCxkFbSo=,tag:sLGGVVJyQ43kg4rTH/IMVg==,type:comment]
+opencost:
+    opencost:
+        #ENC[AES256_GCM,data:dtZrs4ABfqCy8uGWZum9nFkxtZhHd/Vikwsbfb32JoR7UnJQB+LRL2oUKnsklGkithIRHozgDfoft1HM1V/PRTbCCYsDfujeQk08hChRgUBUVx4cR5nISyhBBrfRnMy5dEZmT8AOIkgN3GWMgg==,iv:Xjj29z/g3dSLCyzHbjkP6dbruEV7ER+RBO8Cb6GVM24=,tag:kKNlXxle8uEQNhNI1WPVUQ==,type:comment]
+        cloudProviderApiKey: ENC[AES256_GCM,data:I7onM04bozxqpTVzF4AV4yD3xmsPT8+7HbG80R3LJ90S4MoqYJlB,iv:f66mhthLedifV71x2WX++4eIpJ27fZs+4gZtUMviw50=,tag:dFE2F6+mnBbEL2csADuVhA==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2022-03-14T20:52:45Z"
-          enc: CiQA4OM7eK/8mPoQEPzqGpKV5GIQg9REc3N5FYzKTOnO//OHGZUSSQDm5XgWwnAnX6mERcDbhzrS/hheFHiZM15BxZT9Dye2WpTciCrZRtrcjy64oWxcSxNHQikceNAdV+a9aEjG/zvwaOfjVIIJlaU=
+          created_at: "2023-03-24T14:29:43Z"
+          enc: CiUA4OM7eOviGmLwdAM5U5YrV72R5kb4ZOMtDhzqN5jlXWGEAOmwEkkALQgViE+eNzkH5p3OUm/Py9w1bUeektw7GhN2OM/gtLdk6Dle5A2FjhsVZ19NKJAYcQRTn1GEY5gULAjgWxrXIkFIO2cM+aCT
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-23T10:29:01Z"
-    mac: ENC[AES256_GCM,data:tnc2+Gdu/vuQvBA5LtsapIaIgHX1FrmsS2+mrz5FSqhpG5VRKEGG/zNjO0q3tJl55jLNHA1M5630xW9U5XqZOGcp8p+k9HRgwf2V3BxH2NTckbQpARmrRiZWE/TOGdxhEwNeNaRT0OF7g/GNMILBoZpeQZ+WnAxEafTPPxuXmAU=,iv:2m/mQ8Rb0wAV16TM3QCGc2mOE8UvkkCvwiAXsY/LCz0=,tag:bIU1IA1ubfJr8WPvER3/ZA==,type:str]
+    lastmodified: "2023-03-24T14:29:43Z"
+    mac: ENC[AES256_GCM,data:GDfS3+prTDHDnlxRuUH6rh4XVmhMsJ9ZlmsxfnxY2YUq+dQFv6LlU93p+Dr8jtITybMYjdA1PTT5vLhFth9b+p34qzO2C4f51CNrHe6mov2VI1Y1HdmW2vKvLPotUbLpRU37Aki8ct5KLSdMCb3PzJWgwdAF2R+lA/1ZhShsz8A=,iv:UfZfvHIYqWwBqSPfVWrXL31EyHguUbFv3oTQTG6YS2Y=,tag:TMGSI1MY3axdiYAv4C+GuA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -1,29 +1,30 @@
 prometheusIngressAuthSecret:
-    username: ENC[AES256_GCM,data:3jCF2C9r86coRsyA08IjCwzJN1qlmCarCq48PKQuwdHTHRfuAEIC4GEfnqoE0kICqLx/Ial0qjN+iRHuN7MksA==,iv:Dvftu9C8NrzP734RDAhiyNGK4J+40xEBsgBWg6tzghY=,tag:TSat9zMlAq6bWxf+/QdYzQ==,type:str]
-    password: ENC[AES256_GCM,data:vW/q4XycDPPEQ9wEwAzR6Q5QMeNXPFyX+6rDmg4yLyPWGiVAsDNgX1QuQZp5DC0WoHIccQ8KetKEfVAOVUeFQg==,iv:+eMjRrcfFdrDamA5X6rTmYXbtClgFgLrHNOcOPMjHds=,tag:EOjW3TbvDTQk0WhLzkP0hg==,type:str]
+    username: ENC[AES256_GCM,data:+SDmpSIy7Jl1LOV6dfhcUEKtod+LCMWqhFcvsGB4y76GvZWCAPeaIP3zB9Y3sUKRu8y1Lkrzq7LjEPjbpHqS6g==,iv:wMZcIUE/SVlIWzrcFmK6tZ/6Sbla1EQ/bMU2L9bOV1c=,tag:NicTCSS8ZvDJLubU81cvjw==,type:str]
+    password: ENC[AES256_GCM,data:ld0/HlQNsHGtcrwzHMNpJhlZfg3QIWRhAqfkxc/i7roI8OjFSxkQYEq+Cm4fH1TR1qZ8gLgheF/ejUhXhGF6RQ==,iv:RCMRrHfRjcWL1xM2FhiPv8hHSA6zMyiUi2ZteLpYO8w=,tag:QP0o5Atuft45Naxb/nqWNg==,type:str]
 grafana:
     grafana.ini:
         auth.github:
-            client_id: ENC[AES256_GCM,data:VrlrhKsRZntii1S2fkrSmclE/F4=,iv:97teDRGrhr6s/I/hFVTHmgyMoP6a5cD0rOhSCYHseLw=,tag:wKq7UD4PU1nBIbw+H8qn/Q==,type:str]
-            client_secret: ENC[AES256_GCM,data:cTBoQnd31OhrU5Q1m8n1Ieg8PvE8/mqZEEGOZNRCyKi7vf4OU7YVkw==,iv:u3R9rHis17uPDSBVqU/CCAR3eQB4N1kcK/ks7aV+mCc=,tag:8i8JQGU7ybEKHi9d865Rjg==,type:str]
-#ENC[AES256_GCM,data:BI6MIXgAkb71EM8JSrsamUVrr0/EhRJv2VbOyA==,iv:9kftViYkNFCIoSdK0q+7HEVjDu/K81qRg/vTAnAeAAM=,tag:BJqsGgaaAcE9aoLq1sIqig==,type:comment]
-#ENC[AES256_GCM,data:TyzGF4l6uyLcoQZSZ/EeJWctRJlEEWHqSCyWqzjsPH11Jkff9YB2PD5BAyQ1NZ6vXS4lNYhsrQ==,iv:3V5vaq1wPXL1LI44Rm2HQ4TGAy9xG/RyRulxDD9qbAc=,tag:vF1egJ1wIquiRkyW1EZX9A==,type:comment]
-#ENC[AES256_GCM,data:vJ0HZUkrf8b1tw/omRvB6Lnx8GMvf2Xoczl44DUpZkik6X7hCmzwzRbZyIR62mAkGtVdcHF5Vw==,iv:ovE4BH2zdhQQRcvVHfxhsByHPOUOM+l4gq/ZCxkFbSo=,tag:sLGGVVJyQ43kg4rTH/IMVg==,type:comment]
+            client_id: ENC[AES256_GCM,data:Vdy5BQ2kfO6syUc5mVxqmc2Q4Ys=,iv:9G4Bg1296JBEU+Z9EbGRCpz9b5IsPfVWPTGs8dTJJx8=,tag:0Bf+jaoRkwSXL+DYaKEwoQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:7r1IbsOzn6IfTVyA14oCNxPSO141enQVB0bauzBncuoADg5tzJ+OJQ==,iv:VDQAlzlVR8pyt36BEruwagMwM+y6nyHAM+kIFI9vbZY=,tag:Xy6viteqcD08IXCNfFxCug==,type:str]
+#ENC[AES256_GCM,data:Zs8ZdY7zHpeG7OE2RvUkGP2nrjNUygnr/Y8JfA==,iv:dKAKvfVnwBBACcfIeglPNLwp/9QlnZRx9wNBk5I9Zas=,tag:ndRgJifE9Vgg4erGOBunSg==,type:comment]
+#ENC[AES256_GCM,data:85U2At6crhslCSeI8E76u/mncwvGzukdwVBQ0NbiIjOoFuoIR++HoY9bYuymdIHj/mjDpe+jxQ==,iv:FNzQofee5i+vP+LRs1DjIqYqNDppTAO3A6mtbkXFy6k=,tag:3nksmAP4i9jOIXYdUN1RSw==,type:comment]
+#ENC[AES256_GCM,data:5hFuajqMdYEbTJz/zus5ahbjNNnrOxkEe3Txsz3cGn+L7W9s9t2FazX4SlAtvZLplXrRp2PMJA==,iv:YwcHR7O9U/Jr9jQvOZXj5Ve6R1Gec4DUUES/IZLbq2w=,tag:YXJvkzF/qZFpfKz7cFEBiw==,type:comment]
 opencost:
     opencost:
-        #ENC[AES256_GCM,data:dtZrs4ABfqCy8uGWZum9nFkxtZhHd/Vikwsbfb32JoR7UnJQB+LRL2oUKnsklGkithIRHozgDfoft1HM1V/PRTbCCYsDfujeQk08hChRgUBUVx4cR5nISyhBBrfRnMy5dEZmT8AOIkgN3GWMgg==,iv:Xjj29z/g3dSLCyzHbjkP6dbruEV7ER+RBO8Cb6GVM24=,tag:kKNlXxle8uEQNhNI1WPVUQ==,type:comment]
-        cloudProviderApiKey: ENC[AES256_GCM,data:I7onM04bozxqpTVzF4AV4yD3xmsPT8+7HbG80R3LJ90S4MoqYJlB,iv:f66mhthLedifV71x2WX++4eIpJ27fZs+4gZtUMviw50=,tag:dFE2F6+mnBbEL2csADuVhA==,type:str]
+        exporter:
+            #ENC[AES256_GCM,data:aVVNiYJdj/eR6VxB3O5LxoaBhQ+0osVnC6znbGQI8l39f9/iN66jlA9zgFac2PGZK1W3uPfhPnVzf04LwYfw9dwONxehYQUrd/bJyG0eI/6finWIdxoehc2zemi9BZwzjoHeGHHn//ytel7jDg==,iv:6IqUJqIoEVjN2BpJKnuU4lPeH3S4dQNMWlTur02pHC8=,tag:I+M8B+TQzmQE7USOGK5r/w==,type:comment]
+            cloudProviderApiKey: ENC[AES256_GCM,data:O7ZQ5E+LMoyFHPq/vYDOlMKAmwPz30ywvfXZIiOxrspSQiiZ2knD,iv:zMLmuAuXJDbbuqrvq1V/ROq9vS9XnjXdF3lErXMlqF4=,tag:JDS2Iv0/F1zTX+OmFllSzQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-03-24T14:29:43Z"
-          enc: CiUA4OM7eOviGmLwdAM5U5YrV72R5kb4ZOMtDhzqN5jlXWGEAOmwEkkALQgViE+eNzkH5p3OUm/Py9w1bUeektw7GhN2OM/gtLdk6Dle5A2FjhsVZ19NKJAYcQRTn1GEY5gULAjgWxrXIkFIO2cM+aCT
+          created_at: "2023-03-24T15:40:44Z"
+          enc: CiUA4OM7eMmceBkbXRroZ47XDqBzBo8UXDtZNzCry2bGy5HxQAOdEkkALQgViPGYiCS1U4AfrLCGVQCrmVca3l50kyYY0WBqaZ7GX4OLgT/sGSyLF804BxsgkuMbgZTAp7QvFTXe3SFQ8enVEfQgVZG6
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-24T14:29:43Z"
-    mac: ENC[AES256_GCM,data:GDfS3+prTDHDnlxRuUH6rh4XVmhMsJ9ZlmsxfnxY2YUq+dQFv6LlU93p+Dr8jtITybMYjdA1PTT5vLhFth9b+p34qzO2C4f51CNrHe6mov2VI1Y1HdmW2vKvLPotUbLpRU37Aki8ct5KLSdMCb3PzJWgwdAF2R+lA/1ZhShsz8A=,iv:UfZfvHIYqWwBqSPfVWrXL31EyHguUbFv3oTQTG6YS2Y=,tag:TMGSI1MY3axdiYAv4C+GuA==,type:str]
+    lastmodified: "2023-03-24T15:40:45Z"
+    mac: ENC[AES256_GCM,data:w9BjRoOjXh4CcPKhnJbP3rEWWunKfaOTcz4aO6yRBH4ZJXO+VBEQFPbEGjl578z0zYpRisYwaLmMQFcBmbwZeGpIkkIzP2S2WdTfgj0etue6WEkOv5HiTtrKi+LMVuSZqFZOSz2qiA1TuExVxwGplKTsllZa7pbzmIZajmiwetw=,iv:Hb/whNgsdyZX1Q+tZ+49riYn5MNC0+JVy172bt5xdC0=,tag:tStWjUJ83HZ65jFV/JfpAA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -11,6 +11,23 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.pilot.2i2c.cloud
+    # TODO(pnasrat) figure way to conditionalize
+    # TODO(pnasrat): Experimental
+    # Testing OpenCost to display and report on shared costs
+    # https://github.com/2i2c-org/infrastructure/issues/1923
+    # Source: https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml
+    extraScrapeConfigs: |
+      - job_name: opencost
+        honor_labels: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        dns_sd_configs:
+        - names:
+          - opencost.support
+          type: 'A'
+          port: 9003
 
 grafana:
   grafana.ini:
@@ -26,3 +43,15 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.pilot.2i2c.cloud
+
+# TODO(pnasrat): Experimental
+# Testing OpenCost to display and report on shared costs
+# https://github.com/2i2c-org/infrastructure/issues/1923
+opencost:
+  enabled: true
+  opencost:
+    prometheus:
+      # Note the external config supports basic auth but unsure if supports multiple prometheuses
+      internal:
+        namespaceName: support
+        serviceName: prometheus

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -54,4 +54,5 @@ opencost:
       # Note the external config supports basic auth but unsure if supports multiple prometheuses
       internal:
         namespaceName: support
-        serviceName: prometheus
+        serviceName: support-prometheus-server
+        port: 80

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -41,3 +41,12 @@ dependencies:
     version: "0.0.1-0.dev.git.27.h01b4f25"
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled
+
+  # opencost cost monitoring for kubernetes.
+  # TODO(pnasrat): Experimental
+  # Testing OpenCost to display and report on shared costs
+  # https://github.com/2i2c-org/infrastructure/issues/1923
+  - name: opencost
+    version: 1.7.0
+    repository: https://opencost.github.io/opencost-helm-chart
+    condition: opencost.enabled

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -19,6 +19,7 @@ required:
   - prometheusIngressAuthSecret
   - cryptnono
   - redirects
+  - opencost
   - global
 properties:
   # cluster-autoscaler is a dependent helm chart, we rely on its schema
@@ -47,6 +48,13 @@ properties:
     additionalProperties: true
   # Enables  https://github.com/yuvipanda/cryptnono/ to prevent cryptomining
   cryptnono:
+    type: object
+    additionalProperties: true
+  # opencost is a dependent helm chart.
+  # TODO(pnasrat): Experimental
+  # Testing OpenCost to display and report on shared costs
+  # https://github.com/2i2c-org/infrastructure/issues/1923
+  opencost:
     type: object
     additionalProperties: true
   redirects:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -242,6 +242,12 @@ grafana:
 cryptnono:
   enabled: true
 
+# TODO(pnasrat): Experimental
+# Testing OpenCost to display and report on shared costs
+# https://github.com/2i2c-org/infrastructure/issues/1923
+opencost:
+  enabled: false
+
 # Configuration of templates provided directly by this chart
 # -------------------------------------------------------------------------------
 #


### PR DESCRIPTION
This adds a configurable OpenCost service to the support chart to enable testing of billing for shared clusters and enables it in the 2i2c GCP shared cluster.



Ref #1923