### PR TITLE
Bump grafana, prometheus, and cluster-autoscaler

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -6,24 +6,26 @@ description: Cluster wide depdencies for deployed hubs
 dependencies:
   # Prometheus for collection of metrics.
   # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+  #
   # We have deliberately chosen to use the helm chart rather than the prometheus
   # operator, as we will never have more than one prometheus installation per
   # cluster. The operator thus adds functionality we will not use, at a complexity
   # cost. If we ever have multiple prometheii on the same cluster, we can
   # reconsider using the operator.
   - name: prometheus
-    version: 22.6.2
+    version: 22.6.6
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 6.57.0
+    version: 6.57.2
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from
   # a single IP entrypoint to various services exposed via k8s Ingress resources
   # that references this controller.
+  # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
   - name: ingress-nginx
     version: 4.7.0
     repository: https://kubernetes.github.io/ingress-nginx
@@ -31,7 +33,7 @@ dependencies:
   # cluster-autoscaler for k8s clusters where it doesn't come out of the box (EKS)
   # https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
   - name: cluster-autoscaler
-    version: 9.29.0
+    version: 9.29.1
     repository: https://kubernetes.github.io/autoscaler
     condition: cluster-autoscaler.enabled
 


### PR DESCRIPTION
The cert-manager version bump in #2632 wasn't deployed because the support chart wasn't touched as part of the PR.

My goal with this PR is to touch the support chart and get a redeploy, so I took the change to bump a few patch versions of grafana/prometheus/cluster-autoscaler chart dependencies as well.