### PR TITLE
Revert "Enable unlisted image choice for researchdelight hub"

### DIFF
--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -40,9 +40,6 @@ basehub:
             name: 2i2c
             url: https://2i2c.org
     hub:
-      image:
-        name: quay.io/2i2c/experimental-hub
-        tag: "0.0.1-0.dev.git.6406.hc1091b1c"
       config:
         JupyterHub:
           authenticator_class: cilogon
@@ -64,13 +61,6 @@ basehub:
           profile_options: &profile_options
             image:
               display_name: Image
-              unlisted_choice: &profile_list_unlisted_choice
-                enabled: True
-                display_name: "Custom image"
-                validation_regex: "^.+:.+$"
-                validation_message: "Must be a valid public docker image, including a tag"
-                kubespawner_override:
-                  image: "{value}"
               choices:
                 pangeo:
                   display_name: Pangeo Notebook
@@ -152,7 +142,6 @@ basehub:
           profile_options:
             image:
               display_name: Image
-              unlisted_choice: *profile_list_unlisted_choice
               choices:
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2880

Ref https://github.com/2i2c-org/infrastructure/issues/2873

This did not pass CI, needs https://github.com/2i2c-org/infrastructure/issues/2869
to be fixed