### PR TITLE
jmte: Reduce amount of RAM requested for massive GPU

### DIFF
--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -182,7 +182,7 @@ basehub:
         - display_name: "Massive GPU: 64 CPU, 256 GB, 1 T4 Tensor Core GPU"
           description: "A dedicated machine for you with one GPU attached."
           kubespawner_override:
-            mem_guarantee: 224G
+            mem_guarantee: 200G
             mem_limit: null
             node_selector:
               node.kubernetes.io/instance-type: g4dn.16xlarge


### PR DESCRIPTION
This was reported via slack (I am working on migrating the JMTE folks to using support@ for support). The massive GPU option was not triggering new pod scale up. The current memory request is too big, I presume since there is extra memory allocated for the GPU stuff (compared to regular 16xlarge). With this change, I am able to bring a new node up.