### PR TITLE
Use main branch of kubespawner with important bugfix

### DIFF
--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -30,7 +30,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.7080.h0da36d1e"
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -125,7 +125,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7067.hdae5e902"
+      tag: "0.0.1-0.dev.git.7080.h0da36d1e"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -39,7 +39,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.7080.h0da36d1e"
       allowNamedServers: true
       config:
         Authenticator:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -34,7 +34,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.7080.h0da36d1e"
       allowNamedServers: true
       config:
         Authenticator:

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -122,7 +122,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.6863.h406a3546"
+        tag: "0.0.1-0.dev.git.7080.h0da36d1e"
       config:
         CILogonOAuthenticator:
           oauth_callback_url: "https://staging.openscapes.2i2c.cloud/hub/oauth_callback"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -526,7 +526,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.6074.h895181eb"
+      tag: "0.0.1-0.dev.git.7080.h0da36d1e"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -2,6 +2,8 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
 # Brings in https://github.com/jupyterhub/kubespawner/pull/787
+# This kubespawner version includes an important bugfix pending 6.1.0 release
+# tracked in https://github.com/jupyterhub/kubespawner/issues/767
 git+https://github.com/jupyterhub/kubespawner@d60146f5fe9cd31e09acf13c377d9334ecf59c9b
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
 git+https://github.com/yuvipanda/jupyterhub-fancy-profiles@b624031b661f71a278a37bb1fae0b8d6f316d6b3

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -1,1 +1,4 @@
+# This kubespawner version includes an important bugfix pending 6.1.0 release
+# tracked in https://github.com/jupyterhub/kubespawner/issues/767
+git+https://github.com/jupyterhub/kubespawner@d60146f5fe9cd31e09acf13c377d9334ecf59c9b
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db

--- a/helm-charts/images/hub/unlisted-choice-requirements.txt
+++ b/helm-charts/images/hub/unlisted-choice-requirements.txt
@@ -1,3 +1,5 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 # Brings on using `unlisted_choice` in profile options per https://github.com/2i2c-org/infrastructure/issues/2146
-git+https://github.com/jupyterhub/kubespawner@8cc569c78bcdb342e694f7344219e43d522f4809
+# This kubespawner version includes an important bugfix pending 6.1.0 release
+# tracked in https://github.com/jupyterhub/kubespawner/issues/767
+git+https://github.com/jupyterhub/kubespawner@d60146f5fe9cd31e09acf13c377d9334ecf59c9b


### PR DESCRIPTION
I think without this merged before we restart any hub pod, we may end up making jupyterhub not realizing that an old user pod was still running - making jupyterhub end up re-starting the user pod and deleting the proxy's route to the user pod.

In other words, its quite critical to not restart our hub pods until this PR is merged.

## Related

- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3229
- https://github.com/jupyterhub/kubespawner/pull/742
- https://github.com/jupyterhub/kubespawner/issues/767

## Empirical feedback

To use the main branch of kubespawner seems to have worked out well in other contexts, I suggest we go for it: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3229#issuecomment-1732637727