### PR TITLE
Exclude changes to hub tests from triggering hubs re-deploy

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -13,6 +13,9 @@ on:
       - master
     paths:
       - deployer/**
+      # Exclude changes to the tests directory from
+      # triggering this workflow
+      - "!deployer/tests/**"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**
@@ -22,6 +25,9 @@ on:
       - master
     paths:
       - deployer/**
+      # Exclude changes to the tests directory from
+      # triggering this workflow
+      - "!deployer/tests/**"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**


### PR DESCRIPTION
If the hub test changes, we shouldn't redeploy all the hubs.