### PR TITLE
Adding carbonplan-notebook

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -63,6 +63,7 @@ basehub:
                   display_name: Carbonplan Notebook
                   slug: "carbonplan"
                   kubespawner_override:
+                    # Source: https://github.com/carbonplan/envs/pull/20
                     image: quay.io/carbonplan/carbonplan-notebook:519ccf74350f
                 forest-offset-fires:
                   display_name: Forest Offset Fires

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -59,6 +59,11 @@ basehub:
                   slug: "main"
                   kubespawner_override:
                     image: carbonplan/main-single-user:latest
+                carbonplan-notebook:
+                  display_name: Carbonplan Notebook
+                  slug: "carbonplan"
+                  kubespawner_override:
+                    image: quay.io/carbonplan/carbonplan-notebook:519ccf74350f
                 forest-offset-fires:
                   display_name: Forest Offset Fires
                   slug: forest-offset-fires


### PR DESCRIPTION
Adding option for `carbonplan-notebook`, an image generated with repo2docker and hosted on quay.io.