### PR TITLE
Add workflow to automatically assign authors to PRs

### DIFF
--- a/.github/workflows/auto-author-assign-pull-request.yaml
+++ b/.github/workflows/auto-author-assign-pull-request.yaml
@@ -1,0 +1,17 @@
+# Automatically assign the authors to a PR
+name: Auto Author Assign Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2


### PR DESCRIPTION
See https://github.com/2i2c-org/team-compass/issues/744

The plan is to turn this into a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows) that will make the workflow automatically run on a list of selected repositories across the organization.

Normally, I would like to keep this workflow in https://github.com/2i2c-org/.github to have everything that is "standardized" in one place. But since the required workflows is a relatively new GitHub feature and we never used it, I want to make sure it works, while still enjoy the perks of having auto assignation of authors to PR in this repo, where most of the 2i2c PRs are opened against.