### PR TITLE
Move nasa-veda hub URL

### DIFF
--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -24,7 +24,7 @@ hubs:
       - enc-staging.secret.values.yaml
   - name: prod
     display_name: "NASA VEDA (prod)"
-    domain: nasa-veda.2i2c.cloud
+    domain: veda.2i2c.cloud
     helm_chart: daskhub
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed

--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -16,20 +16,14 @@ hubs:
     domain: staging.veda.2i2c.cloud
     helm_chart: daskhub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
       - common.values.yaml
       - staging.values.yaml
       - enc-staging.secret.values.yaml
   - name: prod
     display_name: "NASA VEDA (prod)"
-    domain: veda.2i2c.cloud
+    domain: hub.openveda.cloud
     helm_chart: daskhub
     helm_chart_values_files:
-      # The order in which you list files here is the order the will be passed
-      # to the helm upgrade command in, and that has meaning. Please check
-      # that you intend for these files to be applied in this order.
       - common.values.yaml
       - prod.values.yaml
       - enc-prod.secret.values.yaml

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -4,11 +4,11 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-prod
   jupyterhub:
     ingress:
-      hosts: [veda.2i2c.cloud]
+      hosts: [hub.openveda.cloud]
       tls:
         - hosts: [veda.2i2c.cloud]
           secretName: https-auto-tls
     hub:
       config:
         GitHubOAuthenticator:
-          oauth_callback_url: https://veda.2i2c.cloud/hub/oauth_callback
+          oauth_callback_url: https://hub.openveda.cloud/hub/oauth_callback

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -6,7 +6,7 @@ basehub:
     ingress:
       hosts: [hub.openveda.cloud]
       tls:
-        - hosts: [veda.2i2c.cloud]
+        - hosts: [hub.openveda.cloud]
           secretName: https-auto-tls
     hub:
       config:

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -4,11 +4,11 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-prod
   jupyterhub:
     ingress:
-      hosts: [nasa-veda.2i2c.cloud]
+      hosts: [veda.2i2c.cloud]
       tls:
-        - hosts: [nasa-veda.2i2c.cloud]
+        - hosts: [veda.2i2c.cloud]
           secretName: https-auto-tls
     hub:
       config:
         GitHubOAuthenticator:
-          oauth_callback_url: https://nasa-veda.2i2c.cloud/hub/oauth_callback
+          oauth_callback_url: https://veda.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -4,11 +4,11 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging
   jupyterhub:
     ingress:
-      hosts: [staging.veda.2i2c.cloud]
+      hosts: [staging.hub.openveda.cloud]
       tls:
-        - hosts: [staging.veda.2i2c.cloud]
+        - hosts: [staging.hub.openveda.cloud]
           secretName: https-auto-tls
     hub:
       config:
         GitHubOAuthenticator:
-          oauth_callback_url: https://staging.veda.2i2c.cloud/hub/oauth_callback
+          oauth_callback_url: https://staging.hub.openveda.cloud/hub/oauth_callback

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -27,9 +27,9 @@ redirects:
     # nasa-veda.2i2c.cloud was the old URL
     # Moved due to https://github.com/2i2c-org/infrastructure/issues/3029
     - from: nasa-veda.2i2c.cloud
-      to: veda.2i2c.cloud
+      to: hub.openveda.cloud
     - from: staging.nasa-veda.2i2c.cloud
-      to: staging.veda.2i2c.cloud
+      to: staging.hub.openveda.cloud
 
 prometheus:
   server:

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -28,6 +28,8 @@ redirects:
     # Moved due to https://github.com/2i2c-org/infrastructure/issues/3029
     - from: nasa-veda.2i2c.cloud
       to: veda.2i2c.cloud
+    - from: staging.nasa-veda.2i2c.cloud
+      to: staging.veda.2i2c.cloud
 
 prometheus:
   server:

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -22,6 +22,13 @@ grafana:
         hosts:
           - grafana.nasa-veda.2i2c.cloud
 
+redirects:
+  rules:
+    # nasa-veda.2i2c.cloud was the old URL
+    # Moved due to https://github.com/2i2c-org/infrastructure/issues/3029
+    - from: nasa-veda.2i2c.cloud
+      to: veda.2i2c.cloud
+
 prometheus:
   server:
     ingress:

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -41,11 +41,3 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.nasa-veda.2i2c.cloud
-
-redirects:
-  rules:
-    # nasa-veda was previously used in the domain name, but domains including
-    # nasa that doesn't end in .gov can get blocked so the name was reduced to
-    # just veda, see https://github.com/2i2c-org/infrastructure/issues/3029
-    - from: staging.nasa-veda.2i2c.cloud
-      to: staging.veda.2i2c.cloud


### PR DESCRIPTION
We keep redirects in place from the old URL, in case there are external links already present.

The OAuth callback URL needs to be changed at
https://github.com/organizations/2i2c-org/settings/applications/2096065 just before merging.

Ref https://github.com/2i2c-org/infrastructure/issues/3029