### PR TITLE
Add GPU support for smithsonian hub

### DIFF
--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -47,6 +47,7 @@ basehub:
           scope:
             - read:org
         Authenticator:
+          enable_auth_state: true
           # This hub uses GitHub Orgs auth and so we don't set allowed_users in
           # order to not deny access to valid members of the listed orgs. These
           # people should have admin access though.

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -59,18 +59,6 @@ basehub:
         enabled: true
 
     singleuser:
-      image:
-        # Pending information about what image to use in
-        # https://github.com/2i2c-org/infrastructure/issues/2323, the
-        # pangeo/pangeo-notebook image was setup initially as it includes recent
-        # versions of dask/distributed which is relevant for a use with
-        # dask-gateway.
-        #
-        # image source:    https://github.com/pangeo-data/pangeo-docker-images
-        # image published: https://quay.io/repository/pangeo/pangeo-notebook?tab=tags
-        #
-        name: quay.io/pangeo/pangeo-notebook
-        tag: "2023.02.27"
       profileList:
         # NOTE: About node sharing
         #
@@ -113,12 +101,23 @@ basehub:
                   display_name: Jupyter SciPy Notebook
                   slug: scipy
                   kubespawner_override:
-                    image: jupyter/scipy-notebook:2023-06-26
+                    image: "jupyter/scipy-notebook:2023-09-04"
                 pangeo:
                   display_name: Pangeo Notebook
                   slug: pangeo
                   kubespawner_override:
-                    image: quay.io/pangeo/pangeo-notebook:2023.02.27
+                    image: "quay.io/pangeo/pangeo-notebook:2023.08.29"
+                tensorflow: &image_tensorflow
+                  display_name: Pangeo Tensorflow ML Notebook
+                  slug: tensorflow
+                  kubespawner_override:
+                    image: "pangeo/ml-notebook:2023.08.29"
+                pytorch: &image_pytorch
+                  display_name: Pangeo PyTorch ML Notebook
+                  default: true
+                  slug: pytorch
+                  kubespawner_override:
+                    image: "pangeo/pytorch-notebook:2023.08.29"
             requests:
               # NOTE: Node share choices are in active development, see comment
               #       next to profileList: above.
@@ -160,3 +159,22 @@ basehub:
             mem_limit: null
             node_selector:
               node.kubernetes.io/instance-type: r5.xlarge
+
+        - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
+          slug: gpu
+          description: "Start a container on a dedicated node with a GPU"
+          profile_options:
+            image:
+              display_name: Image
+              choices:
+                tensorflow: *image_tensorflow
+                pytorch: *image_pytorch
+          kubespawner_override:
+            mem_limit: null
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
+            mem_guarantee: 14G
+            node_selector:
+              node.kubernetes.io/instance-type: g4dn.xlarge
+            extra_resource_limits:
+              nvidia.com/gpu: "1"

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -38,7 +38,8 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
-          allowed_organizations:
+          populate_teams_in_auth_state: true
+          allowed_organizations: &allowed_github_orgs
             - 2i2c-org
             - smithsonian
             - sidatasciencelab
@@ -77,6 +78,7 @@ basehub:
           description: &profile_list_description "Start a container with at least a chosen share of capacity on a node of this type"
           slug: small
           default: true
+          allowed_teams: *allowed_github_orgs
           profile_options:
             image: &profile_options_image
               display_name: Image
@@ -163,6 +165,9 @@ basehub:
         - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
           slug: gpu
           description: "Start a container on a dedicated node with a GPU"
+          allowed_teams:
+            - 2i2c-org:hub-access-for-2i2c-staff
+            - Smithsonian-SDCH:gpu-users
           profile_options:
             image:
               display_name: Image

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -117,7 +117,6 @@ basehub:
                     image: "pangeo/ml-notebook:2023.08.29"
                 pytorch: &image_pytorch
                   display_name: Pangeo PyTorch ML Notebook
-                  default: true
                   slug: pytorch
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2023.08.29"

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -28,6 +28,12 @@ local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
+    {
+        instanceType: "g4dn.xlarge",
+        tags+: {
+            "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
+        },
+    },
 ];
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged


### PR DESCRIPTION
- Bump up the pangeo notebook version to match latest pytorch and ml images. This shall be communicated to the community champion too.
- Remove redundant 'image' tag, as we use profileList
- Add GPU to eksctl
- Awaiting GPU quota increase being granted
- Restrict GPU access to github team provided by community

Fixes https://github.com/2i2c-org/infrastructure/issues/3089