### PR TITLE
Disable directory size reporter

### DIFF
--- a/helm-charts/basehub/templates/home-dirsize-reporter.yaml
+++ b/helm-charts/basehub/templates/home-dirsize-reporter.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.nfs.enabled }}
+{{- if .Values.nfs.dirsizeReporter.enabled }}
 # To provide data for the jupyterhub/grafana-dashboards dashboard about free
 # space in the shared volume, which contains users home folders etc, we deploy
 # prometheus node-exporter to collect this data for prometheus server to scrape.
@@ -73,4 +74,5 @@ spec:
         - name: shared-volume
           persistentVolumeClaim:
             claimName: home-nfs
+{{- end }}
 {{- end }}

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -159,10 +159,19 @@ properties:
     required:
       - enabled
       - shareCreator
+      - dirsizeReporter
       - pv
     properties:
       enabled:
         type: boolean
+      dirsizeReporter:
+        type: object
+        additionalProperties: false
+        required:
+          - enabled
+        properties:
+          enabled:
+            type: boolean
       shareCreator:
         type: object
         additionalProperties: false

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -35,6 +35,8 @@ staticWebsite:
 
 nfs:
   enabled: true
+  dirsizeReporter:
+    enabled: false
   shareCreator:
     enabled: true
     tolerations: []


### PR DESCRIPTION
Let's disable this metric for a week, to see if this is the *cause* of our prometheus directory size explosion.

Ref https://github.com/2i2c-org/infrastructure/issues/2930