### PR TITLE
Remove experimental custom image support from LEAP

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -37,9 +37,6 @@ basehub:
             name: LEAP
             url: https://leap-stc.github.io
     hub:
-      image:
-        name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6478.h0ab34873"
       allowNamedServers: true
       config:
         Authenticator:
@@ -192,13 +189,6 @@ basehub:
                     cpu_limit: 16
             image: &profile_list_profile_options_image
               display_name: Image
-              unlisted_choice: &profile_list_unlisted_choice
-                enabled: True
-                display_name: "Custom image"
-                validation_regex: "^.+:.+$"
-                validation_message: "Must be a valid public docker image, including a tag"
-                kubespawner_override:
-                  image: "{value}"
               choices:
                 pangeo_new:
                   display_name: Base Pangeo Notebook ("2023.07.05")
@@ -278,7 +268,6 @@ basehub:
           profile_options:
             image:
               display_name: Image
-              unlisted_choice: *profile_list_unlisted_choice
               choices:
                 tensorflow_new:
                   display_name: Pangeo Tensorflow ML Notebook ("2023.07.05")

--- a/deployer/tests/test_hub_health.py
+++ b/deployer/tests/test_hub_health.py
@@ -41,16 +41,6 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
                 # This is because we would have lost its api token from the previous run.
                 await hub.delete_user(username)
 
-        # Temporary fix for https://github.com/2i2c-org/infrastructure/issues/2146#issuecomment-1649445203
-        # FIXME: Remove this once a fix in kubespawner gets implemented
-        user_options = {}
-        if "leap" in hub_url:
-            user_options = {
-                "profile": "medium-full",
-                "requests": "mem_8",
-                "image": "pangeo",
-            }
-
         # Create a new user, start a server and execute a notebook
         await execute_notebook(
             hub_url,
@@ -62,7 +52,6 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             delete_user=False,  # To be able to delete its server in case of failure
             stop_server=True,  # If the health check succeeds, this will delete the server
             validate=False,  # Don't validate notebook outputs. We only care that it runs top-to-bottom without error.
-            user_options=user_options,
         )
     finally:
         if orig_service_token:


### PR DESCRIPTION
It's currently broken, and we're past our 4 week policy for having unmerged experiments running! Let's revert it, and deploy it again once we have it working.

https://2i2c.freshdesk.com/a/tickets/848

Ref https://github.com/2i2c-org/infrastructure/issues/2887 
Ref https://github.com/2i2c-org/infrastructure/issues/2869