### PR TITLE
Allow customizing the expected status code for uptime checks

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -26,6 +26,9 @@ hubs:
   - name: hackanexoplanet
     display_name: "ESA Hack An Exoplanet"
     domain: hackanexoplanet.2i2c.cloud
+    uptime_check:
+      # This is an ephemeral hub, fully password protected with HTTP Basic Auth
+      expected_status: 401
     helm_chart: basehub
     helm_chart_values_files:
       - hackanexoplanet.values.yaml

--- a/deployer/cluster.schema.yaml
+++ b/deployer/cluster.schema.yaml
@@ -216,6 +216,19 @@ properties:
             description: |
               A long form name for the hub to display on our website. This is usually
               the name of the community we run the hub for.
+          uptime_check:
+            type: object
+            description: |
+              Optional configuration for how uptime checks should be performed
+              on this hub.
+            additionalProperties: false
+            properties:
+              expected_status:
+                type: string
+                description: |
+                  Status code expected from hitting the health checkpoint for
+                  this hub. Defaults to 200, can be overriden in case we have
+                  basic auth setup for the entire hub
           domain:
             type: string
             description: |

--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -162,6 +162,23 @@ jupyterhub:
           url: ""
 ```
 
+
+## Customizing the uptime check to expect a HTTP `401`
+
+Our [uptime checks](uptime-checks) expect a HTTP `200` response to consider a
+hub as live. However, since we protect the entire hub at the Ingress level,
+all endpoints will return a HTTP `401` asking for a password. We can configure
+our uptime checks to allow for `401` as a valid response in the appropriate
+`cluster.yaml` definition for this hub.
+
+```yaml
+  - name: <name-of-hub>
+    display_name: <display-name>
+    uptime_check:
+      # This is an ephemeral hub, fully password protected with HTTP Basic Auth
+      expected_status: 401
+```
+
 ## Use `nbgitpuller` for distributing content
 
 We encourage users to use [nbgitpuller](https://github.com/jupyterhub/nbgitpuller)


### PR DESCRIPTION
Required when we support ephemeral password protected hubs, as the password protection is accomplished via HTTP Basic Auth. All endpoints are thus protected, including `/hub/health`.

Ref https://github.com/2i2c-org/infrastructure/issues/2497