### PR TITLE
leap: Bump pangeo notebook version

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -76,7 +76,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2023.02.08"
+        tag: "2023.06.20"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access
@@ -198,17 +198,17 @@ basehub:
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:ebeb9dd"
+                    image: "pangeo/pangeo-notebook:2023.06.20"
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:ebeb9dd"
+                    image: "pangeo/ml-notebook:2023.06.20"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:ebeb9dd"
+                    image: "pangeo/pytorch-notebook:2023.06.20"
                 leap-pangeo-edu:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
@@ -261,12 +261,12 @@ basehub:
                   default: true
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:ebeb9dd"
+                    image: "pangeo/ml-notebook:2023.06.20"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:ebeb9dd"
+                    image: "pangeo/pytorch-notebook:2023.06.20"
           kubespawner_override:
             node_selector:
               cloud.google.com/gke-nodepool: nb-gpu-t4


### PR DESCRIPTION
Unsure if I bumped the version in all the right places. Particularly I am not sure what the tag [here](https://github.com/2i2c-org/infrastructure/blob/13accf612fefb5a718c51849152f33b288fe8611/config/clusters/leap/common.values.yaml#L79) does. 