### PR TITLE
documentation: add hub login page template example

### DIFF
--- a/docs/howto/features/login-page.md
+++ b/docs/howto/features/login-page.md
@@ -5,6 +5,7 @@ Each Hub deployed in a cluster has a collection of metadata about who it is depl
 For an example, see [the log-in page of the staging hub](https://staging.2i2c.cloud/hub/login).
 
 The log-in pages are built with [the base template at this repository](https://github.com/2i2c-org/default-hub-homepage). Values are inserted into each template based on each hub configuration.
+By default, the main branch of this repository will be used for customization. But both the repository and the branch can be configured for each hub.
 
 You may customize the configuration for a hub's homepage `jupyterhub.homepage.templateVars` in the appropriate hub values file under `config/clusters/<cluster_name>`. Changing these values for a hub will ensure that the hub's landing page updates automatically.
 Some example config is below.
@@ -13,6 +14,8 @@ Some example config is below.
 jupyterhub:
   custom:
     homepage:
+      gitRepoBranch: "<cluster-name>-<hub-name>"
+      gitRepoUrl: "https://github.com/some-org/some-repo"
       templateVars:
         org:
           name: Org Name


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/2349 together with https://github.com/2i2c-org/default-hub-homepage/pull/22