### PR TITLE
Grant access to the catalystproject-latam hub to czi-catalystproject

### DIFF
--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -39,6 +39,7 @@ jupyterhub:
       GitHubOAuthenticator:
         allowed_organizations:
           - 2i2c-org:hub-access-for-2i2c-staff
+          - czi-catalystproject
         scope:
           - read:org
   singleuser:


### PR DESCRIPTION
czi-catalystproject is a GitHub org. Membership in this org should grant access to the catalystproject-latam hub