### PR TITLE
Bump prometheus volume size for 2i2c shared cluster

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -3,6 +3,9 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    persistentVolume:
+      # 100Gi filled up!
+      size: 256Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -5,7 +5,7 @@ prometheus:
   server:
     persistentVolume:
       # 100Gi filled up, and this is source of our billing data.
-      size: 1Ti
+      size: 512Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -4,8 +4,8 @@ prometheusIngressAuthSecret:
 prometheus:
   server:
     persistentVolume:
-      # 100Gi filled up!
-      size: 256Gi
+      # 100Gi filled up, and this is source of our billing data.
+      size: 1Ti
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
100Gi filled up on 30/6

Discovered by looking at https://grafana.pilot.2i2c.cloud/d/bUnRC_Qnz/nfs-and-support-information?orgId=1