### PR TITLE
Remove dupe pangeo-notebook options + bump version

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -200,38 +200,22 @@ basehub:
                 kubespawner_override:
                   image: "{value}"
               choices:
-                pangeo_new:
-                  display_name: Base Pangeo Notebook ("2023.07.05")
-                  default: true
-                  slug: "pangeo_new"
-                  kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2023.07.05"
                 pangeo:
                   display_name: Base Pangeo Notebook
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:ebeb9dd"
-                tensorflow_new:
-                  display_name: Pangeo Tensorflow ML Notebook ("2023.07.05")
-                  slug: "tensorflow_new"
-                  kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.07.05"
+                    image: "pangeo/pangeo-notebook:2023.08.29"
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:ebeb9dd"
-                pytorch_new:
-                  display_name: Pangeo PyTorch ML Notebook ("2023.07.05")
-                  slug: "pytorch_new"
-                  kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.07.05"
+                    image: "pangeo/ml-notebook:2023.08.29"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:ebeb9dd"
+                    image: "pangeo/pytorch-notebook:2023.08.29"
                 leap-pangeo-edu:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
@@ -280,26 +264,16 @@ basehub:
               display_name: Image
               unlisted_choice: *profile_list_unlisted_choice
               choices:
-                tensorflow_new:
-                  display_name: Pangeo Tensorflow ML Notebook ("2023.07.05")
-                  slug: "tensorflow_new"
-                  kubespawner_override:
-                    image: "pangeo/ml-notebook:2023.07.05"
                 tensorflow:
                   display_name: Pangeo Tensorflow ML Notebook
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:ebeb9dd"
-                pytorch_new:
-                  display_name: Pangeo PyTorch ML Notebook ("2023.07.05")
-                  slug: "pytorch_new"
-                  kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2023.07.05"
+                    image: "pangeo/ml-notebook:2023.08.29"
                 pytorch:
                   display_name: Pangeo PyTorch ML Notebook
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:ebeb9dd"
+                    image: "pangeo/pytorch-notebook:2023.08.29"
           kubespawner_override:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility


### PR DESCRIPTION
Removing specific duplicate versions now that custom image choices are working.
Also bumping the image to the latest version.