### PR TITLE
Upgrade to z2jh 3.0.2 from 3.0.0-beta.1 - oauthenticator 15.1 bumped to 16.0

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -80,8 +80,6 @@ jupyterhub:
           - "email"
           - "profile"
         oauth_callback_url: https://cosmicds.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://github.com/login/oauth/authorize
         allowed_idps:
           # The username claim here is used to do *authorization*, for both
           # admin use and any allow listing we want to do.

--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -76,9 +76,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        scope:
-          - "email"
-          - "profile"
         oauth_callback_url: https://cosmicds.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           # The username claim here is used to do *authorization*, for both

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -33,15 +33,6 @@ basehub:
         tag: "2022.06.02"
     hub:
       config:
-        Authenticator:
-          # This hub uses GitHub Org auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed orgs.
-          #
-          # You must always set admin_users, even if it is an empty list,
-          # otherwise `add_staff_user_ids_to_admin_users: true` will fail
-          # silently and no staff members will have admin access.
-          admin_users: []
         JupyterHub:
           authenticator_class: "github"
         GitHubOAuthenticator:
@@ -50,3 +41,8 @@ basehub:
             - 2i2c-org
           scope:
             - read:org
+        Authenticator:
+          # You must always set admin_users, even if it is an empty list,
+          # otherwise `add_staff_user_ids_to_admin_users: true` will fail
+          # silently and no staff members will have admin access.
+          admin_users: []

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -41,8 +41,3 @@ basehub:
             - 2i2c-org
           scope:
             - read:org
-        Authenticator:
-          # You must always set admin_users, even if it is an empty list,
-          # otherwise `add_staff_user_ids_to_admin_users: true` will fail
-          # silently and no staff members will have admin access.
-          admin_users: []

--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -57,11 +57,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
-          ]
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -34,8 +34,6 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: github
-        Authenticator:
-          enable_auth_state: true
         GitHubOAuthenticator:
           populate_teams_in_auth_state: true
           allowed_organizations:
@@ -43,6 +41,8 @@ basehub:
             - 2i2c-org:research-delight-team
           scope:
             - read:org
+        Authenticator:
+          enable_auth_state: true
     singleuser:
       image:
         name: quay.io/2i2c/researchdelight-image

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -30,7 +30,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.6935.h7141d766"
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -36,8 +36,3 @@ jupyterhub:
           - 2i2c-org
         scope:
           - read:org
-      Authenticator:
-        # You must always set admin_users, even if it is an empty list,
-        # otherwise `add_staff_user_ids_to_admin_users: true` will fail
-        # silently and no staff members will have admin access.
-        admin_users: []

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -28,15 +28,6 @@ jupyterhub:
           url: https://2i2c.org
   hub:
     config:
-      Authenticator:
-        # This hub uses GitHub Org auth and so we don't set
-        # allowed_users in order to not deny access to valid members of
-        # the listed orgs.
-        #
-        # You must always set admin_users, even if it is an empty list,
-        # otherwise `add_staff_user_ids_to_admin_users: true` will fail
-        # silently and no staff members will have admin access.
-        admin_users: []
       JupyterHub:
         authenticator_class: "github"
       GitHubOAuthenticator:
@@ -45,3 +36,8 @@ jupyterhub:
           - 2i2c-org
         scope:
           - read:org
+      Authenticator:
+        # You must always set admin_users, even if it is an empty list,
+        # otherwise `add_staff_user_ids_to_admin_users: true` will fail
+        # silently and no staff members will have admin access.
+        admin_users: []

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -49,17 +49,14 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      Authenticator:
-        # This hub uses GitHub Orgs auth and so we don't set
-        # allowed_users in order to not deny access to valid members of
-        # the listed orgs. These people should have admin access though.
-        admin_users:
-          - LaCrecerelle
-          - matthew-brett
       GitHubOAuthenticator:
+        oauth_callback_url: "https://ds.lis.2i2c.cloud/hub/oauth_callback"
         allowed_organizations:
           - 2i2c-org
           - lisacuk
         scope:
           - read:org
-        oauth_callback_url: "https://ds.lis.2i2c.cloud/hub/oauth_callback"
+      Authenticator:
+        admin_users:
+          - LaCrecerelle
+          - matthew-brett

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -39,8 +39,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.uk.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -65,8 +65,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -42,11 +42,9 @@ jupyterhub:
           http://github.com/login/oauth/authorize:
             username_derivation:
               username_claim: "preferred_username"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &aup_users
           - swalker
           - shaolintl

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -40,8 +40,6 @@ jupyterhub:
         scope:
           - "profile"
         oauth_callback_url: "https://aup.pilot.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://github.com/login/oauth/authorize
         allowed_idps:
           http://github.com/login/oauth/authorize:
             username_derivation:

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -37,8 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        scope:
-          - "profile"
         oauth_callback_url: "https://aup.pilot.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://github.com/login/oauth/authorize:

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -43,9 +43,32 @@ jupyterhub:
             username_derivation:
               username_claim: "preferred_username"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &aup_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - swalker
           - shaolintl
-        admin_users: *aup_users

--- a/config/clusters/2i2c/binder-staging.values.yaml
+++ b/config/clusters/2i2c/binder-staging.values.yaml
@@ -83,8 +83,6 @@ binderhub:
             - yuvipanda@2i2c.org
         CILogonOAuthenticator:
           oauth_callback_url: "https://binder-staging.hub.2i2c.cloud/hub/oauth_callback"
-          shown_idps:
-            - http://google.com/accounts/o8/id
           allowed_idps:
             http://google.com/accounts/o8/id:
               username_derivation:

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -39,11 +39,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
-          ]
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -44,9 +44,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "email"
-            - "profile"
           oauth_callback_url: "https://dask-staging.2i2c.cloud/hub/oauth_callback"
           allowed_idps:
             http://google.com/accounts/o8/id:

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -48,8 +48,6 @@ basehub:
             - "email"
             - "profile"
           oauth_callback_url: "https://dask-staging.2i2c.cloud/hub/oauth_callback"
-          shown_idps:
-            - http://accounts.google.com/o/oauth2/auth
           allowed_idps:
             http://google.com/accounts/o8/id:
               username_derivation:

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -31,10 +31,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://demo.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          # Allow Google for 2i2c.org anr dmbl
-          - https://accounts.google.com/o/oauth2/auth
-          - https://enterprise.login.utexas.edu/idp/shibboleth
         allowed_idps:
           # UTexas hub
           https://enterprise.login.utexas.edu/idp/shibboleth:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -66,8 +66,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://imagebuilding-demo.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -60,7 +60,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6765.h33942a27"
+      tag: "0.0.1-0.dev.git.6935.h7141d766"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -39,9 +39,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://mtu.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://sso.mtu.edu/idp/shibboleth
         allowed_idps:
           # Allow 2i2c staff to login with Google
           http://google.com/accounts/o8/id:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -55,20 +55,18 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: cilogon
-      Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
-        allowed_users: &neurohackademy_users
-          - arokem
-        admin_users: *neurohackademy_users
       CILogonOAuthenticator:
         oauth_callback_url: https://neurohackademy.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:
             username_derivation:
               username_claim: "preferred_username"
+      OAuthenticator:
+        allow_existing_users: True
+      Authenticator:
+        allowed_users: &neurohackademy_users
+          - arokem
+        admin_users: *neurohackademy_users
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -62,11 +62,34 @@ jupyterhub:
             username_derivation:
               username_claim: "preferred_username"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &neurohackademy_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - arokem
-        admin_users: *neurohackademy_users
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -84,8 +84,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -67,8 +67,6 @@ jupyterhub:
         scope:
           - "profile"
         oauth_callback_url: https://neurohackademy.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - https://github.com/login/oauth/authorize
         allowed_idps:
           http://github.com/login/oauth/authorize:
             username_derivation:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -64,8 +64,6 @@ jupyterhub:
           - arokem
         admin_users: *neurohackademy_users
       CILogonOAuthenticator:
-        scope:
-          - "profile"
         oauth_callback_url: https://neurohackademy.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -56,8 +56,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -34,9 +34,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://temple.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - https://fim.temple.edu/idp/shibboleth
-          - https://accounts.google.com/o/oauth2/auth
         allowed_idps:
           https://fim.temple.edu/idp/shibboleth:
             username_derivation:

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -38,9 +38,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://ucmerced.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - urn:mace:incommon:ucmerced.edu
-          - https://accounts.google.com/o/oauth2/auth
         allowed_idps:
           urn:mace:incommon:ucmerced.edu:
             username_derivation:

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -33,14 +33,6 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: github
-        Authenticator:
-          # This hub uses GitHub Orgs auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed orgs. These people should have admin access though.
-          admin_users:
-            - jameshalgren
-            - arpita0911patel
-            - karnesh
         GitHubOAuthenticator:
           allowed_organizations:
             - 2i2c-org
@@ -48,6 +40,11 @@ basehub:
             - NOAA-OWP
           scope:
             - read:org
+        Authenticator:
+          admin_users:
+            - jameshalgren
+            - arpita0911patel
+            - karnesh
     singleuser:
       image:
         # Image build repo: https://github.com/2i2c-org/awi-ciroh-image

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -136,9 +136,6 @@ jupyterhub:
           - "102749090965437723445" # Byron Chu (Cybera)
           - "115909958579864751636" # Michael Jones (Cybera)
           - "106951135662332329542" # Elmar Bouwer (Cybera)
-        shown_idps:
-          - https://accounts.google.com/o/oauth2/auth
-          - https://login.microsoftonline.com/common/oauth2/v2.0/authorize
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -193,11 +193,34 @@ basehub:
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          allowed_users: &users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             - maxrjones
-          admin_users: *users
 
 dask-gateway:
   traefik:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -215,8 +215,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -188,8 +188,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -192,11 +192,9 @@ basehub:
             http://github.com/login/oauth/authorize:
               username_derivation:
                 username_claim: "preferred_username"
+        OAuthenticator:
+          allow_existing_users: True
         Authenticator:
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to
-          #        be configured explicitly.
-          #
           allowed_users: &users
             - maxrjones
           admin_users: *users

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -190,8 +190,6 @@ basehub:
         CILogonOAuthenticator:
           scope:
             - "profile"
-          shown_idps:
-            - http://github.com/login/oauth/authorize
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
+++ b/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
@@ -33,8 +33,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://unitefa-conicet.latam.catalystproject.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
         allowed_idps:
           # The username claim here is used to do *authorization*, for both
           # admin use and any allow listing we want to do.

--- a/config/clusters/cloudbank/bcc.values.yaml
+++ b/config/clusters/cloudbank/bcc.values.yaml
@@ -33,8 +33,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://bcc.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://ccsf.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csm.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -35,10 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://csulb.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://its-shib.its.csulb.edu/idp/shibboleth
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -38,9 +38,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -33,10 +33,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -34,9 +34,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://elcamino.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/evc.values.yaml
+++ b/config/clusters/cloudbank/evc.values.yaml
@@ -33,10 +33,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://evc.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://fresno.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - https://idp.scccd.edu/idp/shibboleth
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:
             username_derivation:

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://glendale.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -36,11 +36,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &howard_users
           - ericvd@berkeley.edu
           - gwashington@scs.howard.edu

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -59,8 +59,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://howard.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -37,11 +37,34 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &howard_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - ericvd@berkeley.edu
           - gwashington@scs.howard.edu
           - anthony.fgordon64@gmail.com
           - mikayladorange@gmail.com
-        admin_users: *howard_users

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -38,10 +38,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://sso.humboldt.edu/idp/metadata
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -36,11 +36,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &lacc_users
           - PINEDAEM@laccd.edu
           - LAMKT@laccd.edu

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -59,8 +59,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -37,12 +37,35 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &lacc_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - PINEDAEM@laccd.edu
           - LAMKT@laccd.edu
           - ericvd@berkeley.edu
           - k_usovich@berkeley.edu
           - sean.smorris@berkeley.edu
-        admin_users: *lacc_users

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://lacc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://laney.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://datahub.mills.edu/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://miracosta.fedgw.com/gateway
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://norco.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -36,11 +36,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &palomar_users
           - aculich@berkeley.edu
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -37,11 +37,34 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &palomar_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - aculich@berkeley.edu
           - sean.smorris@berkeley.edu
           - tcanon@palomar.edu
           - PChen@palomar.edu
-        admin_users: *palomar_users

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -59,8 +59,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://palomar.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://pasadena.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sacramento.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -35,10 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -62,8 +62,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -39,11 +39,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &sbcc_users
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -40,10 +40,33 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &sbcc_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu
           - nfguebels@pipeline.sbcc.edu
-        admin_users: *sbcc_users

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc-dev.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://idp.sbcc.edu/idp/shibboleth
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -62,8 +62,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -39,11 +39,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &sbcc_users
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://idp.sbcc.edu/idp/shibboleth
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -40,10 +40,33 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &sbcc_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - ericvd@gmail.com
           - sean.smorris@berkeley.edu
           - nfguebels@pipeline.sbcc.edu
-        admin_users: *sbcc_users

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -29,10 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sjcc.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -38,10 +38,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://sjsu.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://idp01.sjsu.edu/idp/shibboleth
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://skyline.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -36,11 +36,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &staging_users
           - sean.smorris@berkeley.edu
         admin_users: *staging_users

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -59,8 +59,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -37,8 +37,31 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &staging_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - sean.smorris@berkeley.edu
-        admin_users: *staging_users

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -37,9 +37,33 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
       OAuthenticator:
+        # WARNING: Don't use allow_existing_users with config to allow an
+        #          externally managed group of users, such as
+        #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+        #          common expectations for an admin user.
+        #
+        #          The broken expectation is that removing a user from the
+        #          externally managed group implies that the user won't have
+        #          access any more. In practice the user will still have
+        #          access if it had logged in once before, as it then exists
+        #          in JupyterHub's database of users.
+        #
         allow_existing_users: True
       Authenticator:
-        allowed_users: &tuskegee_users
+        # WARNING: Removing a user from admin_users or allowed_users doesn't
+        #          revoke admin status or access.
+        #
+        #          OAuthenticator.allow_existing_users allows any user in the
+        #          JupyterHub database of users able to login. This includes
+        #          any previously logged in user or user previously listed in
+        #          allowed_users or admin_users, as such users are added to
+        #          JupyterHub's database on startup.
+        #
+        #          To properly revoke access, remove the user from the list,
+        #          deploy the change, and finally delete the user via the
+        #          /hub/admin panel.
+        #
+        admin_users:
           - yasmeen.rawajfih@gmail.com
           - Wu.fan01@gmail.com
           - yanlisa@berkeley.edu
@@ -47,4 +71,3 @@ jupyterhub:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - sean.smorris@gmail.com
-        admin_users: *tuskegee_users

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -59,8 +59,10 @@ jupyterhub:
         #          allowed_users or admin_users, as such users are added to
         #          JupyterHub's database on startup.
         #
-        #          To properly revoke access, remove the user from the list,
-        #          deploy the change, and finally delete the user via the
+        #          To revoke admin status or access for a user when
+        #          allow_existing_users is enabled, first remove the user from
+        #          admin_users or allowed_users, then deploy the change, and
+        #          finally revoke the admin status or delete the user via the
         #          /hub/admin panel.
         #
         admin_users:

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -36,11 +36,9 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
+      OAuthenticator:
+        allow_existing_users: True
       Authenticator:
-        # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-        #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-        #        configured explicitly.
-        #
         allowed_users: &tuskegee_users
           - yasmeen.rawajfih@gmail.com
           - Wu.fan01@gmail.com

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -29,9 +29,6 @@ jupyterhub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: "https://tuskegee.cloudbank.2i2c.cloud/hub/oauth_callback"
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - urn:mace:incommon:berkeley.edu
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -36,18 +36,16 @@ basehub:
             url: https://science.nasa.gov/earth-science/focus-areas/climate-variability-and-change/ocean-physics
     hub:
       config:
+        JupyterHub:
+          authenticator_class: github
+        OAuthenticator:
+          allow_existing_users: True
         Authenticator:
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to
-          #        be configured explicitly.
-          #
           allowed_users: &gridsst_users
             - alisonrgray
             - nikki-t
             - dgumustel
           admin_users: *gridsst_users
-        JupyterHub:
-          authenticator_class: github
     singleuser:
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -39,13 +39,36 @@ basehub:
         JupyterHub:
           authenticator_class: github
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          allowed_users: &gridsst_users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             - alisonrgray
             - nikki-t
             - dgumustel
-          admin_users: *gridsst_users
     singleuser:
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -61,8 +61,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -49,11 +49,9 @@ basehub:
         - name: volume-mount-ownership-fix
           image: busybox
           command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan",
-            ]
+            - sh
+            - -c
+            - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
           securityContext:
             runAsUser: 0
           volumeMounts:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -222,8 +222,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -227,9 +227,33 @@ basehub:
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          allowed_users: &users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             # This is just listing a few of the users/admins, a lot of
             # users has been added manually, see:
             # https://github.com/pangeo-data/jupyter-earth/issues/53
@@ -249,7 +273,6 @@ basehub:
             - whyjz # Whyjay Zheng
             - yuvipanda # Yuvi Panda
             - jonathan-taylor # Jonathan Taylor
-          admin_users: *users
       allowNamedServers: true
 
 dask-gateway:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -226,11 +226,9 @@ basehub:
             http://github.com/login/oauth/authorize:
               username_derivation:
                 username_claim: "preferred_username"
+        OAuthenticator:
+          allow_existing_users: True
         Authenticator:
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-          #        configured explicitly.
-          #
           allowed_users: &users
             # This is just listing a few of the users/admins, a lot of
             # users has been added manually, see:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -247,8 +247,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -224,8 +224,6 @@ basehub:
         CILogonOAuthenticator:
           scope:
             - "profile"
-          shown_idps:
-            - http://github.com/login/oauth/authorize
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -42,14 +42,6 @@ basehub:
         tag: "0.0.1-0.dev.git.6863.h406a3546"
       allowNamedServers: true
       config:
-        Authenticator:
-          enable_auth_state: true
-          # This hub uses GitHub Teams auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed teams. These people should have admin access though.
-          admin_users:
-            - rabernat
-            - jbusecke
         JupyterHub:
           authenticator_class: github
           # Announcement is a JupyterHub feature to present messages to users in
@@ -76,6 +68,11 @@ basehub:
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
+        Authenticator:
+          enable_auth_state: true
+          admin_users:
+            - rabernat
+            - jbusecke
     singleuser:
       image:
         name: pangeo/pangeo-notebook

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -39,7 +39,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.6935.h7141d766"
       allowNamedServers: true
       config:
         JupyterHub:

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -33,18 +33,15 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: github
-        Authenticator:
-          # This hub uses GitHub Orgs auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed orgs. These people should have admin access though.
-          admin_users:
-            - khider
         GitHubOAuthenticator:
           allowed_organizations:
             - 2i2c-org
             - LinkedEarth
           scope:
             - read:org
+        Authenticator:
+          admin_users:
+            - khider
     singleuser:
       image:
         # User image repo: https://quay.io/repository/linkedearth/pyleoclim

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -39,14 +39,6 @@ basehub:
     hub:
       allowNamedServers: true
       config:
-        Authenticator:
-          # This hub uses GitHub Teams auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed teams. These people should have admin access though.
-          admin_users:
-            - rabernat
-            - johannag126
-            - jbusecke
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
@@ -55,6 +47,11 @@ basehub:
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
+        Authenticator:
+          admin_users:
+            - rabernat
+            - johannag126
+            - jbusecke
     singleuser:
       extraFiles:
         jupyter_notebook_config.json:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -88,8 +88,6 @@ basehub:
         CILogonOAuthenticator:
           scope:
             - "profile"
-          shown_idps:
-            - http://github.com/login/oauth/authorize
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -90,11 +90,9 @@ basehub:
             http://github.com/login/oauth/authorize:
               username_derivation:
                 username_claim: "preferred_username"
+        OAuthenticator:
+          allow_existing_users: True
         Authenticator:
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-          #        configured explicitly.
-          #
           allowed_users: &users
             - roxyboy
             - lesommer

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -113,8 +113,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -91,13 +91,36 @@ basehub:
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          allowed_users: &users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             - roxyboy
             - lesommer
             - auraoupa
-          admin_users: *users
 
       allowNamedServers: true
 dask-gateway:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -86,8 +86,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -37,21 +37,6 @@ basehub:
     hub:
       allowNamedServers: true
       config:
-        Authenticator:
-          # We are restricting profiles based on GitHub Team membership and
-          # so need to persist auth state
-          enable_auth_state: true
-          # This hub uses GitHub Teams auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed teams. These people should have admin access though.
-          admin_users:
-            - tsnow03
-            - JessicaS11
-            - jdmillstein
-            - dfelikson
-            - fperez
-            - scottyhq
-            - jomey
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
@@ -64,6 +49,19 @@ basehub:
             - CryoInTheCloud:cryocloudadvanced
           scope:
             - read:org
+        Authenticator:
+          # We are restricting profiles based on GitHub Team membership and
+          # so need to persist auth state
+          enable_auth_state: true
+          admin_users:
+            - tsnow03
+            - JessicaS11
+            - jdmillstein
+            - dfelikson
+            - fperez
+            - scottyhq
+            - jomey
+
     singleuser:
       extraFiles:
         # jupyter_server_config.json is defined by basehub, this entry adds to it

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -89,11 +89,9 @@ basehub:
         - name: volume-mount-ownership-fix
           image: busybox
           command:
-            [
-              "sh",
-              "-c",
-              "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
-            ]
+            - sh
+            - -c
+            - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
           securityContext:
             runAsUser: 0
           volumeMounts:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -34,7 +34,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.6935.h7141d766"
       allowNamedServers: true
       config:
         Authenticator:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -58,16 +58,14 @@ basehub:
             http://github.com/login/oauth/authorize:
               username_derivation:
                 username_claim: "preferred_username"
+        OAuthenticator:
+          allow_existing_users: True
         Authenticator:
           admin_users: &users
             - amfriesz
             - jules32
             - erinmr
             - betolink
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-          #        configured explicitly.
-          #
           allowed_users: *users
 dask-gateway:
   gateway:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -81,8 +81,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -56,8 +56,6 @@ basehub:
         CILogonOAuthenticator:
           scope:
             - "profile"
-          shown_idps:
-            - http://github.com/login/oauth/authorize
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -59,14 +59,37 @@ basehub:
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          admin_users: &users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             - amfriesz
             - jules32
             - erinmr
             - betolink
-          allowed_users: *users
 dask-gateway:
   gateway:
     extraConfig:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -54,8 +54,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          scope:
-            - "profile"
           allowed_idps:
             http://github.com/login/oauth/authorize:
               username_derivation:

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -122,7 +122,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.6935.h7141d766"
       config:
         CILogonOAuthenticator:
           oauth_callback_url: "https://staging.openscapes.2i2c.cloud/hub/oauth_callback"

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -34,16 +34,6 @@ basehub:
         node.kubernetes.io/instance-type: n1-standard-2
     hub:
       config:
-        Authenticator:
-          admin_users: &admin_users
-            - paigemar@umich.edu
-          # FIXME: In z2jh 3.0.0-beta.1, a truthy allowed_users implies
-          #        allow_existing_users=True, while in z3jh 3.0.0 this needs to be
-          #        configured explicitly.
-          #
-          allowed_users: *admin_users
-          # Delete any prior existing users in the db that don't pass username_pattern
-          delete_invalid_users: true
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
@@ -52,3 +42,11 @@ basehub:
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"
+        OAuthenticator:
+          allow_existing_users: True
+        Authenticator:
+          admin_users: &admin_users
+            - paigemar@umich.edu
+          allowed_users: *admin_users
+          # Delete any prior existing users in the db that don't pass username_pattern
+          delete_invalid_users: true

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -43,10 +43,33 @@ basehub:
               username_derivation:
                 username_claim: "email"
         OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
           allow_existing_users: True
         Authenticator:
-          admin_users: &admin_users
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To properly revoke access, remove the user from the list,
+          #          deploy the change, and finally delete the user via the
+          #          /hub/admin panel.
+          #
+          admin_users:
             - paigemar@umich.edu
-          allowed_users: *admin_users
           # Delete any prior existing users in the db that don't pass username_pattern
           delete_invalid_users: true

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -48,8 +48,6 @@ basehub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
           oauth_callback_url: "https://coessing.2i2c.cloud/hub/oauth_callback"
-          shown_idps:
-            - https://accounts.google.com/o/oauth2/auth
           allowed_idps:
             http://google.com/accounts/o8/id:
               username_derivation:

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -71,5 +71,3 @@ basehub:
           #
           admin_users:
             - paigemar@umich.edu
-          # Delete any prior existing users in the db that don't pass username_pattern
-          delete_invalid_users: true

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -65,8 +65,10 @@ basehub:
           #          allowed_users or admin_users, as such users are added to
           #          JupyterHub's database on startup.
           #
-          #          To properly revoke access, remove the user from the list,
-          #          deploy the change, and finally delete the user via the
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
           #          /hub/admin panel.
           #
           admin_users:

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -38,15 +38,6 @@ basehub:
     hub:
       allowNamedServers: true
       config:
-        Authenticator:
-          # This hub uses GitHub Teams auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed teams. These people should have admin access though.
-          admin_users:
-            - rabernat
-            - jhamman
-            - scottyhq
-            - TomAugspurger
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
@@ -55,6 +46,12 @@ basehub:
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
+        Authenticator:
+          admin_users:
+            - rabernat
+            - jhamman
+            - scottyhq
+            - TomAugspurger
     singleuser:
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.c90ee430400a347f"

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -228,11 +228,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
-          ]
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -36,13 +36,6 @@ jupyterhub:
   hub:
     allowNamedServers: true
     config:
-      Authenticator:
-        # This hub uses GitHub Teams auth and so we don't set
-        # allowed_users in order to not deny access to valid members of
-        # the listed teams. These people should have admin access though.
-        admin_users:
-          - gizmo404
-          - jtkmckenna
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
@@ -51,6 +44,10 @@ jupyterhub:
           - QuantifiedCarbon:jupyterhub
         scope:
           - read:org
+      Authenticator:
+        admin_users:
+          - gizmo404
+          - jtkmckenna
   singleuser:
     image:
       # pangeo/pangeo-notebook is maintained at: https://github.com/pangeo-data/pangeo-docker-images

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -48,9 +48,6 @@ basehub:
             - read:org
         Authenticator:
           enable_auth_state: true
-          # This hub uses GitHub Orgs auth and so we don't set allowed_users in
-          # order to not deny access to valid members of the listed orgs. These
-          # people should have admin access though.
           admin_users:
             - MikeTrizna # Mike Trizna
             - rdikow # Rebecca Dikow

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -42,9 +42,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        shown_idps:
-          - https://authentication.ubc.ca
-          - http://google.com/accounts/o8/id
         allowed_idps:
           https://authentication.ubc.ca:
             username_derivation:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -81,8 +81,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://r-staging.datatools.utoronto.ca/hub/oauth_callback
-        shown_idps:
-          - https://idpz.utorauth.utoronto.ca/shibboleth
         allowed_idps:
           https://idpz.utorauth.utoronto.ca/shibboleth:
             username_derivation:

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -34,13 +34,6 @@ basehub:
             url: https://people.climate.columbia.edu/projects/sponsor/National%20Science%20Foundation
     hub:
       config:
-        Authenticator:
-          # This hub uses GitHub Teams auth and so we don't set
-          # allowed_users in order to not deny access to valid members of
-          # the listed teams. These people should have admin access though.
-          admin_users:
-            - einatlev-ldeo
-            - SamKrasnoff
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
@@ -49,6 +42,10 @@ basehub:
             - VICTOR-Community:victoraccess
           scope:
             - read:org
+        Authenticator:
+          admin_users:
+            - einatlev-ldeo
+            - SamKrasnoff
     singleuser:
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods

--- a/docs/howto/features/per-user-db.md
+++ b/docs/howto/features/per-user-db.md
@@ -60,11 +60,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-            [
-                "sh",
-                "-c",
-                "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /var/lib/postgresql/data && ls -lhd /home/jovyan ",
-            ]
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /var/lib/postgresql/data && ls -lhd /home/jovyan
         securityContext:
             runAsUser: 0
         volumeMounts:

--- a/docs/hub-deployment-guide/configure-auth/cilogon.md
+++ b/docs/hub-deployment-guide/configure-auth/cilogon.md
@@ -115,8 +115,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        scope:
-          - "profile"
         oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:

--- a/docs/hub-deployment-guide/configure-auth/cilogon.md
+++ b/docs/hub-deployment-guide/configure-auth/cilogon.md
@@ -69,10 +69,6 @@ jupyterhub:
           - admin@anu.edu.au
       CILogonOAuthenticator:
         oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
-        # Show only the option to login with Google and ANU's provider
-        shown_idps:
-          - http://google.com/accounts/o8/id
-          - https://idp2.anu.edu.au/idp/shibboleth
         # Allow to only login into the hub using Google or ANU's provider
         allowed_idps:
           http://google.com/accounts/o8/id:
@@ -122,8 +118,6 @@ jupyterhub:
         scope:
           - "profile"
         oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
-        shown_idps:
-          - http://github.com/login/oauth/authorize
         allowed_idps:
           http://github.com/login/oauth/authorize:
             username_derivation:

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -118,11 +118,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && chown 1000:1000 /home/jovyan/shared-public && ls -lhd /home/jovyan ",
-          ]
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 3.0.0-beta.1.git.6208.h7b44299a
+    version: 3.0.2
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
     version: 0.1.0-0.dev.git.80.h358d32f

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -177,9 +177,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          - "sh"
-          - "-c"
-          - "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && ls -lhd /home/jovyan"
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared && ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -177,11 +177,9 @@ jupyterhub:
       - name: volume-mount-ownership-fix
         image: busybox
         command:
-          [
-            "sh",
-            "-c",
-            "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && ls -lhd /home/jovyan ",
-          ]
+          - "sh"
+          - "-c"
+          - "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared && ls -lhd /home/jovyan"
         securityContext:
           runAsUser: 0
         volumeMounts:
@@ -394,7 +392,7 @@ jupyterhub:
                 interfaces:
                   - value: "/tree"
                     title: Classic Notebook
-                    description:
+                    description: >-
                       The original single-document interface for creating
                       Jupyter Notebooks.
                   - value: "/lab"
@@ -420,8 +418,8 @@ jupyterhub:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-          allowPrivilegeEscalation: False
-          readOnlyRootFilesystem: True
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
           - name: custom-templates
             mountPath: /srv/repo
@@ -488,8 +486,8 @@ jupyterhub:
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
-          allowPrivilegeEscalation: False
-          readOnlyRootFilesystem: True
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
           - name: custom-templates
             mountPath: /srv/repo
@@ -526,7 +524,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.6074.h895181eb"
+      tag: "0.0.1-0.dev.git.6863.h406a3546"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -524,7 +524,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.6863.h406a3546"
+      tag: "0.0.1-0.dev.git.6935.h7141d766"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -1,3 +1,13 @@
+# This is the configuration for chartpress, a CLI for Helm chart management.
+#
+# chartpress can be used to:
+# - Build images
+# - Update Chart.yaml (version) and values.yaml (image tags)
+# - Package and publish Helm charts to a GitHub based Helm chart repository
+#
+# For more information about chartpress, see the projects README.md file:
+# https://github.com/jupyterhub/chartpress
+#
 charts:
   - name: basehub
     imagePrefix: quay.io/2i2c/pilot-
@@ -5,16 +15,16 @@ charts:
       hub:
         valuesPath: jupyterhub.hub.image
         buildArgs:
-          REQUIREMENTS_FILE: "requirements.txt"
+          REQUIREMENTS_FILE: requirements.txt
       unlisted-choice-experiment:
         imageName: quay.io/2i2c/unlisted-choice-experiment
         buildArgs:
-          REQUIREMENTS_FILE: "unlisted-choice-requirements.txt"
-        contextPath: "images/hub"
+          REQUIREMENTS_FILE: unlisted-choice-requirements.txt
+        contextPath: images/hub
         dockerfilePath: images/hub/Dockerfile
       dynamic-image-building-experiment:
         imageName: quay.io/2i2c/dynamic-image-building-experiment
         buildArgs:
-          REQUIREMENTS_FILE: "dynamic-image-building-requirements.txt"
-        contextPath: "images/hub"
-        dockerfilePath: "images/hub/Dockerfile"
+          REQUIREMENTS_FILE: dynamic-image-building-requirements.txt
+        contextPath: images/hub
+        dockerfilePath: images/hub/Dockerfile

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,7 +12,11 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:3.0.0-beta.1
+FROM jupyterhub/k8s-hub:3.0.2
+
+# chartpress.yaml defines multiple hub images differentiated only by a
+# requirements.txt file with dependencies, this build argument allows us to
+# re-use this Dockerfile for all images.
 ARG REQUIREMENTS_FILE
 
 COPY ${REQUIREMENTS_FILE} /tmp/

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -1,6 +1,6 @@
 # Image lives at quay.io/2i2c/second-hub-experimental
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
+git+https://github.com/jupyterhub/kubespawner@8cc569c78bcdb342e694f7344219e43d522f4809
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
 git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@b36ece00b5e7fcba5d4485e7ab70992705601c3c


### PR DESCRIPTION
- Fixes #2774 

This PR would benefit from a careful review as typos could break things not tested until actual users show up and use their identity provider to login.

I've tested this on a few staging hubs successfully so far.

## Self review on the following commits

For each commit checked, I've checked for unelated changes to the commit
description.

- [x] 18ddef93 - oauthenticator 16: remove shown_idps, allowed_idps now provides that effect
  For each idp removed in shown_idps, there looked to be an entry in
  allowed_idps.
- [x] 640660d5 - oauthenticator 16: remove explicit scope, profile is included anyhow
  Assumes we upgrade to oauthenticator 16 in a subsequent commmit, because there
  "profile" and "email" scopes are included by default. In oauthenticator 16,
  there is also another scope included.

  Overall, this upgrade will cause scope changes, and we will end up requesting
  a bit more than we did before no matter what, but I think it should be fine.
- [x] 435432d2 - oauthenticator 16: add allow_existing_users where allowed_users was configured
  Besides adding `allow_existing_users=True` where `allowed_users` was
  configured (that implied `allow_existing_users=True` in OAuthenticator <16),
  this commit also removes fixme comments related to the pending upgrade and
  sometimes relocates keys under `hub.config` to have a consistent ordering.
- [x] 0da0b3ea - oauthenticator 16: remove outdated comment about allowed_users
  The comments like below has been removed:

  > This hub uses GitHub Org auth and so we don't set allowed_users in order to
  > not deny access to valid members of the listed orgs.

  This comment related to `oauthenticator<16` when it was unreasonable to
  combine `allowed_users` with allowing members of an external github org/team,
  because then you had to be listed in both (or be an existing user and in the
  github org/team) to gain access.

  With oauthenticator 16, this is no longer the case - you can be part of
  either `allowed_users` or `allowed_organizations`.
- [x] 0c43b0c7 - auth config: remove outdated workaround setting empty admin_users
  The comments like below has been removed:

  > You must always set admin_users, even if it is an empty list,
  > otherwise `add_staff_user_ids_to_admin_users: true` will fail
  > silently and no staff members will have admin access.

  They were a remnant since before #2299 that fixed this.
- [x] 63eabbcb - oauthenticator 16: remove redundant spec of allowed_users, add warnings
  Systematically removed specification of `allowed_users` in favor of
  `admin_users` only, its sufficient to specify just `admin_users` in
  OAuthenticator 16 to grant them access, and because a falsy or truthy
  `allowed_users` config doesn't matter now that the explicit configuration
  `allow_existing_users` has been introduced.
  - [x] I'll iterate on the comment leading with `To properly revoke access,` as
    it doesn't mention admin status in any way which it should as well.
- [x] 7201a884 - auth config: remove temporary config addition
  The pangeo-hubs/coessing hub had `delete_invalid_users` specified, but I'm
  almost 100% this isn't relevant and has either mistakenly been introduced or
  was just temporarily used to cleanup the database of user with a trick.
- [x] a3bb0033 - basehub: tweak values to avoid formatting conflicts
  When using `chartpress` I found that config was changed, and that pre-commit
  also could end up changing it back. To avoid a battle between autoformatting
  stuff, I updated the config to have the autoformatters settle.
  - [x] This commit mistakenly includes a version bump of the hub image in
    basehub. This isn't much of an issue as `fa134cea` provides a final bump of
    all the hub images.
- [x] 28cd4f54 - basehub: refactor, simplify chowning container's command
  This commit was added for consistency with the previous commit, where
  chartpress had modified syntax of a chown command in basehub's values
  specifically and I wanted all to look similar. As part of this I also reduced
  the complexity of the command by letting a single `chown` command update
  multiple folders at once.
- [x] 4545ef61 - basehub: upgrade z2jh from 3.0.0-beta.1 to 3.0.2
  This commit include some unrelated refactoring for consistency in
  chartpress.yaml, and added a comment or two.
- [x] 37d99115 - dynamic image building experiment: bump kubespawner's main branch further
  I had in another PR updated the `unlisted_choice` experiment image to have a
  more recent version of kubespawner with misc fixes, but I had missed out on
  that also the dynamic-image-building-experiment used kubespawner's main
  branch. Due to this, I ended up making sure they were both updated to the same
  version. This change is in other words quite unrelated (at least assuming the
  previous kubespawner commit was modern enough, a requirement for z2jh 3).
- [x] fa134cea - basehub: update hub image's to a z2jh 3.0.2 derived image
  This is what