### PR TITLE
[EVENT] OHW nodepool scaleup

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -57,7 +57,7 @@ notebook_nodes = {
   # Nodepool for OceanHackWeek. Tracking issue: https://github.com/2i2c-org/infrastructure/issues/2879
   "ohw" : {
     # We expect around 100 users
-    min : 0,
+    min : 4,
     max : 100,
     machine_type : "n2-highmem-16",
     labels : {


### PR DESCRIPTION
ref: https://github.com/2i2c-org/infrastructure/issues/2879

We are using n2-highmem-16 machines which have 16 CPUs and 128GB each.
The requests/limits for the OHW profiles are 0.5/2 CPUs and 4/8GB.
Taking the lower limits, this works out to a maximum of 32 users per node.
We are expecting 100 users, so need a minimum of 3 nodes.

I have requested 4 to provide some wiggle room.