### PR TITLE
Adding a cfis to the domain whitelist

### DIFF
--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -124,6 +124,7 @@ jupyterhub:
           - wsrd.ca
           - ucalgary.ca
           - ualberta.ca
+          - cfis.com
           - "*.ca"
       CILogonOAuthenticator:
         # We set up admin_users, but *not* allowed users. Those are set up via the extraConfig


### PR DESCRIPTION
One of the schools for an upcoming hackathon uses the domain cfis.com. This change adds the domain to our whitelist.