### PR TITLE
2i2c, climatematch: Logo update

### DIFF
--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -29,8 +29,8 @@ jupyterhub:
       templateVars:
         org:
           name: ClimateMatch Academy
-          # Logo picked up from https://academy.climatematch.io/
-          logo_url: https://lh4.googleusercontent.com/85uZrx6hg_hiPt7KowTIAbpl8FqQeIMxToKqSnQEzjU8c-ON6EoAzJ3WzOqc3pVr0iUUXIl6GlrxXpFiviGzES2Zt6UNJ4o2Zl-6yNDZa52-YOCBCIVyeWbD6tXeySXL4g=w1280
+          # Logo copied from https://academy.climatematch.io/
+          logo_url: https://gist.github.com/jmunroe/e6dad8dd4a64826427f41c83222ac2bf/raw/d7171928dbfb88d82e653ce833e73231ad97a06b/CMA_logo_nameBY_transpoval.png
           url: https://academy.climatematch.io/
         designed_by:
           name: 2i2c

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
         org:
           name: ClimateMatch Academy
           # Logo copied from https://academy.climatematch.io/
-          logo_url: https://gist.github.com/jmunroe/e6dad8dd4a64826427f41c83222ac2bf/raw/d7171928dbfb88d82e653ce833e73231ad97a06b/CMA_logo_nameBY_transpoval.png
+          logo_url: https://github.com/2i2c-org/infrastructure/assets/3837114/ac3ec52f-1e62-440a-b2bd-8052e5f38897
           url: https://academy.climatematch.io/
         designed_by:
           name: 2i2c


### PR DESCRIPTION
It appears that URL to the logo accessed https://academy.climatematch.io/ is not persistent -- I've copied the contents into a gist as a alternative place to host the image file for this logo. https://2i2c.freshdesk.com/a/tickets/804