### PR TITLE
Update cloudbank image to use new data8 style image

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -1,5 +1,5 @@
 jupyterhub:
   singleuser:
     image:
-      name: quay.io/2i2c/2i2c-hubs-image
-      tag: "14107b8a85fb"
+      name: quay.io/2i2c/cloudbank-data8-image
+      tag: aa7e0df7adf4


### PR DESCRIPTION
Before we merge this, we must use the configurator to specify the old image for any hubs that want to use otter 3 or RStudio.

Ref https://github.com/2i2c-org/infrastructure/issues/2435
Ref https://github.com/2i2c-org/infrastructure/issues/2435