### PR TITLE
[deployer] Set an empty string default value for the commandline arg to make it optional

### DIFF
--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -45,7 +45,7 @@ helm_charts_dir = Path(__file__).parent.parent.joinpath("helm-charts")
 def use_cluster_credentials(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     commandline: str = typer.Argument(
-        ...,
+        "",
         help="Optional shell command line to run after authenticating to this cluster",
     ),
 ):


### PR DESCRIPTION
Otherwise it fails with `Missing argument 'COMMANDLINE'.`
No default value, will make it required.
Ref https://typer.tiangolo.com/tutorial/arguments/optional/#alternative-old-typerargument-as-the-default-value                                                                                                                        