### PR TITLE
Update our docs noxfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ To do so, follow these steps:
    ```console
    $ pip install nox
    ```
+
 2. Build the documentation:
 
    ```console
    $ nox -s docs
    ```
 
-This should create a local environment in a `.nox` folder, build the documentation (as specified in the `noxfile.py` configuration), and the output will be in `docs/_build/html`.
+This should create a local environment in a `.nox` folder, build the documentation (as specified in the `noxfile.py` configuration), and the output will be in `docs/_build/dirhtml`.
 
 To build live documentation that updates when you update local files, run the following command:
 
 ```console
-$ nox -s docs-live
+$ nox -s docs -- live
 ```
 
 ### Manually with `conda`
@@ -52,11 +53,11 @@ If you wish to manually build the documentation, you can use `conda` to do so.
 
 3. Build the documentation:
 
-   ```
+   ```bash
    make html
    ```
 
-This will generate the HTML for the documentation in the `docs/_build/html` folder.
+This will generate the HTML for the documentation in the `docs/_build/dirhtml` folder.
 You may preview the documentation by opening any of the `.html` files inside.
 
 ### Build the documentation with a live server

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinx-copybutton
 sphinx-design
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinxcontrib-mermaid
+sphinxcontrib-jquery

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,13 +5,9 @@ nox.options.reuse_existing_virtualenvs = True
 BUILD_COMMAND = ["-b", "dirhtml", "docs", "docs/_build/dirhtml"]
 
 
-def install_deps(session):
-    session.install("-r", "docs/requirements.txt")
-
-
 @nox.session(venv_backend="conda")
 def docs(session):
-    install_deps(session)
+    session.install("-r", "docs/requirements.txt")
     session.run("sphinx-build", *BUILD_COMMAND)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,7 @@ BUILD_COMMAND = ["-b", "dirhtml", "docs", "docs/_build/dirhtml"]
 
 @nox.session(venv_backend="conda")
 def docs(session):
+    """Build the documentation. Use `-- live` for a live server to preview changes."""
     session.install("-r", "docs/requirements.txt")
 
     if "live" in session.posargs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-BUILD_COMMAND = ["-b", "html", "docs", "docs/_build/html"]
+BUILD_COMMAND = ["-b", "dirhtml", "docs", "docs/_build/dirhtml"]
 
 
 def install_deps(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,10 +22,10 @@ def docs(session):
         cmd = ["sphinx-autobuild"]
         for folder in AUTOBUILD_IGNORE:
             cmd.extend(["--ignore", f"*/{folder}/*"])
-        
+
         # Find an open port to serve on
         cmd.extend(["--port", "0"])
-    
+
     else:
         cmd = ["sphinx-build"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,15 +8,25 @@ BUILD_COMMAND = ["-b", "dirhtml", "docs", "docs/_build/dirhtml"]
 @nox.session(venv_backend="conda")
 def docs(session):
     session.install("-r", "docs/requirements.txt")
-    session.run("sphinx-build", *BUILD_COMMAND)
 
+    if "live" in session.posargs:
+        session.posargs.pop(session.posargs.index("live"))
 
-@nox.session(name="docs-live", venv_backend="conda")
-def docs_live(session):
-    install_deps(session)
+        # Add folders to ignore
+        AUTOBUILD_IGNORE = [
+            "_build",
+            "tmp",
+        ]
 
-    cmd = ["sphinx-autobuild"]
-    for path in ["*/_build/*", "*/tmp/*"]:
-        cmd.extend(["--ignore", path])
-    cmd.extend(BUILD_COMMAND)
+        cmd = ["sphinx-autobuild"]
+        for folder in AUTOBUILD_IGNORE:
+            cmd.extend(["--ignore", f"*/{folder}/*"])
+        
+        # Find an open port to serve on
+        cmd.extend(["--port", "0"])
+    
+    else:
+        cmd = ["sphinx-build"]
+
+    cmd.extend(BUILD_COMMAND + session.posargs)
     session.run(*cmd)


### PR DESCRIPTION
This PR brings the noxfile for building the infrastructure documentation inline with what we have for our [team compass](https://github.com/2i2c-org/team-compass/blob/main/noxfile.py). The changes are:

- Use the dirhtml builder instead of the html builder. There was a warning within the sphinx logs instructing to do so.
- Combine the docs and doc-live functions in the noxfile into one. This is beneficial because previously when running the docs function nox would create an env called docs, and when running the docs-live function it would create a new env called docs-live - needlessly reinstalling the same env under a different path. Now the same environment is used, just the sphinx command is changed to either do a normal build or launch a live preview server.
- I also added a missing package that my local build failed on when I tried to build.