### PR TITLE
Move cloudbank hubs to filestore home directory storage

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -1,8 +1,11 @@
 nfs:
   pv:
-    serverIP: nfs-server-01
+    mountOptions:
+      - soft
+      - noatime
+    serverIP: 10.80.94.178
     # MUST HAVE TRAILING SLASH
-    baseShareName: /export/home-01/homes/
+    baseShareName: /homes/homes/
 jupyterhub:
   singleuser:
     cpu:


### PR DESCRIPTION
Similar to https://github.com/2i2c-org/infrastructure/pull/2672. That PR has information on the process used to deploy this.

Ref https://github.com/2i2c-org/infrastructure/issues/1105