### PR TITLE
Switch utoronto R hub to use CILogon

### DIFF
--- a/config/clusters/utoronto/enc-r-prod.secret.values.yaml
+++ b/config/clusters/utoronto/enc-r-prod.secret.values.yaml
@@ -1,20 +1,24 @@
 jupyterhub:
+    singleuser:
+        extraFiles:
+            github-app-private-key.pem:
+                stringData: ENC[AES256_GCM,data:eIBimJbX5QXIoGZMJBBeKjUtDuF/WxrR4E4r8f9PpBVOuDaNplIDD9MPVjVgiUiAMdgPLvgn+afku7SMYAZ8qlbv9Rx7xEBdY9sv5MCxYxF0/1QDV7JPoA16+N8sNLi7TPp3JLnIbtx/MFXSipts6XftTRHpW1xaFoz+s7rOII9AgHWNxcLQxHcttn7YlhbmzlHlhqd0YxNcO1w6PM8r+qJGWcsxWOfRrbD6STRSjkPUaHY8mL8wwVmYFKc73+v/ga0+uoLU0lycRZFHnc7tAeuuRCSFimqOeeO44caRLNXOsIt/vNTc0kDTLL7OOd9//KR6dEITwPdXY/sWweDMI/zO9NJxCs6/GLS6sVNzKnTzbXwXT5Vtpae/ZfpidjIX2Z0IzPb5Ylj7PN+laG1ecT3h+gg5Wts7MfwehS24RGUUm+bXWasd5QUOkBnYd0N3Jjv9Tl5AEyTm7Hcnq5r3x9vMJy5xoAqbiRmnoxMvdIyZq7U9RtfJBBDjeS0XjL3a8pDDABc0QabuBqy/4lHyZMWBhKDh/TFP+sZAshm5TCB/3/zMue1a6qOhuHF8l0A87rfOW8QecMkgPtiUZtmuu7+43DGkzlQWKxPMrIPTZNhFiY2HIp6pcY5B0qpQ5mSNocEoIDhA7DDR8jxrkDDel1VEsLJ5ZT/x0C+mRPiP/JFAi9SxeaatsN5XTcyT34ZMe17w22v+dV/w34CJBPfczlILGpNPHQUsWKzEnBBDOsnjbH05IxUExI+9Z34IZ5NVXcY/gpFmqqO03roQChD4/IY+H3X2JnVUAt9s54Mvjk5bJl5oInGvyfyhnn0iOnJT6sstiT/ssNLZFtOzTkPEYAGThPLNl4YC3TZMGz96DqHRrX1IZe8q5nvigTcFFSPeiKjN1yZMFxwVQkcnae7RwrcHFD23KzqiziDmJOmcy922tkr71Ph182twX00IizFha9B354wkBcTqBCTLznBU19Y0Kw5iJ2KlL49B5i6yVDPBVM0oMIiShoE7J5PG2rjuitFX4SHeYZvOou/gTzYLlzuMa1uu7dHC+wM7ASbwTfVwuAdvxe43jqTtILX3QXADIsP2KmXKQ0ZyD6g6oJk9TYssOBCY8VueeG7ffpbEs4KIz8D3oTMOS3jY135iXX0w0FZdDj0dkHEXZGRVPG4vLLnRgp/1NplCvRvc8sbH1+Jcdwbv1BACQhz+7lNpigRN+2uBYL8D98kTuOowd0Yd+qp9Vqej2JfPrqxgCRPUhXHCL2kcUy+0LiUNPC6qseK2Rh8pulM/HCoT0i/I1YyZ+Grss+r4GauT3NG6s6hRJ5xlzwrpd3xu+U9O7pIJ2Ezuq0XJeeqfvIAtJc7pPnERubvfjQG/jC+Jxmse8HlSOMlThtcTRCwFLGMMlSkzqAcKP+qOwJQO5NBHfTsfhe5G92c+rc5F/wSn2vA6x9ZtN3wRxHXBO6iZfSy7zJiiGgMIeYhTL4Nb3sC726yLEIU7l/xRe76desFGx1BjNBzOVDuFvfJ/wkcbA7YOhC4MtMBFWZ/pnDCnkMRkt4jk8jO/3YqZxIo1uWSTPy29BCdxpQMEXwQWqZzlNXmxgNG2ZZPOsjTjeSEB3K3SyOaie5GCe/Iwu8tj0Cvt6jgtvnoOc+kzul7wQnHldyUf2rNgiIoPBZ5jov6SEMJSCiup2sH2MGaE+74Z8seLDuJzXEEk1sn6likbwxl42ffoPma3++/jbpU+3l5ZzZQB5EAON9xgmMQ4/1DeuSYH8lGxj/07D7MoQb4+36sKWjEArxbCyfFbBnK9fqwgX+WKqFGzGvqWCxfkJqyhCCqE5y8V2SCoQFqVR3yyP3x4dlwgauF2aicLoytV+HbjDrTdyfwY63DdGBKPlahch+WoRBoL4JrECbo4FtGnpf+4BInb1YLKlOUyZLkXFtfdBUFWjWij/2OBtEbWj27cMt5izcwKQqC7mDYrZs8PBpRwdqe40Jsqvbh432lRq1c5HZ3nUygP56ww5xuKnotU8CNFVKbaOADCcOQuA+/r1jsD85vOCyyAgWH5HZqIzGG0XZkauVZK9GZf80O+dn5qwsGmaBRbwX/W81dIgj7B1wiCsHO0MjOAfmL6nSDsIP745lU3YesiPM6nnYXdW1e9jlPUArWuU3stSlVc26hxeMgkEE9i8wEv5mvtXyBZH9CahnF/rpqGK5mNq0Y5B4lnP2bwipuP8gOgJaovW4Utr36/lzU3CpGXVOE=,iv:cGjuzsgse6BW8eVG0l+rY90rulElfNmygR7nUq7zP8M=,tag:RkEdWzQsn6bP6/Oq79A7Uw==,type:str]
     hub:
         config:
             CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:gsi4wGP3KtDCezfu4mAUtpMQptPSUIHQOZyzvAkbu9uIGvf1RFV8ML5Wz9uspcgHDMj0,iv:cycdQNpE6olX3woPFBLdxm4B8yScTD2TOEpyiy8Ol60=,tag:zRkN1zfrDbq9L0XNIR7G1Q==,type:str]
-                client_secret: ENC[AES256_GCM,data:i8PpWDA8ucH+cxBh2Qop3N/cAGIFP4orCykM5up4J6cmxzfNUDoyraiO1kztBPMyZtVWibr4W0YzSi7KRgmDcx/ZLhn4LTKT5T3KKLmsCEOUqbV6Gw4=,iv:/b2kBbtcWzeyfxDBVV4jzJIQgW7kHaTxL8uorgMtItU=,tag:2UTAiuk1k7K+KNvRvUEgHg==,type:str]
+                client_id: ENC[AES256_GCM,data:ARzvJffJ56/EOr5cdzvJHjABrP3Ci70AkanIXUNzuGoDiLx57CiDfYuXEdaJy/6EuC8r,iv:+gEsMfsfBMplhOnyJfXNvM/e85HqOG9SrJMSJg1WBWQ=,tag:d0KfAyDt2WRKnk8RVuMiSA==,type:str]
+                client_secret: ENC[AES256_GCM,data:X9VbvTJIdtt0hezxJXVPK/MmzZF7QZLujXRZ2pu/GrYyv7AwhiME2USaF8heoDoFrJW5xQR+2At3x4tKP1DCG6OgTYtr7xgaDcIl9kb9XqMKowjFpI0=,iv:ulKAmBazJ6fWttMw1aeN4oN06kjgq3g1tRF5DNdN2Ig=,tag:R00Va+fmLUEmowS0JgDMpA==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-06-09T16:26:07Z"
-          enc: CiUA4OM7ePz4zxTW9gGyP+R+Ng1CPdjOQdobZmjEkDrabACZMFpmEkkAyiwFHC780SlrXHfs645OfSr3Iw5v1V0sAuS004/AsgArQ51wD5II1UtNxOHN4X+tPL4RIxReSeSZSD2aPP9i7ISk0FiwZxWy
+          created_at: "2023-06-09T16:43:35Z"
+          enc: CiUA4OM7eGx4W+aSgAiqgi/J/FPX1c6yS8EcS4KMfS7QyGr0nF/YEkkAyiwFHB2cwFBc6EbBUSn5hmCU0EpyS0NUjBz/0RkSubNwEWoS4KpbPa0gh50KoHZdDtWiDynuDrGEmypmvYnhauD6FwVCONFk
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-06-09T16:26:08Z"
-    mac: ENC[AES256_GCM,data:Bm9P7IJjThqHpa8iCh7meDZHyUOKxrXHXaMSYzvZ4vS/lDjYCwd32W6EYtwfmSOb909Sj4EezmtmM+/cMH05ksfaAOOf0UVu5EDHvYhSsGtwBuNSeYLXYLgCGiuS9G3fb5VkH6brFEeVgY2iMw0FAPWtmkCWr7LpTEFQE3T4RAo=,iv:AeUBS98WDDgFQbA5ei/u2htqB8R9jRyR8Q6GYiTYcXs=,tag:oY3KEPA2QP3sXKAplyHnCw==,type:str]
+    lastmodified: "2023-06-09T16:43:37Z"
+    mac: ENC[AES256_GCM,data:h/vUttypmWXBtUWF1/jd9ggK9LTITgPQ30sPYY7M1h/CNXtClEJqfdShYixnFL2soYhjECS7oBdKenA0nxSwl5m6otlJAl8s9SrSetuZfgFXmolmRYfon2br0me1KBdrP2xY0kpH4BY9zkdXHvCGA5lxgQeLzz/VdH9zmWZoSo0=,iv:SObVpgO78dJa2ySaY1JxpAm5ROrvacYPOat4MAQaSzM=,tag:uje6EgYCBvqwpc8f2rrtLA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/utoronto/enc-r-prod.secret.values.yaml
+++ b/config/clusters/utoronto/enc-r-prod.secret.values.yaml
@@ -1,24 +1,20 @@
 jupyterhub:
-    singleuser:
-        extraFiles:
-            github-app-private-key.pem:
-                stringData: ENC[AES256_GCM,data:WBoI5eVPCqIgPJYUrEeNLd6QYE07KDgVtJv33WJ63M9g6jX6ZjBBwjcN2OQYR8XGGVK0XH/GMb/CkkPYajlhEB4H0m7kFzv/1rEAIZly03H7CIk1Q+umjtX+JoPciVAlTZNXlZ2Zvcj1u7s+6K7tSivp7WhO9JDQFIpyDlfR7nUXDBUKTNwKaoQqJ8Z8tIDXp2y01xtQkfpCJHDI75gGcdulvuKwLIIFEzIxSrXV18xBncylQYxrJM/wpD5PDWD4Ke8JQMcis8pWTXo1Gpce02p3/Mbjpq2O9QD5PdcsfdGocDcZOMAbJHgSY+BT/aUwY9RY1cYEfx4A6VObHnPk/KJj6FdSP3R0ftdTi9evpKPbP7QK2fFxqKZLqskNup4z6oggqZiaZgYiGz9cl3bMRahJXZK8g9WkSYff5ZYQIq0D1y/S+lkPDaDTavFWxdCwff9060cG3dsV5B7KYLyn+j5DOaM7kQkujNVLXgsAe5MQQ2YhszHhNOp6A1dx117ZwFdyuGZC/2HBTvakuo1XJeN48XatxnaUz0FfmpquoGOigws6znPiuX5T2JG7PRqWwQq1Sq9aDNkd/VICRxqG0ETCBJJ8t6d3kP0cj7Xi0NyC5Mf0vmg8N3tTfO32WjwNrzWDfySpFcK/aCNXMimr5XZ5sTZj2vRZ+2kkf5b/GRJh7PlSFXoKaYiSRNTc8PSx+9VL9nOkzDd1549HRoJBX27am88pQm/4GOqAGoR72VjsDViIS9w551kKa3/pqqPHq9t8U4GZi6MaWhbPmI4t12O5ezSuQbNi/X3Gu1zo7zevzwoadSt4SypBxYmcHdcrdM5r1Tt9uIh7ycfIgIsYCoNIxi7dop5S795/jZ4JFwQIidsf8o6LzJq8khYXWi/8UPE9W2EH8n+Ln1szcAdxcOrXubuAdwSNQ07nHreAY0c4mWKx/6alhuROH+HL2Tfb9ydZaIrD/J4+w/d4/PKljrijUxDXlgpiieCs9wTKWIuO3L2tShA3q5RWkKQeWq7P1aBLiO5YRY/1qd35paXAB71rIPZMYQEN9P0iTPIsWfxCaJtHfhP9Dt7iDixd2d/1/vEQ2Qs9uvSxjpsYeaI4/CmWoBHfOYSGh7lPa1RQzoFUPcV3cfoAl9+UURD/pcj8K0Ec1H7NT8DdIJCwqQSLeuctjphCiWL2dtaYKVK2HrIIoutHufHCUaTaBl2aJyTsTuTeyEiVlnz9UegXAhH0sCAPhP9Pcn4C57vLqjOPNjmOzA2IvbbsaCNblVb25EsFSMkitIkklYsPi2CMoif73DI0EHvB/51yvtYlogBUHdqkCmj0tHkuwF4tBPbmWG123Rs2yGtFrcJD57/KqCCLGjyhC+e2TiVvK7AWyuXE4DLqMOSbO+P4IqnxdL/UD7GJ2LSSfsLJzcj4GdYSIoKXjkgd1XCQ35zFyN9YPvs+3f1zg++rBkWuy0+EUb1u0soAYrvm9yhXJGVMJ1DJnBD3v9NPi9p8LJunLsE0+BBf0Zlk9HeGYPY/MoU1qWi52VvL/CMemYADSeoKrEfkXtSVtUeJzkglR9XMtt89fYXRFhlDLvLzBxx14x8VAkGTFV62b9UAnNxrF6LHPgv2B7OTPvqjrbKTY1Ss2ofgrrbgSR7MLFPGnbgVZ5CrjissqNd1/RABKhts/bQomoK3EpS6H41NrrQh4sWwFlV5mh23UmpUcMQZFPLugM69/ofryE3Cn7NxQ3g+FLxsG3+r4ZdL178a4lsAsdOwNouDlxoPT37i0FSBA5WYT7r397eWHVxP/fXDV9C7ds+slaPcCClSGoUCuHjSusKMr02gEQkvKDirPXsbsxOO74Kf6ddyOtbQUUD0uZ+aRy4/G4cxXQ6EERRsQxAbSb4wnmWJ/FtqNc91J4NHcJv6+ubq2jaG7Cwd7It3iwHyXXFFZgKqiOIP2hvEp/WSCYzR0ejFG7kLLRskl58QhByUruosIwnJxA93XAUTKXW72UIN31R+ZffEo22jLgjKlOOP5yjCVA/emZ1i1pEoWxSCDYjCnGyOBaZf8g92Aau1NSaBX05zGvlwJp2O2YYETWDcssriuf6CNfOAI3vBR+Oj6QQa46YfY8pH4dmL/4kIkZIPUEhmUxEA7rHYzYgwcwaoAIWfYaESa7YqV6Q8UIxvOeN/FhMLB2MYtbUAKirncnL/hKK3aO8OQpr7mpnXlIYzmklumwuoGBsJZ0zMk0DhHi5xjd5L5SY=,iv:sml8ZE7+tO+7MId9/5XQpYA6sMXD9MhQAznzGsQOHV8=,tag:ITulLSSMTWTStGeOrAPP6g==,type:str]
     hub:
         config:
-            AzureAdOAuthenticator:
-                client_id: ENC[AES256_GCM,data:NRIJj6slolCvidb+x0f4xI+mbsis8Bl4BACcca0OhyVrycmG,iv:CA8HR207ItxRul1UaEwNBEbbxvOSagpgkq4VseVlj9s=,tag:q0z0HcLBgcljE6OB0suKmw==,type:str]
-                client_secret: ENC[AES256_GCM,data:hkfjIVkw3f1t/1TRORLKf16BfCVZ3pr7w5HeIY73hOIj5HNwr5oYzw==,iv:DyC09nr+LnKNQKuA9gghU6MXZnIDjbSag/XGnUwAZm4=,tag:0E3E9K+vhHgg3j6jebZg4w==,type:str]
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:gsi4wGP3KtDCezfu4mAUtpMQptPSUIHQOZyzvAkbu9uIGvf1RFV8ML5Wz9uspcgHDMj0,iv:cycdQNpE6olX3woPFBLdxm4B8yScTD2TOEpyiy8Ol60=,tag:zRkN1zfrDbq9L0XNIR7G1Q==,type:str]
+                client_secret: ENC[AES256_GCM,data:i8PpWDA8ucH+cxBh2Qop3N/cAGIFP4orCykM5up4J6cmxzfNUDoyraiO1kztBPMyZtVWibr4W0YzSi7KRgmDcx/ZLhn4LTKT5T3KKLmsCEOUqbV6Gw4=,iv:/b2kBbtcWzeyfxDBVV4jzJIQgW7kHaTxL8uorgMtItU=,tag:2UTAiuk1k7K+KNvRvUEgHg==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2022-02-24T18:09:31Z"
-          enc: CiQA4OM7eOdvNAZ+zUSwT0PqdTYnrcEdl/SXGm7kpyMR1ZOtWnYSSQDm5XgWDUzIYL2PKXD9wHbao/Aqsv6kweTN3XDslnZDyOIFGtYEm1s+8cM9HCWfnSA0UOVQTZoly/a2oc59PnqTdnkLV0iu7dY=
+          created_at: "2023-06-09T16:26:07Z"
+          enc: CiUA4OM7ePz4zxTW9gGyP+R+Ng1CPdjOQdobZmjEkDrabACZMFpmEkkAyiwFHC780SlrXHfs645OfSr3Iw5v1V0sAuS004/AsgArQ51wD5II1UtNxOHN4X+tPL4RIxReSeSZSD2aPP9i7ISk0FiwZxWy
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-31T20:17:48Z"
-    mac: ENC[AES256_GCM,data:ZHtBcFWZRkZeRv+UB7m7IGtVlo++NeKfu1B777Pfc7eXjnyZcLi99ojVxANB+kA1c7lICmgmNEMPWKxK922ejOBGJN8pAnJjpHxVswWZ1enAzSzkvnsFZoMEZdMkar9zNMK8AjMUeO7139cqnM/yVj72voiCfTS/C5JdJ1hg82w=,iv:2TV5yr9CkDBWJVoi2OPPqXirRs5up4XdpQ4O0qTRDHw=,tag:EDuhGi1hRT73lbs2nsqLDA==,type:str]
+    lastmodified: "2023-06-09T16:26:08Z"
+    mac: ENC[AES256_GCM,data:Bm9P7IJjThqHpa8iCh7meDZHyUOKxrXHXaMSYzvZ4vS/lDjYCwd32W6EYtwfmSOb909Sj4EezmtmM+/cMH05ksfaAOOf0UVu5EDHvYhSsGtwBuNSeYLXYLgCGiuS9G3fb5VkH6brFEeVgY2iMw0FAPWtmkCWr7LpTEFQE3T4RAo=,iv:AeUBS98WDDgFQbA5ei/u2htqB8R9jRyR8Q6GYiTYcXs=,tag:oY3KEPA2QP3sXKAplyHnCw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/utoronto/enc-r-staging.secret.values.yaml
+++ b/config/clusters/utoronto/enc-r-staging.secret.values.yaml
@@ -1,20 +1,24 @@
 jupyterhub:
+    singleuser:
+        extraFiles:
+            github-app-private-key.pem:
+                stringData: ENC[AES256_GCM,data:17fSL8gW8JIzPwSCe3Ppb+n7RjaiX+udqYh3cwAHq7uApvasT690QAmNQDEED8anBTby2WtXUyvT2zFE0yQ6SCiDs5sO2XPlNyWVDjf0mWO8msd9ZiRiufQm+hfLxqT9EMiHMIgnh7njy51DOgb/OMONKbsYSggnY7d7kdU7S11r3cVFmYYTtcc4P/OJqLNeGI1nKiyA0hSYnw+oCA+gzUTDebOfOkB25dsFxRC57g52I2F1dQ/HEUo2Jgn5/TupjwJF67rAiKL7cUUSmShsEFIc1Ee2V68rByi7B6+vEDnYG5Uuz8FSv/pz+coqLPZ+SvOIcnkr8CJOzn3wG3lfWBjPmk5UpGBbVt+dkV77cYh5HNTh6uq+ZJ4tKl0qicvQEqcPHT3SRBRGx3Ad89RtvnlZQqd3QJF1UMrCAwlRahm+ggydlVrDhIhEQZoEMoNBVSH3ezRttdMkiOPeAstliklXfygg1Cx6Hfwe3WPiPDvgnsvNlcrUavHWIHoII7vTls84XimcqUNTuiKW5V7Hy9UYtoj5ejTe7S/Qo9u9+1dVY52V5Vp5CuJU6l/6iOM0ebUYVQh07Err9DzPH9m90NG2qoZbZA5ByPeoho/cYKBpZSnsNz4xXWB7cEoZqfXAmjDVQZ+rNBCh9gavaT0bdWeQetkffukfsTBsiK6JnfREfrOZJoc8T1hL2TGS/rG1GESeFXQwMH8g0fd7w5KsDiv0/4ch+frbjHIS5t2SDacJakCSyUOJTEsB8zSmyip/jN9ePrfDKGVCeyVCGrrEpie+qouZngArjixO7Z9DZ64my5PMPXHvghObQ6vddqcSPrSBYyea105ELRjHMI7TDdSDOde6/wGuR58ytBkFtnBO4NOCoicDDybok/ItuzezaEuYdhcGAHUxUawtJxvHWAt3nyBYPWyxdRqI6aYx++n+wTk/cqQeNmZGpFeBwsNIfVib8QBmhoj2ME3GNUQAYCitoTM7hCPdLxZZIciCsRc8+k/4DF67nnJAxMGK2aKJs0Gs6HPhh7RgIvFuufCdcASoyNfSTIjhlqaELL0kw3CzJ5u+dkU4O1Sq+ma2NsmpDLrVYuV5XdnRlE9QP5nQ4QJmMC79vEZ992Rc12dqTfya8vyXct70oJgZ9Ise6ruB6IEE0CMwdcJ5bNS7E5s+lrZ9fdDVuaaCITfZvpNIcyvjUCgzSo+iV9NMAiUyrQse/HeerUUFifKcsZtjY2/l+YHYnRvt18mZ+vGaNVEZKM+NRRwMakd6J64GkgECAZA678DkA2KrpFoshSll3sDMeHFM+gjtwLANyFg0B7u3z6SETZ69eWG6Q7i8xmIaGWfvgJ0lei3L6+IgQxur3m3O4u0/iymEj6xPHNiWe9y4TVgtCxQ++K7WvN9bKxc0GAhLcj/vz+DqrYHSiuiegAd0pA6566uWb4uu8BbRGmSdlxll3gezGmregyp5ttTtaaN8bA3GjRefWsohBUy2OFrNixX1TF2oNpZ4dJ+DyYp7zkRYzz0Y8iqrLUrO66nu/ikxlWeAloBn98DRSHlVXhgLW38WU53198kqWZVLHf9Me7+WmzifLU6Fp24/43YqNOCZ1pjG0ttyCIZfvNKOv9oUfLuwFhqbIOnWxxPPTe+Oz9HCV2b5orvlgvTD1Abqk1R3tKOTpOQfFFqWzSdmUvzX8tLwmVuz20iZ6hV0AQ2T06enL/Ue6OWIi75k93bl3M+1O2/bblaf8bkAapdI4E5zGZuszLVYetAr+81I2IXCOtpsqLP0Dt1EmUr937ipxVYk0hA+N/wgvmtebp71TIuyDOGGrTnOUSBvylye9xnAuN+WlmoRmAQQWt8B+qDNvNPp/L9vAC29yw7TDyhDpgBUKXbCYK8oDR0wRbfX+9/da42vsh+t5WchgmCBFici6PKQmsgqbg7cUTDKf83vKNaVfTfNadsz60ZYrA0DiiqyD4w404dP1vLBWYoYdbTOTsdcBGwOPQc8FJQwJE39qOsWPjqORi8mBNSbDSrK4fwAOS/xAIBhBLAKBlvQQJ6wDWsIfpEKOABtedvDLh7vX7vmTVAIfXimnwnsXoNV3BSMi11e4MUdb7efPWHHDe/qCVKZhFIiAJFuab1GK4Kmk7NUoe4rQ1lepbzr/uumJXW5GsvY6lNXfNjWmQvFsXArsFzmZNoWFw00qZQT7Lfx65+hPmrShRze3K28vK7CMAyUK88EQnHfb9nUImVRxwh2d5s=,iv:D0edSPA6ubZpty/gfFMByNxqu3Ja/QVVRXtt2PZn/Fc=,tag:NTGuO+dsj8XBeM0G588R2Q==,type:str]
     hub:
         config:
             CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:zj5wbHjz7CuyDchFZGIQj0C9kJZiqIDTRZgVbetpHQuAKrDcqTQSoq/nj1x7SsoD8sVl,iv:jobrlgJ0LBrYybaQU/viY028EhZFNyO9uRM1vIUCvtE=,tag:QDU9F7S2b/RDhPdLKqRo0Q==,type:str]
-                client_secret: ENC[AES256_GCM,data:pxE4UiBYcPQ3IQ7K75+iQH0clxrrHG9j+Y5hjKOr5AKeJqBHDIXtNTQAgDtLeTn+TqMw/HQBN9RY1JPSP6vHMbYhEaDB6YmCyCThQcBUDPy25koCU9Q=,iv:QYPIWWWblYQDVOvesh5SVRwpjdssaG1ev2LvzpB1zwk=,tag:hfq6SlLylm+HY5kmiUCRHw==,type:str]
+                client_id: ENC[AES256_GCM,data:DnYA2sJgWkCCZpCTjoZ5XcxhO1uhfV9dch13K9erQQK8IXB2IMnHd64c+KcqzQI12Uiw,iv:uF0FhQFmFgFbTv+sXAW819XSDHFdMqmmudDqLOylGxw=,tag:GY+fEBPtB/RbB/DrOeUkFg==,type:str]
+                client_secret: ENC[AES256_GCM,data:xgxkU5aVMuwgnf8lWSrBpUyyft6SqKC8+FOoQpGu1cUTSR53IeXfUuC5s7I4EbTGFhsaLTSPtbtZyEGOqnlV5Zfi7sS3fDk5fhfiEnzh0RyS0mWoS34=,iv:LI1owPscYbUbuHZM03qsNS6JwWQfU+gHXqFsiKv0AwM=,tag:JmRu/X/KFUZOibeJ+LzJBw==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-06-09T16:22:26Z"
-          enc: CiUA4OM7eBS+M6qCd6hF4O+xo93bOTsH1Itm4awYVPomrCyDcvdEEkkAyiwFHEXJxBW8f/uwuQDeh9LDrSWQ13CA5Eh+TJLqNiHnRoCUPbrt9MhKDZgD89xdfkEatI5z6pyDjK+dRHEnW0izoj4vYzFI
+          created_at: "2023-06-09T16:43:26Z"
+          enc: CiUA4OM7eImkcPappqi2n0nibml1DPRAQdUjOFw04tqZ+3ebMwtEEkkAyiwFHGWVXZSIevQL7zrgJ3eTBe6NU2wds/R9pPUg3Fo1fLE2KLDRB+eZRo8fj/y8jF4vskd5ORolrC8DNNM/0FagXz5ThO0f
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-06-09T16:22:27Z"
-    mac: ENC[AES256_GCM,data:oHAxxq3XcmpW4dloiWC5eBnLCSBeHl3VilC/cIy3FGn0iQZGeD/fNsTKCis2YKYgrnHrxLsqeHDjpkk9+YSR+wlHMA50/NTvdfL2FKTqusk2TSQpGofU3y3yaVlay1g6Hm5DDj3/AkSo7VjpnB0L86c+9gHdSUvBpuRw2qBLKec=,iv:tyRfxXKxp8RJmdsCRO6DVXDZZxV4R1NWv13KOZiw750=,tag:BE3vRA4Ly7Y8WkWOAS4NLw==,type:str]
+    lastmodified: "2023-06-09T16:43:27Z"
+    mac: ENC[AES256_GCM,data:MvINT1mjrwX2draFIcTZhghqj1/f/clweaFC5TAYH6qXrsbOClOLRYcYDPK4cJkhu+yhOIY6TUq7u9JKOe8tN89r3P3fJzGMqHQCydg57/AsnUMAWC5B2iUFzejNzNkh3m1eKcDklF/dQoeWIKpDMu4FlXOonIkh7AAK1XE5tXk=,iv:PuKRO2m59cZP6XiQv2CPwuvY5TC1ZnNuu6r/efWgqDA=,tag:qJ8LH4mq00m3ZoxVejOsqw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/utoronto/enc-r-staging.secret.values.yaml
+++ b/config/clusters/utoronto/enc-r-staging.secret.values.yaml
@@ -1,24 +1,20 @@
 jupyterhub:
-    singleuser:
-        extraFiles:
-            github-app-private-key.pem:
-                stringData: ENC[AES256_GCM,data:EsWpZIVpvybE/J9sBhb05Tkxw2tAHaEX/UXZmKAS7POvTdGSb3fbrDdZXCgVfU99BXoHvb+s/bHN7bFL8dJjvWO/K/Ai6YWWwciFjh1YyqFcTsYCyITxiCIh08rvrzy3NkIvcne0ISI2P2kfRumKK8Ny6pdrN95Qv4MIKx7Ci+fgaC9zM1/ZsUDwPnHfWc7Y6tWFpyQ6Ay5ZamfWtkBj9AH1aNhMXinA/a/AMM26rs5FGXXSSisWLyrVIqMaCHw6Ezy3e4DRe8QCMjGPM8D7e7bc3O+JTvQTvBdFBKM7/nBvs60MUEE0K2gM00r2nJqivbG/vo1DG3tv0hc7oJ69bXHxdxgadeTuHeCiU6YLpkHWKYdX/gcLJz+K8zKTVQ8MOFISRcKKQEC4z4zdxCx/DuAfjIrGkT5u6V1ENKn17Sj7Wy1jYQHLfOYV7qtWJexP/ret1SGd90jiaORnjw1OmIQRznOuSNwNEJy2v2KJ3E1+rZLh0nrPcZHCBWApbeCYo58TGFVDtmqF8F+E0WCUuELu/sRk0sjbPJqYmvkM3SSLEKsoUoKPm217rgV+TRSeFXJJIU+oZDUKZR3M83yvKng8OJPgcKFUr9WzLuCWQ712/q0s2E7JvRSvkrV2IAh9lCSgLqtMHl2dVs6OD1/WfDDNnACPKlzyMVWk8WYnrhHMJwThEsWJt2AlS2Vn9XhCC336DVV7LDh3TI7X/LOtg2ZkDBOVVPM+znLiHPvT273/xszM0/VwUQFmSI/elnv4DwYli1HDjnqyl0j0Lw9LeMPXTnTuYeUA14jUbRhUa1PqsdB3Tb/ZQYF2Ikm2ct35YkKgyxoqFfUxuTQF3rq+t/XzDk9hCeyYpm97kzz4g50RlOpsYtP8uGoIMsRo041DqT/eBXXGKnN0UrY7bfhZyxiikqZru9CmpCArhBUERAyJqzKGpyFIWlQjrs4ldmD9Ji7atI6KGgY047hv1RunTpBRkMvvJuLA8fruq8DGyTJD8TZFAZbUWnJ/AkcO0ysqNnJnkP4gcXadveyQ8j3hka2pcUTWWL1H19R7IRZ/PHg9KzY0VOCqtaYEe1gY4xAwJqPqle3E8ka5NLI9GS56y6UA6i9k5t6RRG7LrHvTJyCqtl5hQTDwJGsXSv5o0dkWZPq+fKVLNYpqaDIkD2P/VoC8DCrbqI5Q291w22mhsx6dZc5/Rghg/bXJ1kr9KMgtbAqbrgOKhnuRNx24/cYpHFMiCVMn/o7oNSBjkyh7mg9X7ao8TPjtXJEU++XQ/9/vD8a2NPFZEQ5/lAFbk9eMf8Gu7s/j79noSpt/Onk/JhoCgzZRHA8Khxz4YwAHk6P6b8bRmjeDkGWesfF+YFdftZFOqgwDmvjRmfcPtT9Tnlq63T+hgXlo5jDE06cEeIPz5RvO/3CHDH8AjuC/aqHrfojTirUqnIa5d0GqFZPxe6SHJJUB0vY5+roCZz/GcXumM2bXLQdgCQdi4Ouu76KasueHGlc/KyCYlPdOudNy2Cyz50ZCl4AB5S5gpRXa8SGlgNVPzeQDthhIYMwYEjz6/kS82zOj9n7LwgGJ+NGOrEPmcl1ZZNvYGdt9OVg9M38LUoin8X2mRlE/LNgoUpnUQ6QvtFyEPZiI5QglcDsKgrlQfhZVk8jFRjyhyCY0EwVavD2+1KWhDFF1qYd2BsOixkMMAGXBcUJCxMXcccSSe5Gt1qTfF1i+s2Yy72zf9u7RlItKceyftJqOTY0tdMYSF82ghqpoELhobiVYfxGseAEQTpd/L0TWhZQtLAj8i2lCHcYDCPIMXw5PIqkgH+kIJ8qv9eh9tplcW/P/5QSqtqSDV5llGRdhMPUmL05wp4pUndd7NdMCm9r80TVjZCGsx+feWs8mbZFJltUo9Y1HCDitnw4ONFJasxVJTkZ8xDDa0D+iEIiyB5UrJGY83k5CywpfKjbVRKvP17+TbpFr/wNUNyCfNdAXkRQ2doBjXqhOKJVsyeJ6M8m8JIuIV5bA1IGDrOEgC+KQc8oeIxR8+bV84irubPd1CH7bFndm/41Ye6rNNdd/yuRWUKtj0GCFdJQIAWVrHE3/gw8ZFCe4SBl8iIuv4P3RT69olIbuJAuVNyMJpAgQcRLH4yD7gsfwSQquEftbJCetPXM9GDuILk7Re+9zgKVJLDNyYctrIlpFvyxD/A6a8jJyVJzqIHVp8TmXWy1XxyPcSiYq9ysUwHQZwOGvPgJftC8uwzLWEHI=,iv:0/wWZcMZwP9XXASWPCHk1PgmM2gTZEw8hkyZd9lEWCk=,tag:i44AuDtv0bWAzsiQlMg/LQ==,type:str]
     hub:
         config:
-            AzureAdOAuthenticator:
-                client_id: ENC[AES256_GCM,data:082nKaBVlegQiGmtVti7PPBz+T7GLTCyB6910E6EgXnedDJZ,iv:mqE0/hkXIp2leSohgkdgdEB7cy6rgy7nH+2NkJCcZ6o=,tag:Ii23/LAfbXi0F66GPmpmRQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:DEYYnc/bxBcJtAJ/TBY/IggBbqdp8tVUM1GgdsayEUGelEtvhmbarQ==,iv:5hWqi8Cag0wRYnfA82I8FI58mQUi4Rm0TRaCr764sb0=,tag:uj91hvmqqc2FwJkYeo1Ebw==,type:str]
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:zj5wbHjz7CuyDchFZGIQj0C9kJZiqIDTRZgVbetpHQuAKrDcqTQSoq/nj1x7SsoD8sVl,iv:jobrlgJ0LBrYybaQU/viY028EhZFNyO9uRM1vIUCvtE=,tag:QDU9F7S2b/RDhPdLKqRo0Q==,type:str]
+                client_secret: ENC[AES256_GCM,data:pxE4UiBYcPQ3IQ7K75+iQH0clxrrHG9j+Y5hjKOr5AKeJqBHDIXtNTQAgDtLeTn+TqMw/HQBN9RY1JPSP6vHMbYhEaDB6YmCyCThQcBUDPy25koCU9Q=,iv:QYPIWWWblYQDVOvesh5SVRwpjdssaG1ev2LvzpB1zwk=,tag:hfq6SlLylm+HY5kmiUCRHw==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2022-02-24T18:08:21Z"
-          enc: CiQA4OM7eBanK+HbBPB2vHvIZKJONEYQrsehrIP5d0u8r0+7R/gSSADm5XgWfJP/jYs7/3IkZmdvNF+pWLMrS5rbDoUJjrqcKlUcDL6u5jrbSXFF/lE4nSuyFrKSxNkMm28dvYAMsqHrZIFwVBLXOg==
+          created_at: "2023-06-09T16:22:26Z"
+          enc: CiUA4OM7eBS+M6qCd6hF4O+xo93bOTsH1Itm4awYVPomrCyDcvdEEkkAyiwFHEXJxBW8f/uwuQDeh9LDrSWQ13CA5Eh+TJLqNiHnRoCUPbrt9MhKDZgD89xdfkEatI5z6pyDjK+dRHEnW0izoj4vYzFI
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-09-08T07:48:01Z"
-    mac: ENC[AES256_GCM,data:rr/BWRngZh08Su8zP+eJ4OqLuT7IbG7/voAh1iPuwHPPLIeeNTnIopelD/6OLjhCbkiZhtij2y6lASwa5xzwmLuvvxiAdQrX6f+ZqOgBZ1KxuJzELQxSY4X2L6cgCeGFnhHhQY1EoYqsGEwjSk6zrPPtR93sBL80ZmL+swHtz3E=,iv:jFbf45ItjJV/ALnyk0xNyy7dnvtcGuIj3+pQNTqWcaM=,tag:mYHTUwzMJSERSvya1OMNGQ==,type:str]
+    lastmodified: "2023-06-09T16:22:27Z"
+    mac: ENC[AES256_GCM,data:oHAxxq3XcmpW4dloiWC5eBnLCSBeHl3VilC/cIy3FGn0iQZGeD/fNsTKCis2YKYgrnHrxLsqeHDjpkk9+YSR+wlHMA50/NTvdfL2FKTqusk2TSQpGofU3y3yaVlay1g6Hm5DDj3/AkSo7VjpnB0L86c+9gHdSUvBpuRw2qBLKec=,iv:tyRfxXKxp8RJmdsCRO6DVXDZZxV4R1NWv13KOZiw750=,tag:BE3vRA4Ly7Y8WkWOAS4NLw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -6,10 +6,20 @@ jupyterhub:
         default_url: /rstudio
   hub:
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       KubeSpawner:
         # Ensures container working dir is homedir
         # https://github.com/2i2c-org/infrastructure/issues/2559
         working_dir: /home/rstudio
+      CILogonOAuthenticator:
+        oauth_callback_url: https://r-staging.datatools.utoronto.ca/hub/oauth_callback
+        shown_idps:
+          - https://idpz.utorauth.utoronto.ca/shibboleth
+        allowed_idps:
+          https://idpz.utorauth.utoronto.ca/shibboleth:
+            username_derivation:
+              username_claim: "email"
   singleuser:
     storage:
       # From https://jupyterhub-image.guide/rocker.html#step-7-setup-zero-to-jupyterhub-configuration-for-home-directory

--- a/config/clusters/utoronto/r-prod.values.yaml
+++ b/config/clusters/utoronto/r-prod.values.yaml
@@ -10,6 +10,5 @@ jupyterhub:
         # prod stores logs, so let's make it big
         storage: 60Gi
     config:
-      AzureAdOAuthenticator:
+      CILogonOAuthenticator:
         oauth_callback_url: https://r.datatools.utoronto.ca/hub/oauth_callback
-        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r.datatools.utoronto.ca

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -6,6 +6,5 @@ jupyterhub:
         secretName: https-auto-tls
   hub:
     config:
-      AzureAdOAuthenticator:
+      CILogonOAuthenticator:
         oauth_callback_url: https://r-staging.datatools.utoronto.ca/hub/oauth_callback
-        logout_redirect_url: https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=https://r-staging.datatools.utoronto.ca


### PR DESCRIPTION
AzureAD has given us trouble in the past too. This makes that CILogon's problem, and the current issues with AzureAD don't seem to happen here. This can't currently work for the main hub because we use opaque oid as user identifier, rather than email. If we can make a mapping, that should also be possible.

Ref https://github.com/2i2c-org/infrastructure/issues/2628