### PR TITLE
Move *most* hubs on shared cluster to filestore (2i2c and cloudbank cluster)

### DIFF
--- a/config/clusters/2i2c/basehub-common.values.yaml
+++ b/config/clusters/2i2c/basehub-common.values.yaml
@@ -1,0 +1,9 @@
+nfs:
+  enabled: true
+  pv:
+    mountOptions:
+      - soft
+      - noatime
+    serverIP: 10.234.45.250
+    # MUST HAVE TRAILING SLASH
+    baseShareName: /homes/

--- a/config/clusters/2i2c/basehub-common.values.yaml
+++ b/config/clusters/2i2c/basehub-common.values.yaml
@@ -6,4 +6,4 @@ nfs:
       - noatime
     serverIP: 10.234.45.250
     # MUST HAVE TRAILING SLASH
-    baseShareName: /homes/
+    baseShareName: /homes/homes/

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -21,6 +21,7 @@ hubs:
     domain: staging.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - staging.values.yaml
       - enc-staging.secret.values.yaml
   - name: hackanexoplanet
@@ -31,6 +32,7 @@ hubs:
       expected_status: 401
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - hackanexoplanet.values.yaml
       - enc-hackanexoplanet.secret.values.yaml
   - name: dask-staging
@@ -38,9 +40,7 @@ hubs:
     domain: dask-staging.2i2c.cloud
     helm_chart: daskhub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - daskhub-common.values.yaml
       - dask-staging.values.yaml
       - enc-dask-staging.secret.values.yaml
   - name: binder-staging
@@ -55,9 +55,7 @@ hubs:
     domain: demo.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - basehub-common.values.yaml
       - demo.values.yaml
       - enc-demo.secret.values.yaml
   - name: ohw
@@ -65,9 +63,7 @@ hubs:
     domain: oceanhackweek.2i2c.cloud
     helm_chart: daskhub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - daskhub-common.values.yaml
       - ohw.values.yaml
       - enc-ohw.secret.values.yaml
   - name: pfw
@@ -75,9 +71,7 @@ hubs:
     domain: pfw.pilot.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - basehub-common.values.yaml
       - pfw.values.yaml
       - enc-pfw.secret.values.yaml
   - name: catalyst-cooperative
@@ -85,9 +79,7 @@ hubs:
     domain: catalyst-cooperative.pilot.2i2c.cloud
     helm_chart: daskhub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - daskhub-common.values.yaml
       - catalyst-cooperative.values.yaml
       - enc-catalyst-cooperative.secret.values.yaml
   - name: aup
@@ -95,9 +87,7 @@ hubs:
     domain: aup.pilot.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
+      - basehub-common.values.yaml
       - aup.values.yaml
       - enc-aup.secret.values.yaml
   - name: temple
@@ -105,6 +95,7 @@ hubs:
     domain: temple.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - temple.values.yaml
       - enc-temple.secret.values.yaml
   - name: ucmerced
@@ -112,6 +103,7 @@ hubs:
     domain: ucmerced.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - ucmerced.values.yaml
       - enc-ucmerced.secret.values.yaml
   - name: cosmicds
@@ -119,6 +111,7 @@ hubs:
     domain: cosmicds.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - cosmicds.values.yaml
       - enc-cosmicds.secret.values.yaml
   - name: climatematch
@@ -126,5 +119,6 @@ hubs:
     domain: climatematch.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
+      - basehub-common.values.yaml
       - climatematch.values.yaml
       - enc-climatematch.secret.values.yaml

--- a/config/clusters/2i2c/daskhub-common.values.yaml
+++ b/config/clusters/2i2c/daskhub-common.values.yaml
@@ -7,4 +7,4 @@ basehub:
         - noatime
       serverIP: 10.234.45.250
       # MUST HAVE TRAILING SLASH
-      baseShareName: /homes/
+      baseShareName: /homes/homes/

--- a/config/clusters/2i2c/daskhub-common.values.yaml
+++ b/config/clusters/2i2c/daskhub-common.values.yaml
@@ -1,0 +1,10 @@
+basehub:
+  nfs:
+    enabled: true
+    pv:
+      mountOptions:
+        - soft
+        - noatime
+      serverIP: 10.234.45.250
+      # MUST HAVE TRAILING SLASH
+      baseShareName: /homes/

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -1,3 +1,9 @@
+nfs:
+  pv:
+    serverIP: nfs-server-01
+    # MUST HAVE TRAILING SLASH
+    baseShareName: /export/home-01/homes/
+
 jupyterhub:
   ingress:
     hosts:

--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -1,3 +1,8 @@
+nfs:
+  pv:
+    serverIP: nfs-server-01
+    # MUST HAVE TRAILING SLASH
+    baseShareName: /export/home-01/homes/
 jupyterhub:
   singleuser:
     cpu:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -53,9 +53,6 @@ nfs:
       - soft
       - noatime
       - vers=4.2
-    serverIP: nfs-server-01
-    # MUST HAVE TRAILING SLASH
-    baseShareName: /export/home-01/homes/
 
 # Use NFS provided by an in cluster server with the nfs-external-provisioner chart
 inClusterNFS:


### PR DESCRIPTION
Looking at Grafana, temple is the only hub that seems to currently consistently have users. The process for moving a hub over is:

1. Wait for the hub to have no users
2. Do an rsync just for that hub's home directories. For most of these hubs I expect this will be pretty quick.
3. If no users had logged on while this rsync was happening, proceed. If not, go to 1.
4. Delete the PV, PVC and pod providing shared homedirectory metrics. This will need to be done manually once, as we are changing the PV and that is immutable. This is a rare enough event that not automating this is fine, plus I don't actually want to automate deleting PVs (just in case it deletes data we actually want!). Note that if any users are actually on the hub, it won't actually delete (thanks to https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection)
5. Deploy the change, move things to the new homedirectory.
6. Repeat!

Ref https://github.com/2i2c-org/infrastructure/issues/1105