### PR TITLE
jmte, daskhub: fix failure to stop scraping dask-worker metrics

### DIFF
--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -323,7 +323,6 @@ dask-gateway:
                     "scheduler_extra_pod_labels": extra_labels,
                     "scheduler_extra_pod_annotations": scheduler_extra_pod_annotations,
                     "worker_extra_pod_labels": extra_labels,
-                    "worker_extra_pod_annotations": scheduler_extra_pod_annotations,
                     "worker_cores": 0.85 * chosen_worker_cpu,
                     "worker_cores_limit": chosen_worker_cpu,
                     "worker_memory": "%fG" % (0.85 * chosen_worker_memory),


### PR DESCRIPTION
A mistake was made in https://github.com/2i2c-org/infrastructure/pull/2686 that was spotted by @damianavila in https://github.com/2i2c-org/infrastructure/pull/2686/files#r1239775340, where we still scraped JMTE's dask-worker pod's metrics.