### PR TITLE
Move ohw back to main home page

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -64,7 +64,6 @@ basehub:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
       homepage:
-        gitRepoBranch: "2i2c-ohw"
         templateVars:
           org:
             name: OceanHackWeek


### PR DESCRIPTION
This change reverts the OHW homepage repo to using the default english language version, over the spanish version available in https://github.com/2i2c-org/default-hub-homepage/tree/2i2c-ohw