### PR TITLE
basehub: avoid creating empty shared-readwrite directory for non-admins

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -72,7 +72,7 @@ jupyterhub:
           [
             "sh",
             "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
           ]
         securityContext:
           runAsUser: 0
@@ -83,7 +83,7 @@ jupyterhub:
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
           - name: home
             mountPath: /home/jovyan/shared-public

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -42,7 +42,7 @@ jupyterhub:
           [
             "sh",
             "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
           ]
         securityContext:
           runAsUser: 0
@@ -53,7 +53,7 @@ jupyterhub:
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
           - name: home
             mountPath: /home/jovyan/shared-public

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -94,7 +94,7 @@ basehub:
             [
               "sh",
               "-c",
-              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
             ]
           securityContext:
             runAsUser: 0
@@ -105,7 +105,7 @@ basehub:
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home
-              mountPath: /home/jovyan/shared-readwrite
+              mountPath: /home/jovyan/shared
               subPath: _shared
             - name: home
               mountPath: /home/jovyan/shared-public

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -234,7 +234,7 @@ jupyterhub:
           [
             "sh",
             "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
           ]
         securityContext:
           runAsUser: 0
@@ -245,7 +245,7 @@ jupyterhub:
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
           - name: home
             mountPath: /home/jovyan/shared-public

--- a/docs/howto/features/per-user-db.md
+++ b/docs/howto/features/per-user-db.md
@@ -63,7 +63,7 @@ jupyterhub:
             [
                 "sh",
                 "-c",
-                "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /var/lib/postgresql/data && ls -lhd /home/jovyan ",
+                "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /var/lib/postgresql/data && ls -lhd /home/jovyan ",
             ]
         securityContext:
             runAsUser: 0
@@ -71,9 +71,10 @@ jupyterhub:
           - name: home
             mountPath: /home/jovyan
             subPath: "{username}"
-          # Here so we can chown it appropriately
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
           - name: postgres-db
             mountPath: /var/lib/postgresql/data

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -117,7 +117,7 @@ jupyterhub:
           [
             "sh",
             "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
           ]
         securityContext:
           runAsUser: 0
@@ -128,7 +128,7 @@ jupyterhub:
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
           - name: home
             mountPath: /home/jovyan/shared-public

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -177,7 +177,7 @@ jupyterhub:
           [
             "sh",
             "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared-readwrite && ls -lhd /home/jovyan ",
+            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && ls -lhd /home/jovyan ",
           ]
         securityContext:
           runAsUser: 0
@@ -185,9 +185,10 @@ jupyterhub:
           - name: home
             mountPath: /home/jovyan
             subPath: "{username}"
-          # Here so we can chown it appropriately
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
           - name: home
-            mountPath: /home/jovyan/shared-readwrite
+            mountPath: /home/jovyan/shared
             subPath: _shared
     cmd:
       # Explicitly define this, as it's no longer set by z2jh


### PR DESCRIPTION
This is one step towards resolving #2946. It was caused by mounting the `_shared` directory to a users directory in the path `shared-readwrite` in an initContainer, as that causes the creation of an empty folder in the home directory that isn't later hidden by mounting `shared-readwrite` again on top of it.

We can avoid creating these empty `shared-readwrite` folders in the users home directory for non-admin users by not mounting that folder in the initContainer. This is what this PR does.

---

In the future we can cleanup the empty `shared-readwrite` folder for all users (non-admin is users is what matters), but if an admin becomes a non-admin at some point, they may still have an empty `shared-readwrite` folder owned by root lurking in their home directory - not because it was mounted, but once was mounted and that led to the creation of an empty root owned dir in their home directory.

For notes from a deep dive I did into this, see #2953.