### PR TITLE
support, node-exporter: increase cpu requests/limit from 5m to 10m

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -103,7 +103,10 @@ prometheus:
     # resources for the node-exporter was set after inspecting cpu and memory
     # use via prometheus and grafana.
     #
-    # node-exporter is typically found using between 0-3m CPU and 2-22Mi memory.
+    # node-exporter is typically found using between 0-3m CPU and 2-22Mi memory,
+    # but we've seen it fail to report cpu/memory use metrics from time to time
+    # when requesting and limiting to 5m, so we've increased requests/limit it
+    # to 10m.
     #
     # PromQL queries for CPU and memory use:
     # - CPU:    sum(rate(container_cpu_usage_seconds_total{container="node-exporter", namespace="support"}[5m])) by (pod)
@@ -111,10 +114,10 @@ prometheus:
     #
     resources:
       limits:
-        cpu: 5m
+        cpu: 10m
         memory: 30Mi
       requests:
-        cpu: 5m
+        cpu: 10m
         memory: 30Mi
 
   networkPolicy:


### PR DESCRIPTION
We've seen gaps in reported cpu/memory, which stems from the prometheus-node-exporter pod on individual node's fail to respond to prometheus-server scraping it for information.

With this change, I hope that we may get it to run robustly even when the node's under heavy load.

I think this may be a relevant clue for us to understand how to ensure user pods are running robustly, but its such a complicated topic and I really don't get the details.

My hypothesis is that the "broken pipe" error observed in the node-exporter pod that fails to report metrics is caused by responding to prometheus-server takes more than 10s, and that prometheus-server cuts the connection at that point, which presents itself like this for the node-exporter software.

> ```
>ts=2023-06-08T19:56:54.525Z caller=stdlib.go:105 level=error caller="error encoding and sending metric family: write tcp 10.1.0.15:9100" msg="->10.1.0.5:49060: write: broken pipe"
>```

## Related

- I suggest this preliminary closes #2634, but not the branched off issue #2647