### PR TITLE
ubc-eoas: allow all UBC authenticated users, not just EOAS associated users

### DIFF
--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -47,8 +47,6 @@ jupyterhub:
               username_claim: email
               action: strip_idp_domain
               domain: eoas.ubc.ca
-            allowed_domains:
-              - eoas.ubc.ca
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: email


### PR DESCRIPTION
This is a proposal for UBC-EOAS in https://2i2c.freshdesk.com/a/tickets/955, not yet confirmed to be a wanted solution to allowing students access to the ubc-eoas hub.

I'm not 100% confident that this has the desired effect, but I think so - allowing all users, and stripping the domain name for users with a certain domain name.

---

If we receive confirmation from Henryk, anyone is welcome to merge this! I think it could be urgent.