### PR TITLE
utoronto: fix logo link

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
         interface_selector: true
         org:
           name: University of Toronto
-          logo_url: https://raw.githubusercontent.com/utoronto-2i2c/homepage/master/extra-assets/images/home-hero.png
+          logo_url: https://raw.githubusercontent.com/2i2c-org/default-hub-homepage/utoronto-prod/extra-assets/images/home-hero.png
           url: https://www.utoronto.ca/
         designed_by:
           name: 2i2c


### PR DESCRIPTION
I'm not sure when this broke, but its related to the deletion of a utoronto-2i2c github organization project.

---

Before:
![image](https://github.com/2i2c-org/infrastructure/assets/3837114/0e9ba7ec-b029-4a63-9b1a-3ae7dac27e20)

After:
![image](https://github.com/2i2c-org/infrastructure/assets/3837114/0cb4ad0e-49cf-44c9-9b7d-65550be945f0)
