### PR TITLE
Increase grafana HTTP timeout when querying prometheus

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -212,6 +212,15 @@ prometheus:
         nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
         # If we enable external ingress into prometheus, we must secure it with HTTPS
         cert-manager.io/cluster-issuer: letsencrypt-prod
+        # Increase timeout for each query made by the grafana frontend to the
+        # grafana backend to 2min, which is the default timeout for prometheus
+        # queries. This also matches the timeout for the dataproxy in grafana,
+        # set under `grafana.grafana.ini` below. These two timeouts are set together
+        # to allow prometheus the best chance of executing queries we care about.
+        # While grafana in the same cluster does not go through nginx to access
+        # prometheus, the central grafana used does go through nginx. So we
+        # increase the timeout here as well.
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
     strategy:
       # type is set to Recreate as we have a persistent disk attached. The
       # default of RollingUpdate would fail by getting stuck waiting for a new

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -327,8 +327,13 @@ grafana:
       # of 1m to avoid HTTP 413 (Request Entity Too Large) when making POST
       # request (via jupyterhub/grafana-dashboard's deploy script, from a github
       # workflow) to update dashboards with json files representing them.
-      #
       nginx.ingress.kubernetes.io/proxy-body-size: 64m
+      # Increase timeout for each query made by the grafana frontend to the
+      # grafana backend to 2min, which is the default timeout for prometheus
+      # queries. This also matches the timeout for the dataproxy in grafana,
+      # set under `grafana.ini` below. These two timeouts are set together
+      # to allow prometheus the best chance of executing queries we care about.
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
       cert-manager.io/cluster-issuer: letsencrypt-prod
 
   # grafana is partially configured for GitHub authentication here, but the
@@ -353,6 +358,8 @@ grafana:
       # wait until that much time.
       # See https://prometheus.io/docs/prometheus/latest/command-line/prometheus/
       # for default prometheus query timeouts.
+      # Because our grafana is behind an nginx ingress, this should match the
+      # read timeout set above under `ingress.annotations`.
       timeout: 120
     server:
       root_url: ""

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -344,6 +344,16 @@ grafana:
   #       client_secret: ""
   #
   grafana.ini:
+    # dataproxy is used to make requests to prometheuses via the backend.
+    # This allows authless access to prometheus server in the same namespace.
+    dataproxy:
+      # Enable logging so we can debug grafana timeouts
+      logging: true
+      # Default prometheus query timeout is 120s, so let's allow grafana to
+      # wait until that much time.
+      # See https://prometheus.io/docs/prometheus/latest/command-line/prometheus/
+      # for default prometheus query timeouts.
+      timeout: 120
     server:
       root_url: ""
     auth.github:


### PR DESCRIPTION
Prior to this, the 30s timeout was masking the *real* error messages from Prometheus on why some queries were timing out. By matching the grafana timeout to the prometheus timeout, we can better see and debug root cause of our issues.

Ref https://github.com/2i2c-org/infrastructure/issues/2934