### PR TITLE
shared cluster: Move temple hub to filestore as home dir

### DIFF
--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -1,9 +1,3 @@
-nfs:
-  pv:
-    serverIP: nfs-server-01
-    # MUST HAVE TRAILING SLASH
-    baseShareName: /export/home-01/homes/
-
 jupyterhub:
   ingress:
     hosts:


### PR DESCRIPTION
Will wait for there to be no users to get this done.

Ref https://github.com/2i2c-org/infrastructure/issues/1105