### PR TITLE
[smithsonian] Set minimum nodepool size to 5

### DIFF
--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -92,7 +92,7 @@ local daskNodes = [
             // instanceTypes always have a .
             name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
-            minSize: 0,
+            minSize: 5,
             maxSize: 500,
             instanceType: n.instanceType,
             ssh: {


### PR DESCRIPTION
ref: https://github.com/2i2c-org/infrastructure/issues/2854

I have performed the scale up.

However, because the jsonnet file is written in such a way that nodepool definitions are defined in a loop, I had to scale _all_ notebook nodes to a minimum of 5. Whereas I think scaling _just_ the r5.xlarge nodepool would have sufficed. I'm not sure what the simplest way to achieve this in jsonnet would be though.