### PR TITLE
Switch to jupyter/scipy-notebook as 'default'

### DIFF
--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -26,6 +26,9 @@ jupyterhub:
           name: AUP
           url: https://www.aup.edu/
   singleuser:
+    image:
+      name: quay.io/2i2c/2i2c-hubs-image
+      tag: "14107b8a85fb"
     memory:
       limit: 8G
       guarantee: 6G

--- a/config/clusters/2i2c/pfw.values.yaml
+++ b/config/clusters/2i2c/pfw.values.yaml
@@ -25,6 +25,10 @@ jupyterhub:
         funded_by:
           name: JROST & IOI
           url: https://investinopen.org/blog/jrost-rapid-response-fund-awardees
+  singleuser:
+    image:
+      name: quay.io/2i2c/2i2c-hubs-image
+      tag: "14107b8a85fb"
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -25,6 +25,10 @@ jupyterhub:
         funded_by:
           name: University of California, Merced
           url: http://www.ucmerced.edu/
+  singleuser:
+    image:
+      name: quay.io/2i2c/2i2c-hubs-image
+      tag: "14107b8a85fb"
   hub:
     config:
       Authenticator:

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -56,6 +56,9 @@ jupyterhub:
           - http://google.com/accounts/o8/id
 
   singleuser:
+    image:
+      name: quay.io/2i2c/2i2c-hubs-image
+      tag: "14107b8a85fb"
     defaultUrl: /lab
     profileList:
       - display_name: "Small: m5.large"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -273,8 +273,8 @@ jupyterhub:
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     image:
-      name: quay.io/2i2c/2i2c-hubs-image
-      tag: "14107b8a85fb"
+      name: jupyter/scipy-notebook
+      tag: "2023-06-19"
     storage:
       type: static
       static:


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/issues/2336 lists issues with the current 'default' image, and the history of how it came to be. The primary reason for its existence was addressed in https://github.com/2i2c-org/infrastructure/issues/2435, so it fundamentally does not really need to exist anymore.

However, there are still 4 hubs using that image, inherited from the default. This PR does the following:

- Switches to jupyter/scipy-notebook as the 'default', when nothing else is specified. Note that because all our hubs have an image specified *somewhere* except for these 4 (see the spreadsheet linked to from https://github.com/2i2c-org/infrastructure/issues/2582), this will actually have *no effect* for existing hubs at all! Just means that *future* hubs will get this image as the default.
- Explicitly sets the image for the 4 hubs still using the old 'default' image. These communities will need to be reached out to, and the image changed.

After this, I believe we can archive the old 'default' image!

Ref https://github.com/2i2c-org/infrastructure/issues/2336 (EDIT by Erik: fixes #2336)