### PR TITLE
gcp/aws, dask worker nodes: towards single r5.4xlarge/n2-highmem-16 dask worker node pool

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -43,6 +43,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -44,13 +44,17 @@ local notebookNodes = [
     },
 ];
 
-// Node definitions for dask worker nodes. Config here is merged
-// with our dask worker node definition, which uses spot instances.
-// A `node.kubernetes.io/instance-type label is set to the name of the
-// *first* item in instanceDistribution.instanceTypes, to match
-// what we do with notebook nodes. Pods can request a particular
-// kind of node with a nodeSelector
 local daskNodes = [
+    // Node definitions for dask worker nodes. Config here is merged
+    // with our dask worker node definition, which uses spot instances.
+    // A `node.kubernetes.io/instance-type label is set to the name of the
+    // *first* item in instanceDistribution.instanceTypes, to match
+    // what we do with notebook nodes. Pods can request a particular
+    // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -51,10 +51,7 @@ local notebookNodes = [
 // what we do with notebook nodes. Pods can request a particular
 // kind of node with a nodeSelector
 local daskNodes = [
-    { instancesDistribution+: { instanceTypes: ["r5.large"] }},
-    { instancesDistribution+: { instanceTypes: ["r5.xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["r5.2xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["r5.8xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 
 {

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -44,6 +44,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -64,6 +64,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -64,9 +64,7 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-    { instancesDistribution+: { instanceTypes: ["m5.large"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.4xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["m5.16xlarge"] }},
+    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 
 

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -37,6 +37,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -36,6 +36,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -37,6 +37,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -41,9 +41,7 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
-    { instancesDistribution+: { instanceTypes: ["r5.xlarge"] }},
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
-    { instancesDistribution+: { instanceTypes: ["r5.16xlarge"] }},
 ];
 
 

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -41,6 +41,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -36,6 +36,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -48,6 +48,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 <% else %>

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -38,6 +38,10 @@ local daskNodes = [
     // *first* item in instanceDistribution.instanceTypes, to match
     // what we do with notebook nodes. Pods can request a particular
     // kind of node with a nodeSelector
+    //
+    // A not yet fully established policy is being developed about using a single
+    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+    //
     { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
 ];
 

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -48,6 +48,11 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "medium" : {
     min : 0,

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -22,6 +22,11 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "worker" : {
     min : 0,

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -26,7 +26,7 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4"
+    machine_type : "n2-highmem-16"
   },
 }
 

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -67,8 +67,13 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
-  "medium" : {
+  "worker" : {
     min : 0,
     max : 200,
     machine_type : "n2-highmem-16",

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -97,6 +97,11 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "medium" : {
     min : 0,

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -33,11 +33,11 @@ notebook_nodes = {
 }
 
 dask_nodes = {
-  "medium" : {
+  "worker" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-16"
-  },
+    machine_type : "n2-highmem-16",
+  }
 }
 
 hub_cloud_permissions = {

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -32,6 +32,11 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "worker" : {
     min : 0,

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -70,6 +70,11 @@ notebook_nodes = {
   }
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "worker" : {
     min : 0,

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -71,26 +71,11 @@ notebook_nodes = {
 }
 
 dask_nodes = {
-  "small" : {
+  "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
-  },
-  "medium" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-4",
-  },
-  "large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-  },
-  "huge" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
-  },
+    machine_type : "n2-highmem-16",
+  }
 }
 
 hub_cloud_permissions = {

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -40,6 +40,11 @@ notebook_nodes = {
 
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 dask_nodes = {
   "worker" : {
     min : 0,

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -41,32 +41,11 @@ notebook_nodes = {
 }
 
 dask_nodes = {
-  "small" : {
+  "worker" : {
     min : 0,
-    max : 20,
-    machine_type : "n1-standard-2",
-  },
-  "medium" : {
-    min : 0,
-    max : 20,
-    machine_type : "n1-standard-8",
-  },
-  "large" : {
-    min : 0,
-    max : 20,
-    machine_type : "n1-standard-16",
-  },
-  "very-large" : {
-    min : 0,
-    max : 20,
-    machine_type : "n1-standard-32",
-  },
-  "huge" : {
-    min : 0,
-    max : 20,
-    machine_type : "n1-standard-64",
-  },
-
+    max : 100,
+    machine_type : "n2-highmem-16",
+  }
 }
 
 user_buckets = {

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -75,6 +75,11 @@ notebook_nodes = {
   },
 }
 
+# TODO: Transition to a single n2-highmem-16 worker node pool to be able to
+#       provide standardized worker pod config for all daskhubs.
+#
+#       Tracked in https://github.com/2i2c-org/infrastructure/issues/2687
+#
 dask_nodes = {
   "small" : {
     min : 0,

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -75,6 +75,11 @@ notebook_nodes = {
   },
 }
 
+# Setup a single node pool for dask workers.
+#
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+#
 # TODO: Transition to a single n2-highmem-16 worker node pool to be able to
 #       provide standardized worker pod config for all daskhubs.
 #

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -1,3 +1,17 @@
+# SETTING UP TO WORK WITH THIS FILE:
+# -------------------------------------------------------------------------------
+#
+# The terraform state associated with this file is stored in a dedicated GCP
+# bucket, so in order to work with this file you need to do the following after
+# clearing a local .terraform folder.
+#
+# terraform init -backend-config backends/pangeo-backend.hcl
+# terraform workspace list
+# terraform workspace select <...>
+#
+# The GCP project having the bucket is https://console.cloud.google.com/?project=columbia
+#
+
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -85,6 +85,14 @@ notebook_nodes = {
 #
 #       Tracked in https://github.com/2i2c-org/infrastructure/issues/2687
 #
+#       The node pool to setup should look like this:
+#
+#       "worker" : {
+#         min : 0,
+#         max : 100,
+#         machine_type : "n2-highmem-16",
+#       },
+#
 dask_nodes = {
   "small" : {
     min : 0,

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -56,17 +56,17 @@ notebook_nodes = {
   }
 }
 
-# TODO: Transition to a single n2-highmem-16 worker node pool to be able to
-#       provide standardized worker pod config for all daskhubs.
+# Setup a single node pool for dask workers.
 #
-#       Tracked in https://github.com/2i2c-org/infrastructure/issues/2687
+# A not yet fully established policy is being developed about using a single
+# node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-  }
+  },
 }
 
 user_buckets = {}

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -60,7 +60,7 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4",
+    machine_type : "n2-highmem-16",
   }
 }
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -56,6 +56,11 @@ notebook_nodes = {
   }
 }
 
+# TODO: Transition to a single n2-highmem-16 worker node pool to be able to
+#       provide standardized worker pod config for all daskhubs.
+#
+#       Tracked in https://github.com/2i2c-org/infrastructure/issues/2687
+#
 dask_nodes = {
   "worker" : {
     min : 0,


### PR DESCRIPTION
This is addressing #2687 for all clusters (AWS, GCP) except the pangeo-hubs GCP cluster. With this PR all clusters' dask-worker node pools are reduced to a single node pool of type `r5.4xlarge` (AWS) or `n2-highmem-16` (GCP). The motivation is found in #2687.

I've considered the change individuall for each community, and I think this is fine. Overall, I expect some cost reduction to follow.

This work is motivated to provide a default dask-gateway configuration that works for all our daskhub clusters, without providing individual dask-gateway config for individual clusters like we do for singleuser.profileList now. LEAP is interested in testing out such dask-gateway configuration, and this is tracked in https://github.com/2i2c-org/infrastructure/issues/2364.