### PR TITLE
tf: Allow omitting optional fields in node definitions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
   # Run `terraform fmt` on all our terraform files automatically
   - repo: https://github.com/yuvipanda/terraform-bin
-    rev: v2.0.0
+    rev: v3.0.0
     hooks:
       - id: terraform-fmt
 

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -5,7 +5,7 @@ resourcegroup_name = "2i2c-utoronto-cluster"
 
 kubernetes_version = "1.26.3"
 
-storage_size = 5120
+storage_size     = 5120
 storage_protocol = "NFS"
 
 ssh_pub_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
@@ -13,7 +13,7 @@ ssh_pub_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2a
 global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 
-location = "canadacentral"
+location          = "canadacentral"
 core_node_vm_size = "Standard_E4s_v3"
 notebook_nodes = {
   "default" : {

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -15,13 +15,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-highmem-4"
   },
 }
 

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -34,35 +34,17 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-4"
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-16"
   },
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-64"
   },
 }
 
@@ -70,13 +52,7 @@ dask_nodes = {
   "medium" : {
     min : 0,
     max : 200,
-    machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-16"
   },
 }
 

--- a/terraform/gcp/projects/basehub-template.tfvars
+++ b/terraform/gcp/projects/basehub-template.tfvars
@@ -28,41 +28,17 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    labels : {},
-    gpu : {
-      # Tip: use this flag to enable GPU on this machine type
-      # if there is GPU availability in the chosen the zone
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 }
-
-# Config connector is needed on multi-tenant clusters for bucket access 
-# Tip: uncomment the line below if this cluster will need buckets and list them below
-# config_connector_enabled = true
 
 user_buckets = {}

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -21,13 +21,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "n2-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-4"
   },
 }
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -15,13 +15,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-highmem-4"
   },
 }
 
@@ -29,13 +23,7 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-highmem-4"
   },
 }
 

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -58,36 +58,16 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    labels : {},
-    gpu : {
-      # Tip: use this flag to enable GPU on this machine type
-      # if there is GPU availability in the chosen the zone
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 }
 
@@ -96,11 +76,5 @@ dask_nodes = {
     min : 0,
     max : 200,
     machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 }

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -60,18 +60,11 @@ notebook_nodes = {
     min : 1,
     max : 100,
     machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "gpu-t4" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    labels : {},
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",
@@ -88,12 +81,6 @@ dask_nodes = {
     # on why some dask computations are dying off.
     # See https://github.com/2i2c-org/infrastructure/issues/2396
     preemptible : false,
-    machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-16"
   },
 }

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -23,24 +23,12 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "e2-highmem-4"
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "e2-highmem-16"
   },
 }
 
@@ -48,13 +36,7 @@ dask_nodes = {
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "e2-highmem-16"
   },
 }
 

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -39,57 +39,32 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n1-standard-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "gpu-t4" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    labels : {},
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",
       count : 1
     }
-  },
+  }
 }
 
 dask_nodes = {
@@ -97,45 +72,21 @@ dask_nodes = {
     min : 0,
     max : 100,
     machine_type : "n1-standard-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 }
 

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -15,57 +15,27 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-standard-2"
   },
   "medium" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-standard-8"
   },
   "large" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-standard-16"
   },
   "very-large" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-32",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-standard-32"
   },
   "huge" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-64",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n1-standard-64"
   },
 
 }
@@ -75,56 +45,26 @@ dask_nodes = {
     min : 0,
     max : 20,
     machine_type : "n1-standard-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "very-large" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-32",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge" : {
     min : 0,
     max : 20,
     machine_type : "n1-standard-64",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 
 }

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -20,20 +20,20 @@ notebook_nodes = {
     max : 20,
     machine_type : "n1-highmem-4",
   },
-  "climatematch": {
-    min: 0,
-    max: 100,
-    machine_type: "n1-highmem-2",
-    labels: {
-      "2i2c.org/community": "climatematch"
+  "climatematch" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-highmem-2",
+    labels : {
+      "2i2c.org/community" : "climatematch"
     },
-    taints: [{
-      key: "2i2c.org/community",
-      value: "climatematch",
-      effect: "NO_SCHEDULE"
+    taints : [{
+      key : "2i2c.org/community",
+      value : "climatematch",
+      effect : "NO_SCHEDULE"
     }],
-    resource_labels: {
-      "community": "climatematch"
+    resource_labels : {
+      "community" : "climatematch"
     }
   }
 }

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -19,12 +19,6 @@ notebook_nodes = {
     min : 0,
     max : 20,
     machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "climatematch": {
     min: 0,
@@ -38,11 +32,6 @@ notebook_nodes = {
       value: "climatematch",
       effect: "NO_SCHEDULE"
     }],
-    gpu: {
-      enabled: false,
-      type: "",
-      count: 0
-    },
     resource_labels: {
       "community": "climatematch"
     }
@@ -54,12 +43,6 @@ dask_nodes = {
     min : 0,
     max : 100,
     machine_type : "n1-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   }
 }
 

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -25,67 +25,31 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n2-standard-48",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge" : {
     min : 0,
     max : 100,
     machine_type : "n2-standard-96",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large-highcpu" : {
     min : 0,
     max : 100,
     machine_type : "n2-highcpu-32",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge-highcpu" : {
     min : 0,
     max : 100,
     machine_type : "n2-highcpu-96",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   }
 }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -69,13 +69,20 @@ variable "notebook_nodes" {
     min : number,
     max : number,
     machine_type : string,
-    labels : map(string),
+    labels : optional(map(string), {}),
     taints : optional(list(object({
       key : string,
       value : string,
       effect : string
     })), [])
-    gpu : object({ enabled : bool, type : string, count : number }),
+    gpu : optional(
+      object({
+        enabled : optional(bool, false),
+        type : optional(string, ""),
+        count : optional(number, 1)
+      }),
+      {}
+    ),
     resource_labels : optional(map(string), {})
   }))
   description = "Notebook node pools to create"
@@ -88,13 +95,20 @@ variable "dask_nodes" {
     max : number,
     preemptible : optional(bool, true),
     machine_type : string,
-    labels : map(string),
+    labels : optional(map(string), {}),
     taints : optional(list(object({
       key : string,
       value : string,
       effect : string
     })), [])
-    gpu : object({ enabled : bool, type : string, count : number }),
+    gpu : optional(
+      object({
+        enabled : optional(bool, false),
+        type : optional(string, ""),
+        count : optional(number, 1)
+      }),
+      {}
+    ),
     resource_labels : optional(map(string), {})
   }))
   description = "Dask node pools to create. Defaults to notebook_nodes"


### PR DESCRIPTION
`optional` is a newish feature of Terraform that lets us omit certain fields from node definitions. This makes node definitions much easier to read, and stops requiring us to change *all* .tfvar files each time we add another way a nodepool can be customized.