### PR TITLE
meom-ige: reference NFS server IP with a fully qualified DNS name

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -9,7 +9,7 @@ basehub:
         - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
         - retrans=2
         - noresvport
-      serverIP: nfs-server-01
+      serverIP: nfs-server-01.us-central1-b.c.meom-ige-cnrs.internal
       baseShareName: /export/home-01/homes/
   jupyterhub:
     custom:


### PR DESCRIPTION
Was failing with this otherwise:

```
 Warning  FailedMount  8m55s (x22 over 43m)  kubelet  MountVolume.SetUp failed for volume "prod-home-nfs" : mount failed: exit status 1
Mounting command: /home/kubernetes/containerized_mounter/mounter
Mounting arguments: mount -t nfs -o noresvport,retrans=2,rsize=1048576,soft,timeo=600,wsize=1048576 nfs-server-01:/export/home-01/homes/prod /var/lib/kubelet/pods/d9d6a9ac-3194-4226-b5f0-135419bd6225/volumes/kubernetes.io~nfs/prod-home-nfs
Output: Mount failed: mount failed: exit status 32
Mounting command: chroot
Mounting arguments: [/home/kubernetes/containerized_mounter/rootfs mount -t nfs -o noresvport,retrans=2,rsize=1048576,soft,timeo=600,wsize=1048576 nfs-server-01:/export/home-01/homes/prod /var/lib/kubelet/pods/d9d6a9ac-3194-4226-b5f0-135419bd6225/volumes/kubernetes.io~nfs/prod-home-nfs]
Output: mount.nfs: Failed to resolve server nfs-server-01: Name or
service not known
```

Testing dns resolution on the node works fine, but kubelet can't seem to resolve it correctly. I suspect something about resolv.conf and ndots, but given we don't even want to support having a separate NFS server outside, this is a decent fix for now.