### PR TITLE
Tweak logic for when artifacts should be uploaded

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -122,8 +122,8 @@ jobs:
         # Only run this steps in PRs when the matrices are not empty
         if: >
           github.event_name == 'pull_request' &&
-          env.support-and-staging-matrix-jobs != '[]' &&
-          env.prod-hub-matrix-jobs != '[]'
+          (env.support-and-staging-matrix-jobs != '[]' ||
+          env.prod-hub-matrix-jobs != '[]')
         uses: actions/upload-artifact@v3.1.0
         with:
           name: pr


### PR DESCRIPTION
I noticed I wasn't getting a deployment plan comment on https://github.com/2i2c-org/infrastructure/pull/2815, even though the PR would trigger a deploy of the support chart and a staging hub - but there isn't a prod hub being added.

Due to the `and` logic in the statement controlling when artifacts get uploaded, this case was being missed and a deployment plan not provided. This PR changes that logic to include an `or`  which I believe which allow either one of the support-staging or prod matrices to be empty, but not both, for artifacts to be uploaded.