### PR TITLE
(part 2) Mention PR author and workflow run in GHA-failure message on Slack

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -139,6 +139,8 @@ jobs:
         if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
+          # Warning: there are multiple "Report Status" steps in this file (one per job).
+          # Make sure they are all updated
           notify_when: "failure"
           status: ${{ job.status }} # required
           # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
@@ -161,7 +163,7 @@ jobs:
     # see this post for feature requests for this to be improved:
     # https://github.community/t/bug-jobs-output-should-return-a-list-for-a-matrix-job/128626/32?u=consideratio
     #
-    # IMPORTANT: names can include alphanumerics, '-', and '_', but not '.', so
+    # Warning: names can include alphanumerics, '-', and '_', but not '.', so
     #            we replace '.' for '-' in cluster names.
     #
     # If you are adding a new cluster, please remember to list it here!
@@ -272,7 +274,7 @@ jobs:
       - name: Report Status
         if: always()
         uses: ravsamhq/notify-slack-action@v2
-        # Important: there are multiple "Report Status" steps in this file (one per job).
+        # Warning: there are multiple "Report Status" steps in this file (one per job).
         # Make sure they are all updated
         with:
           notify_when: "failure"
@@ -338,7 +340,7 @@ jobs:
         if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
-          # Important: there are multiple "Report Status" steps in this file (one per job).
+          # Warning: there are multiple "Report Status" steps in this file (one per job).
           # Make sure they are all updated
           notify_when: "failure"
           status: ${{ job.status }} # required
@@ -406,7 +408,7 @@ jobs:
         if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
-          # Important: there are multiple "Report Status" steps in this file (one per job).
+          # Warning: there are multiple "Report Status" steps in this file (one per job).
           # Make sure they are all updated
           notify_when: "failure"
           status: ${{ job.status }} # required

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -267,14 +267,19 @@ jobs:
 
       # https://github.com/ravsamhq/notify-slack-action
       # Needs to be added per job
-      # When https://github.com/integrations/slack/issues/1563 gets implemented,
+      # FIXME: when https://github.com/integrations/slack/issues/1563 gets implemented,
       # we can use that instead
       - name: Report Status
         if: always()
         uses: ravsamhq/notify-slack-action@v2
+        # Important: there are multiple "Report Status" steps in this file (one per job).
+        # Make sure they are all updated
         with:
           notify_when: "failure"
           status: ${{ job.status }} # required
+          # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
+          message_format: '{emoji} Hey @${{ github.event.head_commit.author.name }}! *{workflow}* {status_message} for "${{ github.event.head_commit.message }} - <{commit_url}|{commit_sha}>". Checkout the run at {run_url}.'
+          footer: "<{run_url}|Failing Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GHA_FAILURES_WEBHOOK_URL }}
 
@@ -333,6 +338,8 @@ jobs:
         if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
+          # Important: there are multiple "Report Status" steps in this file (one per job).
+          # Make sure they are all updated
           notify_when: "failure"
           status: ${{ job.status }} # required
           # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
@@ -399,7 +406,12 @@ jobs:
         if: always()
         uses: ravsamhq/notify-slack-action@v2
         with:
+          # Important: there are multiple "Report Status" steps in this file (one per job).
+          # Make sure they are all updated
           notify_when: "failure"
           status: ${{ job.status }} # required
+          # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
+          message_format: '{emoji} Hey @${{ github.event.head_commit.author.name }}! *{workflow}* {status_message} for "${{ github.event.head_commit.message }} - <{commit_url}|{commit_sha}>". Checkout the run at {run_url}.'
+          footer: "<{run_url}|Failing Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GHA_FAILURES_WEBHOOK_URL }}

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -335,6 +335,9 @@ jobs:
         with:
           notify_when: "failure"
           status: ${{ job.status }} # required
+          # Message should look like: "Hey @author! Deploy and test hubs failed for "Add new hub - 9305e08".
+          message_format: '{emoji} Hey @${{ github.event.head_commit.author.name }}! *{workflow}* {status_message} for "${{ github.event.head_commit.message }} - <{commit_url}|{commit_sha}>". Checkout the run at {run_url}.'
+          footer: "<{run_url}|Failing Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GHA_FAILURES_WEBHOOK_URL }}
 


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/2828

This action needs to run once per job, so it appears in every job of deploy-hubs.