### PR TITLE
Add an extra step to make the job run even if first step is skipped

### DIFF
--- a/.github/workflows/auto-author-assign-pull-request.yaml
+++ b/.github/workflows/auto-author-assign-pull-request.yaml
@@ -14,4 +14,14 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.2
+      - name: Automatically assign PR author
+        id: assignation
+        uses: toshimaru/auto-author-assign@v1.6.2
+      # This workflow is triggered by PR opening/reopening.
+      # But because we use this workflow as a required workflow for other repositories
+      # in the 2i2c organization, it is **expected** to run successfully
+      # for each PR commit in those repositories.
+
+      # So we add an extra echo step that will make the job run
+      # even if the assignation action step skips.
+      - run: echo Assignment operation status was ${{ steps.assignation.conclusion }}


### PR DESCRIPTION
Should resolve the issue in https://github.com/2i2c-org/team-compass/issues/744#issuecomment-1568509907:

The action we use in the workflow, https://github.com/marketplace/actions/auto-author-assign skips running if someone is already assigned, or a bot is the PR author (which makes sense).
But the [required workflow feature](https://docs.github.com/en/actions/using-workflows/required-workflows) expects the workflow to successfully run every time the PR is updated, otherwise PR merged is disabled. Which will won't because of the first item that will make it to only run once and then skip