### PR TITLE
Fixing dependabot comment workflow

### DIFF
--- a/.github/workflows/comment-dependabot-prs.yaml
+++ b/.github/workflows/comment-dependabot-prs.yaml
@@ -1,7 +1,7 @@
 # From https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added
 name: Comment dependabot PRs with specific label
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 jobs:

--- a/.github/workflows/comment-dependabot-prs.yaml
+++ b/.github/workflows/comment-dependabot-prs.yaml
@@ -14,6 +14,6 @@ jobs:
       - name: Add comment
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.number }}
           body: |
             After merging this PR, remember to take the additional manual steps described in https://infrastructure.2i2c.org/en/latest/topic/infrastructure/hub-image.html#updating-the-hub-image


### PR DESCRIPTION
### Context

Certain PRs opened by dependabot require extra actions to be taken when merging, such as updating our hub image. We have a GitHub Actions workflow that adds comments to these PRs explaining the next steps to take, but it was not working. This PR aims to fix that issue.

---

Problems encountered causing this workflow to fail and how they were resolved:

- The issue/pr number was not located under `github.context.issue.number`, but instead `github.context.number`
- `GITHUB_TOKEN` did not have enough permissions to work in PRs from forks, and the peter-evens/create-or-update-comment action does not support this. So had to update the trigger to `pull_request_target`
  - **Note:** _For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission **unless the permissions key is specified**_ (which it is, emphasis added) from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target (warning box)