### PR TITLE
Rename UI project to `jupyterhub-fancy-profiles`

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -125,7 +125,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7060.h0593e80c"
+      tag: "0.0.1-0.dev.git.7067.hdae5e902"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -138,12 +138,9 @@ jupyterhub:
           - read:org
 
     extraConfig:
-      enable-prototype-UI: |
-        from kubespawner_dynamic_building_ui import TEMPLATE_PATHS, STATIC_HANDLER_TUPLE
-        c.KubeSpawner.additional_profile_form_template_paths = TEMPLATE_PATHS
-
-        # Add extra handler to serve JS & CSS assets
-        c.JupyterHub.extra_handlers.append(STATIC_HANDLER_TUPLE)
+      enable-fancy-profiles: |
+        from jupyterhub_fancy_profiles import setup_ui
+        setup_ui(c)
 
 binderhub-service:
   nodeSelector:

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -2,6 +2,6 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 # Brings in https://github.com/jupyterhub/kubespawner/pull/787
-git+https://github.com/yuvipanda/kubespawner@46d561d2687b3d6d5ea0dd0e25db42945c886b91
-# Brings in https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui
-git+https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui.git@e7a3b86879ada4065d70343b51453e144ab6cad3
+git+https://github.com/jupyterhub/kubespawner@d60146f5fe9cd31e09acf13c377d9334ecf59c9b
+# Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
+git+https://github.com/yuvipanda/jupyterhub-fancy-profiles@b624031b661f71a278a37bb1fae0b8d6f316d6b3


### PR DESCRIPTION
- `kubespawner-dynamic-imagebuilder-ui` has been renamed to`jupyterhub-fancy-profiles`,
   as that more accurately describes the project. 

Ref https://github.com/2i2c-org/infrastructure/issues/3104
