### PR TITLE
Reset UToronto Resource Requests

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -55,8 +55,8 @@ jupyterhub:
       limit: 4
       guarantee: 0.01
     memory:
-      limit: 4G
-      guarantee: 2G
+      limit: 2G
+      guarantee: 1G
     extraFiles:
       github-app-private-key.pem:
         mountPath: /etc/github/github-app-private-key.pem

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -47,12 +47,15 @@ jupyterhub:
               ongoing basis. To reach the support site, please visit: <a href="https://act.utoronto.ca/jupyterhub-support">https://act.utoronto.ca/jupyterhub-support/</a>.
             </div>
   singleuser:
-    # Set limit and guarantee to be same for equity reasons during the exam
     cpu:
-      limit: 1
-      guarantee: 1
+      # Each node has about 8 CPUs total, and if we limit users to no more than
+      # 4, no single user can take down a full node by themselves. We have to
+      # set the guarantee to *something*, otherwise it is set to be equal
+      # to the limit!
+      limit: 4
+      guarantee: 0.01
     memory:
-      limit: 2G
+      limit: 4G
       guarantee: 2G
     extraFiles:
       github-app-private-key.pem:


### PR DESCRIPTION
- Revert https://github.com/2i2c-org/infrastructure/pull/2489 because the exam is over
- Revert https://github.com/2i2c-org/infrastructure/pull/2484 because we got a misreport

Ref #2316 