### PR TITLE
meom-ige: specify one default profile list entry

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -41,6 +41,7 @@ basehub:
         # RAM on a node, not total node capacity
         - display_name: "Small"
           description: "~2 CPU, ~8G RAM"
+          default: true
           kubespawner_override:
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
With a modern version of kubespawner, we will always see a default value in the server options, but without we will not. Currently meom-ige has failures I don't understand yet on staging when the deployer check is used, therefore I'd like to fix this to rule this out as the cause.