### PR TITLE
utoronto, default hub: update image to include graphviz

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
       JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "c68f2eb785f9"
+      tag: "e533070e58f2"
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
Resolve the support ticket request https://2i2c.freshdesk.com/a/tickets/697 by Scott, graphviz the python package and the non-python dependencies on graphviz software is installed via conda-forge (python-graphviz) and assumed to function by this test:

```python
import graphviz
dot = graphviz.Digraph('round-table', comment='The Round Table')  
dot.node('A', 'King Arthur')
dot
```

![image](https://github.com/2i2c-org/infrastructure/assets/3837114/e7173610-b823-4c4b-a1e7-856c23742fc6)
