### PR TITLE
nasa-veda: Pin to using JupyterLab 3

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -67,7 +67,7 @@ basehub:
       image:
         name: pangeo/pangeo-notebook
         # Uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
-        tag: "2023.05.18"
+        tag: "2023.07.05"
       profileList:
         # NOTE: About node sharing
         #

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -66,7 +66,8 @@ basehub:
       defaultUrl: /lab
       image:
         name: pangeo/pangeo-notebook
-        tag: "2023.06.20"
+        # Uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
+        tag: "2023.05.18"
       profileList:
         # NOTE: About node sharing
         #


### PR DESCRIPTION
This brings in https://github.com/pangeo-data/pangeo-docker-images/pull/469, which
pins JupyterLab < 4 so we don't break jupyterlab-git or dask-labextension

Ref https://2i2c.freshdesk.com/a/tickets/798