### PR TITLE
[Attept 2] Update workflow to trigger on commit and remove redundant step

### DIFF
--- a/.github/workflows/auto-author-assign-pull-request.yaml
+++ b/.github/workflows/auto-author-assign-pull-request.yaml
@@ -6,6 +6,12 @@ on:
     types:
       - opened
       - reopened
+      # Normally, it's enough for this workflow to be triggered only once, on PR opening/reopening.
+      # But because we use this workflow as a required workflow for other repositories
+      # in the 2i2c organization, it is **expected** to run successfully
+      # for each PR commit in those repositories.
+      # So we trigger it for each commit
+      - synchronize
 
 permissions:
   pull-requests: write
@@ -17,11 +23,3 @@ jobs:
       - name: Automatically assign PR author
         id: assignation
         uses: toshimaru/auto-author-assign@v1.6.2
-      # This workflow is triggered by PR opening/reopening.
-      # But because we use this workflow as a required workflow for other repositories
-      # in the 2i2c organization, it is **expected** to run successfully
-      # for each PR commit in those repositories.
-
-      # So we add an extra echo step that will make the job run
-      # even if the assignation action step skips.
-      - run: echo Assignment operation status was ${{ steps.assignation.conclusion }}


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/pull/2590 didn't solve the issue. I now believe I've misunderstood it and the issue is that the workflow doesn't trigger for commits if not explicitly listed as a trigger and not the job is skipped (it might be both though)

Previously, I thought that the triggers listed in this workflow are ignored when enabling the required workflows and the commit one is auto-added.

Note that I plan to self-merge this to see if it works, before abandoning this required workflows idea.