### PR TITLE
Increase resources for openscapes prometheus

### DIFF
--- a/config/clusters/openscapes/support.values.yaml
+++ b/config/clusters/openscapes/support.values.yaml
@@ -11,6 +11,9 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.openscapes.2i2c.cloud
+    persistentVolume:
+      # 100Gi was too little
+      size: 200Gi
     resources:
       requests:
         memory: 8Gi


### PR DESCRIPTION
It's not been collecting any data for a few weeks as it was in a CrashLoop. Looking
at disk space graph, it's full


<img width="1728" alt="image" src="https://github.com/2i2c-org/infrastructure/assets/30430/6c23912e-4f82-4434-9bfe-0425a16f34c9">


Fixes https://github.com/2i2c-org/infrastructure/issues/2911