### PR TITLE
Add more hub features to the table of features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ docs/tmp
 docs/reference/terraform.md
 docs/_static/hub-stats.json
 docs/_static/hub-table.json
+docs/_static/hub-options-table.json
 
 # Common editor config
 .vscode

--- a/docs/helper-programs/generate-general-info-table-about-hubs.py
+++ b/docs/helper-programs/generate-general-info-table-about-hubs.py
@@ -5,7 +5,7 @@ This is used in two places:
 - docs/_static/hub-table.json is published with the docs and meant for re-use in other parts of 2i2c
 - docs/tmp/hub-table.csv is read by reference/hubs.md to create a list of hubs
 """
-from utils import get_clusters_list, turn_list_into_df, write_df_to_json_and_csv_files
+from utils import get_clusters_list, turn_list_into_df, write_list_to_json_and_csv_files
 from yaml import safe_load
 
 
@@ -77,11 +77,11 @@ def build_hub_list_entry(
     }
 
 
-def build_hub_statistics_df():
+def build_hub_statistics_df(hub_list):
     # Write some quick statistics for display
     # Calculate total number of community hubs by removing staging and demo hubs
     # Remove `staging` hubs to count the total number of communites we serve
-    hubs_general_info_df = turn_list_into_df()
+    hubs_general_info_df = turn_list_into_df(hub_list)
     filter_out = ["staging", "demo"]
     community_hubs = hubs_general_info_df.loc[
         hubs_general_info_df["name"].map(
@@ -166,10 +166,10 @@ def main():
             )
 
     # Write raw data to CSV and JSON
-    write_df_to_json_and_csv_files(hub_list, "hub-table")
+    write_list_to_json_and_csv_files(hub_list, "hub-table")
 
-    community_hubs_by_cluster = build_hub_statistics_df()
-    write_df_to_json_and_csv_files(community_hubs_by_cluster, "hub-stats")
+    community_hubs_by_cluster = build_hub_statistics_df(hub_list)
+    write_list_to_json_and_csv_files(community_hubs_by_cluster, "hub-stats")
 
     print("Finished updating list of hubs and statics tables...")
 

--- a/docs/helper-programs/generate-hub-features-table.py
+++ b/docs/helper-programs/generate-hub-features-table.py
@@ -53,19 +53,16 @@ def get_user_anonymization_feature_status(hub_config, daskhub_type, binderhub_ty
 def get_custom_homepage_feature_status(hub_config, daskhub_type, binderhub_type):
     try:
         if daskhub_type:
-            return hub_config["basehub"]["jupyterhub"]["custom"]["homepage"][
-                "gitRepoBranch"
-            ]
+            hub_config["basehub"]["jupyterhub"]["custom"]["homepage"]["gitRepoBranch"]
+            return True
         elif binderhub_type:
-            return hub_config["binderhub"]["jupyterhub"]["custom"]["homepage"][
-                "gitRepoBranch"
-            ]
+            hub_config["binderhub"]["jupyterhub"]["custom"]["homepage"]["gitRepoBranch"]
+            return True
 
-        return hub_config["jupyterhub"]["custom"]["homepage"]["gitRepoBranch"]
+        hub_config["jupyterhub"]["custom"]["homepage"]["gitRepoBranch"]
+        return True
     except KeyError:
-        pass
-
-    return False
+        return False
 
 
 def get_allusers_feature_status(hub_config, daskhub_type, binderhub_type):

--- a/docs/helper-programs/generate-hub-features-table.py
+++ b/docs/helper-programs/generate-hub-features-table.py
@@ -5,8 +5,9 @@ This is used in two places:
 - docs/_static/hub-options-table.json is published with the docs and meant for re-use in other parts of 2i2c
 - docs/tmp/hub-options-table.csv is read by reference/hubs.md to create a list of hubs
 """
-from utils import get_clusters_list, write_df_to_json_and_csv_files
+from utils import get_clusters_list, write_list_to_json_and_csv_files
 from yaml import safe_load
+
 
 def get_hub_authentication(hub_config, daskhub_type, binderhub_type):
     # Return the value of `authenticator_class` from the `hub_config` dictionary
@@ -26,7 +27,7 @@ def get_hub_authentication(hub_config, daskhub_type, binderhub_type):
     except KeyError:
         pass
 
-    return ""
+    return
 
 
 def get_user_anonymization_feature_status(hub_config, daskhub_type, binderhub_type):
@@ -45,6 +46,7 @@ def get_user_anonymization_feature_status(hub_config, daskhub_type, binderhub_ty
         return hub_config["jupyterhub"]["custom"]["auth"]["anonymizeUsername"]
     except KeyError:
         return False
+
 
 def build_options_list_entry(hub, authenticator, anonymization_status):
     return {
@@ -109,7 +111,7 @@ def main():
             )
 
     # Write raw data to CSV and JSON
-    write_df_to_json_and_csv_files(options_list, "hub-options-table")
+    write_list_to_json_and_csv_files(options_list, "hub-options-table")
     print("Finished updating list of hubs features table...")
 
 

--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -29,14 +29,10 @@ A table of all running hubs across all of our clusters.
 
 ## Hub options table
 
-<div class="full-width hubs-table">
-
 ```{csv-table}
 :header-rows: 1
 :file: ../tmp/hub-options-table.csv
 ```
-
-</div>
 
 ## Community hub statistics
 


### PR DESCRIPTION
This is a follow-up to https://github.com/2i2c-org/infrastructure/pull/2839  towards the sprint 1's  version of https://github.com/2i2c-org/meta/issues/628

Adds:
- user id anonymisation
- allusers setup
- community specific domain
- custom login page