### PR TITLE
Bump utoronto R image

### DIFF
--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -11,4 +11,4 @@ jupyterhub:
     defaultUrl: /rstudio
     image:
       name: quay.io/2i2c/utoronto-r-image
-      tag: "cba149c9ee05"
+      tag: "c8cb3c4f3c31"


### PR DESCRIPTION
Brings in https://github.com/2i2c-org/utoronto-r-image/pull/2

For https://github.com/2i2c-org/utoronto-r-image/pull/2