### PR TITLE
cd tooling: update kubectl, helm, and remove no longer needed workaround

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -118,28 +118,11 @@ runs:
     # the github-runner image. See
     # https://github.com/actions/runner-images/issues/5925#issuecomment-1216417721.
     #
-    # Snippet based on
-    # https://github.com/actions/runner-images/blob/9753e7301e19e29b89b0622b811bbb9b3891d02e/images/linux/scripts/installers/google-cloud-sdk.sh#L9-L13.
-    #
     - name: Install gke-gcloud-auth-plugin
       if: inputs.provider == 'gcp'
       run: |
-        REPO_URL="https://packages.cloud.google.com/apt"
-        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] $REPO_URL cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
-
-        # FIXME: A cached version of a gpg key is used from the way back
-        #        machine, dated 2023-02-23.
-        #
-        #        https://web.archive.org/web/20230223152417/https://packages.cloud.google.com/apt/doc/apt-key.gpg
-        #
-        #        The live gpg key at https://packages.cloud.google.com/apt/doc/apt-key.gpg
-        #        is inaccessible with a HTTP 500 response.
-        #
-        #        When the live gpg key is available agian, we can revert to doing this:
-        #
-        #            sudo wget -q https://packages.cloud.google.com/apt/doc/apt-key.gpg -O /usr/share/keyrings/cloud.google.gpg
-        #
-        echo "xsBNBGKItdQBCADWmKTNZEYWgXy73FvKFY5fRro4tGNa4Be4TZW3wZpct9Cj8EjykU7S9EPoJ3EdKpxFltHRu7QbDi6LWSNA4XxwnudQrYGxnxx6Ru1KBHFxHhLfWsvFcGMwit/znpxtIt9UzqCm2YTEW5NUnzQ4rXYqVQK2FLG4weYJ5bKwkY+ZsnRJpzxdHGJ0pBiqwkMT8bfQdJymUBown+SeuQ2HEqfjVMsIRe0dweD2PHWeWo9fTXsz1Q5abiGckyOVyoN9//DgSvLUocUcZsrWvYPaN+o8lXTO3GYFGNVsx069rxarkeCjOpiQOWrQmywXISQudcusSgmmgfsRZYW7FDBy5MQrABEBAAHNUVJhcHR1cmUgQXV0b21hdGljIFNpZ25pbmcgS2V5IChjbG91ZC1yYXB0dXJlLXNpZ25pbmcta2V5LTIwMjItMDMtMDctMDhfMDFfMDEucHViKcLAYgQTAQgAFgUCYoi11AkQtT3IDRPt7wUCGwMCGQEAAMGoCAB8QBNIIN3Q2D3aahrfkb6axd55zOwR0tnriuJRoPHoNuorOpCv9aWMMvQACNWkxsvJxEF8OUbzhSYjAR534RDigjTetjK2i2wKLz/kJjZbuF4ZXMynCm40eVm1XZqU63U9XR2RxmXppyNpMqQO9LrzGEnNJuh23icaZY6no12axymxcle/+SCmda8oDAfa0iyA2iyg/eU05buZv54MC6RB13QtS+8vOrKDGr7RYp/VYvQzYWm+ck6DvlaVX6VB51BkLl23SQknyZIJBVPm8ttU65EyrrgG1jLLHFXDUqJ/RpNKq+PCzWiyt4uy3AfXK89RczLu3uxiD0CQI0T31u/IzsBNBGKItdQBCADIMMJdRcg0Phv7+CrZz3xRE8Fbz8AN+YCLigQeH0B9lijxkjAFr+thB0IrOu7ruwNY+mvdP6dAewUur+pJaIjEe+4s8JBEFb4BxJfBBPuEbGSxbi4OPEJuwT53TMJMEs7+gIxCCmwioTggTBp6JzDsT/cdBeyWCusCQwDWpqoYCoUWJLrUQ6dOlI7s6p+iIUNIamtyBCwb4izs27HdEpX8gvO9rEdtcb7399HyO3oD4gHgcuFiuZTpvWHdn9WYwPGM6npJNG7crtLnctTR0cP9KutSPNzpySeAniHx8L9ebdD9tNPCWC+OtOcGRrcBeEznkYh1C4kzdP1ORm5upnknABEBAAHCwF8EGAEIABMFAmKItdQJELU9yA0T7e8FAhsMAABJmAgAhRPk/dFj71bU/UTXrkEkZZzE9JzUgan/ttyRrV6QbFZABByf4pYjBj+yLKw3280//JWurKox2uzEq1hdXPedRHICRuh1Fjd00otaQ+wGF3kY74zlWivB6Wp6tnL9STQ1oVYBUv7HhSHoJ5shELyedxxHxurUgFAD+pbFXIiK8cnAHfXTJMcrmPpC+YWEC/DeqIyEcNPkzRhtRSuERXcq1n+KJvMUAKMD/tezwvujzBaaSWapmdnGmtRjjL7IxUeGamVWOwLQbUr+34MwzdeJdcL8fav5LA8Uk0ulyeXdwiAK8FKQsixI+xZvz7HUs8ln4pZwGw/TpvO9cMkHogtgzQ==" | base64 -d | sudo tee -a /usr/share/keyrings/cloud.google.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
         sudo apt-get update -y
         sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -80,7 +80,7 @@ runs:
         #
         # - helm versions: https://github.com/helm/helm/releases
         #
-        version: v3.11.1
+        version: v3.12.0
 
     # Manually update a pinning of kubectl to a minor version based on:
     #

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -84,10 +84,10 @@ runs:
 
     # Manually update a pinning of kubectl to a minor version based on:
     #
-    # - the current range of k8s version in our k8s clusters, as of 2023-03-07,
-    #   this is k8s 1.22 - 1.24
-    # - the expected change in this range, as of 2023-03-07, is to expand to
-    #   1.22 - 1.25
+    # - the current range of k8s version in our k8s clusters, as of 2023-05-24,
+    #   this is k8s 1.22 - 1.25
+    # - the expected change in this range, as of 2023-05-24, is to expand to
+    #   1.22 - 1.26
     # - the kubectl <-> k8s api-server skew policy of +/- one minor version
     # - the policy of attempting to update our kubectl version here to be +/-
     #   one minor versions of future k8s clusters additions or upgrades, so that
@@ -105,7 +105,7 @@ runs:
     #
     - uses: azure/setup-kubectl@v3
       with:
-        version: "v1.24.10"
+        version: "v1.25.10"
 
     # This action use the github official cache mechanism internally
     - name: Install sops


### PR DESCRIPTION
- cd tooling: update helm from 3.11.1 to 3.12.0
- cd tooling: update kubectl 1.24.10 to 1.25.10
- cd tooling: remove temporary fix of gcloud plugin setup
