### PR TITLE
Enable the prototype UI for the imagebuilding-demo hub

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -44,7 +44,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6758.h4c000253"
+      tag: "0.0.1-0.dev.git.6760.h17ca642b"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -27,6 +27,20 @@ jupyterhub:
           name: ""
           url: ""
           custom_html: <a href="https://www.dfg.de/">DFG</a>, <a href="https://www.cessda.eu/">CESSDA</a>, <a href="https://www.gesis.org/">GESIS</a>, FKZ/Project number <a href="https://gepris.dfg.de/gepris/projekt/460234259?language=en">460234259</a>
+  singleuser:
+    profileList:
+      # The mem-guarantees are here so k8s doesn't schedule other pods
+      # on these nodes.
+      - display_name: "Small"
+        description: "~2 CPU, ~2G RAM"
+        # default set to small because that node pool is configured with
+        # min_nodes 1, so we should make use of it.
+        default: true
+        kubespawner_override:
+          # Expllicitly unset mem_limit, so it overrides the default memory limit we set in
+          # basehub/values.yaml
+          mem_limit: 2G
+          cpu_limit: 2
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
@@ -40,6 +54,13 @@ jupyterhub:
         # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
+    extraConfig:
+      enable-prototype-UI: |
+        from kubespawner_dynamic_building_ui import TEMPLATE_PATHS, STATIC_HANDLER_TUPLE
+        c.KubeSpawner.additional_profile_form_template_paths = TEMPLATE_PATHS
+
+        # Add extra handler to serve JS & CSS assets
+        c.JupyterHub.extra_handlers.append(STATIC_HANDLER_TUPLE)
 
 binderhub-service:
   nodeSelector:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -29,13 +29,29 @@ jupyterhub:
           custom_html: <a href="https://www.dfg.de/">DFG</a>, <a href="https://www.cessda.eu/">CESSDA</a>, <a href="https://www.gesis.org/">GESIS</a>, FKZ/Project number <a href="https://gepris.dfg.de/gepris/projekt/460234259?language=en">460234259</a>
   singleuser:
     profileList:
-      # The mem-guarantees are here so k8s doesn't schedule other pods
-      # on these nodes.
       - display_name: "Small"
         description: "~2 CPU, ~2G RAM"
-        # default set to small because that node pool is configured with
-        # min_nodes 1, so we should make use of it.
-        default: true
+        profile_options:
+          image:
+            display_name: Image
+            unlisted_choice: &profile_list_unlisted_choice
+              enabled: True
+              display_name: "Custom image"
+              validation_regex: "^.+:.+$"
+              validation_message: "Must be a valid public docker image, including a tag"
+              kubespawner_override:
+                image: "{value}"
+            choices:
+              pangeo_new:
+                display_name: Base Pangeo Notebook ("2023.07.05")
+                default: true
+                slug: "pangeo_new"
+                kubespawner_override:
+                  image: "pangeo/pangeo-notebook:2023.07.05"
+              pangeo:
+                display_name: Base Pangeo Notebook
+                default: true
+                slug: "pangeo"
         kubespawner_override:
           # Expllicitly unset mem_limit, so it overrides the default memory limit we set in
           # basehub/values.yaml
@@ -44,7 +60,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6760.h17ca642b"
+      tag: "0.0.1-0.dev.git.6761.hdbdb41fb"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -53,7 +53,7 @@ jupyterhub:
                 default: true
                 slug: "pangeo"
         kubespawner_override:
-          # Expllicitly unset mem_limit, so it overrides the default memory limit we set in
+          # Explicitly unset mem_limit, so it overrides the default memory limit we set in
           # basehub/values.yaml
           mem_limit: 2G
           cpu_limit: 2
@@ -74,8 +74,6 @@ jupyterhub:
       enable-prototype-UI: |
         from kubespawner_dynamic_building_ui import TEMPLATE_PATHS, STATIC_HANDLER_TUPLE
         c.KubeSpawner.additional_profile_form_template_paths = TEMPLATE_PATHS
-        print(TEMPLATE_PATHS)
-        print(STATIC_HANDLER_TUPLE)
 
         # Add extra handler to serve JS & CSS assets
         c.JupyterHub.extra_handlers.append(STATIC_HANDLER_TUPLE)

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -60,7 +60,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6761.hdbdb41fb"
+      tag: "0.0.1-0.dev.git.6763.h9e592303"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -44,7 +44,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6478.h0ab34873"
+      tag: "0.0.1-0.dev.git.6758.h4c000253"
     config:
       JupyterHub:
         authenticator_class: cilogon
@@ -58,6 +58,8 @@ jupyterhub:
       enable-prototype-UI: |
         from kubespawner_dynamic_building_ui import TEMPLATE_PATHS, STATIC_HANDLER_TUPLE
         c.KubeSpawner.additional_profile_form_template_paths = TEMPLATE_PATHS
+        print(TEMPLATE_PATHS)
+        print(STATIC_HANDLER_TUPLE)
 
         # Add extra handler to serve JS & CSS assets
         c.JupyterHub.extra_handlers.append(STATIC_HANDLER_TUPLE)

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -60,7 +60,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6763.h9e592303"
+      tag: "0.0.1-0.dev.git.6765.h33942a27"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -24,13 +24,3 @@ RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 
 COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
 USER $NB_USER
-
-SHELL ["/bin/bash", "--login", "-i", "-c"]
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-RUN source /root/.bashrc && nvm install 12.14.1
-SHELL ["/bin/bash", "--login", "-c"]
-
-RUN node --version
-RUN npm --version
-
-RUN npm install https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git#078402e89197a336de49477a5fc92321674a7f3d

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -22,12 +22,15 @@ RUN pip install -r /tmp/${REQUIREMENTS_FILE}
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 
-RUN apt-get update -qq --yes > /dev/null && \
-    apt-get install --yes -qq \
-    nodejs \
-    npm
-
-RUN npm install yuvipanda/prototype-kubespawner-dynamic-building-ui@078402e89197a336de49477a5fc92321674a7f3d
-
 COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
 USER $NB_USER
+
+SHELL ["/bin/bash", "--login", "-i", "-c"]
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+RUN source /root/.bashrc && nvm install 12.14.1
+SHELL ["/bin/bash", "--login", "-c"]
+
+RUN node --version
+RUN npm --version
+
+RUN npm install https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git#078402e89197a336de49477a5fc92321674a7f3d

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -22,5 +22,12 @@ RUN pip install -r /tmp/${REQUIREMENTS_FILE}
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 
+RUN apt-get update -qq --yes > /dev/null && \
+    apt-get install --yes -qq \
+    nodejs \
+    npm
+
+RUN npm install yuvipanda/prototype-kubespawner-dynamic-building-ui@078402e89197a336de49477a5fc92321674a7f3d
+
 COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
 USER $NB_USER

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@def501f1d60b8e5629745acb0bcc45b151b1decc
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui@ce6fd9a67edc7cbe62dd8701954f8dd0bb94b312
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui@078402e89197a336de49477a5fc92321674a7f3d

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/GeorgianaElena/prototype-kubespawner-dynamic-building-ui.git@add-static-assets
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@b36ece00b5e7fcba5d4485e7ab70992705601c3c

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@def501f1d60b8e5629745acb0bcc45b151b1decc
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui@078402e89197a336de49477a5fc92321674a7f3d
+git+https://github.com/GeorgianaElena/prototype-kubespawner-dynamic-building-ui.git@add-static-assets

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -1,6 +1,6 @@
 # Image lives at quay.io/2i2c/second-hub-experimental
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@def501f1d60b8e5629745acb0bcc45b151b1decc
+git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
 git+https://github.com/GeorgianaElena/prototype-kubespawner-dynamic-building-ui.git@add-static-assets


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/2884

The prototype UI shows, although it takes a bit of time to load:
![Screen Recording 2023-08-25 at 14 33 38](https://github.com/2i2c-org/infrastructure/assets/7579677/e1c1dfc6-00c4-4768-abd3-795f53150d7b)


## Important Note
There is one caveat:
I built the static assets with webpack locally then pushed them to GitHub so I can have them available. I didn't manage to do this very easily on the hub. It's at  https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui/compare/main...GeorgianaElena:prototype-kubespawner-dynamic-building-ui:add-static-assets?expand=1.

@yuvipanda, what do you think? What would be the correct way to do this?