### PR TITLE
Disable pre-puller in ohw hub after event

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -10,12 +10,6 @@ basehub:
         - secretName: https-auto-tls
           hosts:
             - oceanhackweek.2i2c.cloud
-    # Enabled prepuller for event: https://github.com/2i2c-org/infrastructure/issues/2879
-    prePuller:
-      hook:
-        enabled: true
-      continuous:
-        enabled: true
     singleuser:
       nodeSelector:
         2i2c.org/community: ohw


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#2924