### PR TITLE
Revert Bump image for cryocloud

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -139,7 +139,7 @@ basehub:
                   slug: "python"
                   kubespawner_override:
                     # Image repo: https://github.com/CryoInTheCloud/hub-image
-                    image: "quay.io/cryointhecloud/cryo-hub-image:034c99c07b90"
+                    image: "quay.io/cryointhecloud/cryo-hub-image:98e6196ee90a"
                 rocker:
                   display_name: R
                   slug: "rocker"


### PR DESCRIPTION
This reverts commit 8ce1e49eb51ce6ab1e1be28885f927d4ba876038.

Due to deploy start script fails mkdir failures with EEXIST

https://github.com/2i2c-org/infrastructure/pull/2550