### PR TITLE
Add climatematch academy hub

### DIFF
--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -1,0 +1,58 @@
+jupyterhub:
+  singleuser:
+    memory:
+      limit: 2G
+      guarantee: 1G
+    nodeSelector:
+      2i2c.org/community: climatematch
+    extraTolerations:
+      - key: "2i2c.org/community"
+        operator: "Equal"
+        value: "climatematch"
+        effect: "NoSchedule"
+    defaultUrl: /lab
+    image:
+      name: pangeo/pangeo-notebook
+      tag: 2023.05.18
+  ingress:
+    hosts:
+      - climatematch.2i2c.cloud
+    tls:
+      - secretName: https-auto-tls
+        hosts:
+          - climatematch.2i2c.cloud
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    homepage:
+      templateVars:
+        org:
+          name: ClimateMatch Academy
+          # logo_url: https://avatars.githubusercontent.com/u/33128979
+          logo_url: https://intercoonecta.github.io/_static/OHWe.png
+          url: https://academy.climatematch.io/
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: ClimateMatch Academy
+          url: https://academy.climatematch.io/
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        oauth_callback_url: https://climatematch.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - 2i2c-org
+          - ClimateMatchAcademy:2023students
+        scope:
+          - read:org
+      Authenticator:
+        admin_users:
+          - WesleyTheGeolien
+          - abodner

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -29,8 +29,8 @@ jupyterhub:
       templateVars:
         org:
           name: ClimateMatch Academy
-          # logo_url: https://avatars.githubusercontent.com/u/33128979
-          logo_url: https://intercoonecta.github.io/_static/OHWe.png
+          # Logo picked up from https://academy.climatematch.io/
+          logo_url: https://lh5.googleusercontent.com/jiClOwOU8X41s0wnAtRniiTqMXgylAyeXlKGQbzmeeJF8rpU1_CGkaHa6YA6chNcFrKfI0a4m2zNl_Hfy4Dk2JSyBKtrept5Cuwm1m65mkIMRZtUQMQxa7IIEfhSL6fDDg=w1280
           url: https://academy.climatematch.io/
         designed_by:
           name: 2i2c

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -131,3 +131,10 @@ hubs:
     helm_chart_values_files:
       - cosmicds.values.yaml
       - enc-cosmicds.secret.values.yaml
+  - name: climatematch
+    display_name: "ClimateMatch"
+    domain: climatematch.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - climatematch.values.yaml
+      - enc-climatematch.secret.values.yaml

--- a/config/clusters/2i2c/enc-climatematch.secret.values.yaml
+++ b/config/clusters/2i2c/enc-climatematch.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:U0VRT8n+lgPkQUOo7CH7CV04Dhc=,iv:9Tcc+Vy8/Rk2cSCe/VsF045HtARj2PACM3g4t0RoVU4=,tag:8AOmG1YJN8/hY3Jw8yoCrg==,type:str]
+                client_secret: ENC[AES256_GCM,data:2rUcLmhlUXmLlFPFnJQchfDhHu4dEubFVo0x4Iu2f/MQjfelcb/fFA==,iv:sE77q/mQSE4cFGaNSycLpKPrKS6t0zY67X1JvmgnIDQ=,tag:9yBey0MWIOzYNsTiyIS7qQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-06-01T06:58:34Z"
+          enc: CiUA4OM7eKskQ878uYZJxAsE9kUKQNB7W5eba6wvDgO6ZTSZXuWJEkkAyiwFHFyv7h+CbRDLbV4c6A20Jjt6j9IJSHEX5kzPEeAc5dopxCCF4J3YNRvS7VIGwfxyunsWGoAexahri4V38kTWgUvBZA1W
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-06-01T06:58:35Z"
+    mac: ENC[AES256_GCM,data:HjkgEFvMoHHrjsr4GkkLcBi8Zbu83XnL4ppmTbup7rVQVIhRC2VLxeLpugSjDJxqPVPN7VGUf0PQuw92MVVMakHhHfLCeLFaXpCISsLDlU96qe62bL0KoVajG0+OkDhEETnA2JQ5RkxFzqzVO8cRf7tZGaDUe0xBa926MREOkeU=,iv:UtTFsjWO2ACZTYK/yTWcqrFLLq7ljAzKiQ2FByu/+ig=,tag:1O3xXJrnJwhqqv3dYOh4Tg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/docs/howto/features/dedicated-nodepool.md
+++ b/docs/howto/features/dedicated-nodepool.md
@@ -1,0 +1,72 @@
+# Setup a dedicated nodepool for a hub on a shared cluster
+
+Some hubs on shared clusters require dedicated nodepools, for a few reasons:
+
+1. Helpful to pre-warm during events, as we can scale a single nodepool up/down
+   without worrying about effects from other hubs on the same cluster.
+2. (In the future) Helpful with cost isolation, as we can track how much a
+   nodepool is costing us.
+
+## GCP
+
+1. Setup a new nodepool in terraform, via the `<cluster-name>.tfvars` for the
+   cluster. Add the new nodepool to `notebook_nodes`:
+
+   ```terraform
+   notebook_nodes = {
+     "<community-name>": {
+         min: 0,
+         max: 100,
+         machine_type: "<machine-type>",
+         labels: {
+            "2i2c.org/community": "<community-name>"
+         },
+         taints: [{
+            key: "2i2c.org/community",
+            value: "<community-name>",
+            effect: "NO_SCHEDULE"
+         }],
+         gpu: {
+            enabled: false,
+            type: "",
+            count: 0
+         },
+         resource_labels: {
+            "community": "<community-name>"
+         }
+      }
+   }
+   ```
+
+   This sets up a new node with:
+
+   1. Kubernetes labels so we can tell the scheduler that user pods of this hub
+      should come to this nodepool.
+   2. Kubernetes taints so user pods of *other* hubs will not be scheduled on this
+      nodepool.
+   3. GCP Resource Labels (unrelated to Kubernetes Labels!) that help us track costs.
+      The key name here is different from (1) and (2) because it must start with a
+      letter, and can not contain `/`.
+
+   Once done, run `terraform apply` appropriately to bring this nodepool up.
+
+2. Configure the hub's helm values to use this nodepool, and this nodepool only.
+
+   ```yaml
+   jupyterhub:
+      singleuser:
+         nodeSelector:
+            2i2c.org/community: <community-name>
+         extraTolerations:
+            - key: "2i2c.org/community"
+              operator: "Equal"
+              value: "<community-name>"
+              effect: "NoSchedule"
+   ```
+
+   ```{note}
+   If this is a `daskhub`, nest these under a `basehub` key.
+   ```
+
+   This tells JupyterHub to place user pods from this hub on the nodepool we had
+   just created!

--- a/docs/howto/features/index.md
+++ b/docs/howto/features/index.md
@@ -39,3 +39,9 @@ image.md
 :caption: Hub Types
 ephemeral.md
 ```
+
+```{toctree}
+:maxdepth: 2
+:caption: Other
+dedicated-nodepool.md
+```

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -383,9 +383,9 @@ resource "google_container_node_pool" "dask_worker" {
     }, each.value.labels)
 
     taint = concat([{
-        key    = "k8s.dask.org_dedicated"
-        value  = "worker"
-        effect = "NO_SCHEDULE"
+      key    = "k8s.dask.org_dedicated"
+      value  = "worker"
+      effect = "NO_SCHEDULE"
       }],
       each.value.taints
     )

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -312,7 +312,8 @@ resource "google_container_node_pool" "notebook" {
         effect = "NO_SCHEDULE"
         key    = "nvidia.com/gpu"
         value  = "present"
-      }] : []
+      }] : [],
+      each.value.taints
     )
     machine_type = each.value.machine_type
 
@@ -324,6 +325,8 @@ resource "google_container_node_pool" "notebook" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]
+
+    resource_labels = each.value.resource_labels
 
     // Set these values explicitly so they don't "change outside terraform"
     tags = []
@@ -379,11 +382,14 @@ resource "google_container_node_pool" "dask_worker" {
       "k8s.dask.org/node-purpose" = "worker",
     }, each.value.labels)
 
-    taint = [{
-      key    = "k8s.dask.org_dedicated"
-      value  = "worker"
-      effect = "NO_SCHEDULE"
-    }]
+    taint = concat([{
+        key    = "k8s.dask.org_dedicated"
+        value  = "worker"
+        effect = "NO_SCHEDULE"
+      }],
+      each.value.taints
+    )
+
     machine_type = each.value.machine_type
 
     # Our service account gets all OAuth scopes so it can access
@@ -394,6 +400,8 @@ resource "google_container_node_pool" "dask_worker" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]
+
+    resource_labels = each.value.resource_labels
 
     // Set these values explicitly so they don't "change outside terraform"
     tags = []

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -25,6 +25,27 @@ notebook_nodes = {
       type : "",
       count : 0
     }
+  },
+  "climatematch": {
+    min: 0,
+    max: 100,
+    machine_type: "n1-highmem-2",
+    labels: {
+      "2i2c.org/community": "climatematch"
+    },
+    taints: [{
+      key: "2i2c.org/community",
+      value: "climatematch",
+      effect: "NO_SCHEDULE"
+    }],
+    gpu: {
+      enabled: false,
+      type: "",
+      count: 0
+    },
+    resource_labels: {
+      "community": "climatematch"
+    }
   }
 }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -65,7 +65,19 @@ variable "k8s_versions" {
 }
 
 variable "notebook_nodes" {
-  type        = map(object({ min : number, max : number, machine_type : string, labels : map(string), gpu : object({ enabled : bool, type : string, count : number }) }))
+  type        = map(object({
+    min : number,
+    max : number,
+    machine_type : string,
+    labels : map(string),
+    taints : optional(list(object({
+      key : string,
+      value: string,
+      effect : string
+    })), [])
+    gpu : object({ enabled : bool, type : string, count : number }),
+    resource_labels : optional(map(string), {})
+  }))
   description = "Notebook node pools to create"
   default     = {}
 }
@@ -77,7 +89,13 @@ variable "dask_nodes" {
     preemptible : optional(bool, true),
     machine_type : string,
     labels : map(string),
-    gpu : object({ enabled : bool, type : string, count : number })
+    taints : optional(list(object({
+      key : string,
+      value: string,
+      effect : string
+    })), [])
+    gpu : object({ enabled : bool, type : string, count : number }),
+    resource_labels : optional(map(string), {})
   }))
   description = "Dask node pools to create. Defaults to notebook_nodes"
   default     = {}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -65,14 +65,14 @@ variable "k8s_versions" {
 }
 
 variable "notebook_nodes" {
-  type        = map(object({
+  type = map(object({
     min : number,
     max : number,
     machine_type : string,
     labels : map(string),
     taints : optional(list(object({
       key : string,
-      value: string,
+      value : string,
       effect : string
     })), [])
     gpu : object({ enabled : bool, type : string, count : number }),
@@ -91,7 +91,7 @@ variable "dask_nodes" {
     labels : map(string),
     taints : optional(list(object({
       key : string,
-      value: string,
+      value : string,
       effect : string
     })), [])
     gpu : object({ enabled : bool, type : string, count : number }),


### PR DESCRIPTION
- Add ability to setup resource labels for nodepools, to allow us to try tracking cloud costs on a per nodepool basis in the future (https://cloud.google.com/resource-manager/docs/creating-managing-labels). Changing these requires recreating the nodepool, so setting it now.
- Allow adding taints to nodepools, so we can properly dedicate a particular nodepool to a particular hub. Given this hub is expected to get a few thousand users, this is useful.
- Put climatematch on its own nodepool, but keep it small as the event is not expected to start until July 17.

Ref https://github.com/2i2c-org/infrastructure/issues/2524