### PR TITLE
[nasa-ghg] Set custom homepage for production and staging

### DIFF
--- a/config/clusters/nasa-ghg/prod.values.yaml
+++ b/config/clusters/nasa-ghg/prod.values.yaml
@@ -8,6 +8,10 @@ basehub:
       tls:
         - hosts: [hub.ghg.center]
           secretName: https-auto-tls
+    custom:
+      homepage:
+        gitRepoBranch: "master"
+        gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -10,7 +10,7 @@ basehub:
           secretName: https-auto-tls
     custom:
       homepage:
-        gitRepoBranch: "master"
+        gitRepoBranch: "staging"
         gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
     hub:
       config:


### PR DESCRIPTION
After successfully testing custom homepage templates on staging (https://github.com/2i2c-org/infrastructure/pull/3065), we now want to do the same for production, please.

Ready for review/merging.