### PR TITLE
Latest tag added for carbonplan-notebook

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -64,7 +64,7 @@ basehub:
                   slug: "carbonplan"
                   kubespawner_override:
                     # Source: https://github.com/carbonplan/envs/pull/20
-                    image: quay.io/carbonplan/carbonplan-notebook:519ccf74350f
+                    image: quay.io/carbonplan/carbonplan-notebook:latest
                 forest-offset-fires:
                   display_name: Forest Offset Fires
                   slug: forest-offset-fires


### PR DESCRIPTION
`carbonplan-notebook` image now points to latest for hub testing. 

https://github.com/2i2c-org/infrastructure/pull/2615#issuecomment-1577206799