### PR TITLE
carbonplan, openscapes, 2i2c-ohw: cleanup of misc config

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -10,10 +10,6 @@ basehub:
         - secretName: https-auto-tls
           hosts:
             - oceanhackweek.2i2c.cloud
-    prePuller:
-      continuous:
-        # Todo: turn this off after the event
-        enabled: true
     singleuser:
       networkPolicy:
         # In clusters with NetworkPolicy enabled, do not

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -181,7 +181,6 @@ basehub:
           limits:
             cpu: 1
             memory: 4Gi
-        nodeSelector: {}
     hub:
       resources:
         requests:
@@ -196,7 +195,6 @@ basehub:
         enabled: false
       readinessProbe:
         enabled: false
-      nodeSelector: {}
       config:
         Authenticator:
           allowed_users: &users

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -190,9 +190,6 @@ basehub:
           cpu: 1
           memory: 4Gi
       allowNamedServers: true
-      networkPolicy:
-        # FIXME: For dask gateway
-        enabled: false
       config:
         Authenticator:
           allowed_users: &users

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -193,8 +193,6 @@ basehub:
       networkPolicy:
         # FIXME: For dask gateway
         enabled: false
-      readinessProbe:
-        enabled: false
       config:
         Authenticator:
           allowed_users: &users

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -243,9 +243,6 @@ basehub:
           matchNodePurpose: require
     hub:
       allowNamedServers: true
-      networkPolicy:
-        # FIXME: For dask gateway
-        enabled: false
       readinessProbe:
         enabled: false
       config:


### PR DESCRIPTION
- 2i2c, ohw: stop continuous prePuller, supposed to be disabled earlier
- carbonplan: remove redundant config
- carbonplan: remove no longer necessary opt-out of readinessProbe
- carbonplan + openscapes: stop disabling hub network policy
