### PR TITLE
Add basic CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This team will be the default owner for everything in
+# the repo. Unless a later match takes precedence,
+# @2i2c-org/engineering will be requested for
+# review when someone opens a pull request.
+# Documentation about how to edit this file is available at
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+*       @2i2c-org/engineering


### PR DESCRIPTION
This adds a [`CODEOWNERS file`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) that will make the engineering team be requested to review PRs inside the `infrastructure` repository, by default.

I thought this would be useful because this is usually the case for most PRs opened here.

A few extra notes:
- we should be able to manually remove the assignment if we want to ping a specific person
- because we don't have `Require review from Code Owners` set as a branch protection rule, then is **not** necessary for someone in the team to approve the PR to make it merge ready, anyone can do it, just like before.
- I tracked down some discussions about codeowners on slack in the context of using it for allowing outside collaborators self-merge PRs that touch specific files. Unfortunately codeowners feature cannot be used to do this, or just not yet?