### PR TITLE
Add opencost as optional support component

### DIFF
--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -6,6 +6,10 @@ grafana:
         auth.github:
             client_id: ENC[AES256_GCM,data:8h2NTnOgi69C9r2rPhAsovA9j5w=,iv:ChibKvAdzbI3F8ew21Fy2TqAIdCgpf0J0A1wICsAuIo=,tag:6JAlaJ8H/6MvJwXS8gDAzQ==,type:str]
             client_secret: ENC[AES256_GCM,data:/bm7OcoLM8f8kUbP/bSAi8iFO6mETEydjiqwqXd2qGzwl6D213Okdw==,iv:syKMxz6GIfH2CeN+pSekebcS2mQgrEizt56eJz1rZJs=,tag:9jzXPcnBbNL6SLNHJ859zg==,type:str]
+opencost:
+    opencost:
+        exporter:
+            cloudProviderApiKey: ENC[AES256_GCM,data:uLzI1anI84U6oMigemRrcn/ppyviP7Xw1WZSOMJ2L2kn9p7/EqK5,iv:ZZbuIubZNcnh7JZKBNp4RO6jBxE/yTs8vmpiQpfIcvo=,tag:xI1YlaJJEoHfCq+SSfSG8g==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -15,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-23T10:29:01Z"
-    mac: ENC[AES256_GCM,data:tnc2+Gdu/vuQvBA5LtsapIaIgHX1FrmsS2+mrz5FSqhpG5VRKEGG/zNjO0q3tJl55jLNHA1M5630xW9U5XqZOGcp8p+k9HRgwf2V3BxH2NTckbQpARmrRiZWE/TOGdxhEwNeNaRT0OF7g/GNMILBoZpeQZ+WnAxEafTPPxuXmAU=,iv:2m/mQ8Rb0wAV16TM3QCGc2mOE8UvkkCvwiAXsY/LCz0=,tag:bIU1IA1ubfJr8WPvER3/ZA==,type:str]
+    lastmodified: "2023-07-19T14:09:13Z"
+    mac: ENC[AES256_GCM,data:U9K5wciS3b0LQeh7QTdm7WaHUDyR3Oxf3zHOrd0oZ3eN64MIS8tFhQCMgwiDDyFGVF5+gHXs/bKDMlBKHWl74r/2WDfTW6vPGsJ4Vt07C5wuiPg5IJmyoJbE6dqPt4zvbrVdgvhOThVM0QUtVC4pdeDHLms0/h9CY37BunvFxbM=,iv:uZbGXiaG5JR+yaGIYE6ifU2/kRUKwx0g7WXhQ98No9k=,tag:6I3FyMA9dtELBQPfjan3lA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -14,6 +14,23 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.pilot.2i2c.cloud
+    # TODO(pnasrat) figure way to conditionalize
+    # TODO(pnasrat): Experimental
+    # Testing OpenCost to display and report on shared costs
+    # https://github.com/2i2c-org/infrastructure/issues/1923
+    # Source: https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml
+    extraScrapeConfigs: |
+      - job_name: opencost
+        honor_labels: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        dns_sd_configs:
+        - names:
+          - opencost.support
+          type: 'A'
+          port: 9003
 
 grafana:
   grafana.ini:
@@ -33,3 +50,21 @@ grafana:
           - grafana.pilot.2i2c.cloud
   plugins:
     - grafana-bigquery-datasource
+
+# TODO(pnasrat): Experimental
+# Testing OpenCost to display and report on shared costs
+# https://github.com/2i2c-org/infrastructure/issues/1923
+opencost:
+  enabled: true
+  opencost:
+    # -- The GCP Pricing API provided in secrets.
+    #cloudProviderApiKey: ""
+    # -- Default cluster ID to use if cluster_id is not set in Prometheus metrics.
+    exporter:
+      defaultClusterId: "pilot-hubs-cluster"
+    prometheus:
+      # Note the external config supports basic auth but unsure if supports multiple prometheuses
+      internal:
+        namespaceName: support
+        serviceName: support-prometheus-server
+        port: 80

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -45,3 +45,12 @@ dependencies:
     version: "0.0.1-0.dev.git.27.h01b4f25"
     repository: https://yuvipanda.github.io/cryptnono/
     condition: cryptnono.enabled
+
+  # opencost cost monitoring for kubernetes.
+  # TODO(pnasrat): Experimental
+  # Testing OpenCost to display and report on shared costs
+  # https://github.com/2i2c-org/infrastructure/issues/1923
+  - name: opencost
+    version: 1.7.0
+    repository: https://opencost.github.io/opencost-helm-chart
+    condition: opencost.enabled

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -49,6 +49,13 @@ properties:
   cryptnono:
     type: object
     additionalProperties: true
+  # opencost is a dependent helm chart.
+  # TODO(pnasrat): Experimental
+  # Testing OpenCost to display and report on shared costs
+  # https://github.com/2i2c-org/infrastructure/issues/1923
+  opencost:
+    type: object
+    additionalProperties: true
   redirects:
     type: object
     additionalProperties: false

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -410,6 +410,12 @@ cryptnono:
 # -------------------------------------------------------------------------------
 #
 
+# TODO(pnasrat): Experimental
+# Testing OpenCost to display and report on shared costs
+# https://github.com/2i2c-org/infrastructure/issues/1923
+opencost:
+  enabled: false
+
 prometheusIngressAuthSecret:
   enabled: false
   username: ""


### PR DESCRIPTION
This adds a configurable OpenCost service to the support chart to enable testing of enhanced billing for shared clusters and enables it in the 2i2c GCP shared cluster.