### PR TITLE
daskhub: stop scraping worker pods for dask specific metrics

### DIFF
--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -308,7 +308,7 @@ dask-gateway:
                 if ":" not in options.image:
                     raise ValueError("When specifying an image you must also provide a tag")
                 extra_labels = {}
-                extra_annotations = {
+                scheduler_extra_pod_annotations = {
                     "prometheus.io/scrape": "true",
                     "prometheus.io/port": "8787",
                 }
@@ -321,9 +321,9 @@ dask-gateway:
                     # A default image is suggested via DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE env variable
                     "image": options.image,
                     "scheduler_extra_pod_labels": extra_labels,
-                    "scheduler_extra_pod_annotations": extra_annotations,
+                    "scheduler_extra_pod_annotations": scheduler_extra_pod_annotations,
                     "worker_extra_pod_labels": extra_labels,
-                    "worker_extra_pod_annotations": extra_annotations,
+                    "worker_extra_pod_annotations": scheduler_extra_pod_annotations,
                     "worker_cores": 0.85 * chosen_worker_cpu,
                     "worker_cores_limit": chosen_worker_cpu,
                     "worker_memory": "%fG" % (0.85 * chosen_worker_memory),

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -182,7 +182,7 @@ dask-gateway:
             def option_handler(options):
                 if ":" not in options.image:
                     raise ValueError("When specifying an image you must also provide a tag")
-                extra_annotations = {
+                scheduler_extra_pod_annotations = {
                     "hub.jupyter.org/username": safe_username,
                     "prometheus.io/scrape": "true",
                     "prometheus.io/port": "8787",
@@ -195,8 +195,7 @@ dask-gateway:
                     "worker_cores": options.worker_cores,
                     "worker_memory": "%fG" % options.worker_memory,
                     "image": options.image,
-                    "scheduler_extra_pod_annotations": extra_annotations,
-                    "worker_extra_pod_annotations": extra_annotations,
+                    "scheduler_extra_pod_annotations": scheduler_extra_pod_annotations,
                     "scheduler_extra_pod_labels": extra_labels,
                     "worker_extra_pod_labels": extra_labels,
                     "environment": options.environment,


### PR DESCRIPTION
Our prometheus-server instances blow up in memory use and gets OOMKilled when dask-gateway is used extensively. Why isn't obvious, but I suspect scraping individual dask-worker pods metrics adds to the problem, and since we don't use the dask-worker specific metrics, we shouldn't scrape them.

- Closes #2366 