### PR TITLE
Prevent attempts to pull busybox on each startup

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -55,7 +55,7 @@ jupyterhub:
           readOnly: false
     initContainers:
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: buxybox:1.36
         command:
           [
             "sh",

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -37,7 +37,7 @@ jupyterhub:
           readOnly: true
     initContainers:
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: buxybox:1.36
         command:
           [
             "sh",

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -47,7 +47,7 @@ basehub:
         # Need to explicitly set this up and copy what's in basehub/values.yaml
         # as we have an extra 'shared-public' directory here.
         - name: volume-mount-ownership-fix
-          image: busybox
+          image: buxybox:1.36
           command:
             [
               "sh",

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -89,7 +89,7 @@ basehub:
             readOnly: true
       initContainers:
         - name: volume-mount-ownership-fix
-          image: busybox
+          image: buxybox:1.36
           command:
             [
               "sh",

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -102,7 +102,7 @@ basehub:
                       # Need to explicitly fix ownership here, as otherwise these directories will be owned
                       # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
                       - name: volume-mount-ownership-fix
-                        image: busybox
+                        image: buxybox:1.36
                         command:
                           [
                             "sh",
@@ -160,7 +160,7 @@ basehub:
                       # Need to explicitly fix ownership here, as otherwise these directories will be owned
                       # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
                       - name: volume-mount-ownership-fix
-                        image: busybox
+                        image: buxybox:1.36
                         command:
                           [
                             "sh",

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -229,7 +229,7 @@ jupyterhub:
           readOnly: true
     initContainers:
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: buxybox:1.36
         command:
           [
             "sh",

--- a/docs/howto/features/per-user-db.md
+++ b/docs/howto/features/per-user-db.md
@@ -58,7 +58,7 @@ jupyterhub:
       # since initContainers is a list, setting this here overwrites the chowning
       # initContainer we have set in basehub/values.yaml
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: busybox:1.36
         command:
             [
                 "sh",

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -116,7 +116,7 @@ jupyterhub:
           readOnly: true
     initContainers:
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: buxybox:1.36
         command:
           [
             "sh",

--- a/helm-charts/basehub/templates/nfs-share-creator.yaml
+++ b/helm-charts/basehub/templates/nfs-share-creator.yaml
@@ -27,7 +27,7 @@ spec:
 
       containers:
         - name: dummy
-          image: busybox
+          image: busybox:1.36
           env:
             - name: NFS_SHARE_NAME
               value: "{{ .Values.nfs.pv.baseShareName }}{{ .Release.Name }}"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -175,7 +175,7 @@ jupyterhub:
     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
     initContainers:
       - name: volume-mount-ownership-fix
-        image: busybox
+        image: busybox:1.36
         command:
           [
             "sh",


### PR DESCRIPTION
This makes each user server start faster, as kubernetes doesn't try to reach out to the docker registry to check for correct version of the busybox image to pull each time a user server starts.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/3165