### PR TITLE
singleuser post-start lifecycle hook for /veda-docs

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,7 +60,7 @@ basehub:
         name: public.ecr.aws/nasa-veda/nasa-veda-singleuser
         # Based off pangeo/pangeo-notebook:2023.07.05 which uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
         # If updating this tag, also update it in the profile_options section below
-        tag: "b807c7efa97c8df9ca38779f7e59d09f889fde9299b0d19de80389cf6b064f90"
+        tag: "5068290376e8c3151d97a36ae6485bb7ff79650b94aecc93ffb2ea1b42d76460"
       extraFiles:
         k8s-lifecycle-hook-post-start.sh:
           mountPath: "/etc/singleuser/k8s-lifecycle-hook-post-start.sh"
@@ -121,7 +121,7 @@ basehub:
                   display_name: Rocker Geospatial with RStudio
                   slug: rocker
                   kubespawner_override:
-                    image: rocker/binder:4.3
+                    image: rocker/geospatial:geospatial_unstable
                     # Launch RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -61,6 +61,27 @@ basehub:
         # Based off pangeo/pangeo-notebook:2023.07.05 which uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
         # If updating this tag, also update it in the profile_options section below
         tag: "b807c7efa97c8df9ca38779f7e59d09f889fde9299b0d19de80389cf6b064f90"
+      extraFiles:
+        k8s-lifecycle-hook-post-start.sh:
+          mountPath: "/etc/singleuser/k8s-lifecycle-hook-post-start.sh"
+          stringData: |
+            #/bin/bash
+            echo "pulling /veda-docs.."
+            /srv/conda/envs/notebook/bin/gitpuller https://github.com/NASA-IMPACT/veda-docs/ main /home/jovyan/veda-doc-examples || true
+            echo "successfully pulled /veda-docs.."
+      storage:
+        capacity: "10Mi"
+        extraVolumes:
+          - name: user-etc-singleuser
+        extraVolumeMounts:
+          - name: user-etc-singleuser
+            mountPath: /etc/singleuser
+      lifecycleHooks:
+        postStart:
+          exec:
+            command:
+              - "bash"
+              - "/etc/singleuser/k8s-lifecycle-hook-post-start.sh"
       profileList:
         # NOTE: About node sharing
         #

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -121,7 +121,7 @@ basehub:
                   display_name: Rocker Geospatial with RStudio
                   slug: rocker
                   kubespawner_override:
-                    image: rocker/geospatial:geospatial_unstable
+                    image: rocker/geospatial:unstable
                     # Launch RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir


### PR DESCRIPTION
### Changelog

* update `singleuser` image tag to get newest `stac_ipyleaeflet` plugin in there

* use rocker image tag `geospatial_unstable` to get newest GDAL in there based on discussion with rocker folks

* add post-start hook 

### Context about / veda-docs
VEDA (https://staging.nasa-veda.2i2c.cloud/ and https://nasa-veda.2i2c.cloud/) want to have all user pods start up [with the veda-docs](https://github.com/NASA-IMPACT/veda-docs) in a similar fashion to how MSPC is doing it. Even though [we currently have some entry points covered ](https://github.com/NASA-IMPACT/veda-config/pull/243/files#diff-5ae9e3ede6336192cb5241b5424b4f958a8d752aef072b6048add392c93227fbR9) on the dashboard we want to make sure all entrypoints have `/veda-docs`. So we are willing to take the risks with the `post-start` hook for that reason
