### PR TITLE
Increase 2i2c filestore cap to 3.5TiB to match console change

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -12,7 +12,7 @@ enable_network_policy = true
 regional_cluster = false
 
 enable_filestore      = true
-filestore_capacity_gb = 2560
+filestore_capacity_gb = 3584
 
 notebook_nodes = {
   "user" : {


### PR DESCRIPTION
To fix https://2i2c.freshdesk.com/a/tickets/849.

I've already applied this change from the console.