### PR TITLE
cilogin delete_client: Remove duplicated params

### DIFF
--- a/deployer/cilogon_app.py
+++ b/deployer/cilogon_app.py
@@ -314,8 +314,6 @@ def delete_client(admin_id, admin_secret, cluster_name, hub_name, client_id=None
         if not stored_client_id_same_with_cilogon_records(
             admin_id,
             admin_secret,
-            admin_id,
-            admin_secret,
             cluster_name,
             hub_name,
             client_id,


### PR DESCRIPTION
Fix duplicated admin_id and admin_secret call params in delete_client

Ref:

`TypeError: stored_client_id_same_with_cilogon_records() takes 5 positional arguments but 7 were given`