### PR TITLE
Add issue write permission to workflow that requires it

### DIFF
--- a/.github/workflows/comment-pending-deployment-info.yaml
+++ b/.github/workflows/comment-pending-deployment-info.yaml
@@ -8,6 +8,8 @@ jobs:
   ask-for-pending-information:
     if: github.event.label.name == 'new hub'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v3
       - name: Parse new hub request issue template form


### PR DESCRIPTION
I think this workflow was failing because it was missing the permissions key to assign the correct permissions to the GitHub token. See "Resource not accessible by integration" error, e.g., https://github.com/2i2c-org/infrastructure/actions/runs/5359758810/jobs/9723768759

fixes #2708 