### PR TITLE
Revert customized prometheus block duration config

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -180,21 +180,10 @@ prometheus:
         --storage.tsdb.path=/data \
         --web.console.libraries=/etc/prometheus/console_libraries \
         --web.console.templates=/etc/prometheus/consoles \
-        --web.enable-lifecycle \
-        --storage.tsdb.min-block-duration=60m \
-        --storage.tsdb.max-block-duration=60m"
+        --web.enable-lifecycle"
     # extraFlags MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     extraFlags:
       - web.enable-lifecycle
-      # We seem to loose data when restarting prometheus during upgrades, and we
-      # also have had memory peaking issues during startup. These flags may help
-      # us reduce the data loss to at most 60m and has been observed to reduce
-      # the memory peaking before prometheus 2.45 at least.
-      #
-      # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1099293120
-      #
-      - storage.tsdb.min-block-duration=60m
-      - storage.tsdb.max-block-duration=60m
     # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     retention: 366d # Keep data for at least 1 year
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -181,20 +181,20 @@ prometheus:
         --web.console.libraries=/etc/prometheus/console_libraries \
         --web.console.templates=/etc/prometheus/consoles \
         --web.enable-lifecycle \
-        --storage.tsdb.min-block-duration=5m \
-        --storage.tsdb.max-block-duration=5m"
+        --storage.tsdb.min-block-duration=60m \
+        --storage.tsdb.max-block-duration=60m"
     # extraFlags MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     extraFlags:
       - web.enable-lifecycle
       # We seem to loose data when restarting prometheus during upgrades, and we
       # also have had memory peaking issues during startup. These flags may help
-      # us reduce the data loss to at most 30m and has been observed to reduce
+      # us reduce the data loss to at most 60m and has been observed to reduce
       # the memory peaking before prometheus 2.45 at least.
       #
       # ref: https://github.com/prometheus/prometheus/issues/6934#issuecomment-1099293120
       #
-      - storage.tsdb.min-block-duration=5m
-      - storage.tsdb.max-block-duration=5m
+      - storage.tsdb.min-block-duration=60m
+      - storage.tsdb.max-block-duration=60m
     # retention MUST BE UPDATED in prometheus.server.defaultFlagsOverride as well
     retention: 366d # Keep data for at least 1 year
 


### PR DESCRIPTION
Based on suspicion in
https://github.com/2i2c-org/infrastructure/issues/2934#issuecomment-1669619133 that this is contributing to the slowness of prometheus. Could also be related to why disk space usage is growing so much

Ref https://github.com/2i2c-org/infrastructure/issues/2930 Ref https://github.com/2i2c-org/infrastructure/issues/2934


Reverts config changes from #2731 and #2778