### PR TITLE
support: update cert-manager from 1.8.2 to 1.12.1

### DIFF
--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -80,8 +80,13 @@ def use_cluster_credentials(
 @app.command()
 def deploy_support(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
+    # cert-manager versions at https://cert-manager.io/docs/release-notes/,
+    # update to latest when updating and make sure to read upgrade notes.
+    #
+    # "kubectl apply" will be done on CRDs but sometimes more is needed.
+    #
     cert_manager_version: str = typer.Option(
-        "v1.8.2", help="Version of cert-manager to install"
+        "v1.12.1", help="Version of cert-manager to install"
     ),
 ):
     """


### PR DESCRIPTION
I think we should upgrade cert-manager to catch up, which is now something we can do because k8s versions across our clusters are modern enough!!!

Upgrading from 1.8.x to 1.12.x worked out fine [in jupyterhub/mybinder.org-deploy](https://github.com/jupyterhub/mybinder.org-deploy/pull/2638). I read through the changelog thoroughly at that point in time and didn't have reason to believe it would be causing issues either.

---

@2i2c-org/engineering must be aware that the version of cert-manager is currently set in the deployer script, which makes it important that everyone doing `deployer deploy-support` use the latest version of the deployer script after this is merged to avoid ending up trying to downgrading it.

I suggest that this is planned to be merged on a specific date, for example thursday swedish morning next week June 16th, following everyone having local deployer scripts are pinged to upgrade to the master branch version if the deployer script.

Sounds OK?