### PR TITLE
Fix sacramento allowed users pattern

### DIFF
--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -42,4 +42,4 @@ jupyterhub:
           - sean.smorris@berkeley.edu
           - mukarra@scc.losrios.edu
           - w1475529@apps.losrios.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@apps\.losrios\.edu|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@(scc|apps)\.losrios\.edu|deployment-service-check)$'


### PR DESCRIPTION
The hub was crashing because we had an admin user whose username was not in the allowed pattern