### PR TITLE
Bump memory for temple final project period

### DIFF
--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -10,6 +10,13 @@ jupyterhub:
       - secretName: https-auto-tls
         hosts:
           - temple.2i2c.cloud
+  singleuser:
+    memory:
+      # Final projects increase from 256M/1G for finals as per
+      # https://2i2c.freshdesk.com/a/tickets/643
+      # TODO(pnasrat): Remove after 2023-05-02
+      guarantee: 512M
+      limit: 2G
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
As per https://2i2c.freshdesk.com/a/tickets/643

This change puts back the temporary limit bump when Temple were experiencing   user kernel kills at request for final projects running until May 2

To be updated if instructor/community lead gets back with explicit RAM needs. 