### PR TITLE
[doc]: add new table for listing each hub's options; start with authenticator info

### DIFF
--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -26,6 +26,18 @@ A table of all running hubs across all of our clusters.
 
 </div>
 
+
+## Hub options table
+
+<div class="full-width hubs-table">
+
+```{csv-table}
+:header-rows: 1
+:file: ../tmp/hub-options-table.csv
+```
+
+</div>
+
 ## Community hub statistics
 
 Summary statistics of the communities we are serving with with hubs, broken down by cluster and cloud provider.


### PR DESCRIPTION
First step towards https://github.com/2i2c-org/meta/issues/628

This PR:
1. refactors the `render_hubs.py` script into functions as it became quite big (copy-paste, nothing existing was changed)
2. creates a new table called 'Hub options table' (because the first one was already big)

The plan for this table is to start by adding the options identified in [this doc](https://docs.google.com/spreadsheets/d/1ZRCAMyIBOSfPlfHywEKva7WG4-xNVKm18eAWGo_4KJQ/edit?usp=sharing) and for each hub either put an `yes/no` or some value depending on each option.

For now, in this PR, only the authenticator class is listed. Note that it's not that smart to find an authenticator class inside an `extraConfig` setup, like it's the case for the callysto hub.

It looks like this:
<img width="814" alt="Screenshot 2023-07-19 at 19 07 08" src="https://github.com/2i2c-org/infrastructure/assets/7579677/fd0fc0eb-f50d-4a06-883e-c5dea80f4431">

This PR is meant to serve as a starting point for https://github.com/2i2c-org/meta/issues/628 and can definitely be improved with docstrings, and better function names, but I think it should be good enough for a first iteration in making it scalable.