### PR TITLE
utoronto: Provide exact same resources for all exam users

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -47,15 +47,12 @@ jupyterhub:
               ongoing basis. To reach the support site, please visit: <a href="https://act.utoronto.ca/jupyterhub-support">https://act.utoronto.ca/jupyterhub-support/</a>.
             </div>
   singleuser:
+    # Set limit and guarantee to be same for equity reasons during the exam
     cpu:
-      # Each node has about 8 CPUs total, and if we limit users to no more than
-      # 4, no single user can take down a full node by themselves. We have to
-      # set the guarantee to *something*, otherwise it is set to be equal
-      # to the limit!
-      limit: 4
-      guarantee: 0.01
+      limit: 1
+      guarantee: 1
     memory:
-      limit: 4G
+      limit: 2G
       guarantee: 2G
     extraFiles:
       github-app-private-key.pem:


### PR DESCRIPTION
For equity reasons, everyone shall have access to the exact same computing resources.

I checked grafana, nobody has used more than 2G of RAM or 1 CPU for a while.

Ref https://github.com/2i2c-org/infrastructure/issues/2316