### PR TITLE
gcp, dask-worker-nodes: pangeo-hubs to use single dask worker node type

### DIFF
--- a/config/clusters/pangeo-hubs/cluster.yaml
+++ b/config/clusters/pangeo-hubs/cluster.yaml
@@ -1,5 +1,5 @@
 name: pangeo-hubs
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pangeo-hubs-cluster/nodes?project=columbia
+provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pangeo-hubs-cluster/nodes?project=pangeo-integration-te-3eea
 account: columbia
 gcp:
   key: enc-deployer-credentials.secret.json

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -30,6 +30,16 @@ provider "google" {
   # Configuration reference:
   # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override
   #
+  # FIXME: Erik concluded that billing_project could be set to var.project_id at
+  #        least for one cluster, but it required that the project where the
+  #        cluster lived first enabled the GCP API: https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com
+  #
+  #        So, we should probably not reference a new variable here, but enable
+  #        the API for all our existing GCP projects and new GCP projects, and
+  #        then reference var.project_id instead.
+  #
+  #        But who knows, its hard to understand whats going on.
+  #
   user_project_override = true
   billing_project       = var.billing_project_id
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -31,7 +31,7 @@ provider "google" {
   # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override
   #
   user_project_override = true
-  billing_project       = "two-eye-two-see"
+  billing_project       = var.billing_project_id
 }
 
 data "google_client_config" "default" {}

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -94,52 +94,11 @@ notebook_nodes = {
 # A not yet fully established policy is being developed about using a single
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
-# TODO: Transition to a single n2-highmem-16 worker node pool to be able to
-#       provide standardized worker pod config for all daskhubs.
-#
-#       Tracked in https://github.com/2i2c-org/infrastructure/issues/2687
-#
-#       The node pool to setup should look like this:
-#
-#       "worker" : {
-#         min : 0,
-#         max : 100,
-#         machine_type : "n2-highmem-16",
-#       },
-#
 dask_nodes = {
-  "small" : {
+  "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
-  "medium" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
-  },
-  "large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
+    machine_type : "n2-highmem-16",
   },
 }
 

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -2,18 +2,25 @@
 # -------------------------------------------------------------------------------
 #
 # The terraform state associated with this file is stored in a dedicated GCP
-# bucket, so in order to work with this file you need to do the following after
-# clearing a local .terraform folder.
+# bucket, so a new terraform backend has to be chosen. Also, you will need to
+# authenticate with a @columbia.edu account as our @2i2c.org accounts don't have
+# access.
 #
-# terraform init -backend-config backends/pangeo-backend.hcl
-# terraform workspace list
-# terraform workspace select <...>
+# This can look something like this:
 #
-# The GCP project having the bucket is https://console.cloud.google.com/?project=columbia
+#     gcloud auth login --update-adc
 #
-
+#     cd terraform/gcp
+#     rm -rf .terraform
+#
+#     terraform init -backend-config backends/pangeo-backend.hcl
+#     terraform workspace select pangeo-hubs
+#
+#     terraform apply --var-file projects/pangeo-hubs.tfvars
+#
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
+billing_project_id     = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -23,7 +23,7 @@ project_id             = "pangeo-integration-te-3eea"
 billing_project_id     = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
-core_node_machine_type = "n2-highmem-4"
+core_node_machine_type = "n2-highmem-8"
 enable_private_cluster = true
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -23,6 +23,16 @@ variable "project_id" {
   EOT
 }
 
+variable "billing_project_id" {
+  type        = string
+  default     = "two-eye-two-see"
+  description = <<-EOT
+  GCP Project ID associated with billing.
+
+  Should be the id, rather than display name of the project.
+  EOT
+}
+
 variable "k8s_version_prefixes" {
   type = set(string)
   # Available minor versions are picked from the GKE regular release channel. To

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -27,9 +27,13 @@ variable "billing_project_id" {
   type        = string
   default     = "two-eye-two-see"
   description = <<-EOT
-  GCP Project ID associated with billing.
+  This should be a GCP Project ID, not a GCP Billing Account ID as the name
+  indicates. It should be to a project that has a GCP API called Cloud Resource
+  Manager enabled. That can be enabled on a project via the link below:
+  https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com
 
-  Should be the id, rather than display name of the project.
+  What goes on here is confusing, see the comments about the confusion in main.tf
+  for more details.
   EOT
 }
 


### PR DESCRIPTION
`pangeo-hubs` is the last 2i2c cluster that has multiple dask worker node types, so with this terraform applied and merged we can fix #2687.

If we get all clusters to use a single node type with 16 CPU and 128 GB of memory (r5.4xlarge / n2-highmem-16), it enables us to provide good defaults for users using dask-gateway when they decide on how powerful their workers are to be. This is planned in #2687.

I'm not able to get this all the way through myself though as I lack access to the infrastructure.

## Action plan

- Someone else approves this PR
- I check from time to time if there are dask worker nodes active, and when they aren't asks for help
- Someone else applies this terraform change
- I merge the PR

## Current activity

```
gke-pangeo-hubs-cluster-dask-medium-552f8a1e-6ndl   Ready    <none>   16h     v1.26.4-gke.1400
gke-pangeo-hubs-cluster-dask-medium-552f8a1e-ssll   Ready    <none>   21h     v1.26.4-gke.1400
gke-pangeo-hubs-cluster-dask-medium-552f8a1e-z6wp   Ready    <none>   3h23m   v1.26.4-gke.1400
```

Grafana dashboard at https://grafana.gcp.pangeo.2i2c.cloud is down because prometheus is crashing, so I can't understand if there is a history of always having dask worker nodes active or similar. I can get a brief response before it crashes, but it indicates no data is available anyhow...

```
support-prometheus-server-7c4f454847-6h9h6          2/2     Running   21 (2m19s ago)   17d
```