### PR TITLE
Reduce prometheus dataloss during restarts to 5m from 10m

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -181,8 +181,8 @@ prometheus:
         --web.console.libraries=/etc/prometheus/console_libraries \
         --web.console.templates=/etc/prometheus/consoles \
         --web.enable-lifecycle \
-        --storage.tsdb.min-block-duration=10m \
-        --storage.tsdb.max-block-duration=10m"
+        --storage.tsdb.min-block-duration=5m \
+        --storage.tsdb.max-block-duration=5m"
     # extraFlags MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     extraFlags:
       - web.enable-lifecycle
@@ -193,8 +193,8 @@ prometheus:
       #
       # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1099293120
       #
-      - storage.tsdb.min-block-duration=10m
-      - storage.tsdb.max-block-duration=10m
+      - storage.tsdb.min-block-duration=5m
+      - storage.tsdb.max-block-duration=5m
     # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     retention: 366d # Keep data for at least 1 year
 


### PR DESCRIPTION
10m seems to have caused no real issues, let's bring it down some more.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/2731