### PR TITLE
Use a fork of the filter repo to swap GitHub API calls with git commands

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -85,8 +85,11 @@ jobs:
 
       - name: Identify files that have been added or modified
         # Action repo: https://github.com/dorny/paths-filter
-        uses: dorny/paths-filter@v2
+        # Fork of the repo above that we use: https://github.com/frouioui/paths-filter/tree/main
+        # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
+        uses: frouioui/paths-filter@main
         id: changed-files
+        token: ""
         with:
           list-files: csv
           filters: |

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -89,8 +89,8 @@ jobs:
         # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
         uses: frouioui/paths-filter@main
         id: changed-files
-        token: ""
         with:
+          token: ""
           list-files: csv
           filters: |
             changed:

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -85,8 +85,11 @@ jobs:
         # Don't run this step when we manually trigger the workflow
         if: github.event_name != 'workflow_dispatch'
         # Action repo: https://github.com/dorny/paths-filter
-        uses: dorny/paths-filter@v2
+        # Fork of the repo above that we use: https://github.com/frouioui/paths-filter/tree/main
+        # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
+        uses: frouioui/paths-filter@main
         id: file_changes
+        token: ""
         with:
           list-files: csv
           filters: |

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -89,8 +89,8 @@ jobs:
         # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
         uses: frouioui/paths-filter@main
         id: file_changes
-        token: ""
         with:
+          token: ""
           list-files: csv
           filters: |
             common:


### PR DESCRIPTION
Apparently, the action repo https://github.com/dorny/paths-filter can be configured to use `git` commands instead of calling the GitHub API for various things, by passing it an empty token. This would be very beneficial for us, as we would be reducing our API calls and hopefully stop running into rate limit errors (https://github.com/2i2c-org/infrastructure/issues/1686)

However, according to https://github.com/dorny/paths-filter/pull/133 it misses a little something in order for it to work.

How would people feel about using that fork for our repository in order to be able to use this feature?

P.S. Does anyone know if it's possible to pin to a commit for an action repo in the workflow and not use `@main`?