### PR TITLE
Use of highmem nodes for new clusters node pools and require a few tf variables to be set

### DIFF
--- a/docs/topic/infrastructure/cluster-design.md
+++ b/docs/topic/infrastructure/cluster-design.md
@@ -1,43 +1,93 @@
 # Cluster design considerations
 
-## GKE
+## Core nodes' instance type
 
-## Core node size
+Each cluster is setup with a *core node pool*. Its expected to be static in size
+and always running. The core node's instance types should have: allocatable CPU,
+allocatable Memory, and allowed Pods per node, to efficiently schedule and
+reliably run:
 
-In each cluster, we have a *core node pool* that is fairly static in size
-and always running. It needs enough capacity to run:
+1. Kubernetes system pods - network policy enforcement, cluster
+   autoscaler, kube-dns, etc.
 
-1. Kubernetes system components - network policy enforcement, config connector
-   components, cluster autoscaler, kube-dns, etc.
+2. Per-cluster support pods - like prometheus, grafana, cert-manager, etc.
 
-2. Per-cluster support components - like prometheus, grafana, cert-manager,
-   etc.
+3. JupyterHub core pods - like hub, proxy, user-scheduler, etc
 
-3. Hub core components - the hub, proxy, userscheduler, etc
-
-4. (Optional) Dask gatway core components - the API gateway, controller, etc.
+4. (Optional) DaskGatway core pods - like gateway, controller, proxy.
 
 Since the core nodes are *always running*, they form a big chunk of the
-cluster's *base cost* - the amount of money it costs each day, regardless
-of current number of running users. Picking an apporpriate node size and
-count here has a big effect.
+cluster's *base cost* - the amount of money it costs each day, regardless of
+current number of running users. Picking an appropriate instance type for the
+core nodes has a big effect.
 
-### On GKE
+### CPU and Memory
 
-GKE makes sizing this nodepool difficult, since `kube-system` components can take up quite
-a bit of resources. Even though the kind of clusters we run will most likely
-not stress components like `kube-dns` that much, there's no option to provide
-them fewer resource requests. So this will be our primary limitation in
-many ways.
+Kubernetes system Pods on GKE, EKS, and AKS will require different amount of
+allocatable capacity, and it can differ if we enable various features such as
+network policy enforcement.
 
-Adding [Config Connector](https://cloud.google.com/config-connector/docs/overview)
-or enabling [Network Policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)
-requires more resources as well.
+Typically we run out of allocatable Memory faster than CPU, which makes us
+benefit from nodes with a high memory to CPU ratio, such as the `n2-highmem`
+nodes on GCP or `r5` nodes on AWS.
 
-With poorly structured experimentation, the current recommendation is to run
-3 `n1-highmem-2` instances for a cluster without config connector or network policy,
-or a single `n1-highmem-4` instance for a cluster with either of those options
-turned on. This needs to be better investigated.
+### Allocatable pods per node
+
+Node's of different types can only schedule so many pods on them.
+
+- GKE instance types supports 110 pods per node and typically won't have issues
+  with this, unless perhaps in a shared k8s cluster with many JupyterHub
+  installations.
+- EKS instance types support varying amounts of pods per node, and the smallest
+  nodes with two CPU cores typically only allows for 27 pods per node.
+
+### System pods anti-affinity
+
+Pods may be required to run on separate nodes. This has caused multiple nodes be
+required on GKE clusters that has `calico-typha` pods from the network policy
+enforcement.
+
+The `calico-typha` pods vary in amount, from only one to a few, depending on the
+number of nodes in the k8s cluster thanks to a HorizontalPodAutoscaler (HPA).
+The HPA can be re-configured via a k8s ConfigMap.
+
+```yaml
+# Below is a snippet from the ConfigMap calico-typha-horizontal-autoscaler in a
+# GKE cluster with network policy enforcement enabled. It can be edited, and
+# changes to it will be respected across k8s upgrades it seems.
+data:
+  ladder: |-
+    {
+      "coresToReplicas": [],
+      "nodesToReplicas":
+      [
+        [1, 1],
+        [2, 2],
+        [100, 3],
+        [250, 4],
+        [500, 5],
+        [1000, 6],
+        [1500, 7],
+        [2000, 8]
+      ]
+    }
+```
+
+On GKE clusters with network policy enforcement, we look to edit the
+`calico-typha-horizontal-autoscaler` ConfigMap in `kube-system` to avoid scaling
+up to two replicas unless there are very many nodes in the k8s cluster.
+
+### Our instance type choice
+
+We default to setting up new k8s clusters's core node pool with instance types
+of either 2 CPU and 16GB of memory or 4 CPU and 32GB of memory.
+
+On GKE we setup `n2-highmem-2` nodes for new basehub installations and
+`n2-highmem-4` for new daskhub installations. A risk of using `n2-highmem-2` is
+that `prometheus-server` may require more memory than is available.
+
+On EKS we always use the `r5.xlarge` nodes to avoid running low on allocatable
+pods.
 
 ## Network Policy
 

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -48,10 +48,7 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-    { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.2xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.8xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 <% else %>
 local daskNodes = [];

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -101,7 +101,7 @@ local daskNodes = [];
             ssh: {
                 publicKeyPath: 'ssh-keys/<< cluster_name >>.key.pub'
             },
-            instanceType: "m5.xlarge",
+            instanceType: "r5.xlarge",
             minSize: 1,
             maxSize: 6,
             labels+: {

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -36,10 +36,9 @@ local nodeAz = "<< cluster_region >>a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "m5.large" },
-    { instanceType: "m5.xlarge" },
-    { instanceType: "m5.2xlarge" },
-    { instanceType: "m5.8xlarge" },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
 ];
 <% if hub_type == "daskhub" %>
 local daskNodes = [

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -65,7 +65,11 @@ local daskNodes = [];
     metadata+: {
         name: "<< cluster_name >>",
         region: clusterRegion,
-        version: '1.24'
+        {#-
+            version should be the latest support version by the eksctl CLI, see
+            https://eksctl.io/introduction/ for a list of supported versions.
+        #}
+        version: '1.25'
     },
     availabilityZones: masterAzs,
     iam: {

--- a/terraform/gcp/projects/basehub-template.tfvars
+++ b/terraform/gcp/projects/basehub-template.tfvars
@@ -3,7 +3,6 @@
    - multi-tenant with staging & prod hubs
    - regional
    - no scratch buckets support
-   - notebook nodes of same type with core nodes
 */
 
 prefix                 = "{{ cluster_name }}"
@@ -15,7 +14,7 @@ region                 = "{{ cluster_region }}"
 # Default to a HA cluster for reliability
 regional_cluster = true
 
-core_node_machine_type = "n1-highmem-4"
+core_node_machine_type = "n2-highmem-2"
 
 # For multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy  = true
@@ -25,15 +24,39 @@ enable_filestore       = true
 filestore_capacity_gb  = 1024
 
 notebook_nodes = {
-  "user" : {
+  "small" : {
     min : 0,
-    max : 20,
-    machine_type : core_node_machine_type,
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
+    max : 100,
+    machine_type : "n2-highmem-4",
+    labels : {},
+    gpu : {
+      # Tip: use this flag to enable GPU on this machine type
+      # if there is GPU availability in the chosen the zone
+      enabled : false,
+      type : "",
+      count : 0
+    }
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
+    }
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
     }
   },
 }

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -1,6 +1,9 @@
 prefix     = "cb"
 project_id = "cb-1003-1696"
 
+zone       = "us-central1-b"
+region     = "us-central1"
+
 core_node_machine_type = "n1-highmem-4"
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -3,7 +3,6 @@
    - single-tenant with staging & prod hubs
    - regional
    - scratch buckets support
-   - notebook and dask dedicated nodes of different types
 */
 
 prefix                 = "{{ cluster_name }}"
@@ -15,7 +14,7 @@ region                 = "{{ cluster_region }}"
 # Default to a HA cluster for reliability
 regional_cluster = true
 
-core_node_machine_type = "n1-highmem-4"
+core_node_machine_type = "n2-highmem-4"
 
 # Network policy is required to enforce separation between hubs on multi-tenant clusters
 # Tip: uncomment the line below if this cluster will be multi-tenant
@@ -58,7 +57,7 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
+    machine_type : "n2-highmem-4",
     labels : {},
     gpu : {
       # Tip: use this flag to enable GPU on this machine type
@@ -71,7 +70,7 @@ notebook_nodes = {
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-4",
+    machine_type : "n2-highmem-16",
     labels : {},
     gpu : {
       enabled : false,
@@ -82,18 +81,7 @@ notebook_nodes = {
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
-  "huge" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
+    machine_type : "n2-highmem-64",
     labels : {},
     gpu : {
       enabled : false,
@@ -104,43 +92,10 @@ notebook_nodes = {
 }
 
 dask_nodes = {
-  "small" : {
-    min : 0,
-    max : 200,
-    machine_type : "n1-highmem-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
   "medium" : {
     min : 0,
     max : 200,
-    machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
-  "large" : {
-    min : 0,
-    max : 200,
-    machine_type : "n1-highmem-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
-  "huge" : {
-    min : 0,
-    max : 200,
-    machine_type : "n1-highmem-16",
+    machine_type : "n2-highmem-16",
     labels : {},
     gpu : {
       enabled : false,

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -1,6 +1,9 @@
 prefix     = "meom-ige"
 project_id = "meom-ige-cnrs"
 
+zone       = "us-central1-b"
+region     = "us-central1"
+
 core_node_machine_type = "n1-highmem-2"
 
 # Single-tenant cluster, network policy not needed

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -1,5 +1,7 @@
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
+zone                   = "us-central1-b"
+region                 = "us-central1"
 core_node_machine_type = "n1-highmem-4"
 enable_private_cluster = true
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -1,6 +1,9 @@
 prefix     = "pilot-hubs"
 project_id = "two-eye-two-see"
 
+zone       = "us-central1-b"
+region     = "us-central1"
+
 core_node_machine_type = "n1-highmem-4"
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -156,7 +156,7 @@ variable "zone" {
 
 variable "core_node_machine_type" {
   type        = string
-  default     = "n1-highmem-2"
+  default     = "n2-highmem-2"
   description = <<-EOT
   Machine type to use for core nodes.
 
@@ -164,9 +164,8 @@ variable "core_node_machine_type" {
   for a cluster. We should try to run with as few of them
   as possible.
 
-  For single-tenant clusters, a single n1-highmem-2 node seems
-  enough - if network policy and config connector are not on.
-  For others, please experiment to see what fits.
+  For single-tenant clusters, a single n2-highmem-2 node can be
+  enough.
   EOT
 }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -113,7 +113,6 @@ variable "cd_sa_roles" {
 
 variable "region" {
   type        = string
-  default     = "us-central1"
   description = <<-EOT
   GCP Region the cluster & resources will be placed in.
 
@@ -144,7 +143,6 @@ variable "regional_cluster" {
 
 variable "zone" {
   type        = string
-  default     = "us-central1-b"
   description = <<-EOT
   GCP Zone the cluster & nodes will be set up in.
 
@@ -156,7 +154,6 @@ variable "zone" {
 
 variable "core_node_machine_type" {
   type        = string
-  default     = "n2-highmem-2"
   description = <<-EOT
   Machine type to use for core nodes.
 


### PR DESCRIPTION
I've deliberated quite a bit on node pool's instance types, and I think these are good defaults for node pools in new k8s clusters to provide.

I've updated documentation a bit about the choices made for the core node pool specifically. The documentation is certainly not exhausting the discussion or is perfectly written, but I hope it can be seen as an incremental improvement.

### Summary of changes to node pools

GKE:
- `n2` is used systematically over `n1`. They provide a bit better performance per CPU and a 1:8 ratio of CPU:Memory instead of 1:6.5
- `n2-highmem-2` as core node pool for basehubs
- `n2-highmem-4` as core node pool for daskhubs
- `n2-highmem-4`, `-16`, and `-64` for user node pool for basehub and daskhub

EKS:
- `r5` is used systematically over `m5`. They provide a bit better performance per CPU and a 1:8 ratio of CPU:Memory instead of 1:4.
- `r5.xlarge` as core node pool for basehubs and daskhubs (equivalent to `n2-highmem-4`), where the smaller option `r5.large` allows for too few pods per node
- `r5.xlarge`, `r5.4xlarge`, and `r5.16xlarge` for user node pool for basehub and daskhub (equivalent to `n2-highmem-4`, `-16`, and `-64`)

### Related

- #2121
- #2005 