### PR TITLE
utoronto, ingress-nginx: add azure required annotation to Service

### DIFF
--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -42,3 +42,17 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.utoronto.2i2c.cloud
+
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        # This annotation is a requirement for use in Azure provided
+        # LoadBalancer.
+        #
+        # ref: https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration
+        # ref: https://github.com/Azure/AKS/blob/master/CHANGELOG.md#release-2022-09-11
+        # ref: https://github.com/Azure/AKS/issues/2907#issuecomment-1109759262
+        # ref: https://github.com/kubernetes/ingress-nginx/issues/8501#issuecomment-1108428615
+        #
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz

--- a/docs/hub-deployment-guide/deploy-support/configure-support.md
+++ b/docs/hub-deployment-guide/deploy-support/configure-support.md
@@ -58,6 +58,27 @@ cluster-autoscaler:
 ```
 ````
 
+````{warning}
+If you are deploying the support chart on an Azure cluster, you **must** set an annotation for `ingress-nginx`'s k8s Service resource.
+Include the following in your `support.values.yaml` file:
+
+```yaml
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        # This annotation is a requirement for use in Azure provided
+        # LoadBalancer.
+        #
+        # ref: https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration
+        # ref: https://github.com/Azure/AKS/blob/master/CHANGELOG.md#release-2022-09-11
+        # ref: https://github.com/Azure/AKS/issues/2907#issuecomment-1109759262
+        # ref: https://github.com/kubernetes/ingress-nginx/issues/8501#issuecomment-1108428615
+        #
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+```
+````
+
 ## Edit your `cluster.yaml` file
 
 Add the following config as a top-level key to your `cluster.yaml` file.


### PR DESCRIPTION
When Yuvi upgraded utoronto's k8s cluster, the k8s Service for ingress-nginx that is of type LoadBalancer stopped receiving traffic.

It seems that this was caused by a failing health check by a AKS k8s service-controller, which then concluded the ingress-nginx-controller pods supposed to receive traffic via the Service should't get traffic. The issue was that that health check had changed and had to be configured now via an annotation.

This PR adds such annotation to the ingress-nginx Service resource, not just for utoronto which is an azure/AKS based cluster, but for all helm charts. The annotation is azure specific, so my assumption is that this should be fine in non-azure based clusters.

We could put this in utoronto config as well, but then we need to document and keep manage a specific step for Azure based cluster's helm chart config. I lean towards thinking setting it systematically is preferred but am open to setting it just for utoronto.

---

EDIT: Config put in utoronto specifically, but no docs are added on this being required for all AKS based clusters yet.
EDIT: docs added