### PR TITLE
Mention PR author and workflow run in GHA-failure message on Slack

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -141,6 +141,9 @@ jobs:
         with:
           notify_when: "failure"
           status: ${{ job.status }} # required
+          # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
+          message_format: '{emoji} Hey @${{ github.event.head_commit.author.name }}! *{workflow}* {status_message} for "${{ github.event.head_commit.message }} - <{commit_url}|{commit_sha}>". Checkout the run at {run_url}.'
+          footer: "<{run_url}|Failing Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GHA_FAILURES_WEBHOOK_URL }}
   # This job upgrades the support chart, staging hub, and dask-staging hub (if present)


### PR DESCRIPTION
I noticed atm it's pretty hard distinguish where you can get the link to the failing run and which commit it's about without having human readable info and not just commit numbers.

Also, it will do a @mention of the PR author. Because the author might not use the same handle on Slack, the mention might not work.