### PR TITLE
basehub, hub image: `pip` install extra requirements as root

### DIFF
--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -17,9 +17,9 @@ ARG REQUIREMENTS_FILE
 
 COPY ${REQUIREMENTS_FILE} /tmp/
 
+USER root
 RUN pip install -r /tmp/${REQUIREMENTS_FILE}
 
-USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 
 COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py


### PR DESCRIPTION
The base z2jh image installs python packages as root (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/169d927a2b7f86df806fe5e08592b5243a2f0834/images/hub/Dockerfile#L90), and so should we. Without this, they were being installed in $HOME, while the default version was still in /usr/local/lib