### PR TITLE
Add docs about resource bumps being self-mergable

### DIFF
--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -34,6 +34,7 @@ Here are some guidelines for merging and reviewing in this case:
   - Changing basic hub configuration such as the URL of its landing page image
   - Updating the user image of a hub.
   - Updating the max number of nodes for nodepools in a cluster
+  - Emergency (eg exam, outage) related resource bumps
   :::
 - **Be careful when changing config of a hub *during* an event**
   Sometimes, a hub config change needs to happen *immediately*, to help debug something


### PR DESCRIPTION
Add docs to explicitly allow emergency resource bumps as self-approval (if need be)