### PR TITLE
Enable using cosmicds jupyterhub as an authentication *provider*

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -46,11 +46,33 @@ jupyterhub:
       type: none
       extraVolumeMounts: []
   hub:
+    services:
+      # OAuth2 credentials for the CosmicDS portal, which uses
+      # this JupyterHub as authentication *provider*. So when users hit
+      # "Login" in the CosmicDS portal, they're actually redirected to this
+      # JupyterHub (via auth0). This ensures that the portal knows exactly
+      # the (anonymized) usernames of these users, and can do additional work
+      # on their part to track them as necessary.
+      cosmicds-portal:
+        # Don't display this service under 'services' in control panel
+        display: false
+        # Don't ask end user if they want to authorize this service explicitly
+        # This is a trusted service, and we are being used as *authentication*
+        # in this case.
+        oauth_no_confirm: true
+        name: cosmicds-portal
+        oauth_client_id: service-cosmicds-portal
+        # Callback URL for the auth0 tenant, provided to us by auth0
+        oauth_redirect_uri: https://dev-tbr72rd5whnwlyrg.us.auth0.com/login/callback
     config:
       Authenticator:
         admin_users:
           - nmearl
           - patudom
+        # When using JupyterHub as an auth *provider*, we don't want the
+        # end user to see the JupyterHub home page at all - just redirect
+        # them to the upstream auth provider (CILogon) directly.
+        auto_login_oauth2_authorize: true
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:

--- a/config/clusters/2i2c-aws-us/enc-cosmicds.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-cosmicds.secret.values.yaml
@@ -1,22 +1,25 @@
 jupyterhub:
     hub:
+        services:
+            cosmicds-portal:
+                api_token: ENC[AES256_GCM,data:QY4XnFjLgb8KqvVcXignYeJg7Xi5S5IWZ9dAFYy326XFo/oeds7DSDdj2rKam6zRX00ZC1+Cvx+FHlhL0FsjYg==,iv:dgw2az+wRJMt4uwklBcuxaYK64ETnKYH8VX0vS6RzRs=,tag:GP2yWFm9u69iUCogRoCkoQ==,type:str]
         extraEnv:
-            USERNAME_DERIVATION_PEPPER: ENC[AES256_GCM,data:AXMgK5+Gzojb2j65OA87X0BEs4JxjZr1jkemLRNhMp5pxdvt40YyMEO2fyhx+nfNwrvMf9DV6z9Hl7l2XEsbTQ==,iv:B9EBaac4VFOkU+nzxcm7LUzqJRJ4N38o4BbsZqxW69Q=,tag:cERvKEh9TfxyoDyzzVrb1Q==,type:str]
+            USERNAME_DERIVATION_PEPPER: ENC[AES256_GCM,data:mH/CtGOgBMPqUfy74r1sOdxxS2UcUAs/JkSItBgNKguTkV6WmBkd1VvEiRbiFmh86/VZrgFMj9k3B+eUfBSvMw==,iv:ZBhhx3mMrydErwPTNRQ391yUcZo4UIaEooz3exBY3c8=,tag:4eTclvSgvqby9qthqjAEcA==,type:str]
         config:
             CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:bG3o+fgg9Un2YzPxgBisMSpZ7mu0NnF3u7fbHFf3TErMRSNZdbKYne9InZfntOSt9CFP,iv:K+L30QknUdByGTTgs/Xo7xdWAl3ceUjyRi09PFFq0Us=,tag:GRtn+QCLaBjToj4Wk42kEg==,type:str]
-                client_secret: ENC[AES256_GCM,data:G/KW5Lha8iIEbK5nslLGyoM5wT/dokcGZN7cHd15QVdAExghviq1AtvqOIBDGH8O9QPU2YjJOfN+qCE3AGOAtuNFXHWevp5cwhrhD9aOsNqR1Qo4RrQ=,iv:losa6BtAz9dT4m7E3ANejNAJQt3ttKUdu21A00iErHU=,tag:QzBd1z3Qdc0DRDFsWTSZ5g==,type:str]
+                client_id: ENC[AES256_GCM,data:DSAp6gmFnGII9wyLwckBvljwqeokoiaOJdxs8DZdMGtAE68AB4ev5R+e5efCA3CpaFxr,iv:qo012XUuHmAlGbtyG8ty8HupB2GlZ7PLtAeD+9lvRIs=,tag:OU0VSIjWEJj9oh5N+IHwTg==,type:str]
+                client_secret: ENC[AES256_GCM,data:3NsIJWF/nUcXamPgXT4PQPhP8cBMXWSOHMXBZ9YRP/XC5wk34XgkGl3vKnVAD4XSLAsBHFWcPokojYkNvTx87gOhkCqXKt9lsjO0RB9xvyoGW6Pr+nk=,iv:9tKOZTcxBElSJvlMCdBk0Q76XNoSMd8RLMuEs07nXrE=,tag:ghWW2hqEBtwF+ZqPJNVl6Q==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-07-12T23:25:29Z"
-          enc: CiUA4OM7eBXY4SwY7PqtCXIN7/imKKYLzyV95f+5/DHHbo5HCTWcEkkAyiwFHIvAzIjhSO3eQzb0EL6A6KW3ZEu2ZUp7s3PN8gOAy6HIcPbTLQrVnFlbMSAxDT8WShiikQDXHbyjFAKVzqo/KKMuEt9o
+          created_at: "2023-09-05T23:42:06Z"
+          enc: CiUA4OM7eEaWJ1qxGOi9/guRwEoX5kgrSadOZDGIBeCj6peMaRyOEkkAq2nhVZ+03d2/cJEMHW7xNpZPfjRhz/CKvKzJah09I7vJOSLmcnjbtagA605lm0SsKNsMZBPjRfAB7txSFOuAtn0Eh8B7JN/U
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-12T23:25:29Z"
-    mac: ENC[AES256_GCM,data:JOXoIfDhqmOeSCml+lTi56Sd5/8R36scNKTNP5Z3l1CqUJlm9Z3SBOitFWJ3uG78kNKnrYmtqc9ygbeKv3odBfx+IBRWwcp3kg+IGTxYcVzB1Ys+J0j2S0GzI7kPuEBYPuIuXxD1aAuJsolhyAjbS1S7ZqknFiyz+JCiqMMCLAY=,iv:C69JScxiP/XKWiUlu7AtMkf+s/EGnXKwmS8PrptDzZs=,tag:zxIWjO3Alas/uj5cJZqkbg==,type:str]
+    lastmodified: "2023-09-05T23:42:07Z"
+    mac: ENC[AES256_GCM,data:CAQeu301akd2ADKzfVg/l2cqJFpgq4DBLaxxnJP0meqVBEuOI8fOo/sBK0YcRWmF3skhQflsRLqDB+/a2jqoObGO0DJ8GgqH+0jY7KXoGllfYGpSEaa+gS3LBG0pERImY0w9+xc6RntmF9qz7JpN3zxQeLNkMY1FKaCD4jdZXwY=,iv:gEGI+YFnjH+GufdJI0U3kDzoNDW+6IAIHPLQFTcIAFE=,tag:UfXYOo61s9Qotn10fXhslQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
OAuth2 credentials for the CosmicDS portal, which uses this JupyterHub as authentication *provider*. So when users hit "Login" in the CosmicDS portal, they're actually redirected to this JupyterHub (via auth0). This ensures that the portal knows exactly the (anonymized) usernames of these users, and can do additional work on their part to track them as necessary.

From perspective of 2i2c engineers, this is just another JupyterHub service - just one that we don't have to maintain or manage! Our responsibility is to *provide the credentials*, and no more.

Documentation of this feature is coming in a separate PR, so as to not block this one from getting merged.

Ref https://github.com/2i2c-org/infrastructure/issues/3019