### PR TITLE
prometheus: avoid loosing more than 10m data during restarts

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -351,7 +351,7 @@ jupyterhub:
         # Otherwise our prometheus server can't get hub metrics
         authenticate_prometheus: false
       KubeSpawner:
-        # Make sure working directory is ${HOME}
+        # Make sure working directory is where we mount the home folder
         working_dir: /home/jovyan
         # Increase timeout for Jupyter server to become 'ready', until
         # https://github.com/2i2c-org/infrastructure/issues/2047 is fixed

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -126,12 +126,17 @@ prometheus:
   server:
     # Prometheus sometimes seems to run into bugs where the 'write ahead log'
     # used for recovery from crashes and network failures gets massive, and
-    # requires an order of magnitude more RAM to start up than usual (see
-    # https://github.com/prometheus/prometheus/issues/6934). Deleting the WAL
-    # at each startup means we *might* lose some data during restarts, but
-    # that is far preferable to having the entire prometheus server be down.
-    # This may be fixed by prometheus 2.45 which is not out yet
-    # https://github.com/prometheus/prometheus/issues/6934#issuecomment-1586060255
+    # requires an order of magnitude more RAM to start up than usual. This could
+    # have been greatly improved in prometheus 2.45 which is used as of
+    # 2023-06-28, but we stick with a workaround for now until other users have
+    # concluded things have greatly improved for them in prometheus 2.45+.
+    #
+    # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1610921555
+    #
+    # We are deleting the WAL at each startup now, and it has made us lose some
+    # data during restarts, but that is preferable to having the entire
+    # prometheus server be down.
+    #
     # We can't use initContainers here, as they are not run when a container
     # restarts - only when the pod itself is redone. And unfortunately there
     # isn't a simple script we can run that will pass through the args to
@@ -160,6 +165,10 @@ prometheus:
     #              server.prefixURL - ""
     #              server.baseURL - ""
     #
+    #              Currently our adjustments from the defaults are to
+    #              server.retention and server.extraFlags configured
+    #              directly below server.defaultFlagsOverride.
+    #
     command:
       - /bin/sh
     defaultFlagsOverride:
@@ -171,7 +180,24 @@ prometheus:
         --storage.tsdb.path=/data \
         --web.console.libraries=/etc/prometheus/console_libraries \
         --web.console.templates=/etc/prometheus/consoles \
-        --web.enable-lifecycle"
+        --web.enable-lifecycle \
+        --storage.tsdb.min-block-duration=30m \
+        --storage.tsdb.max-block-duration=30m"
+    # extraFlags MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
+    extraFlags:
+      - web.enable-lifecycle
+      # We seem to loose data when restarting prometheus during upgrades, and we
+      # also have had memory peaking issues during startup. These flags may help
+      # us reduce the data loss to at most 30m and has been observed to reduce
+      # the memory peaking before prometheus 2.45 at least.
+      #
+      # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1099293120
+      #
+      - storage.tsdb.min-block-duration=30m
+      - storage.tsdb.max-block-duration=30m
+    # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
+    retention: 366d # Keep data for at least 1 year
+
     ingress:
       annotations:
         # Annotations required to enable basic authentication for any ingress
@@ -243,9 +269,6 @@ prometheus:
       hub.jupyter.org/network-access-hub: "true"
     persistentVolume:
       size: 100Gi
-    # Keep data for at least 1 year
-    # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
-    retention: 366d
     service:
       type: ClusterIP
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -181,8 +181,8 @@ prometheus:
         --web.console.libraries=/etc/prometheus/console_libraries \
         --web.console.templates=/etc/prometheus/consoles \
         --web.enable-lifecycle \
-        --storage.tsdb.min-block-duration=30m \
-        --storage.tsdb.max-block-duration=30m"
+        --storage.tsdb.min-block-duration=10m \
+        --storage.tsdb.max-block-duration=10m"
     # extraFlags MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     extraFlags:
       - web.enable-lifecycle
@@ -193,8 +193,8 @@ prometheus:
       #
       # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1099293120
       #
-      - storage.tsdb.min-block-duration=30m
-      - storage.tsdb.max-block-duration=30m
+      - storage.tsdb.min-block-duration=10m
+      - storage.tsdb.max-block-duration=10m
     # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     retention: 366d # Keep data for at least 1 year
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -187,8 +187,10 @@ prometheus:
         kubernetes.io/ingress.class: nginx
         cert-manager.io/cluster-issuer: letsencrypt-prod
     strategy:
-      # We have a persistent disk attached, so the default (RollingUpdate)
-      # can sometimes get 'stuck' and require pods to be manually deleted.
+      # type is set to Recreate as we have a persistent disk attached. The
+      # default of RollingUpdate would fail by getting stuck waiting for a new
+      # pod trying to mount the same storage that only supports being mounted by
+      # one pod.
       type: Recreate
     resources:
       # Prometheus cpu/memory requests/limits needs to be carefully considered based on:


### PR DESCRIPTION
When we clear the prometheus write ahead log (WAL) on startup, it seems we loose data even when its termenating regularly during for example prometheus chart upgrades. The amount of data lost seem to be up to 2 hours or so.

From summarizing an issue about memory peaking in https://github.com/prometheus/prometheus/issues/6934#issuecomment-1610921555, I think it makes sense for us to pass two flags to help us only loose up to ~30 minutes of metrics. This change has also been observed to reduce memory spikes.

```
# ...
# the end of startup in the line below
ts=2023-06-28T09:25:53.263Z caller=head.go:1293 level=info component=tsdb msg="Head GC completed" caller=truncateMemory duration=2.920359ms

# an event triggered 30m after startup below
ts=2023-06-28T09:55:56.731Z caller=compact.go:523 level=info component=tsdb msg="write block" mint=1687943452954 maxt=1687944600000 ulid=01H40PWMX1QF0JJ7FD4SEG9FG6 duration=1.81850325s
ts=2023-06-28T09:55:56.779Z caller=head.go:1293 level=info component=tsdb msg="Head GC completed" caller=truncateMemory duration=43.444241ms

# `kubectl delete pod` test
ts=2023-06-28T10:01:52.045Z caller=main.go:854 level=warn msg="Received SIGTERM, exiting gracefully..."
ts=2023-06-28T10:01:52.045Z caller=main.go:878 level=info msg="Stopping scrape discovery manager..."
ts=2023-06-28T10:01:52.045Z caller=main.go:892 level=info msg="Stopping notify discovery manager..."
ts=2023-06-28T10:01:52.045Z caller=manager.go:1009 level=info component="rule manager" msg="Stopping rule manager..."
ts=2023-06-28T10:01:52.045Z caller=manager.go:1019 level=info component="rule manager" msg="Rule manager stopped"
ts=2023-06-28T10:01:52.045Z caller=main.go:929 level=info msg="Stopping scrape manager..."
ts=2023-06-28T10:01:52.045Z caller=main.go:874 level=info msg="Scrape discovery manager stopped"
ts=2023-06-28T10:01:52.046Z caller=main.go:888 level=info msg="Notify discovery manager stopped"
ts=2023-06-28T10:01:52.047Z caller=main.go:921 level=info msg="Scrape manager stopped"
ts=2023-06-28T10:01:52.143Z caller=notifier.go:603 level=info component=notifier msg="Stopping notification manager..."
ts=2023-06-28T10:01:52.143Z caller=main.go:1150 level=info msg="Notifier manager stopped"
ts=2023-06-28T10:01:52.143Z caller=main.go:1162 level=info msg="See you next time!"
```

When I forcefully restarted after this PR, the observed data loss was about exactly 30 minutes, from 10:34 (11:34 in gif animation because of timezone stuff). I note that this was after the log message "Head GC completed" as seen in logs above. My guess is that we will have a consistent data loss of 30 min of data loss going onwards when prometheus-server is restarted.

![restart-caused-data-loss](https://github.com/2i2c-org/infrastructure/assets/3837114/db56290f-fc1b-47df-8861-1255e74be50e)

---

I also updated two comments in basehub values in a7d704f