### PR TITLE
Disable automatic image bumps for openscapes

### DIFF
--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -27,6 +27,12 @@ jobs:
           # For each new config_path to monitor, add a new item in this matrix.
           # The Action can read multiple paths to images, but not multiple config files.
           #
+          # Single image: See this example to bump images in the Callysto cluster
+          # - name: "Callysto hub"
+          #   config_path: "config/clusters/callysto/common.values.yaml"
+          #   images_info: '[{"values_path": ".jupyterhub.singleuser.image"}]'
+          #
+          # profileList: See this example to bump images in Openscapes cluster
           # - name: "OpenScapes profiles"
           #   config_path: "config/clusters/openscapes/common.values.yaml"
           #   # Note: if position of images in profileList changes, update the index in these expressions

--- a/.github/workflows/bump-image-tags.yaml
+++ b/.github/workflows/bump-image-tags.yaml
@@ -27,11 +27,10 @@ jobs:
           # For each new config_path to monitor, add a new item in this matrix.
           # The Action can read multiple paths to images, but not multiple config files.
           #
-          # Bump images in openscapes cluster
-          - name: "OpenScapes profiles"
-            config_path: "config/clusters/openscapes/common.values.yaml"
-            # Note: if position of images in profileList changes, update the index in these expressions
-            images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
+          # - name: "OpenScapes profiles"
+          #   config_path: "config/clusters/openscapes/common.values.yaml"
+          #   # Note: if position of images in profileList changes, update the index in these expressions
+          #   images_info: '[{"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.python.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.rocker.kubespawner_override.image"}, {"values_path": ".basehub.jupyterhub.singleuser.profileList[0].profile_options.image.choices.matlab.kubespawner_override.image"}]'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,


### PR DESCRIPTION
- Disabling as per: https://github.com/2i2c-org/infrastructure/pull/2712#issuecomment-1607891982
- Provided more inline comments so if we reenable, folks know how to configure it
- Also disabled this workflow in Actions UI since openscapes was the only cluster we were using it for https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow Leaving the file for the time being in case we want/need to use it as an intermediary as we work towards a better system for communities to self-serve.