### PR TITLE
Authentication config - refactoring and preparation for z2jh 3.0.0

### DIFF
--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -39,10 +39,13 @@ jupyterhub:
       CILogonOAuthenticator:
         scope:
           - "profile"
-        username_claim: "preferred_username"
         oauth_callback_url: "https://aup.pilot.2i2c.cloud/hub/oauth_callback"
         shown_idps:
           - http://github.com/login/oauth/authorize
+        allowed_idps:
+          http://github.com/login/oauth/authorize:
+            username_derivation:
+              username_claim: "preferred_username"
       Authenticator:
         # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
         #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -41,10 +41,13 @@ jupyterhub:
           - "profile"
         username_claim: "preferred_username"
         oauth_callback_url: "https://aup.pilot.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with GitHub
         shown_idps:
           - http://github.com/login/oauth/authorize
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &aup_users
           - swalker
           - shaolintl

--- a/config/clusters/2i2c/binder-staging.values.yaml
+++ b/config/clusters/2i2c/binder-staging.values.yaml
@@ -83,7 +83,6 @@ binderhub:
             - yuvipanda@2i2c.org
         CILogonOAuthenticator:
           oauth_callback_url: "https://binder-staging.hub.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with Google
           shown_idps:
             - http://google.com/accounts/o8/id
           allowed_idps:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -56,6 +56,10 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &neurohackademy_users
           - arokem
         admin_users: *neurohackademy_users

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -136,7 +136,6 @@ jupyterhub:
           - "102749090965437723445" # Byron Chu (Cybera)
           - "115909958579864751636" # Michael Jones (Cybera)
           - "106951135662332329542" # Elmar Bouwer (Cybera)
-        # Only show the option to login with Google and Mirosoft
         shown_idps:
           - https://accounts.google.com/o/oauth2/auth
           - https://login.microsoftonline.com/common/oauth2/v2.0/authorize

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -185,6 +185,17 @@ basehub:
           memory: 4Gi
       allowNamedServers: true
       config:
+        JupyterHub:
+          authenticator_class: cilogon
+        CILogonOAuthenticator:
+          scope:
+            - "profile"
+          shown_idps:
+            - http://github.com/login/oauth/authorize
+          allowed_idps:
+            http://github.com/login/oauth/authorize:
+              username_derivation:
+                username_claim: "preferred_username"
         Authenticator:
           # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
           #        allow_existing_users=True, while in z3jh 3.0.0 this needs to

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -186,6 +186,10 @@ basehub:
       allowNamedServers: true
       config:
         Authenticator:
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to
+          #        be configured explicitly.
+          #
           allowed_users: &users
             - maxrjones
           admin_users: *users

--- a/config/clusters/carbonplan/prod.values.yaml
+++ b/config/clusters/carbonplan/prod.values.yaml
@@ -7,13 +7,5 @@ basehub:
           secretName: https-auto-tls
     hub:
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://carbonplan.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/carbonplan/staging.values.yaml
+++ b/config/clusters/carbonplan/staging.values.yaml
@@ -7,13 +7,5 @@ basehub:
           secretName: https-auto-tls
     hub:
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://staging.carbonplan.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
+++ b/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
@@ -33,8 +33,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://unitefa-conicet.latam.catalystproject.2i2c.cloud/hub/oauth_callback"
-        username_claim: "email"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
         allowed_idps:

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://ccsf.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://elcamino.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://howard.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu
@@ -41,6 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &howard_users
           - ericvd@berkeley.edu
           - gwashington@scs.howard.edu

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://lacc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu
@@ -41,6 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &lacc_users
           - PINEDAEM@laccd.edu
           - LAMKT@laccd.edu

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://datahub.mills.edu/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
-        # Only show and allow option to login with Google and Miracosta institutional provider
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://miracosta.fedgw.com/gateway

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://palomar.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu
@@ -41,6 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &palomar_users
           - aculich@berkeley.edu
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc-dev.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://idp.sbcc.edu/idp/shibboleth
@@ -45,6 +44,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &sbcc_users
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://idp.sbcc.edu/idp/shibboleth
@@ -45,6 +44,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &sbcc_users
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -38,7 +38,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sjsu.cloudbank.2i2c.cloud/hub/oauth_callback
-        username_claim: "email"
         shown_idps:
           - http://google.com/accounts/o8/id
           - https://idp01.sjsu.edu/idp/shibboleth

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu
@@ -41,6 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &staging_users
           - sean.smorris@berkeley.edu
         admin_users: *staging_users

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -29,7 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://tuskegee.cloudbank.2i2c.cloud/hub/oauth_callback"
-        # Only show and allow the option to login with Google
         shown_idps:
           - http://google.com/accounts/o8/id
           - urn:mace:incommon:berkeley.edu
@@ -41,6 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       Authenticator:
+        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+        #        configured explicitly.
+        #
         allowed_users: &tuskegee_users
           - yasmeen.rawajfih@gmail.com
           - Wu.fan01@gmail.com

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -37,6 +37,10 @@ basehub:
     hub:
       config:
         Authenticator:
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to
+          #        be configured explicitly.
+          #
           allowed_users: &gridsst_users
             - alisonrgray
             - nikki-t

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -224,9 +224,12 @@ basehub:
         CILogonOAuthenticator:
           scope:
             - "profile"
-          username_claim: "preferred_username"
           shown_idps:
             - http://github.com/login/oauth/authorize
+          allowed_idps:
+            http://github.com/login/oauth/authorize:
+              username_derivation:
+                username_claim: "preferred_username"
         Authenticator:
           # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
           #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -225,10 +225,13 @@ basehub:
           scope:
             - "profile"
           username_claim: "preferred_username"
-          # Only show the option to login with GitHub
           shown_idps:
             - http://github.com/login/oauth/authorize
         Authenticator:
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+          #        configured explicitly.
+          #
           allowed_users: &users
             # This is just listing a few of the users/admins, a lot of
             # users has been added manually, see:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -83,6 +83,17 @@ basehub:
         enabled: false
     hub:
       config:
+        JupyterHub:
+          authenticator_class: cilogon
+        CILogonOAuthenticator:
+          scope:
+            - "profile"
+          shown_idps:
+            - http://github.com/login/oauth/authorize
+          allowed_idps:
+            http://github.com/login/oauth/authorize:
+              username_derivation:
+                username_claim: "preferred_username"
         Authenticator:
           # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
           #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -84,6 +84,10 @@ basehub:
     hub:
       config:
         Authenticator:
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+          #        configured explicitly.
+          #
           allowed_users: &users
             - roxyboy
             - lesommer

--- a/config/clusters/meom-ige/prod.values.yaml
+++ b/config/clusters/meom-ige/prod.values.yaml
@@ -10,13 +10,5 @@ basehub:
           secretName: https-auto-tls
     hub:
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://meom-ige.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/meom-ige/staging.values.yaml
+++ b/config/clusters/meom-ige/staging.values.yaml
@@ -10,13 +10,5 @@ basehub:
           secretName: https-auto-tls
     hub:
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://staging.meom-ige.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -51,6 +51,17 @@ basehub:
       readinessProbe:
         enabled: false
       config:
+        JupyterHub:
+          authenticator_class: cilogon
+        CILogonOAuthenticator:
+          scope:
+            - "profile"
+          shown_idps:
+            - http://github.com/login/oauth/authorize
+          allowed_idps:
+            http://github.com/login/oauth/authorize:
+              username_derivation:
+                username_claim: "preferred_username"
         Authenticator:
           admin_users: &users
             - amfriesz

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -57,7 +57,10 @@ basehub:
             - jules32
             - erinmr
             - betolink
-          # Without this, any GitHub user can authenticate
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+          #        configured explicitly.
+          #
           allowed_users: *users
 dask-gateway:
   gateway:

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -92,13 +92,5 @@ basehub:
           profile_options: *profile_options
     hub:
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://openscapes.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -124,13 +124,5 @@ basehub:
         name: quay.io/2i2c/unlisted-choice-experiment
         tag: "0.0.1-0.dev.git.6863.h406a3546"
       config:
-        JupyterHub:
-          authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
-          username_claim: "preferred_username"
           oauth_callback_url: "https://staging.openscapes.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with GitHub
-          shown_idps:
-            - http://github.com/login/oauth/authorize

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -37,6 +37,10 @@ basehub:
         Authenticator:
           admin_users: &admin_users
             - paigemar@umich.edu
+          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
+          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
+          #        configured explicitly.
+          #
           allowed_users: *admin_users
           # Delete any prior existing users in the db that don't pass username_pattern
           delete_invalid_users: true
@@ -44,12 +48,9 @@ basehub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
           oauth_callback_url: "https://coessing.2i2c.cloud/hub/oauth_callback"
-          # Only show the option to login with Google
           shown_idps:
             - https://accounts.google.com/o/oauth2/auth
           allowed_idps:
-            # CILogon still uses the old google oidc enpoint instead of the new one listed in `shown_idps`.
-            # Ref https://github.com/ncsa/OA4MP/issues/45
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -41,6 +41,9 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        shown_idps:
+          - https://authentication.ubc.ca
+          - http://google.com/accounts/o8/id
         allowed_idps:
           https://authentication.ubc.ca:
             username_derivation:
@@ -52,9 +55,6 @@ jupyterhub:
               username_claim: email
             allowed_domains:
               - 2i2c.org
-        shown_idps:
-          - https://authentication.ubc.ca
-          - http://google.com/accounts/o8/id
 
   singleuser:
     defaultUrl: /lab

--- a/deployer/config_validation.py
+++ b/deployer/config_validation.py
@@ -162,7 +162,15 @@ def validate_authenticator_config(cluster_name, hub_name):
     For each hub of a specific cluster:
      - It asserts that when the JupyterHub GitHubOAuthenticator is used,
        then `Authenticator.allowed_users` is not set.
-       An error is raised otherwise.
+
+       Before oauthenticator 16 / z2jh 3.0.0-beta.3+, allowed_users was an
+       additional requirement besides being part of an allowed github
+       organization or team, which made the config likely to not be what we
+       intended.
+
+       FIXME: Remove this after we have upgraded to oauthenticator 16 / z2jh
+              3.0.0-beta.3+, as that makes this config reasonable again, where a
+              user can be allowed independently from allowing an organization.
     """
     _prepare_helm_charts_dependencies_and_schemas()
 


### PR DESCRIPTION
I've started working towards getting z2jh 3.0.2 to land, up from 3.0.0-beta.1 with oauthenticator 15.1 - this will end up bumping oauthenticator from 15.1.0 to 16.0.7 with changes we need to adjust to significantly.

To help review the changes, I've extracted these changes that could easily be done beforehand the bump of oauthenticator via the z2jh 3.0 upgrade.

## Review commit by commit

- First two commits: adds comments about `allowed_users` in preparation for #2774
- Last five commits: adds `allowed_idps` alongside `shown_idps` in preparation for #2774 (required for oauthenticator 16)