### PR TITLE
Launch built images in imagebuilder-demo!

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7001.hf02ed7a1"
+      tag: "0.0.1-0.dev.git.7018.h27963022"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -174,6 +174,8 @@ binderhub-service:
       # but pushes images under a different prefix
       image_prefix: us-central1-docker.pkg.dev/two-eye-two-see/binder-staging-registry/binderhub-service-
     KubernetesBuildExecutor:
+      # Get ourselves a newer repo2docker!
+      build_image: quay.io/jupyterhub/repo2docker:2023.06.0-8.gd414e99
       node_selector:
         # Schedule builder pods to run on user nodes only
         hub.jupyter.org/node-purpose: user

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
   singleuser:
     profileList:
       - display_name: "Only Profile Available, this info is not shown in the UI"
-        slug: only-profile
+        slug: only
         profile_options:
           image:
             display_name: Image

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -29,8 +29,8 @@ jupyterhub:
           custom_html: <a href="https://www.dfg.de/">DFG</a>, <a href="https://www.cessda.eu/">CESSDA</a>, <a href="https://www.gesis.org/">GESIS</a>, FKZ/Project number <a href="https://gepris.dfg.de/gepris/projekt/460234259?language=en">460234259</a>
   singleuser:
     profileList:
-      - display_name: "Small"
-        description: "~2 CPU, ~2G RAM"
+      - display_name: "Only Profile Available, this info is not shown in the UI"
+        slug: only-profile
         profile_options:
           image:
             display_name: Image

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -42,21 +42,77 @@ jupyterhub:
               kubespawner_override:
                 image: "{value}"
             choices:
-              pangeo_new:
-                display_name: Base Pangeo Notebook ("2023.07.05")
-                default: true
-                slug: "pangeo_new"
-                kubespawner_override:
-                  image: "pangeo/pangeo-notebook:2023.07.05"
               pangeo:
-                display_name: Base Pangeo Notebook
+                display_name: Pangeo Notebook Image
+                kubespawner_override:
+                  image: pangeo/pangeo-notebook:2023.09.11
+              geospatial:
+                display_name: Rocker Geospatial
                 default: true
-                slug: "pangeo"
-        kubespawner_override:
-          # Explicitly unset mem_limit, so it overrides the default memory limit we set in
-          # basehub/values.yaml
-          mem_limit: 2G
-          cpu_limit: 2
+                slug: geospatial
+                kubespawner_override:
+                  image: rocker/binder:4.3
+                  # Launch into RStudio after the user logs in
+                  default_url: /rstudio
+                  # Ensures container working dir is homedir
+                  # https://github.com/2i2c-org/infrastructure/issues/2559
+                  working_dir: /home/rstudio
+                  # Because this is a list, it will override our default volume mounts
+                  volume_mounts:
+                    # Mount the user home directory
+                    - name: home
+                      mountPath: /home/rstudio
+                      subPath: "{username}"
+                    # Mount the shared readonly directory
+                    - name: home
+                      mountPath: /home/rstudio/shared
+                      subPath: _shared
+                      readOnly: true
+              scipy:
+                display_name: Jupyter SciPy Notebook
+                slug: scipy
+                kubespawner_override:
+                  image: jupyter/scipy-notebook:2023-06-26
+          resources:
+            display_name: Resource Allocation
+            choices:
+              mem_2_7:
+                display_name: 2.7 GB RAM, upto 3.479 CPUs
+                kubespawner_override:
+                  mem_guarantee: 2904451072
+                  mem_limit: 2904451072
+                  cpu_guarantee: 0.434875
+                  cpu_limit: 3.479
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-highmem-4
+                default: true
+              mem_5_4:
+                display_name: 5.4 GB RAM, upto 3.479 CPUs
+                kubespawner_override:
+                  mem_guarantee: 5808902144
+                  mem_limit: 5808902144
+                  cpu_guarantee: 0.86975
+                  cpu_limit: 3.479
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-highmem-4
+              mem_10_8:
+                display_name: 10.8 GB RAM, upto 3.479 CPUs
+                kubespawner_override:
+                  mem_guarantee: 11617804288
+                  mem_limit: 11617804288
+                  cpu_guarantee: 1.7395
+                  cpu_limit: 3.479
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-highmem-4
+              mem_21_6:
+                display_name: 21.6 GB RAM, upto 3.479 CPUs
+                kubespawner_override:
+                  mem_guarantee: 23235608576
+                  mem_limit: 23235608576
+                  cpu_guarantee: 3.479
+                  cpu_limit: 3.479
+                node_selector:
+                  node.kubernetes.io/instance-type: n1-highmem-4
   hub:
     services:
       binder:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7026.h84659789"
+      tag: "0.0.1-0.dev.git.7029.h44cd314e"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
   singleuser:
     profileList:
       - display_name: "Only Profile Available, this info is not shown in the UI"
-        slug: only
+        slug: only-choice
         profile_options:
           image:
             display_name: Image

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7020.had7889bc"
+      tag: "0.0.1-0.dev.git.7022.h56cdd5c1"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7022.h56cdd5c1"
+      tag: "0.0.1-0.dev.git.7026.h84659789"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7018.h27963022"
+      tag: "0.0.1-0.dev.git.7020.had7889bc"
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@512e16082994ca513f34cc12c486714c9e5ad42c
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@ad5d844a50943df18b08f0b368d31f9f8441b1a0

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -1,6 +1,6 @@
 # Image lives at quay.io/2i2c/second-hub-experimental
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
+git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
 git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@512e16082994ca513f34cc12c486714c9e5ad42c

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@2f9b899cb6d7ea91f0e5f69c48562a1cd73fc3da
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@943f2c36d6308903aedd1c828eeb760c7d1f5977

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@5a90351adba7d65286bd5e00e82f156011bf7b83
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@943f2c36d6308903aedd1c828eeb760c7d1f5977
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@512e16082994ca513f34cc12c486714c9e5ad42c

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@ad5d844a50943df18b08f0b368d31f9f8441b1a0
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@19aa3685069894aa8e8236b9865795cd17994f8f


### PR DESCRIPTION
- Provides options for resource allocation that the user can select, showing that you *can* select what kinda resource you want while building image
- Update image choices to be more reflective of what we would have in a real hub
- Brings in a lot of changes from github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui to support the
   following:
   - Built images are now *actually launched*! Yay!
   - The big piece of text proclaiming that this is a prototype that doesn't work is gone, as it does work
   - The build logs are collapsible
   - There's a poorly discsoverable message saying 'build is done, click to launch'.

Ref https://github.com/2i2c-org/infrastructure/issues/3104

Here's a demo!


https://github.com/2i2c-org/infrastructure/assets/30430/64c4b8ab-1669-4b59-8b6d-979e2fb82298



(dropdown slightly tweaked with suggestions from @choldgraf)
<img width="667" alt="image" src="https://github.com/2i2c-org/infrastructure/assets/30430/7483373b-943b-47aa-a9e2-530f70f1351d">

So all the options in the dropdown work *except* for wiring up the built image to be actually launched.
