### PR TITLE
Revert "nasa-cryo bump image"

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -139,7 +139,7 @@ basehub:
                   slug: "python"
                   kubespawner_override:
                     # Image repo: https://github.com/CryoInTheCloud/hub-image
-                    image: "quay.io/cryointhecloud/cryo-hub-image:aae52b78d7ee"
+                    image: "quay.io/cryointhecloud/cryo-hub-image:98e6196ee90a"
                 rocker:
                   display_name: R
                   slug: "rocker"


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2556

Failed again, with:

```
Defaulted container "notebook" out of: notebook, volume-mount-ownership-fix (init)
/srv/conda/envs/notebook/lib/python3.10/subprocess.py:961: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
ln: failed to create symbolic link '/home/jovyan/Desktop/qgis.desktop': File exists
```