### PR TITLE
Document auto-assignement workflow and consider moving the required o…

### DIFF
--- a/.github/workflows/auto-author-assign-pull-request.yaml
+++ b/.github/workflows/auto-author-assign-pull-request.yaml
@@ -6,12 +6,6 @@ on:
     types:
       - opened
       - reopened
-      # Normally, it's enough for this workflow to be triggered only once, on PR opening/reopening.
-      # But because we use this workflow as a required workflow for other repositories
-      # in the 2i2c organization, it is **expected** to run successfully
-      # for each PR commit in those repositories.
-      # So we trigger it for each commit
-      - synchronize
 
 permissions:
   pull-requests: write

--- a/docs/reference/ci-cd/index.md
+++ b/docs/reference/ci-cd/index.md
@@ -31,3 +31,18 @@ GitHub's UI is slightly confusing for distinguishing between _workflows that ran
 
 To help contributors to our `infrastructure` repository find the right workflow run, we have a GitHub Actions workflow that [posts a comment on a just merged Pull Request](https://github.com/2i2c-org/infrastructure/blob/HEAD/.github/workflows/comment-test-link-merged-pr.yaml) with a link to the GitHub Actions run of the `deploy-hubs.yaml` workflow (described in [](cicd/hub)) that the merge triggered.
 Hence, it should be much easier to find the current deployments caused by merges than just following GitHub's UI.
+
+## Required workflows and author auto-assignment
+
+To make the most out of the [Project Boards](https://github.com/orgs/2i2c-org/projects) that 2i2c uses, there is the [`auto-author-assign-pull-request.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.github/workflows/auto-author-assign-pull-request.yaml) workflow that automatically assigns authors to Pull Requests.
+
+Because this is a practice that we wish to have across other 2i2c repositories, an equivalent of the `auto-author-assign-pull-request.yaml` workflow in this repository exists in https://github.com/2i2c-org/.github/tree/HEAD/workflows. The workflow in `.github` repository is marked as a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows). This means that it will run on every PR in the repositories that it's setup as required for.
+
+```{note}
+An additional, slightly different workflow than the one in this repository is set in the `.github` repository
+because we want to avoid adding up to [GitHub's API rate limits](https://docs.github.com/en/rest/rate-limit) for this repository.
+
+This is why, the workflow here, will only trigger when PRs are opened/reopened instead of every time they are updated.
+
+This is because a _GitHub Required Workflow_ is expected to successfully run **for each commit** in that Pull Request, otherwise merging it will be **blocked**.
+```

--- a/docs/reference/ci-cd/index.md
+++ b/docs/reference/ci-cd/index.md
@@ -34,15 +34,15 @@ Hence, it should be much easier to find the current deployments caused by merges
 
 ## Required workflows and author auto-assignment
 
-To make the most out of the [Project Boards](https://github.com/orgs/2i2c-org/projects) that 2i2c uses, there is the [`auto-author-assign-pull-request.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.github/workflows/auto-author-assign-pull-request.yaml) workflow that automatically assigns authors to Pull Requests.
+To make the most out of the [Project Boards](https://github.com/orgs/2i2c-org/projects) that 2i2c uses, the [`auto-author-assign-pull-request.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.github/workflows/auto-author-assign-pull-request.yaml) workflow automatically assigns authors to Pull Requests.
 
-Because this is a practice that we wish to have across other 2i2c repositories, an equivalent of the `auto-author-assign-pull-request.yaml` workflow in this repository exists in https://github.com/2i2c-org/.github/tree/HEAD/workflows. The workflow in `.github` repository is marked as a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows). This means that it will run on every PR in the repositories that it's setup as required for.
+Because this is a practice that we wish to have across other 2i2c repositories, an equivalent of the `auto-author-assign-pull-request.yaml` workflow in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure) exists in https://github.com/2i2c-org/.github/tree/HEAD/workflows. The workflow in the [`2i2c/.github`](https://github.com/2i2c-org/.github) repository is marked as a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows). This means that it will run on every PR in the repositories that it's setup as required for.
 
 ```{note}
-An additional, slightly different workflow than the one in this repository is set in the `.github` repository
-because we want to avoid adding up to [GitHub's API rate limits](https://docs.github.com/en/rest/rate-limit) for this repository.
+An additional, slightly different workflow than the one in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure) is set up in the [`2i2c/.github`](https://github.com/2i2c-org/.github) repository
+because we want to avoid adding up to [GitHub's API rate limits](https://docs.github.com/en/rest/rate-limit) for [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure).
 
-This is why, the workflow here, will only trigger when PRs are opened/reopened instead of every time they are updated.
+Hence, the workflow in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure), will only trigger when PRs are opened/reopened instead of every time they are updated.
 
 This is because a _GitHub Required Workflow_ is expected to successfully run **for each commit** in that Pull Request, otherwise merging it will be **blocked**.
 ```

--- a/docs/reference/ci-cd/index.md
+++ b/docs/reference/ci-cd/index.md
@@ -36,13 +36,13 @@ Hence, it should be much easier to find the current deployments caused by merges
 
 To make the most out of the [Project Boards](https://github.com/orgs/2i2c-org/projects) that 2i2c uses, the [`auto-author-assign-pull-request.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.github/workflows/auto-author-assign-pull-request.yaml) workflow automatically assigns authors to Pull Requests.
 
-Because this is a practice that we wish to have across other 2i2c repositories, an equivalent of the `auto-author-assign-pull-request.yaml` workflow in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure) exists in https://github.com/2i2c-org/.github/tree/HEAD/workflows. The workflow in the [`2i2c/.github`](https://github.com/2i2c-org/.github) repository is marked as a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows). This means that it will run on every PR in the repositories that it's setup as required for.
+Because this is a practice that we wish to have across other 2i2c repositories, an equivalent of the `auto-author-assign-pull-request.yaml` workflow in https://github.com/2i2c-org/infrastructure exists in https://github.com/2i2c-org/.github/tree/HEAD/workflows. The workflow in the https://github.com/2i2c-org/.github repository is marked as a [required workflow](https://docs.github.com/en/actions/using-workflows/required-workflows). This means that it will run on every PR in the repositories that it's setup as required for.
 
 ```{note}
-An additional, slightly different workflow than the one in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure) is set up in the [`2i2c/.github`](https://github.com/2i2c-org/.github) repository
-because we want to avoid adding up to [GitHub's API rate limits](https://docs.github.com/en/rest/rate-limit) for [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure).
+An additional, slightly different workflow than the one in https://github.com/2i2c-org/infrastructure is set up in the https://github.com/2i2c-org/.github repository
+because we want to avoid adding up to [GitHub's API rate limits](https://docs.github.com/en/rest/rate-limit) for https://github.com/2i2c-org/infrastructure.
 
-Hence, the workflow in [`2i2c/infrastructure`](https://github.com/2i2c-org/infrastructure), will only trigger when PRs are opened/reopened instead of every time they are updated.
+Hence, the workflow in https://github.com/2i2c-org/infrastructure, will only trigger when PRs are opened/reopened instead of every time they are updated.
 
 This is because a _GitHub Required Workflow_ is expected to successfully run **for each commit** in that Pull Request, otherwise merging it will be **blocked**.
 ```


### PR DESCRIPTION
I added a section in our CI/CD docs about the auto-assignment workflow.

The docs also reflect another step I wish to take, which is to:
- [x] remove the sync trigger from this workflow (in this PR)
- [x] add another workflow similar to this one that triggers on PR sync events to the `.github` repo (PR to come)
- [x] make the workflow in `.github` required rather than this one because I don't want it to add up to the GitHub API rate limit.

This is because I feel like I've been seeing rate limit error more frequently since adding that.

Reference:  https://github.com/2i2c-org/infrastructure/issues/1686