### PR TITLE
Stop prometheus from balooning memory usage on startup

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -25,6 +25,30 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    extraInitContainers:
+      # Prometheus sometimes seems to run into bugs where the 'write ahead log'
+      # used for recovery from crashes and network failures gets massive, and
+      # requires an order of magnitude more RAM to start up than usual (see
+      # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
+      # at each startup means we *might* lose some data during restarts, but
+      # that is far preferable to having the entire prometheus server be down.
+      # This should be only done for prometheus instances that seem to crash
+      # with messages about loading from the WAL in their logs.
+      - name: kill-wal
+        image: busybox
+        command:
+          [
+            "sh",
+            "-c",
+            "rm -rvf /data/wal/*",
+          ]
+        securityContext:
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+        volumeMounts:
+          - mountPath: /data
+            name: storage-volume
     persistentVolume:
       size: 200Gi
     ingress:
@@ -35,13 +59,3 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.gcp.pangeo.2i2c.cloud
-    resources:
-      # This prometheus instance has required 13+ GB to startup successfully in
-      # the past (2023-02-17) when replaying the "write-ahead log" (WAL) stored
-      # on on disk when it starts up. For more details, see the comments next to
-      # the default values in helm-charts/support/values.yaml.
-      #
-      requests:
-        memory: 32Gi
-      limits:
-        memory: 32Gi

--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -25,30 +25,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    extraInitContainers:
-      # Prometheus sometimes seems to run into bugs where the 'write ahead log'
-      # used for recovery from crashes and network failures gets massive, and
-      # requires an order of magnitude more RAM to start up than usual (see
-      # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
-      # at each startup means we *might* lose some data during restarts, but
-      # that is far preferable to having the entire prometheus server be down.
-      # This should be only done for prometheus instances that seem to crash
-      # with messages about loading from the WAL in their logs.
-      - name: kill-wal
-        image: busybox
-        command:
-          [
-            "sh",
-            "-c",
-            "rm -rvf /data/wal/*",
-          ]
-        securityContext:
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-        volumeMounts:
-          - mountPath: /data
-            name: storage-volume
     persistentVolume:
       size: 200Gi
     ingress:

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -13,6 +13,8 @@ dependencies:
   # cost. If we ever have multiple prometheii on the same cluster, we can
   # reconsider using the operator.
   - name: prometheus
+    # NOTE: CHECK INSTRUCTIONS UNDER prometheus.server.command IN support/values.yaml
+    # EACH TIME THIS VERSION IS BUMPED!
     version: 22.6.6
     repository: https://prometheus-community.github.io/helm-charts
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -143,13 +143,13 @@ prometheus:
     defaultFlagsOverride:
       - -c
       - "rm -rvf /data/wal/* && \
-         /bin/prometheus \
-         --storage.tsdb.retention.time=366d \
-         --config.file=/etc/config/prometheus.yml \
-         --storage.tsdb.path=/data \
-         --web.console.libraries=/etc/prometheus/console_libraries \
-         --web.console.templates=/etc/prometheus/consoles \
-         --web.enable-lifecycle"
+        /bin/prometheus \
+        --storage.tsdb.retention.time=366d \
+        --config.file=/etc/config/prometheus.yml \
+        --storage.tsdb.path=/data \
+        --web.console.libraries=/etc/prometheus/console_libraries \
+        --web.console.templates=/etc/prometheus/consoles \
+        --web.enable-lifecycle"
     ingress:
       annotations:
         # Annotations required to enable basic authentication for any ingress

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -124,30 +124,32 @@ prometheus:
     enabled: true
 
   server:
-    extraInitContainers:
-      # Prometheus sometimes seems to run into bugs where the 'write ahead log'
-      # used for recovery from crashes and network failures gets massive, and
-      # requires an order of magnitude more RAM to start up than usual (see
-      # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
-      # at each startup means we *might* lose some data during restarts, but
-      # that is far preferable to having the entire prometheus server be down.
-      # This may be fixed by prometheus 2.45 which is not out yet
-      # https://github.com/prometheus/prometheus/issues/6934#issuecomment-1586060255
-      - name: kill-wal
-        image: busybox
-        command:
-          [
-            "sh",
-            "-c",
-            "rm -rvf /data/wal/*",
-          ]
-        securityContext:
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-        volumeMounts:
-          - mountPath: /data
-            name: storage-volume
+    # Prometheus sometimes seems to run into bugs where the 'write ahead log'
+    # used for recovery from crashes and network failures gets massive, and
+    # requires an order of magnitude more RAM to start up than usual (see
+    # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
+    # at each startup means we *might* lose some data during restarts, but
+    # that is far preferable to having the entire prometheus server be down.
+    # This may be fixed by prometheus 2.45 which is not out yet
+    # https://github.com/prometheus/prometheus/issues/6934#issuecomment-1586060255
+    # We can't use initContainers here, as they are not run when a container
+    # restarts - only when the pod itself is redone. And unfortunately there
+    # isn't a simple script we can run that will pass through the args to
+    # /bin/prometheus after running the rm. So we improvise here - this is
+    # the commandline of what prometheus is actually executing, copied over.
+    # This must be revalidated with each bump of the prometheus helm chart!
+    command:
+      - /bin/sh
+    defaultFlagsOverride:
+      - -c
+      - "rm -rvf /data/wal/* && \
+         /bin/prometheus \
+         --storage.tsdb.retention.time=366d \
+         --config.file=/etc/config/prometheus.yml \
+         --storage.tsdb.path=/data \
+         --web.console.libraries=/etc/prometheus/console_libraries \
+         --web.console.templates=/etc/prometheus/consoles \
+         --web.enable-lifecycle"
     ingress:
       annotations:
         # Annotations required to enable basic authentication for any ingress
@@ -218,6 +220,7 @@ prometheus:
     persistentVolume:
       size: 100Gi
     # Keep data for at least 1 year
+    # THIS MUST BE COPIED OVER TO prometheus.server.defaultFlagsOverride as well
     retention: 366d
     service:
       type: ClusterIP

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -143,7 +143,7 @@ prometheus:
     defaultFlagsOverride:
       - -c
       - "rm -rvf /data/wal/* && \
-        /bin/prometheus \
+        exec /bin/prometheus \
         --storage.tsdb.retention.time=366d \
         --config.file=/etc/config/prometheus.yml \
         --storage.tsdb.path=/data \

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -138,6 +138,28 @@ prometheus:
     # /bin/prometheus after running the rm. So we improvise here - this is
     # the commandline of what prometheus is actually executing, copied over.
     # This must be revalidated with each bump of the prometheus helm chart!
+    #
+    # IMPORTANT: When upgrading the prometheus chart we need to manually adjust
+    #            to changes to...
+    #
+    #            - The Deployment resource template's container args:
+    #              https://github.com/prometheus-community/helm-charts/blob/44df643f30e8e623f4bb95f646de2662522eb554/charts/prometheus/templates/deploy.yaml#L123-L145
+    #
+    #            - The default values of the config referenced in the template:
+    #              https://github.com/prometheus-community/helm-charts/blob/44df643f30e8e623f4bb95f646de2662522eb554/charts/prometheus/values.yaml
+    #
+    #              In the commit 44df643f linked above, this config was
+    #              referenced and defaulted to:
+    #
+    #              server.retention - "15d"
+    #              server.configPath - "/etc/config/prometheus.yml"
+    #              server.storagePath - ""
+    #              server.persistentVolume.mountPath - "/data"
+    #              server.extraFlags - ["web.enable-lifecycle"]
+    #              server.extraArgs - {}
+    #              server.prefixURL - ""
+    #              server.baseURL - ""
+    #
     command:
       - /bin/sh
     defaultFlagsOverride:
@@ -220,7 +242,7 @@ prometheus:
     persistentVolume:
       size: 100Gi
     # Keep data for at least 1 year
-    # THIS MUST BE COPIED OVER TO prometheus.server.defaultFlagsOverride as well
+    # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     retention: 366d
     service:
       type: ClusterIP

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -131,6 +131,8 @@ prometheus:
       # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
       # at each startup means we *might* lose some data during restarts, but
       # that is far preferable to having the entire prometheus server be down.
+      # This may be fixed by prometheus 2.45 which is not out yet
+      # https://github.com/prometheus/prometheus/issues/6934#issuecomment-1586060255
       - name: kill-wal
         image: busybox
         command:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -124,6 +124,28 @@ prometheus:
     enabled: true
 
   server:
+    extraInitContainers:
+      # Prometheus sometimes seems to run into bugs where the 'write ahead log'
+      # used for recovery from crashes and network failures gets massive, and
+      # requires an order of magnitude more RAM to start up than usual (see
+      # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
+      # at each startup means we *might* lose some data during restarts, but
+      # that is far preferable to having the entire prometheus server be down.
+      - name: kill-wal
+        image: busybox
+        command:
+          [
+            "sh",
+            "-c",
+            "rm -rvf /data/wal/*",
+          ]
+        securityContext:
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+        volumeMounts:
+          - mountPath: /data
+            name: storage-volume
     ingress:
       annotations:
         # Annotations required to enable basic authentication for any ingress

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -2,7 +2,7 @@ prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
-core_node_machine_type = "n2-highmem-8"
+core_node_machine_type = "n2-highmem-4"
 enable_private_cluster = true
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs


### PR DESCRIPTION
https://github.com/prometheus/prometheus/issues/6934 is the core problem, and we can afford to lose a tiny bit of data during restarts by killing the wal at startup instead of giving prometheus a lot of memory to read it all in. We lose data during the WAL reading phase anyway, and the amount of memory required seems ginormous (the linked issue has folks topping out at 64G). Apparently 2.45 is supposed to help, but it's not out yet (see
https://github.com/prometheus/prometheus/issues/6934#issuecomment-1536172431).

Removing the wal on startup is one of the solutions suggested by upstream in https://github.com/prometheus/prometheus/issues/6934#issuecomment-595982266

I've removed the higher memory request for pangeo-hubs, and brought it in line with our other prometheii - and it seems to work fine without any issues. I've thus also reduced the size of the core node, practically reverting https://github.com/2i2c-org/infrastructure/pull/2701

LEAP cluster's prometheus was also down, due to the WAL filling up the disk. This deploy fixed it.