### PR TITLE
awi-ciroh: upgrade k8s to 1.25, and adjust node pools following event

### DIFF
--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -78,6 +78,9 @@ basehub:
         #        the previous 1:1 user:node setup with a node sharing setup. It
         #        is not meant to be retained long term!
         #
+        #        -[ ] Make this cluster have a node sharing setup like in the
+        #             basehub/daskhub template.
+        #
         - display_name: "Small"
           description: 5GB RAM, 2 CPUs
           default: true

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -2,10 +2,17 @@ prefix                 = "awi-ciroh"
 project_id             = "awi-ciroh"
 zone                   = "us-central1-b"
 region                 = "us-central1"
-core_node_machine_type = "n1-highmem-4"
+core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 enable_filestore       = true
 filestore_capacity_gb  = 1024
+
+k8s_versions = {
+  min_master_version: "1.25.8-gke.500",
+  core_nodes_version: "1.25.6-gke.1000",
+  notebook_nodes_version: "1.25.6-gke.1000",
+  dask_nodes_version: "1.25.6-gke.1000",
+}
 
 user_buckets = {
   "scratch-staging": {
@@ -27,110 +34,48 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
+    machine_type : "n2-highmem-4",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
     }
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-4",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
+    machine_type : "n2-highmem-16",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
     }
   },
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
-  "huge" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
-  # added stressfully before an event where we ran out of ssd quota, see
-  # https://github.com/2i2c-org/infrastructure/pull/2539 and the linked
-  # event https://github.com/2i2c-org/infrastructure/issues/2520.
-  #
-  # FIXME: make this cluster have a node sharing setup like in the
-  #        basehub/daskhub template.
-  #
-  "highmem-medium" : {
-    min : 10,
-    max : 100,
-    machine_type : "n2-highmem-16",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
+    machine_type : "n2-highmem-64",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
     }
   },
 }
 
 dask_nodes = {
-  "small" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-2",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
   "medium" : {
     min : 0,
-    max : 100,
-    machine_type : "n1-standard-4",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
-  "large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    }
-  },
-  "huge" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
-    labels: {},
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
+    max : 200,
+    machine_type : "n2-highmem-16",
+    labels : {},
+    gpu : {
+      enabled : false,
+      type : "",
+      count : 0
     }
   },
 }

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -25,6 +25,13 @@ variable "project_id" {
 
 variable "k8s_version_prefixes" {
   type        = set(string)
+  # Available minor versions are picked from the GKE regular release channel. To
+  # see the available versions see
+  # https://cloud.google.com/kubernetes-engine/docs/release-notes-regular
+  #
+  # This list should list all minor versions available in the regular release
+  # channel, so we may want to remove or add minor versions here over time.
+  #
   default     = [
     "1.22.",
     "1.23.",
@@ -35,6 +42,9 @@ variable "k8s_version_prefixes" {
   description = <<-EOT
   A list of k8s version prefixes that can be evaluated to their latest version by
   the output defined in cluster.tf called regular_channel_latest_k8s_versions.
+
+  For details about release channels (rapid, regular, stable), see:
+  https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#channels
   EOT
 }
 


### PR DESCRIPTION
### Prepared for node sharing

The awi-ciroh cluster had a workshop where we ran into limitations from using 1:1 user:node. Due to that we did a behind the scenes quick migration to a node sharing setup.

This node sharing setup is now complemented, allowing us to reconfigure the awi-ciroh hubs without further terraform changes based on their wishes.

### K8s cluster upgrade

I made an opportunistic upgrade of the k8s cluster while adjusting node pools. I also gained some experience which helps create GKE k8s cluster upgrade docs. Those notes are captured and linked from #2157.

### Future work

They now have a UI with small / medium / large / huge, but they will just start on the n2-highmem-16 machine no matter what with a pod requesting memory based on the legacy 1:1 user:node profile list options.

I'll reach out in order to align their setup to a typical node sharing setup, which from this point onwards is just a hub config change.