### PR TITLE
cloudbank: fix permissions granted via username_pattern

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -53,7 +53,7 @@ jupyterhub:
           - craig.persiko@mail.ccsf.edu
           - efuchs@mail.ccsf.edu
           - amy.mclanahan@mail.ccsf.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@mail\.ccsf\.edu|clare.alice.heimer@gmail.com|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@mail\.ccsf\.edu|clare\.alice\.heimer@gmail\.com|deployment-service-check)$'
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -59,7 +59,7 @@ jupyterhub:
         # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
         # FIXME: This doesn't account for educational institutions that have emails that don't end in .edu,
         # as is the case for some non-euroamerican universities.
-        username_pattern: '^(.+@2i2c\.org|.+\.edu|kalkeab@gmail\.com|jhenryestrada@gmail.com|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+\.edu|kalkeab@gmail\.com|jhenryestrada@gmail\.com|deployment-service-check)$'
   cull:
     # Cull after 30min of inactivity
     every: 300

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -51,4 +51,4 @@ jupyterhub:
           - sean.smorris@berkeley.edu
           - mmckeever@santarosa.edu
           - mjmckeever496@gmail.com
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@santarosa\.edu|mjmckeever496@gmail.com|deployment-service-check)$'
+        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@santarosa\.edu|mjmckeever496@gmail\.com|deployment-service-check)$'


### PR DESCRIPTION
The `username_pattern` config is very sensitive, without this change the CCSF hub could be accessed by another other user crafting a gmail account for the purpose of getting access.

`.` in the pattern is any character, while `\.` is specifically they punctuation mark character, so the key fix here is to ensure that when we mean punctuation marks we specify `\.`