### PR TITLE
2i2c-uk, lis: stop bumping image tags, configurator is used

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -33,11 +33,6 @@ jobs:
             # Note: if position of images in profileList changes, update the index in these expressions
             images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
 
-          # Bump user image for the lis hub
-          - name: "LIS user image bump"
-            config_path: "config/clusters/2i2c-uk/lis.values.yaml"
-            images_info: '[{"values_path": ".jupyterhub.singleuser.image"}]'
-
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,
       # so we generate a token from a GitHub App that would allow this.


### PR DESCRIPTION
- Closes #2424

> I think this is currently managed by the configurator, so not sure if this should be autobumped

I've observed the same thing in https://ds.lis.2i2c.cloud/services/configurator/ and concluded that its a hub running in a shared cluster 2i2c-uk, so having prePulling wouldn't scale as whenever there is a scaleup a user from hub A may end up waiting for a node pulling an image from hub B C and D. This can happen because the k8s node's software kubelet is pulling image to start pods in sequence, so there is no guarantee that the pod that triggered scaleup gets its image pulled before the prePuller pod that are functioning as dummy user pods.