### PR TITLE
Specify issue write permission for doc link checker workflow

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   # ref: https://github.com/2i2c-org/.github/blob/main/.github/workflows/documentation-link-check.yaml
   linkcheck:
+    permissions:
+      issues: write
     uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yaml@main
     with:
       docs_path: docs


### PR DESCRIPTION
This workflow kept failing with the error "Resource not available to integration", which is usually an indication that the correct permissions were not assigned to the github token.

- Example: https://github.com/2i2c-org/infrastructure/actions/runs/5340613320/jobs/9680620698

P.S. I'm not sure if specifying the `permissions` key in the workflow file at https://github.com/2i2c-org/.github/blob/main/.github/workflows/documentation-link-check.yaml would have also worked?