### PR TITLE
Revert "[smithsonian] Set minimum nodepool size to 5"

### DIFF
--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -25,7 +25,7 @@ local nodeAz = "us-east-2b";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.xlarge", minSize: 5 },
+    { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
 ];


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2856

Event is over and we can scale the cluster down now, ref: https://github.com/2i2c-org/infrastructure/issues/2854#issuecomment-1671328207

fixes #2854 