### PR TITLE
basehub: faster hub restarts by letting template-sync react to SIGTERM

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -474,7 +474,7 @@ jupyterhub:
 
                 # signal handling can only be done between sleep calls, so this
                 # shouldn't be reduced to the otherwise equivalent "sleep 5m"
-                for i in {1..300}; do
+                for i in $(seq 300); do
                     sleep 1s;
                 done
             done

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -445,10 +445,33 @@ jupyterhub:
         args:
           - -c
           - |
-            ls -lhd /srv/repo;
-            while true; do git fetch origin;
-            git reset --hard origin/$(GIT_REPO_BRANCH);
-            sleep 5m; done
+            handle_sigterm() {
+                echo "SIGTERM received, terminating...";
+                exit;
+            }
+            trap handle_sigterm SIGTERM
+
+            echo "Starting template sync...";
+
+            # print debugging info about commands run and their output using a
+            # temporary subshell with "set -x"
+            (
+                set -x;
+                git remote -v;
+                ls -lhd /srv/repo;
+            )
+
+            echo "Syncing local git repo /srv/repo's against remote origin's branch $GIT_REPO_BRANCH";
+            while true; do
+                git fetch origin;
+                git reset --hard origin/$(GIT_REPO_BRANCH);
+
+                # signal handling can only be done between sleep calls, so this
+                # shouldn't be reduced to the otherwise equivalent "sleep 5m"
+                for i in {1..300}; do
+                    sleep 1s;
+                done
+            done
         env:
           - name: GIT_REPO_BRANCH
             valueFrom:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -449,19 +449,25 @@ jupyterhub:
                 echo "SIGTERM received, terminating...";
                 exit;
             }
-            trap handle_sigterm SIGTERM
+            trap handle_sigterm SIGTERM;
 
             echo "Starting template sync...";
 
-            # print debugging info about commands run and their output using a
-            # temporary subshell with "set -x"
+            echo "";
+            echo "Info about local git repo to be synced:";
             (
+                # set -x causes commands run to be printed, helping log readers
+                # understand what the generated output is about. set -x is
+                # configured within a subshell to just print info about the
+                # specific chosen commands and avoid printing info about running
+                # "echo", "sleep", "set +x", or similar commands.
                 set -x;
                 git remote -v;
                 ls -lhd /srv/repo;
             )
 
-            echo "Syncing local git repo /srv/repo's against remote origin's branch $GIT_REPO_BRANCH";
+            echo "";
+            echo "Syncing local git repo /srv/repo against origin's branch $(GIT_REPO_BRANCH) every 5 minutes...";
             while true; do
                 git fetch origin;
                 git reset --hard origin/$(GIT_REPO_BRANCH);


### PR DESCRIPTION
This change makes the hub pod restart ~29s faster consistently, and that means JupyterHub is unresponsive 29 seconds less during upgrades.

- Closes #2129

## Before
![hub-restart-old](https://github.com/2i2c-org/infrastructure/assets/3837114/999755ff-0d02-43d8-bf77-618b2be6c848)

## After
![hub-restart-new](https://github.com/2i2c-org/infrastructure/assets/3837114/b26b0b62-ba98-4c01-beaa-3d7f16accc54)

```
Starting template sync...

Info about local git repo to be synced:
+ git remote -v
origin	https://github.com/2i2c-org/default-hub-homepage (fetch)
origin	https://github.com/2i2c-org/default-hub-homepage (push)
+ ls -lhd /srv/repo
drwxrwsrwx    5 1000     1000         124 Aug 22 07:44 /srv/repo

Syncing local git repo /srv/repo against origin's branch master every 5 minutes...
HEAD is now at 9472884 Merge pull request #22 from GeorgianaElena/update-instructions
HEAD is now at 9472884 Merge pull request #22 from GeorgianaElena/update-instructions
```
