### PR TITLE
new single user image with ipystack_leaflet

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -66,7 +66,7 @@ basehub:
       defaultUrl: /lab
       image:
         name: public.ecr.aws/nasa-veda/nasa-veda-singleuser
-        # Uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
+        # Based off pangeo/pangeo-notebook:2023.07.05 which uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
         tag: "b807c7efa97c8df9ca38779f7e59d09f889fde9299b0d19de80389cf6b064f90"
       profileList:
         # NOTE: About node sharing

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -65,9 +65,9 @@ basehub:
     singleuser:
       defaultUrl: /lab
       image:
-        name: pangeo/pangeo-notebook
+        name: public.ecr.aws/nasa-veda/nasa-veda-singleuser
         # Uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
-        tag: "2023.07.05"
+        tag: "b807c7efa97c8df9ca38779f7e59d09f889fde9299b0d19de80389cf6b064f90"
       profileList:
         # NOTE: About node sharing
         #


### PR DESCRIPTION
This PR adds a new singleuser image as the default to https://nasa-veda.2i2c.cloud/. It's related to the freshdesk ticket (wish the emails showed the related freshdesk IDs) that Sarah Gibson has responded to.

VEDA has an image building pipeline in place so scientists can build custom images (basically [waiting for this custom options spawner feature to be released](https://github.com/jupyterhub/kubespawner/pull/735)) leveraging the `ONBUILD` command that pangeo uses in it's base image. 

Relevant info:

Repository: https://github.com/NASA-IMPACT/veda-jh-environments/

Base Image: https://github.com/NASA-IMPACT/veda-jh-environments/blob/main/docker-images/base/pangeo-notebook/Dockerfile

Singleuser Image: https://github.com/NASA-IMPACT/veda-jh-environments/tree/main/docker-images/custom/nasa-veda-singleuser

Public ECR: public.ecr.aws/nasa-veda/