### PR TITLE
unlisted_choice experiment: use latest kubespawner, fix nasa-veda redirects

### DIFF
--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -30,7 +30,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6801.h3f4f0c4a"
+        tag: "0.0.1-0.dev.git.6863.h406a3546"
       config:
         JupyterHub:
           authenticator_class: cilogon

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -39,7 +39,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6801.h3f4f0c4a"
+        tag: "0.0.1-0.dev.git.6863.h406a3546"
       allowNamedServers: true
       config:
         Authenticator:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -34,7 +34,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6801.h3f4f0c4a"
+        tag: "0.0.1-0.dev.git.6863.h406a3546"
       allowNamedServers: true
       config:
         Authenticator:

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -32,3 +32,11 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.nasa-veda.2i2c.cloud
+
+redirects:
+  rules:
+    # nasa-veda was previously used in the domain name, but domains including
+    # nasa that doesn't end in .gov can get blocked so the name was reduced to
+    # just veda, see https://github.com/2i2c-org/infrastructure/issues/3029
+    - from: staging.nasa-veda.2i2c.cloud
+      to: staging.veda.2i2c.cloud

--- a/helm-charts/images/hub/unlisted-choice-requirements.txt
+++ b/helm-charts/images/hub/unlisted-choice-requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@934ef321f72e58bd680d35ea5fd6780b2b8b52c7
+git+https://github.com/jupyterhub/kubespawner@8cc569c78bcdb342e694f7344219e43d522f4809


### PR DESCRIPTION
I wasn't sure what caused a recent outage on nasa-veda so I ended up debugging unlisted_choice things. This is bumping the hubs part of the unlisted_choice experiment to the latest kubespawner that has some fixes.

In this PR i've bundled a nasa-veda related missing redirection rule that I want part of this PR to avoid reverting a deployment of that which caused a support ticket question.