### PR TITLE
Provide image options for UBC EOAS

### DIFF
--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -59,14 +59,23 @@ jupyterhub:
           - http://google.com/accounts/o8/id
 
   singleuser:
-    image:
-      name: quay.io/2i2c/2i2c-hubs-image
-      tag: "14107b8a85fb"
     defaultUrl: /lab
     profileList:
       - display_name: "Small: m5.large"
         description: "~2 CPU, ~8G RAM"
         default: true
+        profile_options: &profile_options
+          environment:
+            display_name: Environment
+            choices:
+              eosc211:
+                display_name: EOSC211
+                kubespawner_override:
+                  image: quay.io/henrykmodzelewski/2i2c-eosc211:06063a1a5f70
+              eosc350:
+                display_name: EOSC350
+                kubespawner_override:
+                  image: quay.io/henrykmodzelewski/2i2c-eosc350:2139c0151b51
         kubespawner_override:
           mem_limit: 8G
           mem_guarantee: 6.5G
@@ -74,6 +83,7 @@ jupyterhub:
             node.kubernetes.io/instance-type: m5.large
       - display_name: "Medium: m5.xlarge"
         description: "~4 CPU, ~15G RAM"
+        profile_options: *profile_options
         kubespawner_override:
           mem_limit: 15G
           mem_guarantee: 12G
@@ -81,6 +91,7 @@ jupyterhub:
             node.kubernetes.io/instance-type: m5.xlarge
       - display_name: "Large: m5.2xlarge"
         description: "~8 CPU, ~30G RAM"
+        profile_options: *profile_options
         kubespawner_override:
           mem_limit: 30G
           mem_guarantee: 25G
@@ -88,6 +99,7 @@ jupyterhub:
             node.kubernetes.io/instance-type: m5.2xlarge
       - display_name: "Huge: m5.8xlarge"
         description: "~16 CPU, ~60G RAM"
+        profile_options: *profile_options
         kubespawner_override:
           mem_limit: 60G
           mem_guarantee: 50G

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -71,11 +71,15 @@ jupyterhub:
               eosc211:
                 display_name: EOSC211
                 kubespawner_override:
-                  image: quay.io/henrykmodzelewski/2i2c-eosc211:06063a1a5f70
+                  # Using 'latest' for now so updates do not require 2i2c
+                  # involvement.
+                  image: quay.io/henrykmodzelewski/2i2c-eosc211:latest
               eosc350:
                 display_name: EOSC350
                 kubespawner_override:
-                  image: quay.io/henrykmodzelewski/2i2c-eosc350:2139c0151b51
+                  # Using 'latest' for now so updates do not require 2i2c
+                  # involvement.
+                  image: quay.io/henrykmodzelewski/2i2c-eosc350:latest
         kubespawner_override:
           mem_limit: 8G
           mem_guarantee: 6.5G


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3012

Removes the old stale default image from UBC as well: https://github.com/2i2c-org/infrastructure/issues/2674

Ref https://2i2c.freshdesk.com/a/tickets/905