### PR TITLE
Wire up image building UI to binderhub service in imagebuilding-demo

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -58,6 +58,11 @@ jupyterhub:
           mem_limit: 2G
           cpu_limit: 2
   hub:
+    services:
+      binder:
+        # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
+        # for something more readable and requiring less copy-pasting
+        url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
       tag: "0.0.1-0.dev.git.6765.h33942a27"
@@ -107,6 +112,7 @@ binderhub-service:
         effect: NoSchedule
   config:
     BinderHub:
+      base_url: /services/binder
       use_registry: true
       # Re-uses the registry created for the `binderhub-staging` hub
       # but pushes images under a different prefix

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -65,7 +65,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.6765.h33942a27"
+      tag: "0.0.1-0.dev.git.7001.hf02ed7a1"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@b36ece00b5e7fcba5d4485e7ab70992705601c3c
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@2f9b899cb6d7ea91f0e5f69c48562a1cd73fc3da


### PR DESCRIPTION
- Sets up binderhub as a service in imagebuilding-demo
- Brings in https://github.com/jupyterhub/binderhub/pull/1741 and https://github.com/jupyterhub/binderhub/pull/1742
   to the client, as part of https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui/commit/2f9b899cb6d7ea91f0e5f69c48562a1cd73fc3da


https://github.com/2i2c-org/infrastructure/assets/30430/98861a89-111d-4341-8ea7-b078bed339bb

