### PR TITLE
Cleanup redudant cluster config that was re-setting default values

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -237,8 +237,3 @@ dask-gateway:
       limits:
         cpu: 2
         memory: 4Gi
-      # TODO: figure out a replacement for userLimits.
-    extraConfig:
-      idle: |
-        # timeout after 30 minutes of inactivity
-        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -337,6 +337,3 @@ dask-gateway:
                 handler=option_handler,
             )
         c.Backend.cluster_options = cluster_options
-      idle: |
-        # timeout after 30 minutes of inactivity
-        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -158,9 +158,3 @@ basehub:
             - roxyboy
             - lesommer
             - auraoupa
-dask-gateway:
-  gateway:
-    extraConfig:
-      idle: |
-        # timeout after 30 minutes of inactivity
-        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -73,9 +73,3 @@ basehub:
           #        configured explicitly.
           #
           allowed_users: *users
-dask-gateway:
-  gateway:
-    extraConfig:
-      idle: |-
-        # timeout after 30 minutes of inactivity
-        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -43,9 +43,6 @@ basehub:
     scheduling:
       userScheduler:
         enabled: true
-      userPods:
-        nodeAffinity:
-          matchNodePurpose: require
     hub:
       allowNamedServers: true
       readinessProbe:


### PR DESCRIPTION
- refactor: cleanup redundant config about dask-gateway idle_timeout
- refactor: cleanup redundant config about matchNodePurpose
