### PR TITLE
victor: login page, update logo and linked website

### DIFF
--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -20,9 +20,9 @@ basehub:
         gitRepoBranch: "victor"
         templateVars:
           org:
-            name: Victor
-            logo_url: https://lh3.googleusercontent.com/drive-viewer/AFDK6gOSmgurudnSJrUNMaIdOIEeu8aXUzWS9qZ0Oi3XO3_fFYdfjksmrPQrjv542v_81TCkVPlRT_Acf5BAojMEeYlEzF8nmw=w2880-h1368
-            url: https://people.climate.columbia.edu/projects/view/2387
+            name: VICTOR
+            logo_url: https://i.imgur.com/D2vXQ5k.png
+            url: https://victor.ldeo.columbia.edu
           designed_by:
             name: 2i2c
             url: https://2i2c.org


### PR DESCRIPTION
Based on discussion in https://github.com/2i2c-org/default-hub-homepage/pull/26#issuecomment-1718141309

Since victor currently has a broken logo link, I think this is the desired change. I'll go for a merge and ask @volcanocyber for a retroactive confirmation!