### PR TITLE
2i2c, terraform: transition user nodes & neurohackademy nodes from n1- to n2- nodes

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -80,14 +80,15 @@ jupyterhub:
             choices:
               mem_2_7:
                 display_name: 2.7 GB RAM, upto 3.479 CPUs
-                description: "Use this for the workshop on 2023 September"
+                description: Use this for the workshop on 2023 September
                 kubespawner_override:
                   mem_guarantee: 2904451072
                   mem_limit: 2904451072
                   cpu_guarantee: 0.434875
                   cpu_limit: 3.479
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-highmem-4
+                    # FIXME: guarantee/limits initialized for n1-highmem-4, not n2-
+                    node.kubernetes.io/instance-type: n2-highmem-4
                 default: true
               mem_5_4:
                 display_name: 5.4 GB RAM, upto 3.479 CPUs
@@ -97,7 +98,8 @@ jupyterhub:
                   cpu_guarantee: 0.86975
                   cpu_limit: 3.479
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-highmem-4
+                    # FIXME: guarantee/limits initialized for n1-highmem-4, not n2-
+                    node.kubernetes.io/instance-type: n2-highmem-4
               mem_10_8:
                 display_name: 10.8 GB RAM, upto 3.479 CPUs
                 kubespawner_override:
@@ -106,17 +108,19 @@ jupyterhub:
                   cpu_guarantee: 1.7395
                   cpu_limit: 3.479
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-highmem-4
+                    # FIXME: guarantee/limits initialized for n1-highmem-4, not n2-
+                    node.kubernetes.io/instance-type: n2-highmem-4
               mem_21_6:
                 display_name: 21.6 GB RAM, upto 3.479 CPUs
-                description: "Largest amount of RAM, might take a few minutes to start"
+                description: Largest amount of RAM, might take a few minutes to start
                 kubespawner_override:
                   mem_guarantee: 23235608576
                   mem_limit: 23235608576
                   cpu_guarantee: 3.479
                   cpu_limit: 3.479
                 node_selector:
-                  node.kubernetes.io/instance-type: n1-highmem-4
+                  # FIXME: guarantee/limits initialized for n1-highmem-4, not n2-
+                  node.kubernetes.io/instance-type: n2-highmem-4
   hub:
     services:
       binder:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -46,7 +46,7 @@ jupyterhub:
         effect: "NoSchedule"
     cpu:
       guarantee: 0.5
-      # We're on n1-highmem-16 machines
+      # We're on n2-highmem-16 machines
       limit: 14
     memory:
       guarantee: 4G

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -208,27 +208,23 @@ To enable this access,
     jupyterhub:
       singleuser:
         profileList:
-          - display_name: "Small"
-            description: 5GB RAM, 2 CPUs
+          - display_name: Small
+            description: 1.0 GB RAM
             default: true
             allowed_teams:
               - <org-name>:<team-name>
               - 2i2c-org:hub-access-for-2i2c-staff
             kubespawner_override:
-              mem_limit: 7G
-              mem_guarantee: 4.5G
-              node_selector:
-                node.kubernetes.io/instance-type: n1-standard-2
+              mem_guarantee: 1G
+              mem_limit: 1G
           - display_name: Medium
-            description: 11GB RAM, 4 CPUs
+            description: 4.0 GB RAM
             allowed_teams:
               - <org-name>:<team-name>
               - 2i2c-org:hub-access-for-2i2c-staff
             kubespawner_override:
-              mem_limit: 15G
-              mem_guarantee: 11G
-              node_selector:
-                node.kubernetes.io/instance-type: n1-standard-4
+              mem_guarantee: 4G
+              mem_limit: 4G
     ```
 
     Users who are a part of *any* of the listed teams will be able to access that profile.

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -45,7 +45,7 @@ notebook_nodes = {
     # We expect around 120 users
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-16",
+    machine_type : "n2-highmem-16",
     labels : {
       "2i2c.org/community" : "neurohackademy"
     },

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -22,7 +22,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "n1-highmem-4",
+    machine_type : "n2-highmem-4",
   },
   "climatematch" : {
     min : 0,


### PR DESCRIPTION
I saw that the 2i2c cluster didn't have active users in a node pool using n1-highmem-4, so I took the chance to upgrade it to use n2-highmem-4 instead. I also did this for the neurohackademy nodes.

Use of n2- nodes are motivated in #2923.
