### PR TITLE
pangeo-hubs: add memory request/limit for prometheus-server

### DIFF
--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -35,3 +35,8 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.gcp.pangeo.2i2c.cloud
+    resources:
+      requests:
+        memory: 16Gi
+      limits:
+        memory: 16Gi


### PR DESCRIPTION
This community has had 310 nodes started at the same time. When that
happens, prometheus server collapses, probably because scraping from
310+ node exporters at the same time is too much.
