### PR TITLE
Remove dedicated nodepool for OHW after event

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -17,13 +17,6 @@ basehub:
       continuous:
         enabled: true
     singleuser:
-      nodeSelector:
-        2i2c.org/community: ohw
-      extraTolerations:
-        - key: "2i2c.org/community"
-          operator: "Equal"
-          value: "ohw"
-          effect: "NoSchedule"
       networkPolicy:
         # In clusters with NetworkPolicy enabled, do not
         # allow outbound internet access that's not DNS, HTTP or HTTPS

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -53,24 +53,6 @@ notebook_nodes = {
     resource_labels : {
       "community" : "neurohackademy"
     },
-  },
-  # Nodepool for OceanHackWeek. Tracking issue: https://github.com/2i2c-org/infrastructure/issues/2879
-  "ohw" : {
-    # We expect around 100 users
-    min : 4,
-    max : 100,
-    machine_type : "n2-highmem-16",
-    labels : {
-      "2i2c.org/community" : "ohw"
-    },
-    taints : [{
-      key : "2i2c.org/community",
-      value : "ohw",
-      effect : "NO_SCHEDULE"
-    }],
-    resource_labels : {
-      "community" : "ohw"
-    },
   }
 }
 


### PR DESCRIPTION
- ref: https://github.com/2i2c-org/infrastructure/issues/2879
- reverts https://github.com/2i2c-org/infrastructure/pull/2921 and https://github.com/2i2c-org/infrastructure/pull/2935