### PR TITLE
new nasa-veda-singleuser-init commit hash 53e93ca

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -121,7 +121,7 @@ basehub:
                       # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
                       # image source: https://github.com/NASA-IMPACT/veda-jh-environments/tree/main/docker-images/base/nasa-veda-singleuser-init
                       - name: nasa-veda-singleuser-init
-                        image: public.ecr.aws/nasa-veda/nasa-veda-singleuser-init:d78dd50564f562fd6879256a589db5334963f0d6ecd28266a4cf0a8d2aaccca9
+                        image: public.ecr.aws/nasa-veda/nasa-veda-singleuser-init:53e93ca4fa8b0f979f9bd42fc84ad642deb9851ee449f0b273775b1a367e2ecf
                         command:
                           - "python3"
                           - "/opt/k8s-init-container-nb-docs.py"
@@ -174,7 +174,7 @@ basehub:
                       # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
                       # image source: https://github.com/NASA-IMPACT/veda-jh-environments/tree/main/docker-images/base/nasa-veda-singleuser-init
                       - name: nasa-veda-singleuser-init
-                        image: public.ecr.aws/nasa-veda/nasa-veda-singleuser-init:d78dd50564f562fd6879256a589db5334963f0d6ecd28266a4cf0a8d2aaccca9
+                        image: public.ecr.aws/nasa-veda/nasa-veda-singleuser-init:53e93ca4fa8b0f979f9bd42fc84ad642deb9851ee449f0b273775b1a367e2ecf
                         command:
                           - "python3"
                           - "/opt/k8s-init-container-nb-docs.py"


### PR DESCRIPTION
Changes from #3124 for a new init image:

* make sure the `initContainer` script only returns successful exit code
* log any errors 