### PR TITLE
Create a dedicated nodepool for OHW event

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -11,6 +11,13 @@ basehub:
           hosts:
             - oceanhackweek.2i2c.cloud
     singleuser:
+      nodeSelector:
+        2i2c.org/community: ohw
+      extraTolerations:
+        - key: "2i2c.org/community"
+          operator: "Equal"
+          value: "ohw"
+          effect: "NoSchedule"
       networkPolicy:
         # In clusters with NetworkPolicy enabled, do not
         # allow outbound internet access that's not DNS, HTTP or HTTPS

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -59,7 +59,7 @@ notebook_nodes = {
     # We expect around 100 users
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-16",
+    machine_type : "n2-highmem-16",
     labels : {
       "2i2c.org/community" : "ohw"
     },

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -53,6 +53,24 @@ notebook_nodes = {
     resource_labels : {
       "community" : "neurohackademy"
     },
+  },
+  # Nodepool for OceanHackWeek. Tracking issue: https://github.com/2i2c-org/infrastructure/issues/2879
+  "ohw" : {
+    # We expect around 100 users
+    min : 0,
+    max : 100,
+    machine_type : "n1-highmem-16",
+    labels : {
+      "2i2c.org/community" : "ohw"
+    },
+    taints : [{
+      key : "2i2c.org/community",
+      value : "ohw",
+      effect : "NO_SCHEDULE"
+    }],
+    resource_labels : {
+      "community" : "ohw"
+    },
   }
 }
 


### PR DESCRIPTION
ref: https://github.com/2i2c-org/infrastructure/issues/2879

I've set the minimum to 0 for now. I can scale it up Monday AM before the start of the event.