### PR TITLE
[DO NOT MERGE] Test if updated kubespawner resolves culler failure

### DIFF
--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -30,6 +30,9 @@ jupyterhub:
       name: quay.io/2i2c/2i2c-hubs-image
       tag: "14107b8a85fb"
   hub:
+    image:
+      name: quay.io/2i2c/culler-failure
+      tag: "0.0.1-0.dev.git.7009.h8f624235"
     config:
       Authenticator:
         admin_users:

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -18,3 +18,9 @@ charts:
           REQUIREMENTS_FILE: "dynamic-image-building-requirements.txt"
         contextPath: "images/hub"
         dockerfilePath: "images/hub/Dockerfile"
+      culler-failure:
+        imageName: quay.io/2i2c/culler-failure
+        buildArgs:
+          REQUIREMENTS_FILE: "culler-failure-requirements.txt"
+        contextPath: "images/hub"
+        dockerfilePath: "images/hub/Dockerfile"

--- a/helm-charts/images/hub/culler-failure-requirements.txt
+++ b/helm-charts/images/hub/culler-failure-requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
+# Brings in the head of kubespawner repo c.f. 2023-09-15 13:51 UTC
+git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e


### PR DESCRIPTION
ref https://github.com/2i2c-org/infrastructure/issues/3130

I have opened this for visibility into what I have done, but shouldn't be merged. If updating kubespawner fixes the issue, then we should aim for a new release and update it in the main hub image, not maintain another image.

We are hoping that with the deployment of this image, some long-lived pods will be successfully culled.