### PR TITLE
Set default prometheus disk size to 400Gi

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -277,7 +277,7 @@ prometheus:
       #
       hub.jupyter.org/network-access-hub: "true"
     persistentVolume:
-      size: 200Gi
+      size: 400Gi
     service:
       type: ClusterIP
 


### PR DESCRIPTION
A lot of instances with 200Gi are in fact failing, as noticed in https://github.com/2i2c-org/infrastructure/actions/runs/6104903072, because their disks are full.

The goal is to try to bring these back up first, and then we can work on figuring out why they may be down.

Ref https://github.com/2i2c-org/infrastructure/issues/2930