### PR TITLE
Create filestore for 2i2c shared cluster

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -11,6 +11,9 @@ enable_network_policy = true
 
 regional_cluster = false
 
+enable_filestore      = true
+filestore_capacity_gb = 2560
+
 # Some hubs want a storage bucket, so we need to have config connector enabled
 config_connector_enabled = true
 


### PR DESCRIPTION
This simply creates the filestore. I'll manually mount this in the existing NFS server, and copy files over before actually moving hubs over.

Ref https://github.com/2i2c-org/infrastructure/issues/1105