### PR TITLE
2i2c-aws-us, itcoocean: mount shared-public folder

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -53,6 +53,41 @@ jupyterhub:
         admin_users:
           - eeholmes # Eli Holmes, Community representative
   singleuser:
+    # shared-public for collaboration
+    # See https://2i2c.freshdesk.com/a/tickets/814
+    storage:
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/shared-public
+          subPath: _shared-public
+          readOnly: false
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
+    initContainers:
+      - name: volume-mount-ownership-fix
+        image: busybox
+        command:
+          [
+            "sh",
+            "-c",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+          ]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{username}"
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
+          - name: home
+            mountPath: /home/jovyan/shared-public
+            subPath: _shared-public
     extraEnv:
       SCRATCH_BUCKET: s3://scratch-itcoocean/$(JUPYTERHUB_USER)
       PANGEO_SCRATCH: s3://scratch-itcoocean/$(JUPYTERHUB_USER)

--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -54,17 +54,17 @@ jupyterhub:
           - eeholmes # Eli Holmes, Community representative
   singleuser:
     # shared-public for collaboration
-    # See https://2i2c.freshdesk.com/a/tickets/814
+    # See https://github.com/2i2c-org/infrastructure/issues/2821#issuecomment-1665642853
     storage:
       extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared-public
-          subPath: _shared-public
-          readOnly: false
         - name: home
           mountPath: /home/jovyan/shared
           subPath: _shared
           readOnly: true
+        - name: home
+          mountPath: /home/jovyan/shared-public
+          subPath: _shared-public
+          readOnly: false
     initContainers:
       - name: volume-mount-ownership-fix
         image: busybox

--- a/docs/howto/features/per-user-db.md
+++ b/docs/howto/features/per-user-db.md
@@ -68,18 +68,18 @@ jupyterhub:
         securityContext:
             runAsUser: 0
         volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
-        # Here so we can chown it appropriately
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
-        - name: postgres-db
-          mountPath: /var/lib/postgresql/data
-          # postgres recommends against mounting a volume directly here
-          # So we put data in a subpath
-          subPath: data
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{username}"
+          # Here so we can chown it appropriately
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
+          - name: postgres-db
+            mountPath: /var/lib/postgresql/data
+            # postgres recommends against mounting a volume directly here
+            # So we put data in a subpath
+            subPath: data
     storage:
       extraVolumes:
         - name: postgres-db
@@ -111,27 +111,27 @@ jupyterhub:
             memory: 64Mi
             cpu: 0.01
         env:
-        # Configured using the env vars documented in https://hub.docker.com/_/postgres/
-        # Postgres is only listening on localhost, so we can trust all connections that come to it
-        - name: POSTGRES_HOST_AUTH_METHOD
-          value: "trust"
-        # The name of the default user in our user image is jovyan, so the postgresql superuser
-        # should also be called that
-        - name: POSTGRES_USER
-          value: "jovyan"
-        securityContext:
-          runAsUser: 1000
-        volumeMounts:
-        # Mount the user homedirectory in the postgres db container as well, so postgres commands
-        # that load data into the db from disk work
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
-        - name: postgres-db
-          mountPath: /var/lib/postgresql/data
-          # postgres recommends against mounting a volume directly here
-          # So we put data in a subpath
-          subPath: data
+          # Configured using the env vars documented in https://hub.docker.com/_/postgres/
+          # Postgres is only listening on localhost, so we can trust all connections that come to it
+          - name: POSTGRES_HOST_AUTH_METHOD
+            value: "trust"
+          # The name of the default user in our user image is jovyan, so the postgresql superuser
+          # should also be called that
+          - name: POSTGRES_USER
+            value: "jovyan"
+          securityContext:
+            runAsUser: 1000
+          volumeMounts:
+          # Mount the user homedirectory in the postgres db container as well, so postgres commands
+          # that load data into the db from disk work
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{username}"
+          - name: postgres-db
+            mountPath: /var/lib/postgresql/data
+            # postgres recommends against mounting a volume directly here
+            # So we put data in a subpath
+            subPath: data
 ```
 
 ## Cleanup created disks after use

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -97,14 +97,14 @@ Parts of the *home* volume are mounted in different places for the users:
             singleuser:
               storage:
                 extraVolumeMounts:
-                - name: home
-                  mountPath: /home/jovyan/shared-public
-                  subPath: _shared-public
-                  readOnly: false
-                - name: home
-                  mountPath: /home/jovyan/shared
-                  subPath: _shared
-                  readOnly: true
+                  - name: home
+                    mountPath: /home/jovyan/shared
+                    subPath: _shared
+                    readOnly: true
+                  - name: home
+                    mountPath: /home/jovyan/shared-public
+                    subPath: _shared-public
+                    readOnly: false
               initContainers:
                 - name: volume-mount-ownership-fix
                   image: busybox


### PR DESCRIPTION
Followup to request when setting up the ITCOOcean hub in https://github.com/2i2c-org/infrastructure/issues/2821.

> Question, is it possible for participants to have a second smaller read-write drive that is separate from the admin one? We would like to make it easy for teams to collaborate on shared data and notebooks without having to push that to GitHub.