### PR TITLE
prometheus-node-exporter: declare cpu/mem requests and limits

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -100,6 +100,22 @@ prometheus:
       - key: k8s.dask.org/dedicated
         value: worker
         effect: NoSchedule
+    # resources for the node-exporter was set after inspecting cpu and memory
+    # use via prometheus and grafana.
+    #
+    # node-exporter is typically found using between 0-3m CPU and 2-22Mi memory.
+    #
+    # PromQL queries for CPU and memory use:
+    # - CPU:    sum(rate(container_cpu_usage_seconds_total{container="node-exporter", namespace="support"}[5m])) by (pod)
+    # - Memory: sum(container_memory_usage_bytes{container="node-exporter", namespace="support"}) by (pod)
+    #
+    resources:
+      limits:
+        cpu: 5m
+        memory: 30Mi
+      requests:
+        cpu: 5m
+        memory: 30Mi
 
   networkPolicy:
     enabled: true


### PR DESCRIPTION
We've seen the node-exporter pod be evicted because it has no resource requests/limits when what needs to be evicted are other pods to resolve the situation. Let's not allow that to happen!

- This relates to https://github.com/2i2c-org/infrastructure/issues/90, about setting requests and limits for support chart's pods.

### CPU (leap, 30 last days)

Note that the use dropped at some point. That was me upgrading the GKE based k8s cluster in #2337.

![image](https://user-images.githubusercontent.com/3837114/229230519-2ce58dae-8cdb-4940-b968-82ae386913a5.png)

### Memory (leap, 30 last days)

![image](https://user-images.githubusercontent.com/3837114/229231806-7d240712-4f49-483e-8300-7f75e56e2707.png)

### Why I choose the requests and limits

1. We don't want this pod to starve other pods of CPU if it bursts, but it seems it can only burst to ~3m CPU. Setting a limit on 5m CPU seemed fine.
2. We want to ensure the typical operation is guaranteed CPU wise, which seem to be ~0-3m CPU. Setting a request of 5m CPU seemed fine.
3. We want requests/limits of memory to be the same to avoid getting evicted by memory, and crashing reliably if this is too low instead. I saw that it has peaked at ~21Mi, so I went for 30Mi to be safe, knowing there is a few hundred Mi of memory available still to not cause issues with planned requests/limits in #2121.
