### PR TITLE
DOCS: Package hub list as a JSON object in our documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+##############################################################################
 # Added by 2i2c
 #
 # To clean up ignored files you can use: git clean -Xfd
@@ -28,6 +29,8 @@ Chart.lock
 # Documentation build assets
 docs/tmp
 docs/reference/terraform.md
+docs/_static/hub-stats.json
+docs/_static/hub-table.json
 
 # Common editor config
 .vscode
@@ -38,6 +41,7 @@ docs/reference/terraform.md
 # Don't version control any terraform state
 **.terraform.lock.hcl
 
+##############################################################################
 # Python.gitignore below - Add exceptions above for easier maintenance
 # https://github.com/github/gitignore/blob/main/Python.gitignore
 # --------------------------------------------------------------------
@@ -197,3 +201,4 @@ cython_debug/
 
 # osx
 .DS_Store
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@ extensions = [
 
 intersphinx_mapping = {
     "z2jh": ("https://zero-to-jupyterhub.readthedocs.io/en/latest/", None),
-    "tc": ("https://team-compass.2i2c.org/en/latest/", None),
-    "dc": ("https://docs.2i2c.org/en/latest/", None),
+    "tc": ("https://team-compass.2i2c.org", None),
+    "dc": ("https://docs.2i2c.org", None),
 }
 
 # -- MyST configuration ---------------------------------------------------

--- a/docs/scripts/render_hubs.py
+++ b/docs/scripts/render_hubs.py
@@ -6,6 +6,7 @@ from yaml import safe_load
 
 path_root = Path(__file__).parent.parent
 path_tmp = path_root / "tmp"
+path_static = path_root / "_static"
 path_clusters = path_root / "../config/clusters"
 
 # Grab the latest list of clusters defined in infrastructure/ explicitly ignoring
@@ -118,9 +119,10 @@ for cluster_info in clusters:
 df = pd.DataFrame(hub_list)
 path_tmp.mkdir(exist_ok=True)
 
-# Write raw data
+# Write raw data to CSV and JSON
 path_table = path_tmp / "hub-table.csv"
 df.to_csv(path_table, index=None)
+df.to_json(path_static / "hub-table.json", orient="index")
 
 # Write some quick statistics for display
 # Calculate total number of community hubs by removing staging and demo hubs
@@ -140,6 +142,8 @@ community_hubs_by_cluster.loc[("total", ""), "count"] = community_hubs_by_cluste
 ].sum(0)
 community_hubs_by_cluster["count"] = community_hubs_by_cluster["count"].astype(int)
 
+# Write to CSV and JSON
 path_stats = path_tmp / "hub-stats.csv"
 community_hubs_by_cluster.to_csv(path_stats)
+community_hubs_by_cluster.to_json(path_static / "hub-stats.json", orient="index")
 print("Finished updating list of hubs table...")

--- a/docs/scripts/render_hubs.py
+++ b/docs/scripts/render_hubs.py
@@ -1,4 +1,10 @@
-"""Pull latest list of hubs served by infrastructure/ and save as a CSV table."""
+"""Pull latest list of hubs served by infrastructure/ and save as a CSV table.
+
+This is used in two places:
+
+- docs/_static/hub-table.json is published with the docs and meant for re-use in other parts of 2i2c
+- docs/tmp/hub-table.csv is read by reference/hubs.md to create a list of hubs
+"""
 from pathlib import Path
 
 import pandas as pd


### PR DESCRIPTION
This PR modifies our "generate a list of our active hubs" script to output a **JSON file that is served with our docs** in addition to the CSV file that is used to create the HTML tables.

This is part of an experiment at automating an AirTable script that would automatically read in the JSON file and update a table of records that list all of our currently-running hubs. I don't think publishing the JSON has negative implications, given that all the same data is already present at https://infrastructure.2i2c.org/reference/hubs.html

I don't know if this JSON approach will work or not, but I wanted to quickly expose this data to see if I can get something working with minimal effort to decide if it's worth exploring further.

Here's an example of what the JSON would look like: https://2i2c-pilot-hubs--2509.org.readthedocs.build/_static/hub-table.json

- related to: #2456 