### PR TITLE
basehub: add singleuserAdmin.serviceAccountName config and small refactoring

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -593,11 +593,9 @@ jupyterhub:
                 if not (self.user.admin and custom_admin):
                     return super().start(*args, **kwargs)
 
-                extra_init_containers = custom_admin.get('initContainers', [])
                 extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
                 extra_env = custom_admin.get('extraEnv', {})
 
-                self.init_containers += [container for container in extra_init_containers if container not in self.init_containers]
                 self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
                 self.environment.update(extra_env)
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -577,12 +577,16 @@ jupyterhub:
         memory: 2Gi
     extraConfig:
       01-custom-theme: |
+        # adds a JupyterHub template path and updates template variables
+
         from z2jh import get_config
         c.JupyterHub.template_paths.insert(0,'/usr/local/share/jupyterhub/custom_templates')
         c.JupyterHub.template_vars.update({
             'custom': get_config('custom.homepage.templateVars')
         })
       02-custom-admin: |
+        # adjusts the spawner to add config specific to admin users
+
         from z2jh import get_config
         from kubespawner import KubeSpawner
         from jupyterhub_configurator.mixins import ConfiguratorSpawnerMixin
@@ -593,11 +597,11 @@ jupyterhub:
                 if not (self.user.admin and custom_admin):
                     return super().start(*args, **kwargs)
 
-                extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
-                extra_env = custom_admin.get('extraEnv', {})
+                admin_volume_mounts = custom_admin.get('extraVolumeMounts', [])
+                self.volume_mounts += [vm for vm in admin_volume_mounts if vm not in self.volume_mounts]
 
-                self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
-                self.environment.update(extra_env)
+                admin_environment = custom_admin.get('extraEnv', {})
+                self.environment.update(admin_environment)
 
                 return super().start(*args, **kwargs)
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -603,6 +603,10 @@ jupyterhub:
                 admin_environment = custom_admin.get('extraEnv', {})
                 self.environment.update(admin_environment)
 
+                admin_service_account = custom_admin.get('serviceAccountName'):
+                if admin_service_account:
+                    self.service_account = admin_service_account
+
                 return super().start(*args, **kwargs)
 
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -590,14 +590,16 @@ jupyterhub:
         class CustomSpawner(ConfiguratorSpawnerMixin, KubeSpawner):
             def start(self, *args, **kwargs):
                 custom_admin = get_config('custom.singleuserAdmin', {})
-                if custom_admin and self.user.admin:
-                    extra_init_containers = custom_admin.get('initContainers', [])
-                    extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
-                    extra_env = custom_admin.get('extraEnv', {})
+                if not (self.user.admin and custom_admin):
+                    return super().start(*args, **kwargs)
 
-                    self.init_containers += [container for container in extra_init_containers if container not in self.init_containers]
-                    self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
-                    self.environment.update(extra_env)
+                extra_init_containers = custom_admin.get('initContainers', [])
+                extra_volume_mounts = custom_admin.get('extraVolumeMounts', [])
+                extra_env = custom_admin.get('extraEnv', {})
+
+                self.init_containers += [container for container in extra_init_containers if container not in self.init_containers]
+                self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
+                self.environment.update(extra_env)
 
                 return super().start(*args, **kwargs)
 


### PR DESCRIPTION
I think it could be useful to be able to provide admin users with a different k8s ServiceAccount than for other users, as that would enable us grant them different cloud permissions.

This may be a pre-requisite of resolving #3038 and https://github.com/2i2c-org/infrastructure/issues/2886.

## What this PR includes in detail

1. refactoring to de-nest code for some improved readability
2. cleanup of not-functional and unused `custom.singleuserAdmin.initContainers`
3. refactoring of internal variable name `volume` to `vm` (for `volume_mount`)
4. adding of not-yet-used `custom.singleuserAdmin.serviceAccountName` as its a starting point for #2886