### PR TITLE
Remove separate nodepool for OHW

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -1,14 +1,3 @@
-dask-gateway:
-  gateway:
-    backend:
-      scheduler:
-        extraPodConfig:
-          nodeSelector:
-            2i2c.org/community: ohw
-      worker:
-        extraPodConfig:
-          nodeSelector:
-            2i2c.org/community: ohw
 basehub:
   userServiceAccount:
     annotations:
@@ -72,8 +61,6 @@ basehub:
             mem_guarantee: 4G
             cpu_limit: 2
             cpu_guarantee: 0.5
-      nodeSelector:
-        2i2c.org/community: ohw
     custom:
       cloudResources:
         provider: gcp

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -25,19 +25,6 @@ notebook_nodes = {
       type: "",
       count: 0
     }
-  },
-  "ohw": {
-    min: 1,
-    max: 100,
-    machine_type: "n1-highmem-8",
-    labels: {
-      "2i2c.org/community": "ohw"
-    },
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
   }
 }
 
@@ -47,19 +34,6 @@ dask_nodes = {
     max : 100,
     machine_type : "n1-highmem-4",
     labels: { },
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
-  "ohw": {
-    min: 0,
-    max: 100,
-    machine_type: "n1-highmem-4",
-    labels: {
-      "2i2c.org/community": "ohw"
-    },
     gpu: {
       enabled: false,
       type: "",


### PR DESCRIPTION
It barely has any users, and due to lack of taints, is being used by other hubs as well when needed. This lets us consolidate into the existing pool.

We can bring this back when they are having an event or similar.