### PR TITLE
CI bug fixes

### DIFF
--- a/extra-scripts/comment-deployment-plan-pr.py
+++ b/extra-scripts/comment-deployment-plan-pr.py
@@ -40,7 +40,7 @@ headers = {
 url = "/".join([api_url, "repos", repo, "actions", "runs", run_id, "artifacts"])
 params = {"per_page": 100}
 response = requests.get(url, headers=headers, params=params)
-all_artifacts = response["artifacts"]
+all_artifacts = response.json()["artifacts"]
 
 # If "Link" is present in the response headers, that means that the results are
 # paginated and we need to loop through them to collect all the results.

--- a/extra-scripts/comment-test-link-merged-pr.py
+++ b/extra-scripts/comment-test-link-merged-pr.py
@@ -96,10 +96,10 @@ while ("Link" in response.headers.keys()) and (
 
 workflow_url = next(
     (
-        workflow_run.html_url
+        workflow_run["html_url"]
         for workflow_run in all_workflow_runs
-        if workflow_run.name == workflow_name
-        and workflow_run.head_commit.message == commit_msg
+        if workflow_run["name"] == workflow_name
+        and workflow_run["head_commit"]["message"] == commit_msg
     ),
     False,
 )


### PR DESCRIPTION
1. Use proper dictionary notation to extract values. This should fix a recent failure of this workflow: https://github.com/2i2c-org/infrastructure/actions/runs/5311517846/jobs/9614835484
2. Convert API response to json before trying to subscript it. This should fix a recent failure of this workflow: https://github.com/2i2c-org/infrastructure/actions/runs/5311368741/jobs/9614490263