### PR TITLE
prometheus: fix scraping by fixing broken network policy rules

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -509,6 +509,13 @@ jupyterhub:
       tag: "0.0.1-0.dev.git.4978.h858bd17c"
     networkPolicy:
       enabled: true
+      # interNamespaceAccessLabels=accept makes the hub pod's associated
+      # NetworkPolicy accept ingress from pods in other namespaces that has a
+      # hub.jupyter.org/network-access-hub=true label.
+      #
+      # ref: https://z2jh.jupyter.org/en/stable/resources/reference.html#hub-networkpolicy-internamespaceaccesslabels
+      #
+      interNamespaceAccessLabels: accept
       ingress:
         - from:
             - podSelector:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -537,17 +537,6 @@ jupyterhub:
           ports:
             - port: 10101
               protocol: TCP
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  name: support
-              podSelector:
-                matchLabels:
-                  app: prometheus
-                  component: server
-          ports:
-            - port: http
-              protocol: TCP
     # FIXME: We should think about these resource requests/limits, see
     #        https://github.com/2i2c-org/infrastructure/issues/2127.
     #

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -525,6 +525,19 @@ jupyterhub:
           ports:
             - port: 8081
               protocol: TCP
+        # The jupyterhub-configurator is a managed jupyterhub service, which
+        # means it is started by jupyterhub as a separate process in the hub
+        # pod. Users will access it via the proxy pod, and JupyterHub itself is
+        # accessing it via localhost. This rule makes receiving such request on
+        # port 10101 from these destinations accepted.
+        #
+        # Maybe the container internal rule, for jupyterhub ->
+        # jupyterhub-configurator isn't needed, as the request is directly to
+        # 127.0.0.1:10101.
+        #
+        # ref: The extraConfig.02-custom-admin section below
+        # ref: https://github.com/yuvipanda/jupyterhub-configurator/blob/996405d2a7017153d5abe592b8028fed7a1801bb/jupyterhub_configurator/mixins.py#L7C5-L11
+        #
         - from:
             - podSelector:
                 matchLabels:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -172,8 +172,13 @@ prometheus:
       limits:
         cpu: 4
         memory: 4Gi
-    labels:
-      # For HTTP access to the hub, to scrape metrics
+    podLabels:
+      # To scrape metrics from a hub pod, prometheus-server needs to be
+      # explicitly allowed network access to hub pods in clusters with
+      # NetworkPolicy enforcement enabled. Adding this label does the trick.
+      #
+      # ref: https://z2jh.jupyter.org/en/stable/administrator/security.html#introduction-to-the-chart-s-four-network-policies
+      #
       hub.jupyter.org/network-access-hub: "true"
     persistentVolume:
       size: 100Gi


### PR DESCRIPTION
The prometheus chart in some release updated its labels, and when they did our networkpolicy rule to allow traffic from prometheus-server to jupyterhub to scrape started failing.

- Closes #2647