### PR TITLE
VEDA: Update pangeo-notebook image

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -66,7 +66,7 @@ basehub:
       defaultUrl: /lab
       image:
         name: pangeo/pangeo-notebook
-        tag: "2023.01.13"
+        tag: "2023.06.20"
       profileList:
         # NOTE: About node sharing
         #


### PR DESCRIPTION
:wave: Hi!

I wanted to update the pangeo-notebook image on the VEDA hub. In case this is helpful (@ranchodeluxe mentioned that it might be) it looks like the jupyterhub version is 4.0.1 and the jupyterlab version is 4.0.2. 

As a side note: Is there a standard cadence at which these images get updated or is this the right way to do it?