### PR TITLE
Clarify when node_locations is overriden

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -244,8 +244,10 @@ resource "google_container_node_pool" "notebook" {
   location = google_container_cluster.cluster.location
   version  = var.k8s_versions.notebook_nodes_version
 
-  node_locations = length(each.value.zones) == 0 ? [var.zone] : each.value.zones
-
+  # terraform treats null same as unset, so we only set the node_locations
+  # here if it is explicitly overriden. If not, it will just inherit whatever
+  # is set for the cluster.
+  node_locations = length(each.value.zones) == 0 ? null : each.value.zones
 
   initial_node_count = each.value.min
   autoscaling {
@@ -344,7 +346,11 @@ resource "google_container_node_pool" "dask_worker" {
   location = google_container_cluster.cluster.location
   version  = var.k8s_versions.dask_nodes_version
 
-  node_locations = length(each.value.zones) == 0 ? [var.zone] : each.value.zones
+  # terraform treats null same as unset, so we only set the node_locations
+  # here if it is explicitly overriden. If not, it will just inherit whatever
+  # is set for the cluster.
+  node_locations = length(each.value.zones) == 0 ? null : each.value.zones
+
   # Default to same config as notebook nodepools config
   for_each = var.dask_nodes
 


### PR DESCRIPTION
If zones is not explicitly set for nodepools, it will inherit whatever is set for the cluster itself. This makes the code clearer so that is more obvious.

Fixes https://github.com/2i2c-org/infrastructure/issues/2769