### PR TITLE
support chart, node-exporter: tolerate 2i2c.org/community tainted nodes

### DIFF
--- a/docs/howto/features/dedicated-nodepool.md
+++ b/docs/howto/features/dedicated-nodepool.md
@@ -54,14 +54,14 @@ Some hubs on shared clusters require dedicated nodepools, for a few reasons:
 
    ```yaml
    jupyterhub:
-      singleuser:
-         nodeSelector:
-            2i2c.org/community: <community-name>
-         extraTolerations:
-            - key: "2i2c.org/community"
-              operator: "Equal"
-              value: "<community-name>"
-              effect: "NoSchedule"
+     singleuser:
+       nodeSelector:
+         2i2c.org/community: <community-name>
+       extraTolerations:
+         - key: 2i2c.org/community
+           operator: Equal
+           value: <community-name>
+           effect: NoSchedule
    ```
 
    ```{note}

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -85,21 +85,6 @@ prometheus:
   # values ref: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-node-exporter/values.yaml
   #
   prometheus-node-exporter:
-    tolerations:
-      # Tolerate tainted jupyterhub user nodes
-      - key: hub.jupyter.org_dedicated
-        value: user
-        effect: NoSchedule
-      - key: hub.jupyter.org/dedicated
-        value: user
-        effect: NoSchedule
-      # Tolerate tainted dask worker nodes
-      - key: k8s.dask.org_dedicated
-        value: worker
-        effect: NoSchedule
-      - key: k8s.dask.org/dedicated
-        value: worker
-        effect: NoSchedule
     # resources for the node-exporter was set after inspecting cpu and memory
     # use via prometheus and grafana.
     #


### PR DESCRIPTION
The prometheus-node-exporter chart declares node taint tolerations by default in a way that it allows node-exporter to schedule on nodes with a "NoSchedule" taint, no matter what kind of key/value that goes with the effect of "NoSchedule".

This makes more sense for us than to declare tolerations for all individual taints we may declare, such as 2i2c.org/community.

Without this fix, we end up without node-exporter running on 2i2c.org/community tainted nodes, which in turn makes us unable to get statistics about user pods cpu and memory usage etc for pods on such nodes.