### PR TITLE
Increase LEAP prometheus persistent storage to 500Gi

### DIFF
--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -16,6 +16,8 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.leap.2i2c.cloud
+    persistentVolume:
+      size: 500Gi
     resources:
       requests:
         memory: 20Gi


### PR DESCRIPTION
200Gi was full.

Ref https://2i2c.freshdesk.com/a/tickets/875