### PR TITLE
Simplify git cloning hub templates

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -526,12 +526,21 @@ jupyterhub:
     initContainers:
       - name: templates-clone
         image: alpine/git:2.40.1
-        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
         args:
-          - clone
-          - --
-          - $(GIT_REPO_URL)
-          - /srv/repo
+          - -c
+          # Remove the existing repo first if it exists, as otherwise we will
+          # error out when the pod restarts. /srv/extra-templates-dir is an
+          # emptyDir volume, so it is *not* cleaned up when the pod restarts -
+          # only when the pod is deleted and cleaned back up.
+          # We also mount the emptyDir in `/srv/extra-templates-dir` but
+          # clone into a *subdirectory*, as the mount itself is owned by
+          # root, and git freaks out when that is the case. By putting
+          # the repo in a sub directory, we avoid the permission problems.
+          - |
+            rm -rf /srv/extra-templates-dir/repo;
+            git clone ${GIT_REPO_URL} /srv/extra-templates-dir/repo
         env:
           - name: GIT_REPO_URL
             valueFrom:
@@ -545,25 +554,11 @@ jupyterhub:
           readOnlyRootFilesystem: True
         volumeMounts:
           - name: custom-templates
-            mountPath: /srv/repo
-      - name: templates-ownership-fix
-        image: alpine/git:2.40.1
-        imagePullPolicy: IfNotPresent
-        command:
-          - /bin/sh
-        args:
-          - -c
-          - ls -lhd /srv/repo && chown 1000:1000 /srv/repo && ls -lhd /srv/repo
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: custom-templates
-            mountPath: /srv/repo
+            mountPath: /srv/extra-templates-dir
     extraContainers:
       - name: templates-sync
         image: alpine/git:2.40.1
-        imagePullPolicy: IfNotPresent
-        workingDir: /srv/repo
+        workingDir: /srv/extra-templates-dir/repo
         command:
           - /bin/sh
         args:
@@ -587,11 +582,11 @@ jupyterhub:
                 # "echo", "sleep", "set +x", or similar commands.
                 set -x;
                 git remote -v;
-                ls -lhd /srv/repo;
+                ls -lhd /srv/extra-templates-dir/repo;
             )
 
             echo "";
-            echo "Syncing local git repo /srv/repo against origin's branch $(GIT_REPO_BRANCH) every 5 minutes...";
+            echo "Syncing local git repo /srv/extra-templates-dir/repo against origin's branch $(GIT_REPO_BRANCH) every 5 minutes...";
             while true; do
                 git fetch origin;
                 git reset --hard origin/$(GIT_REPO_BRANCH);
@@ -615,17 +610,17 @@ jupyterhub:
           readOnlyRootFilesystem: True
         volumeMounts:
           - name: custom-templates
-            mountPath: /srv/repo
+            mountPath: /srv/extra-templates-dir
     extraVolumes:
       - name: custom-templates
         emptyDir: {}
     extraVolumeMounts:
       - mountPath: /usr/local/share/jupyterhub/custom_templates
         name: custom-templates
-        subPath: templates
+        subPath: repo/templates
       - mountPath: /usr/local/share/jupyterhub/static/extra-assets
         name: custom-templates
-        subPath: extra-assets
+        subPath: repo/extra-assets
     services:
       configurator:
         url: http://configurator:10101

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -532,7 +532,7 @@ jupyterhub:
           - -c
           # Remove the existing repo first if it exists, as otherwise we will
           # error out when the pod restarts. /srv/extra-templates-dir is an
-          # emptyDir volume, so it is *not* cleaned up when the pod restarts -
+          # emptyDir volume, so it is *not* cleaned up when the pod's containers restarts -
           # only when the pod is deleted and cleaned back up.
           # We also mount the emptyDir in `/srv/extra-templates-dir` but
           # clone into a *subdirectory*, as the mount itself is owned by


### PR DESCRIPTION
- Git clone into a subdirectory of the `emptyDir` mount, as the mount itself is default owned by root. This was the cause of https://github.com/2i2c-org/infrastructure/issues/1695, which was previously solved by adding another initContainer. This PR removes that, speeding up starts.
- Remove existing directory if it exists before cloning. This prevents the container from failing when the *pod* is restarted due to node issues, as that doesn't clear out `emptyDirs`. And git freaks out if the repo already exists
- Remove redundant `IfNotPresent` imagePullPolicy from alpine/git, as that is not needed when we specify a non :latest tag. Thanks to @consideRatio's investigation in https://github.com/2i2c-org/infrastructure/pull/3165#discussion_r1336351693

Ref https://github.com/2i2c-org/infrastructure/issues/3194