### PR TITLE
Allow executing a single command line with use-cluster-credentials

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -170,17 +170,25 @@ Remember to close the opened shell after you've finished by using the `exit` com
 
 **Command line usage:**
 
-```bash
- Usage: deployer use-cluster-credentials [OPTIONS] CLUSTER_NAME                                                         
-                                                                                                                        
- Pop a new shell authenticated to the given cluster using the deployer's credentials                                    
-                                                                                                                        
-╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    cluster_name      TEXT  Name of cluster to operate on [default: None] [required]                                │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+                                                                                    
+ Usage: deployer use-cluster-credentials [OPTIONS] CLUSTER_NAME COMMANDLINE         
+                                                                                    
+ Pop a new shell or execute a command after authenticating to the given cluster     
+ using the deployer's credentials                                                   
+                                                                                    
+╭─ Arguments ──────────────────────────────────────────────────────────────────────╮
+│ *    cluster_name      TEXT  Name of cluster to operate on [default: None]       │
+│                              [required]                                          │
+│ *    commandline       TEXT  Optional shell command line to run after            │
+│                              authenticating to this cluster                      │
+│                              [default: None]                                     │
+│                              [required]                                          │
+╰──────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                      │
+╰──────────────────────────────────────────────────────────────────────────────────╯
+
 ```
 
 

--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -44,9 +44,13 @@ helm_charts_dir = Path(__file__).parent.parent.joinpath("helm-charts")
 @app.command()
 def use_cluster_credentials(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
+    commandline: str = typer.Argument(
+        ...,
+        help="Optional shell command line to run after authenticating to this cluster",
+    ),
 ):
     """
-    Pop a new shell authenticated to the given cluster using the deployer's credentials
+    Pop a new shell or execute a command after authenticating to the given cluster using the deployer's credentials
     """
     # This function is to be used with the `use-cluster-credentials` CLI
     # command only - it is not used by the rest of the deployer codebase.
@@ -66,7 +70,11 @@ def use_cluster_credentials(
         # to change the prompt to f"cluster-{cluster.spec['name']}". This will
         # make it visually clear that the user is now operating in a different
         # shell.
-        subprocess.check_call([os.environ["SHELL"], "-l"])
+        args = [os.environ["SHELL"], "-l"]
+        # If a command to execute is specified, just execute that and exit.
+        if commandline:
+            args += ["-c", commandline]
+        subprocess.check_call(args)
 
 
 @app.command()


### PR DESCRIPTION
Very helpful when trying to execute a single command targeted at a particular cluster and use its result. For example, to run "kubectl version" on all clusters, you can run:

```
ls config/clusters | grep -v template | xargs -L1 -I{} deployer use-cluster-credentials {} "kubectl version"
```