### PR TITLE
leap, m2lines: Bucket public access update

### DIFF
--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -28,20 +28,12 @@ on why users want this!
    very helpful for 'scratch' buckets that are temporary. Set to
    `null` to prevent this cleaning up process from happening, e.g., if users want a persistent bucket.
 
-2. Enable access to these buckets from the hub by [editing `hub_cloud_permissions`](howto:features:cloud-access:access-perms)
+2. Enable access to these buckets from the hub or make them publicly accessible from outside
+   by [editing `hub_cloud_permissions`](howto:features:cloud-access:access-perms)
    in the same `.tfvars` file. Follow all the steps listed there - this
    should create the storage buckets and provide all users access to them!
 
-3. (If requested) Enable public read access to these buckets by editing the
-   `bucket_public_access` list in the same `.tfvars`:
-
-   ```terraform
-   bucket_public_access = [
-      "public-persistent"
-   ]
-   ```
-
-4. You can set the `SCRATCH_BUCKET` (and the deprecated `PANGEO_SCRATCH`)
+3. You can set the `SCRATCH_BUCKET` (and the deprecated `PANGEO_SCRATCH`)
    env vars on all user pods so users can use the created bucket without
    having to hard-code the bucket name in their code. In the hub-specific
    `.values.yaml` file in `config/clusters/<cluster-name>`,
@@ -79,7 +71,7 @@ on why users want this!
 
    You can also add other env vars pointing to other buckets users requested.
 
-5. Get this change deployed, and users should now be able to use the buckets!
+4. Get this change deployed, and users should now be able to use the buckets!
    Currently running users might have to restart their pods for the change to take effect.
    
    

--- a/docs/howto/features/cloud-access.md
+++ b/docs/howto/features/cloud-access.md
@@ -44,6 +44,7 @@ This AWS IAM Role is managed via terraform.
        "<hub-name-slug>": {
            requestor_pays : true,
            bucket_admin_access : ["bucket-1", "bucket-2"]
+           bucket_public_access : ["bucket-1"]
            hub_namespace : "<hub-name>"
        }
    }
@@ -63,7 +64,9 @@ This AWS IAM Role is managed via terraform.
       access to. Used along with the [user_buckets](howto:features:cloud-access:storage-buckets)
       terraform variable to enable the [scratch buckets](topic:features:cloud:scratch-buckets)
       feature.
-   4. (GCP only) `hub_namespace` is the full name of the hub, as hubs are put in Kubernetes
+   4. `bucket_public_access` lists bucket names (as specified in `user_buckets`
+      terraform variable) that should be publicly accessible.
+   5. (GCP only) `hub_namespace` is the full name of the hub, as hubs are put in Kubernetes
       Namespaces that are the same as their names. This is explicitly specified here
       because `<hub-name-slug>` could possibly be truncated on GCP.
 

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -63,13 +63,10 @@ hub_cloud_permissions = {
     requestor_pays : true,
     bucket_admin_access : ["scratch", "persistent"],
     bucket_readonly_access : ["persistent-ro"],
+    bucket_public_access : ["persistent-ro"],
     hub_namespace : "prod"
   }
 }
-
-bucket_public_access = [
-  "persistent-ro"
-]
 
 # Setup notebook node pools
 notebook_nodes = {

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -102,10 +102,7 @@ hub_cloud_permissions = {
   "prod" : {
     requestor_pays : true,
     bucket_admin_access : ["scratch", "persistent", "public-persistent"],
+    bucket_public_access : ["public-persistent"],
     hub_namespace : "prod"
   },
 }
-
-bucket_public_access = [
-  "public-persistent"
-]

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -374,15 +374,6 @@ variable "hub_cloud_permissions" {
   EOT
 }
 
-variable "bucket_public_access" {
-  type        = list(any)
-  default     = []
-  description = <<-EOT
-  A list of GCS storage buckets defined in user_buckets that should be granted public read access.
-
-  EOT
-}
-
 variable "container_repos" {
   type        = list(any)
   default     = []

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -355,6 +355,7 @@ variable "hub_cloud_permissions" {
       requestor_pays : bool,
       bucket_admin_access : set(string),
       bucket_readonly_access : optional(set(string), []),
+      bucket_public_access : optional(set(string), []),
       hub_namespace : string
     })
   )


### PR DESCRIPTION
This allows specifying bucket public access as `hub_cloud_permissions` attribute to be consistent.

Also switches from [`google_storage_default_object_access_control`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_default_object_access_control) to the [`google_storage_bucket_access_control`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_access_control) resource for bucket public access.

_I think_ the difference between the two resources is why https://github.com/2i2c-org/infrastructure/pull/2732 didn't do what it should. The  [`google_storage_default_object_access_control`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_default_object_access_control) says that it's applied to a **new object** within a Google Cloud Storage bucket when no ACL was provided for that object, but the bucket and objects that were meant to be made public already existed and had acl defined for them. Hopefully this fixes it.

Todo:
- [x] update public buckets docs

Fixes https://github.com/2i2c-org/infrastructure/issues/2696

terraform plan output:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # google_storage_bucket_access_control.public_rule["prod.persistent-ro"] will be created
  + resource "google_storage_bucket_access_control" "public_rule" {
      + bucket = "leap-persistent-ro"
      + domain = (known after apply)
      + email  = (known after apply)
      + entity = "allUsers"
      + id     = (known after apply)
      + role   = "READER"
    }

  # google_storage_default_object_access_control.public_rule["persistent-ro"] will be destroyed
  # (because google_storage_default_object_access_control.public_rule is not in configuration)
  - resource "google_storage_default_object_access_control" "public_rule" {
      - bucket       = "leap-persistent-ro" -> null
      - entity       = "allUsers" -> null
      - generation   = 0 -> null
      - id           = "leap-persistent-ro/allUsers" -> null
      - project_team = [] -> null
      - role         = "READER" -> null
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```