### PR TITLE
Set a CPU limit for user pods in UToronto

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -47,6 +47,13 @@ jupyterhub:
               ongoing basis. To reach the support site, please visit: <a href="https://act.utoronto.ca/jupyterhub-support">https://act.utoronto.ca/jupyterhub-support/</a>.
             </div>
   singleuser:
+    cpu:
+      # Each node has about 8 CPUs total, and if we limit users to no more than
+      # 4, no single user can take down a full node by themselves. We have to
+      # set the guarantee to *something*, otherwise it is set to be equal
+      # to the limit!
+      limit: 4
+      guarantee: 0.01
     memory:
       limit: 2G
       guarantee: 1G


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/issues/2445 had an outage because a node was taken out by having its 8 CPU be fully utilized. This restricts a single user from being able to do that. Multiple users running heavy stuff still can, but this is an improvement!