### PR TITLE
openscapes: Bump python image to f577786

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -71,7 +71,7 @@ basehub:
                   default: true
                   slug: python
                   kubespawner_override:
-                    image: openscapes/python:2d9c952
+                    image: openscapes/python:f577786
                 rocker:
                   display_name: R
                   slug: rocker


### PR DESCRIPTION
Ref: support https://2i2c.freshdesk.com/a/tickets/711

Confirmed image exists via docker pull.