### PR TITLE
Clarify NFS docs

### DIFF
--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -17,7 +17,11 @@ This is made available through cloud-specific filestores.
 * Azure: Files
 * AWS: Elastic File System
 
-## Hub directory
+## NFS Client setup
+
+For each hub, there needs to be a:
+
+### Hub directory
 
 A directory is created under the path defined by the `nfs.pv.baseShareName` cluster config.
 Usually, this is `/homes` - for hubs that use the managed NFS provider for the cloud platform.

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -19,7 +19,7 @@ This is made available through cloud-specific filestores.
 
 ## NFS Client setup
 
-For each hub, there needs to be a:
+For each hub, there needs to be the components described by the following subsections.
 
 ### Hub directory
 

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -17,11 +17,7 @@ This is made available through cloud-specific filestores.
 * Azure: Files
 * AWS: Elastic File System
 
-## NFS Client setup
-
-For each hub, there needs to be a:
-
-### Hub directory
+## Hub directory
 
 A directory is created under the path defined by the `nfs.pv.baseShareName` cluster config.
 Usually, this is `/homes` - for hubs that use the managed NFS provider for the cloud platform.


### PR DESCRIPTION
We have this hanging sentence/section in the docs on storage which I think has been left after a rewrite.

<img width="570" alt="Screenshot 2023-07-24 at 15 07 50" src="https://github.com/2i2c-org/infrastructure/assets/44771837/ba090dbd-2413-4de5-82e1-1db8a27d7d7e">

I guess there's two scenarios here, either:

1. It needs to go completely,
2. There's missing info that needs filling in

@yuvipanda I think you worked on these docs last, any insight?
