### PR TITLE
Bump UToronto default & R image tags

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
       JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "e533070e58f2"
+      tag: "736072886c54"
   hub:
     config:
       Authenticator:

--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -17,4 +17,4 @@ jupyterhub:
     defaultUrl: /rstudio
     image:
       name: quay.io/2i2c/utoronto-r-image
-      tag: "56b24a700284"
+      tag: "c5ec9db8ccb2"


### PR DESCRIPTION
Includes otter-grader on request from Nathan Taback

Brings in https://github.com/2i2c-org/utoronto-image/pull/53 and https://github.com/2i2c-org/utoronto-image/pull/53