### PR TITLE
utoronto: Fix R hubs to use correct working_dir for user servers

### DIFF
--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -4,6 +4,12 @@ jupyterhub:
       templateVars:
         # This sets the default selected interface option
         default_url: /rstudio
+  hub:
+    config:
+      KubeSpawner:
+        # Ensures container working dir is homedir
+        # https://github.com/2i2c-org/infrastructure/issues/2559
+        working_dir: /home/rstudio
   singleuser:
     storage:
       # From https://jupyterhub-image.guide/rocker.html#step-7-setup-zero-to-jupyterhub-configuration-for-home-directory


### PR DESCRIPTION
Fixes: #2559

Tested via https://r-staging.datatools.utoronto.ca/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fntaback%2Flearnr_test2&urlpath=rstudio%2F&branch=main