### PR TITLE
Cleanup UX of imagebuilding-demo

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7029.h44cd314e"
+      tag: "0.0.1-0.dev.git.7058.h013054f7"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -125,7 +125,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7058.h013054f7"
+      tag: "0.0.1-0.dev.git.7060.h0593e80c"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -44,10 +44,12 @@ jupyterhub:
             choices:
               pangeo:
                 display_name: Pangeo Notebook Image
+                description: "Python image with scientific, dask and geospatial tools"
                 kubespawner_override:
                   image: pangeo/pangeo-notebook:2023.09.11
               geospatial:
                 display_name: Rocker Geospatial
+                description: "R image with RStudio, the tidyverse & Geospatial tools"
                 default: true
                 slug: geospatial
                 kubespawner_override:
@@ -78,6 +80,7 @@ jupyterhub:
             choices:
               mem_2_7:
                 display_name: 2.7 GB RAM, upto 3.479 CPUs
+                description: "Use this for the workshop on 2023 September"
                 kubespawner_override:
                   mem_guarantee: 2904451072
                   mem_limit: 2904451072
@@ -106,6 +109,7 @@ jupyterhub:
                     node.kubernetes.io/instance-type: n1-highmem-4
               mem_21_6:
                 display_name: 21.6 GB RAM, upto 3.479 CPUs
+                description: "Largest amount of RAM, might take a few minutes to start"
                 kubespawner_override:
                   mem_guarantee: 23235608576
                   mem_limit: 23235608576

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -3,4 +3,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903e
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@19aa3685069894aa8e8236b9865795cd17994f8f
+git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@e7a3b86879ada4065d70343b51453e144ab6cad3

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -1,6 +1,7 @@
 # Image lives at quay.io/2i2c/second-hub-experimental
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@9663b7e0f0d3942962c99a39c375358f19e0718e
+# Brings in https://github.com/jupyterhub/kubespawner/pull/787
+git+https://github.com/yuvipanda/kubespawner@46d561d2687b3d6d5ea0dd0e25db42945c886b91
 # Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
 git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@e7a3b86879ada4065d70343b51453e144ab6cad3


### PR DESCRIPTION
- Get rid of the ancient bootstrap3 code for doing layouts, use moden native
   CSS grid instead. Makes things *much* easier.
- First real feature for profiles that isn't supported in the simple jinja2 template
  shipped with kubespawner - use https://react-select.com/ so we can actually
  have a useful *description* with each option the user can select. This is
  specified by admin when setting up profileList, and is ignored by the default
  profileList renderer. Very useful in setting context!
- UX is generally cleaner and melds in together nicer, vs being more disjointed
   before. 
- The ability to explicitly specify the GitHub repos' ref has been removed, and
   will be re-introduced in the near future. Same for ability to hide the build log,
   although that is less of an issue now that the logs are smaller.
- Brings in https://github.com/jupyterhub/kubespawner/pull/787, so resource
   allocations are oredered.
- 