### PR TITLE
Grafana dashboards for all clusters, and QCL grafana's github auth fixed

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -34,7 +34,6 @@ jobs:
           - cluster_name: utoronto
           - cluster_name: victor
 
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -12,23 +12,24 @@ jobs:
         include:
           # The grafana for 2i2c cluster holds also info about all other clusters
           - cluster_name: 2i2c
+          - cluster_name: 2i2c-aws-us
+          - cluster_name: 2i2c-uk
+          - cluster_name: awi-ciroh
+          - cluster_name: callysto
           - cluster_name: carbonplan
           - cluster_name: cloudbank
+          - cluster_name: gridsst
           - cluster_name: leap
           - cluster_name: m2lines
           - cluster_name: meom-ige
+          - cluster_name: nasa-cryo
+          - cluster_name: nasa-veda
           - cluster_name: openscapes
           - cluster_name: pangeo-hubs
-          - cluster_name: utoronto
-          - cluster_name: awi-ciroh
-          - cluster_name: callysto
-          - cluster_name: 2i2c-uk
-          - cluster_name: nasa-cryo
-          - cluster_name: gridsst
-          - cluster_name: victor
-          - cluster_name: 2i2c-aws-us
           - cluster_name: ubc-eoas
-          - cluster_name: nasa-veda
+          - cluster_name: utoronto
+          - cluster_name: victor
+
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -19,13 +19,17 @@ jobs:
           - cluster_name: carbonplan
           - cluster_name: cloudbank
           - cluster_name: gridsst
+          - cluster_name: jupyter-meets-the-earth
           - cluster_name: leap
+          - cluster_name: linked-earth
           - cluster_name: m2lines
           - cluster_name: meom-ige
           - cluster_name: nasa-cryo
           - cluster_name: nasa-veda
           - cluster_name: openscapes
           - cluster_name: pangeo-hubs
+          - cluster_name: qcl
+          - cluster_name: smithsonian
           - cluster_name: ubc-eoas
           - cluster_name: utoronto
           - cluster_name: victor

--- a/config/clusters/jupyter-meets-the-earth/enc-grafana-token.secret.yaml
+++ b/config/clusters/jupyter-meets-the-earth/enc-grafana-token.secret.yaml
@@ -1,0 +1,15 @@
+grafana_token: ENC[AES256_GCM,data:eEkdDwt4Nh5A3vK+0gZWKFClfX8r432opI5k+DDSs5Xubl8uMBYL7dQDPKwJ1Q==,iv:GIcnnq6A8FlC5n0zIcBtRXarbiVPIyUD4IA0upwv/iY=,tag:hpuE3LjlkOHnfRgS8EEr1Q==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-05-08T23:52:20Z"
+          enc: CiUA4OM7eMWtsPtGolINvWRXEfk4g47adZDWn9sU/Dx5Ncw8DJWgEkkALQgViHdizcHRkCq7nYnKwxDED5hO786C0CzFoP7dTKlncH+CHD4DPVJLTqbipss7jlDs3Aa4j2o3AiwpiLIYhEQ+dOR/xuip
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-05-08T23:52:21Z"
+    mac: ENC[AES256_GCM,data:nCdHJEhLW6PO3sldQunY/aG/ugH75lL+D9YOZUA5HiOR42LXtxP35IO9MEepSpEzmDkC1wkKOHiXGbBeDAZFhhbHbv8oJp9lbO0crO9fKYeMdWy1lg1mTfc1EtJ5Mx7Xujfbh4gMunFaM9+hw2siy1Y6b7GiZ9VLGbiBaLnPgAg=,iv:yexANic9yZn2o0bzJRTDt7n1rtzoFuNV2XLspMsgRZw=,tag:znGhZZudQ0DS4YKcKcpdEg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/qcl/enc-support.secret.values.yaml
+++ b/config/clusters/qcl/enc-support.secret.values.yaml
@@ -1,6 +1,11 @@
 prometheusIngressAuthSecret:
     username: ENC[AES256_GCM,data:iB5bF1oqHG3zAMTf6flHGy82OtBEdH1mJej3nPQNwhpUAYnDAt39GCjUyeL6sNZHplxj7wpjLivlXGajqYxEDQ==,iv:xoVgueVKvSgclTSG46o0p+gImFzp0cu1M4arBwUPtTY=,tag:mysqYMEwFWnDYV/k+VIhCQ==,type:str]
     password: ENC[AES256_GCM,data:ZELmo3NoENJ+ilLbSuFZzaZpqHteZFZM60TS9bGvVNVufsBB38AomEEAXI/MpEXeUWMzs/3L+edcYP3Xuq3ygw==,iv:hkT4M+6KfEBUNt2z8JdKtensjq+ExclbtkXGeZn8ib4=,tag:NN2HowJJrJjSY01+FP641w==,type:str]
+grafana:
+    grafana.ini:
+        auth.github:
+            client_id: ENC[AES256_GCM,data:WhCUHK9/097VWQcEABXkYOG7OH0=,iv:GtaLxzAvjX/LzRxxwpk2P1LgGET+RVO6RjF16ZYC2Kc=,tag:mrIP4WyqddZ1n977OjBOnQ==,type:str]
+            client_secret: ENC[AES256_GCM,data:f8OikvqqVZurJYjEX/H529oH5kd5zdLYkMwtEW1AnmPESEA+CkoCbA==,iv:wn/gvjlpz584Zd9XwWmbcZrQ3k0LFJtoxFknkOcj2yQ=,tag:tPYxG0RuVpVSElhpX9XyDA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -10,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-02T16:01:07Z"
-    mac: ENC[AES256_GCM,data:4pf9l0nXSswiwf7W8sOREinFqgX0AvxREpUJkEf5VwdelMz1M3+qYDT20nK4entSe7iUjsu23j0GXsOoNiP5q/SYE6CaVQyp08JSx3c6ajKakTu5bQykYH22SB1F2ZFagma1aTFe+0Isil64hm+Cqq3wF8pEhp2KF1MrYOkn+XQ=,iv:+8JFA3Z4FfEjVdu7jvxFHam25YFBtlJJvlO3T4BvPDU=,tag:l1Bxs6Qb9RQWhXqmYjY4mg==,type:str]
+    lastmodified: "2023-05-08T22:59:35Z"
+    mac: ENC[AES256_GCM,data:Lg84kK9L3uzhXAhbtpRh4EB1Kg3HCEXmOdMERx5GeT/E4ncW5i+CtEtmtQKjZEVrJXSU9UuBceOvHN1QcB0+cuUBtK10ctnb5J/xgqgLf/LWighiiu0AEIMsxE+a6333hjudo1It7iUPbp9rObWIC1EGuCeIj2tuyoogNQJejW8=,iv:m/vZVIMCAPf9g5fXfcvORvoau9zbaoFnl6OY/VRC0x0=,tag:cZ+Gck1QfhL7x9TExCry3Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/qcl/support.values.yaml
+++ b/config/clusters/qcl/support.values.yaml
@@ -7,6 +7,8 @@ redirects:
       to: staging.quantifiedcarbon.com
     - from: qcl.2i2c.cloud
       to: jupyter.quantifiedcarbon.com
+    - from: grafana.qcl.2i2c.cloud
+      to: grafana.quantifiedcarbon.com
 
 prometheus:
   server:

--- a/config/clusters/qcl/support.values.yaml
+++ b/config/clusters/qcl/support.values.yaml
@@ -23,9 +23,9 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.quantifiedcarbon.com/
-  auth.github:
-    enabled: true
-    allowed_organizations: 2i2c-org
+    auth.github:
+      enabled: true
+      allowed_organizations: 2i2c-org QuantifiedCarbon
   ingress:
     hosts:
       - grafana.qcl.2i2c.cloud

--- a/config/clusters/qcl/support.values.yaml
+++ b/config/clusters/qcl/support.values.yaml
@@ -30,10 +30,10 @@ grafana:
       allowed_organizations: 2i2c-org QuantifiedCarbon
   ingress:
     hosts:
-      - grafana.qcl.2i2c.cloud
       - grafana.quantifiedcarbon.com
+      - grafana.qcl.2i2c.cloud
     tls:
       - secretName: grafana-tls
         hosts:
-          - grafana.qcl.2i2c.cloud
           - grafana.quantifiedcarbon.com
+          - grafana.qcl.2i2c.cloud

--- a/docs/howto/grafana-github-auth.md
+++ b/docs/howto/grafana-github-auth.md
@@ -28,7 +28,15 @@ To enable logging into Grafana using GitHub, follow these steps:
    grafana:
      grafana.ini:
        server:
-         root_url: https://<grafana.ingress.hosts[0]>
+         # root_url should point to the domain we redirect to if we have multiple
+         # domain names configured and redirects from one to another
+         #
+         # FIXME: root_url is also required to be the same as the
+         #        grafana.ingress.hosts[0] config specifically until
+         #        https://github.com/2i2c-org/infrastructure/issues/2533 is
+         #        resolved.
+         #
+         root_url: https://<grafana.ingress.hosts[0]>/
        auth.github:
          enabled: true
          # allowed_organizations should be a space separated list

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -246,7 +246,7 @@ grafana:
   # secret:
   #
   #     server:
-  #       root_url: https://grafana.<cluster_name>.2i2c.cloud
+  #       root_url: https://grafana.<cluster_name>.2i2c.cloud/
   #     auth.github:
   #       enabled: true
   #       allowed_organizations: "2i2c-org some-other-gh-org"


### PR DESCRIPTION
We didn't have github auth setup for QCL, or automation to update the dashboards for QCL or a few other hubs. In this PR I fix this.

The grafana dashboards wasn't updated for:
- linked-earth
- jmte
- smithsonian
- qcl

### Already deployed

The grafana servers have already been updated with the dashboards manually by me, and I've deployed the QCL chart config fixes already. Things seem to work out!

### Related

- #2214 
- https://github.com/2i2c-org/infrastructure/issues/2531
- https://github.com/2i2c-org/infrastructure/issues/2533
- https://github.com/grafana/grafana/issues/66876
- https://github.com/grafana/grafana/pull/66879