### PR TITLE
meom-ige: restore previous profile_list after event

### DIFF
--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -36,59 +36,61 @@ basehub:
         DATA_BUCKET: gs://meom-ige-data
         SCRATCH_BUCKET: "gs://meom-ige-scratch/$(JUPYTERHUB_USER)"
       profileList:
-        # This profile list option was added for the event outlined in
-        # https://github.com/2i2c-org/infrastructure/issues/3126, it is a one
-        # day event taking place september 27th 2023. Access to users in the
-        # temporary group should be removed after the event.
-        - display_name: Grenoble demo
-          default: true
-          allowed_teams:
-            - 2i2c-org:hub-access-for-2i2c-staff
-            - meom-group:hub-users # long term users
-            - demo-dask-grenoble2023:demo # temporary users for event
-          description: Start a server on a machine with 64 CPUs and 512GB of memory
-          slug: demo
-          profile_options:
-            requests:
-              display_name: Resource allocation
-              choices:
-                # mem_8:
-                #   display_name: 8 GB RAM, up to 4 CPU
-                #   kubespawner_override:
-                #     mem_guarantee: 7.593G
-                #     mem_limit: 8G
-                #     cpu_guarantee: 0.984
-                #     cpu_limit: 4
-                # mem_16:
-                #   default: true
-                #   display_name: 16 GB RAM, up to 8 CPU
-                #   kubespawner_override:
-                #     mem_guarantee: 15.186G
-                #     mem_limit: 16G
-                #     cpu_guarantee: 1.969
-                #     cpu_limit: 8
-                mem_32:
-                  display_name: 32 GB RAM, up to 16 CPU
-                  kubespawner_override:
-                    mem_guarantee: 30.372G
-                    mem_limit: 32G
-                    cpu_guarantee: 3.938
-                    cpu_limit: 16
-                # mem_64:
-                #   display_name: 64 GB RAM, up to 32 CPU
-                #   kubespawner_override:
-                #     mem_guarantee: 60.744G
-                #     mem_limit: 64G
-                #     cpu_guarantee: 7.875
-                #     cpu_limit: 32
-          kubespawner_override:
-            node_selector:
-              node.kubernetes.io/instance-type: n2-highmem-64
+        # This profile list option was used for the event outlined in
+        # https://github.com/2i2c-org/infrastructure/issues/3126, it was a one
+        # day event taking place september 27th 2023. Its retained in a comment
+        # to enable a similar event to be prepared for faster in the future.
+        #
+        # - display_name: Grenoble demo
+        #   default: true
+        #   allowed_teams:
+        #     - 2i2c-org:hub-access-for-2i2c-staff
+        #     - meom-group:hub-users # long term users
+        #     - demo-dask-grenoble2023:demo # temporary users for event
+        #   description: Start a server on a machine with 64 CPUs and 512GB of memory
+        #   slug: demo
+        #   profile_options:
+        #     requests:
+        #       display_name: Resource allocation
+        #       choices:
+        #         # mem_8:
+        #         #   display_name: 8 GB RAM, up to 4 CPU
+        #         #   kubespawner_override:
+        #         #     mem_guarantee: 7.593G
+        #         #     mem_limit: 8G
+        #         #     cpu_guarantee: 0.984
+        #         #     cpu_limit: 4
+        #         # mem_16:
+        #         #   default: true
+        #         #   display_name: 16 GB RAM, up to 8 CPU
+        #         #   kubespawner_override:
+        #         #     mem_guarantee: 15.186G
+        #         #     mem_limit: 16G
+        #         #     cpu_guarantee: 1.969
+        #         #     cpu_limit: 8
+        #         mem_32:
+        #           display_name: 32 GB RAM, up to 16 CPU
+        #           kubespawner_override:
+        #             mem_guarantee: 30.372G
+        #             mem_limit: 32G
+        #             cpu_guarantee: 3.938
+        #             cpu_limit: 16
+        #         # mem_64:
+        #         #   display_name: 64 GB RAM, up to 32 CPU
+        #         #   kubespawner_override:
+        #         #     mem_guarantee: 60.744G
+        #         #     mem_limit: 64G
+        #         #     cpu_guarantee: 7.875
+        #         #     cpu_limit: 32
+        #   kubespawner_override:
+        #     node_selector:
+        #       node.kubernetes.io/instance-type: n2-highmem-64
 
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes. They need to be just under total allocatable
         # RAM on a node, not total node capacity
         - display_name: "Small"
+          default: true
           allowed_teams: &allowed_teams_normal_use
             - 2i2c-org:hub-access-for-2i2c-staff
             - meom-group:hub-users # long term users


### PR DESCRIPTION
We are to remove access for a group of users tomorrow Thursday, and I'm also commenting out the profile list entry.

Since this hub doesn't have node sharing yet in the other profile list option, I think its relevant to retain this profile list entry as a comment to make it quicker and easier to setup another event in the future.

### Related
- https://github.com/2i2c-org/infrastructure/issues/3126
- https://2i2c.freshdesk.com/a/tickets/958 and #grenooble