### PR TITLE
Re-enable dirsize reporter for shared cluster

### DIFF
--- a/config/clusters/2i2c/basehub-common.values.yaml
+++ b/config/clusters/2i2c/basehub-common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
   enabled: true
+  dirsizeReporter:
+    enabled: true
   pv:
     mountOptions:
       - soft

--- a/config/clusters/2i2c/daskhub-common.values.yaml
+++ b/config/clusters/2i2c/daskhub-common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
     enabled: true
+    dirsizeReporter:
+      enabled: true
     pv:
       mountOptions:
         - soft


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/issues/2930 was basically solved by
https://github.com/2i2c-org/infrastructure/pull/3093, so let's re-enable this and see how that goes. Doing it only in the shared cluster - let's keep an eye on this.

Ref https://github.com/2i2c-org/infrastructure/issues/3121