### PR TITLE
Provide access to more S3 buckets to NASA Veda

### DIFF
--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -50,7 +50,11 @@ hub_cloud_permissions = {
                     "arn:aws:s3:::nsidc-cumulus-prod-protected",
                     "arn:aws:s3:::nsidc-cumulus-prod-protected/*",
                     "arn:aws:s3:::ornl-cumulus-prod-protected",
-                    "arn:aws:s3:::ornl-cumulus-prod-protected/*"
+                    "arn:aws:s3:::ornl-cumulus-prod-protected/*",
+                    "arn:aws:s3:::podaac-ops-cumulus-public",
+                    "arn:aws:s3:::podaac-ops-cumulus-public/*",
+                    "arn:aws:s3:::podaac-ops-cumulus-protected",
+                    "arn:aws:s3:::podaac-ops-cumulus-protected/*"
                 ]
             },
             {


### PR DESCRIPTION
In the process of getting
https://github.com/2i2c-org/infrastructure/pull/2915 done, I noticed that these extra buckets were accessible from the hub. However, these were added outside terraform, so they were removed when I ran that apply. Adding these in formally so folks don't lose access