### PR TITLE
terraform, gcp: collect info about k8s versions 1.24-1.27

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -33,10 +33,10 @@ variable "k8s_version_prefixes" {
   # channel, so we may want to remove or add minor versions here over time.
   #
   default = [
-    "1.22.",
-    "1.23.",
     "1.24.",
     "1.25.",
+    "1.26.",
+    "1.27.",
     "1.",
   ]
   description = <<-EOT


### PR DESCRIPTION
When initializing or upgrading a GCP based k8s cluster, it is relevant to know what the GKE specific k8s versions are available in the regular release channel for each minor version around.

This PR updates the details we fetch about that from listing minor version info to 1.24 - 1.27. We don't need to list older minor versions as we have no cluster that old, and there is no newer version than 1.27 in the regular release channel.

This relates to #2157, as doing maintenance for gke cluster benefited from collecting this information.