### PR TITLE
[ubc-eoas] Ensure 2i2c staff have admin access

### DIFF
--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -13,6 +13,9 @@ nfs:
 
 jupyterhub:
   custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "google"
     homepage:
       templateVars:
         org:


### PR DESCRIPTION
Gives 2i2c staff admin access to the UBC-EOAS hubs

ref: https://2i2c.slack.com/archives/C028WU9PFBN/p1691082658022549