### PR TITLE
Bump 2i2c shared cluster home directory storage

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -12,7 +12,7 @@ enable_network_policy = true
 regional_cluster = false
 
 enable_filestore      = true
-filestore_capacity_gb = 3584
+filestore_capacity_gb = 4096
 
 notebook_nodes = {
   "user" : {


### PR DESCRIPTION
We were at 99% full.

Ref https://github.com/2i2c-org/infrastructure/issues/2992