### PR TITLE
utoronto: add Erik as admin to make testing on staging easier

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -16,6 +16,7 @@ jupyterhub:
           - 09056164-42f5-4113-9fd7-dd852e63ff1d
           - adb7ebad-9fb8-481a-bc2c-6c0a8b6de670
           - d6601bd7-eae0-4b84-a918-5356992c976e # David Liu
+          - 2a2d9b48-e6eb-46e1-8434-8aaeb7a98dd8 # Erik Sundell (2i2c)
 
       AzureAdOAuthenticator:
         # Everyone else uses email


### PR DESCRIPTION
If this is acceptable, then it will make it a bit easier to test images on staging I think. I would then visit https://staging.utoronto.2i2c.cloud/services/configurator/, update the image, spawn and test use of new image, reset the image configured in the configurator and create a PR to deploy to prod by bumping to use the new image tag via chart config.