### PR TITLE
leap: make bucket public

### DIFF
--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -67,6 +67,10 @@ hub_cloud_permissions = {
   }
 }
 
+bucket_public_access = [
+  "persistent-ro"
+]
+
 # Setup notebook node pools
 notebook_nodes = {
   "medium" : {


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/2696

terraform plan output:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_storage_default_object_access_control.public_rule["persistent-ro"] will be created
  + resource "google_storage_default_object_access_control" "public_rule" {
      + bucket       = "leap-persistent-ro"
      + domain       = (known after apply)
      + email        = (known after apply)
      + entity       = "allUsers"
      + entity_id    = (known after apply)
      + generation   = (known after apply)
      + id           = (known after apply)
      + project_team = (known after apply)
      + role         = "READER"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ regular_channel_latest_k8s_versions = {
      ~ "1."    = "1.26.3-gke.1000" -> "1.27.2-gke.1200"
      ~ "1.22." = "1.22.17-gke.8000" -> "1.22.17-gke.11400"
      ~ "1.23." = "1.23.17-gke.2000" -> "1.23.17-gke.5600"
      ~ "1.25." = "1.25.8-gke.1000" -> "1.25.9-gke.2300"
        # (1 unchanged attribute hidden)
    }
```