### PR TITLE
[catalystproject-africa] Move per-hub config out of common.values.yaml

### DIFF
--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -11,38 +11,6 @@ nfs:
     serverIP: fs-040edb72334e4ac26.efs.af-south-1.amazonaws.com
     baseShareName: /
 jupyterhub:
-  custom:
-    2i2c:
-      add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "github"
-    homepage:
-      templateVars:
-        org:
-          name: Catalyst Project
-          url: "https://chanzuckerberg.com/science/programs-resources/open-science/educationcapacitybuilding/international-interactive-computing-collaboration-2i2c/"
-          logo_url: https://github.com/2i2c-org/infrastructure/assets/6181563/0667c576-7dce-4443-afd2-922288530814
-        designed_by:
-          name: "2i2c"
-          url: https://2i2c.org
-        operated_by:
-          name: "2i2c"
-          url: https://2i2c.org
-        funded_by:
-          name: Chan Zuckerberg Initiative - Open Science
-          url: "https://chanzuckerberg.com/science/programs-resources/open-science/"
-  hub:
-    config:
-      # Authenticator:
-      #   admin_users:
-      #     - future-community-champion
-      JupyterHub:
-        authenticator_class: github
-      GitHubOAuthenticator:
-        allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
-          - czi-catalystproject
-        scope:
-          - read:org
   singleuser:
     image:
       # rocker/binder is maintained at: https://github.com/rocker-org/rocker-versioned2

--- a/config/clusters/catalystproject-africa/staging.values.yaml
+++ b/config/clusters/catalystproject-africa/staging.values.yaml
@@ -4,7 +4,36 @@ jupyterhub:
     tls:
       - hosts: [staging.af.catalystproject.2i2c.cloud]
         secretName: https-auto-tls
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    homepage:
+      templateVars:
+        org:
+          name: Catalyst Project
+          url: "https://chanzuckerberg.com/science/programs-resources/open-science/educationcapacitybuilding/international-interactive-computing-collaboration-2i2c/"
+          logo_url: https://github.com/2i2c-org/infrastructure/assets/6181563/0667c576-7dce-4443-afd2-922288530814
+        designed_by:
+          name: "2i2c"
+          url: https://2i2c.org
+        operated_by:
+          name: "2i2c"
+          url: https://2i2c.org
+        funded_by:
+          name: Chan Zuckerberg Initiative - Open Science
+          url: "https://chanzuckerberg.com/science/programs-resources/open-science/"
   hub:
     config:
+      # Authenticator:
+      #   admin_users:
+      #     - future-community-champion
+      JupyterHub:
+        authenticator_class: github
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.af.catalystproject.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - 2i2c-org:hub-access-for-2i2c-staff
+          - czi-catalystproject
+        scope:
+          - read:org


### PR DESCRIPTION
Inspired by #2830, things like homepage vars and authentication method is probably something that will be defined on a per-hub basis, and therefore should not be located in the common config.