### PR TITLE
Move 2i2c shared prometheus to pd-balanced disk

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -1,11 +1,16 @@
 prometheusIngressAuthSecret:
   enabled: true
 
+prometheusStorageClass:
+  gke:
+    enabled: true
+
 prometheus:
   server:
     persistentVolume:
       # 100Gi filled up, and this is source of our billing data.
-      size: 1Ti
+      size: 512Gi
+      storageClass: balanced-rwo-retain
     ingress:
       enabled: true
       hosts:

--- a/helm-charts/support/templates/pd-ssd.yaml
+++ b/helm-charts/support/templates/pd-ssd.yaml
@@ -1,9 +1,0 @@
-# Create an SSD StorageClass for use by Prometheus
-# See https://kubernetes.io/docs/concepts/storage/storage-classes/#gce for details
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: ssd
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd

--- a/helm-charts/support/templates/storageclass/gke.yaml
+++ b/helm-charts/support/templates/storageclass/gke.yaml
@@ -1,0 +1,15 @@
+# https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver#create_a_storageclass
+# has more information about setting up StorageClass for GCP PD CSI Driver,
+# for use in GKE environments.
+{{- if .Values.prometheusStorageClass.gke.enabled }}
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.prometheusStorageClass.gke.name }}
+parameters: {{ .Values.prometheusStorageClass.gke.parameters | toJson }}
+provisioner: pd.csi.storage.gke.io
+# Don't delete the backing disk when the PVC is deleted
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+{{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -143,6 +143,49 @@ properties:
         type: string
         description: |
           Password for basic auth protecting prometheus
+
+  prometheusStorageClass:
+    type: object
+    additionalProperties: false
+    description: |
+      Provision a separate storageClass specifically for storing prometheus
+      data. Lets us control retentionPolicy (so we do not lose the data
+      when the cluster is deleted) and type of disk used (for performance
+      tuning)
+    required:
+      - gke
+    properties:
+      gke:
+        type: object
+        additionalProperties: false
+        description: |
+          Provision storageClass in a GKE environment, with the appropriate
+          GCP PD CSI provisioner.
+
+          https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver has
+          more information about this provisioner.
+        required:
+          - enabled
+          - parameters
+          - name
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              Enable creating this StorageClass
+          parameters:
+            type: object
+            additionalProperties: true
+            description: |
+              Parameters defining properties of the volume provisioned by this
+              StorageClass.
+
+              For the GCP CSI driver in use here, the parameters are documented at
+              https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver
+          name:
+            type: string
+            description: |
+              Name of the StorageClass to create
   global:
     type: object
     additionalProperties: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -444,6 +444,19 @@ nvidiaDevicePlugin:
     enabled: false
     version: "stable"
 
+# Setup a separate storageClass specifically for prometheus data
+prometheusStorageClass:
+  gke:
+    # Defaults to false, until all GKE clusters have been manually
+    # migrated. Could default to true after that.
+    enabled: false
+    # pd-balanced is SSD backed, much faster than spinning standard disks and
+    # cheaper than pd-ssd. We add the -retain to indicate the retainPolicy
+    # of Retain, rather than the default of Delete
+    name: balanced-rwo-retain
+    parameters:
+      type: pd-balanced
+
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or
 # used.


### PR DESCRIPTION
- Set up our own StorageClass for GKE clusters specifically for use with prometheus data.
- Sets retentionPolicy to 'Retain', so we don't accidentally kill the disk and lose all the data.
- Sets the disk type to 'Balanced', which is backed by SSDs and *much* faster than spinning disks. No more grafana timeouts!
- Move the existing data by manually attaching to a small VM I created, and then copying over to new PVC.
- Reduction in size, as https://github.com/2i2c-org/infrastructure/pull/3093
  drastically reduced the size of the data! We went from about
  512GB to only about 150GB after that. The size explosion has
  been solved! 512GB here still gives us enough room to grow.

Once this lands, I'll manually go through and do this for every single GCP cluster. Grafana timeouts BE GONE.

Ref https://github.com/2i2c-org/infrastructure/issues/2934 
Ref https://github.com/2i2c-org/infrastructure/issues/2717 
Ref https://github.com/2i2c-org/infrastructure/issues/2847 
Fixes https://github.com/2i2c-org/infrastructure/issues/3111