### PR TITLE
Temporarly set user_options for test users and leap hubs

### DIFF
--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -41,6 +41,16 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
                 # This is because we would have lost its api token from the previous run.
                 await hub.delete_user(username)
 
+        # Temporary fix for https://github.com/2i2c-org/infrastructure/issues/2146#issuecomment-1649445203
+        # FIXME: Remove this once a fix in kubespawner gets implemented
+        user_options = {}
+        if "leap" in hub_url:
+            user_options = {
+                "profile": "medium-full",
+                "requests": "mem_8",
+                "image": "pangeo",
+            }
+
         # Create a new user, start a server and execute a notebook
         await execute_notebook(
             hub_url,
@@ -52,6 +62,7 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             delete_user=False,  # To be able to delete its server in case of failure
             stop_server=True,  # If the health check succeeds, this will delete the server
             validate=False,  # Don't validate notebook outputs. We only care that it runs top-to-bottom without error.
+            user_options=user_options,
         )
     finally:
         if orig_service_token:


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/2146

A persistent fix requires some cleanup related to profile handling in `kubespawner` so that it's easier to see where default settings are failing or if they are inconsistent (tracked in https://github.com/jupyterhub/kubespawner/issues/758)