### PR TITLE
grafana: declare cpu/mem requests and limits

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -188,6 +188,31 @@ grafana:
     namespaced: true
     pspEnabled: false
 
+  # initChownData refers to an init container enabled by default that isn't
+  # needed as we don't reconfigure the linux user the grafana server will run
+  # as.
+  initChownData:
+    enabled: false
+
+  # resources for grafana was set after inspecting cpu and memory use via
+  # prometheus and grafana.
+  #
+  # Grafana's memory use seems to increase over time but seems reasonable to
+  # stay below 200Mi for years to come. Grafana's CPU use seems miniscule with
+  # peaks at up to 9m CPU from one user is browsing its dashboards.
+  #
+  # PromQL queries for CPU and memory use:
+  # - CPU:    sum(rate(container_cpu_usage_seconds_total{container="grafana", namespace="support"}[5m])) by (pod)
+  # - Memory: sum(container_memory_usage_bytes{container="grafana", namespace="support"}) by (pod)
+  #
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 10m
+      memory: 200Mi
+
   ingress:
     enabled: true
     annotations:
@@ -241,6 +266,33 @@ grafana:
 #
 cryptnono:
   enabled: true
+  # resources for cryptnono was set after inspecting cpu and memory use via
+  # prometheus and grafana.
+  #
+  # cryptnono has an init container (kubectl-trace-init) and another container
+  # (trace). The init container has been found using up to 1.6Gi and up to about
+  # 600m for 4 minutes. The main container has been found using up to 150Mi but
+  # typically below 100Mi, and miniscule amounts of CPU (0-3m).
+  #
+  # Since cryptnono is a non-critical service, we are at the moment allowing it
+  # to be evicted during node memory pressure by providing a low memory request
+  # compared to the limit. We are also not requesting significant amounts of CPU
+  # so that it doesn't compete well with others initially.
+  #
+  # Note that as of now 2023-03-31 (8367fa5 in yuvipanda/cryptnono), the
+  # resources configuration configure both containers.
+  #
+  # PromQL queries for CPU and memory use:
+  # - CPU:    sum(rate(container_cpu_usage_seconds_total{container="kube-trace-init", namespace="support"}[5m])) by (pod)
+  # - Memory: sum(container_memory_usage_bytes{container="kube-trace-init", namespace="support"}) by (pod)
+  #
+  resources:
+    limits:
+      cpu: 800m
+      memory: 2Gi
+    requests:
+      cpu: 5m
+      memory: 100Mi
 
 # Configuration of templates provided directly by this chart
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
We've seen misc pods be evicted because they has no resource requests/limits and are considered as prime candidates for eviction during node pressure. This is not a big deal, but we can set some resource requests and limits to avoid the situation.

- This relates to https://github.com/2i2c-org/infrastructure/issues/90, about setting requests and limits for support chart's pods.

### CPU (leap, last 6 hours)

I've used this grafana instance a lot recently. This load is the peak load over the year so far.

![image](https://user-images.githubusercontent.com/3837114/229243123-0c542a81-584d-4557-a798-b05c505b43dc.png)

### Memory (leap, last year)

![image](https://user-images.githubusercontent.com/3837114/229242575-d706dffa-2dd2-4931-a6b2-f063ffee68d5.png)
