### PR TITLE
Change update-central-grafana-datasources input Argument to an Option

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -371,18 +371,14 @@ the clusters that we run.
 **Command line usage:**
 ```
                                                                                                                         
- Usage: deployer update-central-grafana-datasources [OPTIONS]                                                           
-                                                    [CENTRAL_GRAFANA_CLUSTER]                                           
-                                                                                                                        
- Update a central grafana with datasources for all our prometheuses                                                     
-                                                                                                                        
-╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│   central_grafana_cluster      [CENTRAL_GRAFANA_CLUSTER]  Name of cluster where the central grafana lives            │
-│                                                           [default: 2i2c]                                            │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+Usage: deployer update-central-grafana-datasources [OPTIONS]                                                                                                                            
+                                                                                                                                                                                         
+ Update the central grafana with datasources for all clusters prometheus instances                                                                                                       
+                                                                                                                                                                                         
+╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --central-grafana-cluster        TEXT  Name of cluster where the central grafana lives [default: 2i2c]                                                                                │
+│ --help                                 Show this message and exit.                                                                                                                    │
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 

--- a/deployer/grafana/central_grafana.py
+++ b/deployer/grafana/central_grafana.py
@@ -99,7 +99,7 @@ def get_clusters_used_as_datasources(cluster_name, datasource_endpoint):
 
 @app.command()
 def update_central_grafana_datasources(
-    central_grafana_cluster=typer.Argument(
+    central_grafana_cluster=typer.Option(
         "2i2c", help="Name of cluster where the central grafana lives"
     )
 ):


### PR DESCRIPTION
I made a mistake where I ran `deployer update-central-grafana-datasources $CLUSTER_NAME` and this started adding all of our cluster prometheus's as data sources to the grafana of the new cluster I'd just deployed, instead of what I (incorrectly) expected it do which was add just my new cluster to the central grafana.

This PR changes the input of `update-central-grafana-datasources` to a `typer.Option` object, rather than a `typer.Argument` object which has the following effect:

- Running `deployer update-central-grafana-datasources` retains the default expected behaviour of adding all cluster to our central grafana in the 2i2c cluster
- Now, if we wish to change which cluster we are treating as the central grafana, the command will be `deployer update-central-grafana-datasources --central-grafana-cluster $CLUSTER_NAME`. I think making people explicitly write this out will make it clear what the script will do, i.e. override which cluster is being used as the central grafana.