### PR TITLE
Add info about user buckets and requestor pays to the options table

### DIFF
--- a/docs/helper-programs/generate-general-info-table-about-hubs.py
+++ b/docs/helper-programs/generate-general-info-table-about-hubs.py
@@ -6,7 +6,7 @@ This is used in two places:
 - docs/tmp/hub-table.csv is read by reference/hubs.md to create a list of hubs
 """
 import pandas as pd
-from utils import get_clusters_list, write_to_json_and_csv_files
+from utils import get_cluster_provider, get_clusters_list, write_to_json_and_csv_files
 from yaml import safe_load
 
 
@@ -128,11 +128,7 @@ def main():
         # Define the cloud provider for this cluster which we'll insert into the table below
         # For clusters where we know the provider but can't guess it from the YAML file,
         # we define a few custom mappings.
-        custom_providers = {"utoronto": "azure"}
-        if cluster["name"] in custom_providers.keys():
-            provider = custom_providers[cluster["name"]]
-        else:
-            provider = cluster["provider"]
+        provider = get_cluster_provider(cluster)
 
         # Don't display anything about Console UI if no info about datacentre available
         cluster_console_url = None

--- a/docs/helper-programs/generate-hub-features-table.py
+++ b/docs/helper-programs/generate-hub-features-table.py
@@ -182,8 +182,6 @@ def build_options_list_entry(hub, hub_count, values_files_features, terraform_fe
         "custom html pages": values_files_features["custom_html"],
         "gh-scoped-creds": values_files_features["gh_scoped_creds"],
         #         "static web pages":
-        #         "shared cluster":
-        #         "buckets":
         #         "dask":
         #         "GPUs":
         #         "profile lists":

--- a/docs/helper-programs/generate-hub-features-table.py
+++ b/docs/helper-programs/generate-hub-features-table.py
@@ -182,7 +182,6 @@ def build_options_list_entry(hub, hub_count, values_files_features, terraform_fe
         "custom html pages": values_files_features["custom_html"],
         "gh-scoped-creds": values_files_features["gh_scoped_creds"],
         #         "static web pages":
-        #         "dask":
         #         "GPUs":
         #         "profile lists":
     }

--- a/docs/helper-programs/utils.py
+++ b/docs/helper-programs/utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 path_root = Path(__file__).parent.parent
 path_clusters = path_root / "../config/clusters"
+path_terraform = path_root / "../terraform/"
 
 
 def get_clusters_list():
@@ -15,6 +16,13 @@ def get_clusters_list():
         for filepath in path_clusters.glob("**/*cluster.yaml")
         if "tests/" not in str(filepath) and "templates" not in str(filepath)
     ]
+
+
+def get_cluster_provider(cluster):
+    custom_providers = {"utoronto": "azure"}
+    if cluster["name"] in custom_providers.keys():
+        return custom_providers[cluster["name"]]
+    return cluster["provider"]
 
 
 def write_to_json_and_csv_files(info, file_name_prefix):

--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -73,6 +73,8 @@ $(document).ready( function () {
             null, // domain column, nothing special configured
             {"render": checkbox}, // dedicated cluster column
             {"render": checkbox}, // dedicated nodepool column
+            {"render": checkbox}, // user buckets (scratch/persistent) column
+            {"render": checkbox}, // requestor pays for buckets storage column
             null, // authenticator column
             {"render": checkbox}, // user anonymisation column
             {"render": checkbox}, // allusers access column

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 myst-parser[sphinx,linkify]
 pandas
 pyyaml
+python-hcl2
 requests
 sphinx-autobuild
 sphinx-copybutton


### PR DESCRIPTION
Add the following new info in the options table:
- user buckets
- requestor pays

This info is parsed from the cluster's terraform file.

Ref: https://github.com/2i2c-org/meta/issues/628