### PR TITLE
Use new upstream Julia notebook for JMTE

### DIFF
--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -133,10 +133,10 @@ basehub:
                   kubespawner_override:
                     image: "quay.io/pangeo/pytorch-notebook:2023.05.18"
                 datascience:
-                  display_name: Jupyter DockerStacks DataScience Image (Python, Julia, R)
+                  display_name: Jupyter DockerStacks Julia Notebook
                   slug: "datascience"
                   kubespawner_override:
-                    image: "jupyter/datascience-notebook:2023-06-19"
+                    image: "jupyter/julia-notebook:2023-06-28"
         - display_name: "4th of Medium: 1-4 CPU, 4-16 GB"
           description: "A shared machine."
           profile_options: *profile_options


### PR DESCRIPTION
The datascience notebook was added primarily to support Julia. We have worked with upstream to add a julia specific notebook (https://github.com/jupyter/docker-stacks/pull/1926), so we use the Julia notebook now!