### PR TITLE
meom-ige: reduce available options to 32GB only

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -52,21 +52,21 @@ basehub:
             requests:
               display_name: Resource allocation
               choices:
-                mem_8:
-                  display_name: 8 GB RAM, up to 4 CPU
-                  kubespawner_override:
-                    mem_guarantee: 7.593G
-                    mem_limit: 8G
-                    cpu_guarantee: 0.984
-                    cpu_limit: 4
-                mem_16:
-                  default: true
-                  display_name: 16 GB RAM, up to 8 CPU
-                  kubespawner_override:
-                    mem_guarantee: 15.186G
-                    mem_limit: 16G
-                    cpu_guarantee: 1.969
-                    cpu_limit: 8
+                # mem_8:
+                #   display_name: 8 GB RAM, up to 4 CPU
+                #   kubespawner_override:
+                #     mem_guarantee: 7.593G
+                #     mem_limit: 8G
+                #     cpu_guarantee: 0.984
+                #     cpu_limit: 4
+                # mem_16:
+                #   default: true
+                #   display_name: 16 GB RAM, up to 8 CPU
+                #   kubespawner_override:
+                #     mem_guarantee: 15.186G
+                #     mem_limit: 16G
+                #     cpu_guarantee: 1.969
+                #     cpu_limit: 8
                 mem_32:
                   display_name: 32 GB RAM, up to 16 CPU
                   kubespawner_override:
@@ -74,13 +74,13 @@ basehub:
                     mem_limit: 32G
                     cpu_guarantee: 3.938
                     cpu_limit: 16
-                mem_64:
-                  display_name: 64 GB RAM, up to 32 CPU
-                  kubespawner_override:
-                    mem_guarantee: 60.744G
-                    mem_limit: 64G
-                    cpu_guarantee: 7.875
-                    cpu_limit: 32
+                # mem_64:
+                #   display_name: 64 GB RAM, up to 32 CPU
+                #   kubespawner_override:
+                #     mem_guarantee: 60.744G
+                #     mem_limit: 64G
+                #     cpu_guarantee: 7.875
+                #     cpu_limit: 32
           kubespawner_override:
             node_selector:
               node.kubernetes.io/instance-type: n2-highmem-64


### PR DESCRIPTION
Folllowup to https://github.com/2i2c-org/infrastructure/issues/3126#issuecomment-1734095217.