### PR TITLE
all hubs: remove unused config jupyterhub.proxy.hosts

### DIFF
--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -20,9 +20,6 @@ basehub:
       tls:
         - hosts: [dask-staging.aws.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [dask-staging.aws.2i2c.cloud]
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -20,9 +20,6 @@ basehub:
       tls:
         - hosts: [researchdelight.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [researchdelight.2i2c.cloud]
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -19,9 +19,6 @@ jupyterhub:
     tls:
       - hosts: [staging.aws.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.aws.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -14,9 +14,6 @@ jupyterhub:
     tls:
       - hosts: [ds.lis.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [ds.lis.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -14,9 +14,6 @@ jupyterhub:
     tls:
       - hosts: [staging.uk.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.uk.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - aup.pilot.2i2c.cloud
   ingress:
     hosts:
       - aup.pilot.2i2c.cloud

--- a/config/clusters/2i2c/catalyst-cooperative.values.yaml
+++ b/config/clusters/2i2c/catalyst-cooperative.values.yaml
@@ -4,10 +4,6 @@ basehub:
       iam.gke.io/gcp-service-account: pilot-hubs-catalyst-coop@two-eye-two-see.iam.gserviceaccount.com
 
   jupyterhub:
-    proxy:
-      https:
-        hosts:
-          - catalyst-cooperative.pilot.2i2c.cloud
     ingress:
       hosts:
         - catalyst-cooperative.pilot.2i2c.cloud

--- a/config/clusters/2i2c/cosmicds.values.yaml
+++ b/config/clusters/2i2c/cosmicds.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - cosmicds.2i2c.cloud
   ingress:
     hosts:
       - cosmicds.2i2c.cloud

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -3,10 +3,6 @@ basehub:
     annotations:
       iam.gke.io/gcp-service-account: pilot-hubs-dask-staging@two-eye-two-see.iam.gserviceaccount.com
   jupyterhub:
-    proxy:
-      https:
-        hosts:
-          - dask-staging.2i2c.cloud
     ingress:
       hosts:
         - dask-staging.2i2c.cloud

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - demo.2i2c.cloud
   ingress:
     hosts:
       - demo.2i2c.cloud

--- a/config/clusters/2i2c/earthlab.values.yaml
+++ b/config/clusters/2i2c/earthlab.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - earthlab.pilot.2i2c.cloud
   ingress:
     hosts:
       - earthlab.pilot.2i2c.cloud

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -3,10 +3,6 @@ basehub:
     annotations:
       iam.gke.io/gcp-service-account: pilot-hubs-ohw@two-eye-two-see.iam.gserviceaccount.com
   jupyterhub:
-    proxy:
-      https:
-        hosts:
-          - oceanhackweek.2i2c.cloud
     ingress:
       hosts:
         - oceanhackweek.2i2c.cloud

--- a/config/clusters/2i2c/peddie.values.yaml
+++ b/config/clusters/2i2c/peddie.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - peddie.pilot.2i2c.cloud
   ingress:
     hosts:
       - peddie.pilot.2i2c.cloud

--- a/config/clusters/2i2c/pfw.values.yaml
+++ b/config/clusters/2i2c/pfw.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - pfw.pilot.2i2c.cloud
   ingress:
     hosts:
       - pfw.pilot.2i2c.cloud

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -15,10 +15,6 @@ staticWebsite:
     enabled: false
 
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - staging.2i2c.cloud
   ingress:
     hosts:
       - staging.2i2c.cloud

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - temple.2i2c.cloud
   ingress:
     hosts:
       - temple.2i2c.cloud

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  proxy:
-    https:
-      hosts:
-        - ucmerced.2i2c.cloud
   ingress:
     hosts:
       - ucmerced.2i2c.cloud

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -10,9 +10,6 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    proxy:
-      https:
-        enabled: false
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [ciroh.awi.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [ciroh.awi.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://awi-ciroh-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.ciroh.awi.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.ciroh.awi.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://awi-ciroh-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/callysto/prod.values.yaml
+++ b/config/clusters/callysto/prod.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [2i2c.callysto.ca]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [2i2c.callysto.ca]
   hub:
     config:
       CILogonOAuthenticator:

--- a/config/clusters/callysto/staging.values.yaml
+++ b/config/clusters/callysto/staging.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [staging.callysto.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.callysto.2i2c.cloud]
   hub:
     config:
       CILogonOAuthenticator:

--- a/config/clusters/carbonplan/prod.values.yaml
+++ b/config/clusters/carbonplan/prod.values.yaml
@@ -5,9 +5,6 @@ basehub:
       tls:
         - hosts: [carbonplan.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [carbonplan.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/carbonplan/staging.values.yaml
+++ b/config/clusters/carbonplan/staging.values.yaml
@@ -5,9 +5,6 @@ basehub:
       tls:
         - hosts: [staging.carbonplan.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.carbonplan.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/cloudbank/avc.values.yaml
+++ b/config/clusters/cloudbank/avc.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [avc.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [avc.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [ccsf.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [ccsf.cloudbank.2i2c.cloud]
   singleuser:
     memory:
       # Increased to help deal with possible kernel restarts

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [csm.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [csm.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/csu.values.yaml
+++ b/config/clusters/cloudbank/csu.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [csu.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [csu.cloudbank.2i2c.cloud]
   prePuller:
     continuous:
       enabled: true

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [demo.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [demo.cloudbank.2i2c.cloud]
   prePuller:
     continuous:
       enabled: true

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [elcamino.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [elcamino.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [fresno.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [fresno.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [glendale.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [glendale.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [howard.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [howard.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [lacc.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [lacc.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [laney.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [laney.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/lassen.values.yaml
+++ b/config/clusters/cloudbank/lassen.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [lassen.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [lassen.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [datahub.mills.edu]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [datahub.mills.edu]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [miracosta.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [miracosta.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [palomar.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [palomar.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [pasadena.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [pasadena.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [sbcc.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [sbcc.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [sjcc.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [sjcc.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [skyline.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [skyline.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [staging.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [tuskegee.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [tuskegee.cloudbank.2i2c.cloud]
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/gridsst/prod.values.yaml
+++ b/config/clusters/gridsst/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [gridsst.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [gridsst.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/gridsst/staging.values.yaml
+++ b/config/clusters/gridsst/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.gridsst.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.gridsst.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -19,8 +19,6 @@ basehub:
         - hosts: [leap.2i2c.cloud]
           secretName: https-auto-tls
     proxy:
-      https:
-        hosts: [leap.2i2c.cloud]
       chp:
         resources:
           requests:

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.leap.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.leap.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://leap-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -10,9 +10,6 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    proxy:
-      https:
-        enabled: false
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/linked-earth/prod.values.yaml
+++ b/config/clusters/linked-earth/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [linkedearth.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [linkedearth.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://linked-earth-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/linked-earth/staging.values.yaml
+++ b/config/clusters/linked-earth/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.linkedearth.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.linkedearth.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://linked-earth-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -10,9 +10,6 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    proxy:
-      https:
-        enabled: false
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/m2lines/prod.values.yaml
+++ b/config/clusters/m2lines/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [m2lines.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [m2lines.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://m2lines-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/m2lines/staging.values.yaml
+++ b/config/clusters/m2lines/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.m2lines.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.m2lines.2i2c.cloud]
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://m2lines-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/meom-ige/prod.values.yaml
+++ b/config/clusters/meom-ige/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [meom-ige.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [meom-ige.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/meom-ige/staging.values.yaml
+++ b/config/clusters/meom-ige/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.meom-ige.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.meom-ige.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [hub.cryointhecloud.com]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [hub.cryointhecloud.com]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-cryo/staging.values.yaml
+++ b/config/clusters/nasa-cryo/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.hub.cryointhecloud.com]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.hub.cryointhecloud.com]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [nasa-veda.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [nasa-veda.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.nasa-veda.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.nasa-veda.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -5,9 +5,6 @@ basehub:
       tls:
         - hosts: [openscapes.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [openscapes.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -5,9 +5,6 @@ basehub:
       tls:
         - hosts: [staging.openscapes.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.openscapes.2i2c.cloud]
     hub:
       config:
         JupyterHub:

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -10,9 +10,6 @@ basehub:
       # Name of Google Filestore share
       baseShareName: /homes/
   jupyterhub:
-    proxy:
-      https:
-        enabled: false
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/pangeo-hubs/prod.values.yaml
+++ b/config/clusters/pangeo-hubs/prod.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [us-central1-b.gcp.pangeo.io]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [us-central1-b.gcp.pangeo.io]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/pangeo-hubs/staging.values.yaml
+++ b/config/clusters/pangeo-hubs/staging.values.yaml
@@ -8,9 +8,6 @@ basehub:
       tls:
         - hosts: [staging.us-central1-b.gcp.pangeo.io]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.us-central1-b.gcp.pangeo.io]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/qcl/prod.values.yaml
+++ b/config/clusters/qcl/prod.values.yaml
@@ -7,9 +7,6 @@ jupyterhub:
     tls:
       - hosts: [jupyter.quantifiedcarbon.com]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [jupyter.quantifiedcarbon.com]
   hub:
     config:
       GitHubOAuthenticator:

--- a/config/clusters/qcl/staging.values.yaml
+++ b/config/clusters/qcl/staging.values.yaml
@@ -7,9 +7,6 @@ jupyterhub:
     tls:
       - hosts: [staging.quantifiedcarbon.com]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.quantifiedcarbon.com]
   hub:
     config:
       GitHubOAuthenticator:

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -5,6 +5,3 @@ basehub:
       tls:
         - hosts: [smithsonian.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [smithsonian.2i2c.cloud]

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -5,6 +5,3 @@ basehub:
       tls:
         - hosts: [staging.smithsonian.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.smithsonian.2i2c.cloud]

--- a/config/clusters/ubc-eoas/prod.values.yaml
+++ b/config/clusters/ubc-eoas/prod.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [ubc-eoas.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [ubc-eoas.2i2c.cloud]
   hub:
     config:
       CILogonOAuthenticator:

--- a/config/clusters/ubc-eoas/staging.values.yaml
+++ b/config/clusters/ubc-eoas/staging.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [staging.ubc-eoas.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.ubc-eoas.2i2c.cloud]
   hub:
     config:
       CILogonOAuthenticator:

--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [jupyter.utoronto.ca]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [jupyter.utoronto.ca]
   scheduling:
     userPlaceholder:
       # Keep at least one spare node around

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [staging.utoronto.2i2c.cloud]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [staging.utoronto.2i2c.cloud]
   custom:
     homepage:
       gitRepoBranch: "utoronto-staging"

--- a/config/clusters/utoronto/r-prod.values.yaml
+++ b/config/clusters/utoronto/r-prod.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [r.datatools.utoronto.ca]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [r.datatools.utoronto.ca]
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -4,9 +4,6 @@ jupyterhub:
     tls:
       - hosts: [r-staging.datatools.utoronto.ca]
         secretName: https-auto-tls
-  proxy:
-    https:
-      hosts: [r-staging.datatools.utoronto.ca]
   hub:
     config:
       AzureAdOAuthenticator:

--- a/config/clusters/victor/prod.values.yaml
+++ b/config/clusters/victor/prod.values.yaml
@@ -9,9 +9,6 @@ basehub:
       tls:
         - hosts: [victor.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [victor.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/victor/staging.values.yaml
+++ b/config/clusters/victor/staging.values.yaml
@@ -9,9 +9,6 @@ basehub:
       tls:
         - hosts: [staging.victor.2i2c.cloud]
           secretName: https-auto-tls
-    proxy:
-      https:
-        hosts: [staging.victor.2i2c.cloud]
     hub:
       config:
         GitHubOAuthenticator:

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -252,20 +252,8 @@ properties:
     additionalProperties: true
     required:
       - custom
-      - proxy
       - ingress
     properties:
-      proxy:
-        type: object
-        additionalProperties: true
-        required:
-          - https
-        properties:
-          hosts:
-            type: array
-            minItems: 1
-            items:
-              type: string
       ingress:
         type: object
         additionalProperties: true


### PR DESCRIPTION
I think the `jupyterhub.proxy.hosts` config is only relevant to the jupyterhub chart if its involved in handling TLS/HTTPS matters, but we let this be done before the jupyterhub chart gets involved (by nginx-ingress controller and cert-manager acting based on provided Ingress resource).

As part of this PR, I also removed two or three hubs configured with `jupyterhub.proxy.https=False` explicitly, which is the default in the jupyterhub chart anyhow but has been needed historically.

### Related

- Observed by @yuvipanda in https://github.com/2i2c-org/infrastructure/pull/2584#discussion_r1208997366