### PR TITLE
[cloudbank] Replace username_pattern for allowed_domains

### DIFF
--- a/config/clusters/cloudbank/bcc.values.yaml
+++ b/config/clusters/cloudbank/bcc.values.yaml
@@ -33,7 +33,13 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://bcc.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains: ["2i2c.org", "berkeley.edu", "peralta.edu"]
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:
@@ -41,4 +47,3 @@ jupyterhub:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - mseidel@peralta.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@peralta\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -38,11 +38,15 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains: ["2i2c.org", "berkeley.edu", "mail.ccsf.edu"]
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -35,10 +35,14 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://ccsf.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains: ["2i2c.org", "berkeley.edu", "mail.ccsf.edu"]
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
@@ -47,7 +51,6 @@ jupyterhub:
           - craig.persiko@mail.ccsf.edu
           - efuchs@mail.ccsf.edu
           - amy.mclanahan@mail.ccsf.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@mail\.ccsf\.edu|deployment-service-check)$'
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://csm.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -40,6 +41,9 @@ jupyterhub:
               - "berkeley.edu"
               - "my.smccd.edu"
               - "smccd.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -29,7 +29,17 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csm.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "my.smccd.edu"
+              - "smccd.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
@@ -37,7 +47,6 @@ jupyterhub:
           - sean.smorris@berkeley.edu
           - pachecoh@smccd.edu
           - hellenpacheco@my.smccd.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@my\.smccd\.edu|.+@smccd\.edu|deployment-service-check)$'
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/cloudbank/csu.values.yaml
+++ b/config/clusters/cloudbank/csu.values.yaml
@@ -38,7 +38,12 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csu.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/csu.values.yaml
+++ b/config/clusters/cloudbank/csu.values.yaml
@@ -38,12 +38,7 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csu.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
+        username_claim: "email"
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -37,11 +37,15 @@ jupyterhub:
         oauth_callback_url: https://csulb.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - https://its-shib.its.csulb.edu/idp/shibboleth
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains: ["2i2c.org", "berkeley.edu", "csulb.edu"]
+          https://its-shib.its.csulb.edu/idp/shibboleth:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -38,12 +38,16 @@ jupyterhub:
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://its-shib.its.csulb.edu/idp/shibboleth
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains: ["2i2c.org", "berkeley.edu", "csulb.edu"]
           https://its-shib.its.csulb.edu/idp/shibboleth:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -35,13 +35,18 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csulb.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains: ["2i2c.org", "berkeley.edu", "csulb.edu"]
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - shabnam.sodagari@csulb.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@csulb\.edu|deployment-service-check)$'
   cull:
     # Cull after 30min of inactivity
     every: 300

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -40,8 +40,12 @@ jupyterhub:
         oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -34,23 +34,16 @@ jupyterhub:
           url: http://cloudbank.org/
   hub:
     config:
-      # JupyterHub:
-      #   authenticator_class: github
-      # GitHubOAuthenticator:
-      #   oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
-      #   allowed_organizations:
-      #     - 2i2c-org
-      #     - ahs-cs-a
-      #   scope:
-      #     - read:org
-      # Authenticator:
-      #   admin_users:
-      #     - sean-morris
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -33,7 +33,13 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains: ["2i2c.org", "berkeley.edu", "dvc.edu"]
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:
@@ -42,4 +48,3 @@ jupyterhub:
           - sean.smorris@berkeley.edu
           - namato@dvc.edu
           - llo@dvc.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@dvc\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -35,11 +35,15 @@ jupyterhub:
         oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains: ["2i2c.org", "berkeley.edu", "dvc.edu"]
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -34,14 +34,17 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://elcamino.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains: ["2i2c.org", "berkeley.edu", "elcamino.edu"]
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - srussell@elcamino.edu
           - ammartinez@elcamino.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@elcamino\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -37,11 +37,15 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains: ["2i2c.org", "berkeley.edu", "elcamino.edu"]
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://fresno.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -41,6 +42,9 @@ jupyterhub:
               - "fresnocitycollege.edu"
               - "students.scccd.net"
               - "my.scccd.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - joellen.green@fresnocitycollege.edu

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -29,11 +29,21 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://fresno.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "fresnocitycollege.edu"
+              - "students.scccd.net"
+              - "my.scccd.edu"
       Authenticator:
         admin_users:
           - joellen.green@fresnocitycollege.edu
           - ericvd@berkeley.edu
           - k_usovich@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@students\.scccd\.net|.+@my\.scccd\.edu|.+@fresnocitycollege\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://glendale.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -40,6 +41,9 @@ jupyterhub:
               - "berkeley.edu"
               - "glendale.edu"
               - "student.glendale.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - simon@glendale.edu

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -29,10 +29,19 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://glendale.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "glendale.edu"
+              - "student.glendale.edu"
       Authenticator:
         admin_users:
           - simon@glendale.edu
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@glendale\.edu|.+@student\.glendale\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://howard.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &howard_users
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -38,7 +38,16 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "humboldt.edu"
       Authenticator:
         # These folks should still have admin tho
         admin_users:
@@ -46,11 +55,6 @@ jupyterhub:
           - sean.smorris@berkeley.edu
           - bl222@humboldt.edu
           - bj117@humboldt.edu
-        # We only want 2i2c users and users with .edu emails to sign up
-        # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
-        # FIXME: This doesn't account for educational institutions that have emails that don't end in .edu,
-        # as is the case for some non-euroamerican universities.
-        username_pattern: '^(.+@2i2c\.org|.+@humboldt.edu|.+@berkeley.edu|deployment-service-check)$'
   cull:
     # Cull after 30min of inactivity
     every: 300

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -40,6 +40,7 @@ jupyterhub:
         oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:humboldt.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -48,6 +49,9 @@ jupyterhub:
               - "2i2c.org"
               - "berkeley.edu"
               - "humboldt.edu"
+          urn:mace:incommon:humboldt.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -41,6 +41,7 @@ jupyterhub:
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:humboldt.edu
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -50,6 +51,9 @@ jupyterhub:
               - "berkeley.edu"
               - "humboldt.edu"
           urn:mace:incommon:humboldt.edu:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://lacc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &lacc_users
           - PINEDAEM@laccd.edu

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -29,11 +29,19 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://laney.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "peralta.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - koh@peralta.edu
           - dsmith@peralta.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@peralta\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://laney.cloudbank.2i2c.cloud/hub/oauth_callback"
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -39,6 +40,9 @@ jupyterhub:
               - "2i2c.org"
               - "berkeley.edu"
               - "peralta.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -32,6 +32,7 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -40,6 +41,9 @@ jupyterhub:
               - "2i2c.org"
               - "berkeley.edu"
               - "mills.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users: &mills_admins
           - aculich@berkeley.edu

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -29,16 +29,20 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://datahub.mills.edu/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "mills.edu"
       Authenticator:
         admin_users: &mills_admins
           - aculich@berkeley.edu
           - sean.smorris@berkeley.edu
           - akonrad@mills.edu
           - wang@mills.edu
-        # We do not define allowed_users here since only usernames matching this regex will be allowed to login into the hub.
-        # Ref: https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.username_pattern
-        username_pattern: '^(.+@mills\.edu|.+@2i2c\.org|aculich@berkeley\.edu|sean.smorris@berkeley\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -33,11 +33,15 @@ jupyterhub:
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://miracosta.fedgw.com/gateway
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
           https://miracosta.fedgw.com/gateway:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -29,7 +29,17 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        # Only show and allow option to login with Google and Miracosta institutional provider
+        shown_idps:
+          - http://google.com/accounts/o8/id
+          - https://miracosta.fedgw.com/gateway
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          https://miracosta.fedgw.com/gateway:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - sfirouzian@miracosta.edu

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -38,6 +38,7 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -47,6 +48,9 @@ jupyterhub:
               - "berkeley.edu"
               - "missioncollege.edu"
               - "mywvm.wvm.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -31,11 +31,22 @@ jupyterhub:
           url: https://missioncollege.edu/
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
       JupyterHub:
         authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
+        # Only show the option to login with Google
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "missioncollege.edu"
+              - "mywvm.wvm.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
@@ -43,4 +54,3 @@ jupyterhub:
           - Max.Sklar@missioncollege.edu
           - Kristen.Purdum@missioncollege.edu
           - Michael.Cao@missioncollege.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@mywvm\.wvm\.edu|.+@missioncollege\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -31,8 +31,12 @@ jupyterhub:
         oauth_callback_url: "https://norco.cloudbank.2i2c.cloud/hub/oauth_callback"
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -29,7 +29,12 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://norco.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
@@ -37,4 +42,3 @@ jupyterhub:
           - caroline.hutchings@norcocollege.edu
           - caroline.hutchings.ncc@gmail.com
         username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@norcocollege\.edu|caroline.hutchings.ncc@gmail.com|deployment-service-check)$'
-        # Only show the option to login with Google

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://palomar.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &palomar_users
           - aculich@berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -37,8 +37,12 @@ jupyterhub:
         oauth_callback_url: https://pasadena.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -35,7 +35,12 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://pasadena.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - yxchang@go.pasadena.edu

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -35,11 +35,20 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sacramento.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "scc.losrios.edu"
+              - "apps.losrios.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - mukarra@scc.losrios.edu
           - w1475529@apps.losrios.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@(scc|apps)\.losrios\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://sacramento.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -46,6 +47,9 @@ jupyterhub:
               - "berkeley.edu"
               - "scc.losrios.edu"
               - "apps.losrios.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -31,14 +31,22 @@ jupyterhub:
           url: https://www.saddleback.edu/
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
       JupyterHub:
         authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "saddleback.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - afoote@saddleback.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@saddleback\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -45,6 +46,9 @@ jupyterhub:
               - "2i2c.org"
               - "berkeley.edu"
               - "saddleback.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -31,14 +31,22 @@ jupyterhub:
           url: https://www.sccollege.edu/Pages/default.aspx
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
       JupyterHub:
         authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "sccollege.edu"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - Kramer_Jessica@sccollege.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@sccollege\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -45,6 +46,9 @@ jupyterhub:
               - "2i2c.org"
               - "berkeley.edu"
               - "sccollege.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
-        # Only show the option to login with Google
+        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &sbcc_users
           - ericvd@gmail.com

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - https://idp.sbcc.edu/idp/shibboleth
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          https://idp.sbcc.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -33,11 +33,15 @@ jupyterhub:
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://idp.sbcc.edu/idp/shibboleth
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
           https://idp.sbcc.edu/idp/shibboleth:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://sjcc.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:
@@ -42,6 +43,9 @@ jupyterhub:
               - "stu.evc.edu"
               - "stu.sjcc.edu"
               - "evc.edu"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - christiaan.desmond@sjcc.edu

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -29,7 +29,19 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sjcc.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - "2i2c.org"
+              - "berkeley.edu"
+              - "sjcc.edu"
+              - "stu.evc.edu"
+              - "stu.sjcc.edu"
+              - "evc.edu"
       Authenticator:
         admin_users:
           - christiaan.desmond@sjcc.edu
@@ -37,4 +49,3 @@ jupyterhub:
           - ericvd@berkeley.edu
           - k_usovich@berkeley.edu
           - sean.smorris@berkeley.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@stu\.evc\.edu|.+@stu\.sjcc\.edu|.+@sjcc\.edu|.+@evc\.edu|deployment-service-check)$'

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -37,8 +37,12 @@ jupyterhub:
         oauth_callback_url: https://skyline.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -35,7 +35,12 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://skyline.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -37,8 +37,12 @@ jupyterhub:
         oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -31,11 +31,16 @@ jupyterhub:
           url: https://www.santarosa.edu/
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: email
       JupyterHub:
         authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
-        # Only show the option to login with Google
+        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &staging_users
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -29,10 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://tuskegee.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
-        # Only show the option to login with Google
+        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         allowed_users: &tuskegee_users
           - yasmeen.rawajfih@gmail.com

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/wlac.values.yaml
+++ b/config/clusters/cloudbank/wlac.values.yaml
@@ -32,8 +32,12 @@ jupyterhub:
         # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/wlac.values.yaml
+++ b/config/clusters/cloudbank/wlac.values.yaml
@@ -29,7 +29,13 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://wlac.cloudbank.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
+        # Only show and allow the option to login with Google
+        shown_idps:
+          - http://google.com/accounts/o8/id
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/2833

cc @sean-morris 

### Notes

1. For the following hubs it was not possible to remove the `username_pattern`, because these hubs need to also allow `gmail` accounts:

```
csu
pasadena
wlac
demo
skyline
norco
miracosta
srjc
```

2. All the hubs login option has been restricted to be allowed only login through Google,  Berkeley, or their specific institutional provider, where that was available and listed in https://cilogon.org/idplist
The ones with their own institutional logins were:
```
CSU Long Beach
Cal Poly Humboldt
MiraCosta College
Santa Barbara City College sbcc
```

3. The `csu` hub is a bit particular, because it wants to allow access to all unis under `California State University` (about 20). I didn't touch that one, but when we'll be upgrading to `oauthenticator 16.0.0`, where we must specify `allowed_idps` and `username_claim` for each of these idps, it would be fun to do it for 20 possible idps 😬 cc @consideRatio and the discusscussion in https://github.com/jupyterhub/oauthenticator/issues/615