### PR TITLE
Cleanup Azure terraform

### DIFF
--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -2,6 +2,10 @@ tenant_id          = "78aac226-2f03-4b4d-9037-b46d56c55210"
 subscription_id    = "ead3521a-d994-4a44-a68d-b16e35642d5b"
 resourcegroup_name = "2i2c-utoronto-cluster"
 
+
+kubernetes_version = "1.26.3"
+
+storage_size = 5120
 storage_protocol = "NFS"
 
 ssh_pub_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
@@ -10,11 +14,11 @@ global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 
 location = "canadacentral"
-
+core_node_vm_size = "Standard_E4s_v3"
 notebook_nodes = {
   "default" : {
     min : 1,
     max : 100,
-    vm_size : "Standard_E8s_v3"
+    vm_size : "Standard_E8s_v3",
   }
 }

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "homes" {
 resource "azurerm_storage_share" "homes" {
   name                 = "homes"
   storage_account_name = azurerm_storage_account.homes.name
-  quota                = 100
+  quota                = var.storage_size
   enabled_protocol     = var.storage_protocol
   lifecycle {
     # Additional safeguard against deleting the share

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -39,7 +39,6 @@ variable "location" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.20.7"
   description = <<-EOT
   Version of kubernetes the cluster should use.
 
@@ -48,9 +47,9 @@ variable "kubernetes_version" {
   EOT
 }
 
+
 variable "core_node_vm_size" {
   type        = string
-  default     = "Standard_E4s_v3"
   description = <<-EOT
   VM Size to use for core nodes
 
@@ -94,13 +93,27 @@ variable "ssh_pub_key" {
 }
 
 variable "notebook_nodes" {
-  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string), kubernetes_version : string }))
+  type = map(object({
+    min : number,
+    max : number,
+    vm_size : string,
+    labels : optional(map(string), {}),
+    taints : optional(list(string), []),
+    kubernetes_version : optional(string, "")
+  }))
   description = "Notebook node pools to create"
   default     = {}
 }
 
 variable "dask_nodes" {
-  type        = map(object({ min : number, max : number, vm_size : string, labels : map(string), taints : list(string), kubernetes_version : string }))
+  type = map(object({
+    min : number,
+    max : number,
+    vm_size : string,
+    labels : optional(map(string), {}),
+    taints : optional(list(string), []),
+    kubernetes_version : optional(string, "")
+  }))
   description = "Dask node pools to create"
   default     = {}
 }
@@ -125,5 +138,12 @@ variable "storage_protocol" {
   The SMB indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST.
   The NFS indicates the share can be accessed by NFSv4.1. Defaults to SMB.
   Changing this forces a new resource to be created.
+  EOT
+}
+
+variable "storage_size" {
+  type        = number
+  description = <<-EOT
+  Size (in GB) of the storage to provision
   EOT
 }


### PR DESCRIPTION
- Mark optional parts of node / dask node definition as optional, so utoronto.tfvars will actually apply
- Parameterize core node size, and specify it explicitly.
- Remove default for k8s version, specify it explicitly. This matches the current k8s version
- Parameterize storage size, and match it to current reality. Note that this can't be applied via tf quite yet, due to https://github.com/2i2c-org/infrastructure/issues/890.

Ref https://github.com/2i2c-org/infrastructure/issues/2594