### PR TITLE
Fix nasa-veda SSO link in hubs page

### DIFF
--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -1,5 +1,6 @@
 name: nasa-veda
 provider: aws # https://smce-veda.signin.aws.amazon.com/console
+account: "smce-veda"
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks


### PR DESCRIPTION
Adds correct account field to cluster config

Tested by local docs build and inspecting docs/tmp/hub-table.csv