### PR TITLE
Increase prometheus disks everywhere

### DIFF
--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -8,9 +8,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    persistentVolume:
-      # 100Gi was too little
-      size: 200Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/pangeo-hubs/support.values.yaml
+++ b/config/clusters/pangeo-hubs/support.values.yaml
@@ -25,8 +25,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    persistentVolume:
-      size: 200Gi
     ingress:
       enabled: true
       hosts:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -268,7 +268,7 @@ prometheus:
       #
       hub.jupyter.org/network-access-hub: "true"
     persistentVolume:
-      size: 100Gi
+      size: 200Gi
     service:
       type: ClusterIP
 


### PR DESCRIPTION
All the failures of
https://github.com/2i2c-org/infrastructure/actions/runs/5781063019/job/15665625371 seem to be because of full disks.

Ref https://github.com/2i2c-org/infrastructure/issues/2930
Ref https://github.com/2i2c-org/infrastructure/issues/2911