### PR TITLE
Use custom homepage for victor

### DIFF
--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -17,6 +17,7 @@ basehub:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
       homepage:
+        gitRepoBranch: "victor"
         templateVars:
           org:
             name: Victor


### PR DESCRIPTION
`templateVars` is required by the schema, so I have left it as is. I'm not sure how this affects the custom homepage branch in https://github.com/2i2c-org/default-hub-homepage

ref: https://2i2c.freshdesk.com/a/tickets/925