### PR TITLE
support, prometheus: fix issue from v21 regression / v22 upgrade

### DIFF
--- a/deployer/cluster.py
+++ b/deployer/cluster.py
@@ -61,6 +61,18 @@ class Cluster:
         )
         print_colour("Done!")
 
+        # FIXME: Revert this addition after one upgrade is made
+        print_colour("Fixing prometheus v22 migration...")
+        subprocess.check_call(
+            [
+                "kubectl",
+                "delete",
+                "--namespace=support",
+                "deploy/support-prometheus-server",
+            ]
+        )
+        print_colour("Done!")
+
         print_colour("Provisioning support charts...")
 
         support_dir = (Path(__file__).parent.parent).joinpath("helm-charts", "support")


### PR DESCRIPTION
v21.0.0 of prometheus chart introduced a regression, and v22.0.0 fixed it, but it was breaking changes involved as v21 introduced a Deployment's `spec.selector.matchLabels` label that would be changing between versions (not good!), and v22 removed it.

The v22 bump was made in https://github.com/2i2c-org/infrastructure/pull/2593 with a workflow that also failed.