### PR TITLE
Increase shared cluster prometheus disk size to 1Ti

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -5,7 +5,7 @@ prometheus:
   server:
     persistentVolume:
       # 100Gi filled up, and this is source of our billing data.
-      size: 512Gi
+      size: 1Ti
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
512Gi was full. We need to still investigate why, but this brings the prometheus back up

Ref https://github.com/2i2c-org/infrastructure/issues/2930