### PR TITLE
Upgrade z2jh version

### DIFF
--- a/config/clusters/2i2c-aws-us/common.values.yaml
+++ b/config/clusters/2i2c-aws-us/common.values.yaml
@@ -3,8 +3,3 @@ basehub:
     scheduling:
       userScheduler:
         enabled: true
-    singleuser:
-      extraEnv:
-        # Temporarily set for *all* pods, including pods without any GPUs,
-        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility

--- a/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
+++ b/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
@@ -255,6 +255,8 @@ basehub:
           kubespawner_override:
             mem_limit: null
             mem_guarantee: 14G
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               node.kubernetes.io/instance-type: g4dn.xlarge
             extra_resource_limits:

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -246,6 +246,8 @@ basehub:
                     image: "pangeo/pytorch-notebook:b9584f6"
           kubespawner_override:
             mem_limit: null
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             mem_guarantee: 14G
             node_selector:
               node.kubernetes.io/instance-type: g4dn.xlarge

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -32,10 +32,6 @@ basehub:
             name: Carbon Plan
             url: https://carbonplan.org
     singleuser:
-      extraEnv:
-        # Temporarily set for *all* pods, including pods without any GPUs,
-        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       serviceAccountName: cloud-user-sa
       image:
         name: carbonplan/trace-python-notebook
@@ -169,6 +165,8 @@ basehub:
                     # Source: https://github.com/carbonplan/benchmark-maps
                     image: quay.io/carbonplan/benchmark-maps:latest
           kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             mem_limit: null
             extra_resource_limits:
               nvidia.com/gpu: "1"

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -45,10 +45,6 @@ basehub:
         JupyterHub:
           authenticator_class: github
     singleuser:
-      extraEnv:
-        # Temporarily set for *all* pods, including pods without any GPUs,
-        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes.
@@ -105,6 +101,8 @@ basehub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2022.10.18"
           kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             mem_limit: null
             extra_resource_limits:
               nvidia.com/gpu: "1"

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -102,16 +102,6 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/hub-jupytearth-org-github-integ
         GH_SCOPED_CREDS_CLIENT_ID: Iv1.a073b1649637af12
-      image:
-        # NOTE: We use the jupyterhub-configurator so this image/tag is not
-        #       relevant. Visit its UI to configure the hub.
-        #
-        #       staging: https://staging.hub.jupytearth.org/services/configurator/
-        #       prod:    https://hub.jupytearth.org/services/configurator/
-        pullPolicy: Always
-        name: 286354552638.dkr.ecr.us-west-2.amazonaws.com/jmte/user-env
-        tag: "latest"
-
       profileList:
         - display_name: "16th of Medium: 0.25-4 CPU, 1-16 GB"
           default: True

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -226,19 +226,6 @@ basehub:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
-        - display_name: "16th of Medium: 0.25-4 CPU, 1-16 GB - Test of latest image"
-          description: "Helps us test an image before we make it the default"
-          profile_options: *profile_options
-          kubespawner_override:
-            image: 286354552638.dkr.ecr.us-west-2.amazonaws.com/jmte/user-env:latest
-            image_pull_policy: Always
-            cpu_guarantee: 0.225
-            mem_guarantee: 0.875G
-            environment:
-              NVIDIA_DRIVER_CAPABILITIES: compute,utility
-            node_selector:
-              node.kubernetes.io/instance-type: m5.xlarge
-            mem_limit: null
 
     hub:
       config:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -102,10 +102,6 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/hub-jupytearth-org-github-integ
         GH_SCOPED_CREDS_CLIENT_ID: Iv1.a073b1649637af12
-
-        # FIXME: Until we can set this just for the GPU nodes, we need to set it for everyon
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility
-
       image:
         # NOTE: We use the jupyterhub-configurator so this image/tag is not
         #       relevant. Visit its UI to configure the hub.
@@ -200,6 +196,8 @@ basehub:
             cpu_guarantee: 3.5
             mem_guarantee: 14G
             mem_limit: null
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               node.kubernetes.io/instance-type: g4dn.xlarge
             extra_resource_limits:
@@ -210,6 +208,8 @@ basehub:
           kubespawner_override:
             mem_guarantee: 56G
             mem_limit: null
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               node.kubernetes.io/instance-type: g4dn.4xlarge
             extra_resource_limits:
@@ -222,6 +222,8 @@ basehub:
             mem_limit: null
             node_selector:
               node.kubernetes.io/instance-type: g4dn.16xlarge
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             extra_resource_limits:
               nvidia.com/gpu: "1"
         - display_name: "16th of Medium: 0.25-4 CPU, 1-16 GB - Test of latest image"
@@ -232,6 +234,8 @@ basehub:
             image_pull_policy: Always
             cpu_guarantee: 0.225
             mem_guarantee: 0.875G
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               node.kubernetes.io/instance-type: m5.xlarge
             mem_limit: null

--- a/config/clusters/jupyter-meets-the-earth/staging.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/staging.values.yaml
@@ -17,3 +17,4 @@ basehub:
       extraEnv:
         # This bucket is created via terraform.
         SCRATCH_BUCKET: s3://jupyter-meets-the-earth-staging-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: s3://jupyter-meets-the-earth-staging-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -80,9 +80,6 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
-        # Temporarily set for *all* pods, including pods without any GPUs,
-        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       profileList:
         # NOTE: About node sharing
         #
@@ -268,6 +265,8 @@ basehub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:ebeb9dd"
           kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               cloud.google.com/gke-nodepool: nb-gpu-t4
             mem_limit: 30G

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -67,9 +67,6 @@ basehub:
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.1c4d967ffc205f98"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/m2lines-pangeo-hub-push-access
-        # Temporarily set for *all* pods, including pods without any GPUs,
-        # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-        NVIDIA_DRIVER_CAPABILITIES: compute,utility
       # User image repo: https://github.com/pangeo-data/pangeo-docker-images
       image:
         name: pangeo/pangeo-notebook
@@ -150,6 +147,8 @@ basehub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:ebeb9dd"
           kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
               cloud.google.com/gke-nodepool: nb-gpu-t4
             mem_limit: 30G

--- a/docs/howto/features/gpu.md
+++ b/docs/howto/features/gpu.md
@@ -86,10 +86,6 @@ a profile. This should be placed in the hub configuration:
 ```yaml
 jupyterhub:
    singleuser:
-      extraEnv:
-         # Temporarily set for *all* pods, including pods without any GPUs,
-         # to work around https://github.com/2i2c-org/infrastructure/issues/1530
-         NVIDIA_DRIVER_CAPABILITIES: compute,utility
       profileList:
         - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
           description: "Start a container on a dedicated node with a GPU"
@@ -109,6 +105,8 @@ jupyterhub:
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:<tag>"
           kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             mem_limit: null
             mem_guarantee: 14G
             node_selector:

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 2.0.1-0.dev.git.5987.h46a632f5
+    version: 3.0.0-beta.1.git.6208.h7b44299a
     repository: https://jupyterhub.github.io/helm-chart/

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -490,7 +490,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.4978.h858bd17c"
+      tag: "0.0.1-0.dev.git.6074.h895181eb"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -50,7 +50,7 @@ basehub:
         # DASK_DISTRIBUTED__DASHBOARD__LINK makes the suggested link to the
         # dashboard account for the /user/<username>/<server-name> prefix in the path.
         # JUPYTERHUB_SERVICE_PREFIX has leading and trailing slashes as appropriate
-        DASK_DISTRIBUTED__DASHBOARD__LINK: "{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
+        DASK_DISTRIBUTED__DASHBOARD__LINK: "$(JUPYTERHUB_SERVICE_PREFIX)proxy/{port}/status"
 
     hub:
       services:

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -43,14 +43,14 @@ basehub:
         #
         # DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE makes the default worker image
         # match the singleuser image.
-        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: "{JUPYTER_IMAGE_SPEC}"
+        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: "{{JUPYTER_IMAGE_SPEC}}"
         # DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT makes some environment
         # variables be copied over to the worker nodes from the user nodes.
-        DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT: '{"SCRATCH_BUCKET": "$(SCRATCH_BUCKET)", "PANGEO_SCRATCH": "$(PANGEO_SCRATCH)"}'
+        DASK_GATEWAY__CLUSTER__OPTIONS__ENVIRONMENT: '{{"SCRATCH_BUCKET": "$(SCRATCH_BUCKET)", "PANGEO_SCRATCH": "$(PANGEO_SCRATCH)"}}'
         # DASK_DISTRIBUTED__DASHBOARD__LINK makes the suggested link to the
         # dashboard account for the /user/<username>/<server-name> prefix in the path.
         # JUPYTERHUB_SERVICE_PREFIX has leading and trailing slashes as appropriate
-        DASK_DISTRIBUTED__DASHBOARD__LINK: "$(JUPYTERHUB_SERVICE_PREFIX)proxy/{port}/status"
+        DASK_DISTRIBUTED__DASHBOARD__LINK: "{{JUPYTERHUB_SERVICE_PREFIX}}proxy/{{port}}/status"
 
     hub:
       services:

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,7 +12,7 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:2.0.1-0.dev.git.5984.h78a29217
+FROM jupyterhub/k8s-hub:3.0.0-beta.1
 
 COPY requirements.txt /tmp/
 

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -1,3 +1,1 @@
-oauthenticator==15.1.0
-jupyterhub-kubespawner==4.3.0
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db


### PR DESCRIPTION
- Brings in KubeSpawner 6 ([changelog](https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html)). Primary changes for us are:
   - https://github.com/jupyterhub/kubespawner/pull/650 to deal with https://github.com/2i2c-org/infrastructure/issues/1530
   - https://github.com/jupyterhub/kubespawner/pull/724, to allow us to build complex profileList UI (needed for our binderhub work)
   - https://github.com/jupyterhub/kubespawner/pull/642 which needs [more escaping](https://github.com/2i2c-org/infrastructure/pull/2719/commits/cbeb7dede0e36e4d3c01ecd658cb5f280b835ff1)
- OAuthenticator version does not change, as we were already using the version present in this z2jh version
- JupyterHub 4.0 is used ([changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)), from 3.1.1
  - User images should be eventually upgraded to JupyterHub 4.x, but not immediately necessary

Tested on:

- staging.2i2c.cloud, all good.
- staging.utoronto.2i2c.cloud, because it is using jupyter-server 1.0 explicitly. Works fine.
- staging.jmte.2i2c.cloud, which helped us catch dask-gateway related escaping issues. There is still another issue to be sorted. I also discovered that https://github.com/jupyterhub/kubespawner/issues/702 was manifesting here, and causing the smallest server option to not start. I've removed the extra profile, and everything works now.
- Tested GPU on staging.jmte.2i2c.cloud, worked ok
