### PR TITLE
Fix typo in nasa-ghg cluster.yaml file

### DIFF
--- a/config/clusters/nasa-ghg/cluster.yaml
+++ b/config/clusters/nasa-ghg/cluster.yaml
@@ -1,4 +1,4 @@
-name: nasa-veda
+name: nasa-ghg
 provider: aws # https://smce-veda.signin.aws.amazon.com/console
 account: "smce-ghg-center"
 aws:


### PR DESCRIPTION
Leftover from copy pasting the whole directory.

Fixes this failure: https://github.com/2i2c-org/infrastructure/actions/runs/5824107737/job/15792435418#step:6:69

- EDIT: Closes #2960