### PR TITLE
update to point to new image with stac_ipyleaflet

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,7 +60,7 @@ basehub:
         name: public.ecr.aws/nasa-veda/nasa-veda-singleuser
         # Based off pangeo/pangeo-notebook:2023.07.05 which uses JupyterLab <4, so jupyterlab-git and dask-dashboard work
         # If updating this tag, also update it in the profile_options section below
-        tag: "b807c7efa97c8df9ca38779f7e59d09f889fde9299b0d19de80389cf6b064f90"
+        tag: "ff1d8629d2e646942a11ba5af4f078f3a3edb06962e7da9903e7f321f2c08cbe"
       profileList:
         # NOTE: About node sharing
         #


### PR DESCRIPTION
This PR should update the singleuser image in the **staging environment  (https://staging.nasa-veda.2i2c.cloud/)** to include the new `stac_ipyleaflet` library.




_For reference:_

Repository: https://github.com/NASA-IMPACT/veda-jh-environments/

Base Image: https://github.com/NASA-IMPACT/veda-jh-environments/blob/main/docker-images/base/pangeo-notebook/Dockerfile

Singleuser Image: https://github.com/NASA-IMPACT/veda-jh-environments/tree/main/docker-images/custom/nasa-veda-singleuser

Public ECR: public.ecr.aws/nasa-veda/