### PR TITLE
Bump up awi-ciroh home directory by 512GiB

### DIFF
--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -5,7 +5,7 @@ region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 enable_filestore       = true
-filestore_capacity_gb  = 1024
+filestore_capacity_gb  = 1536
 
 k8s_versions = {
   min_master_version : "1.25.8-gke.500",


### PR DESCRIPTION
It's almost full, as identified by the pagerduty page

```
10.11.233.234:/homes/staging 1007G  896G   60G  94% /home
```