### PR TITLE
daskhub: update to use dask-gateway 2023.9.0

### DIFF
--- a/deployer/deployer.py
+++ b/deployer/deployer.py
@@ -157,7 +157,7 @@ def deploy(
         help="Name of hub to operate deploy. Omit to deploy all hubs on the cluster",
     ),
     dask_gateway_version: str = typer.Option(
-        "2023.1.0", help="Version of dask-gateway to install CRDs for"
+        "2023.9.0", help="Version of dask-gateway to install CRDs for"
     ),
     debug: bool = typer.Option(
         False,

--- a/helm-charts/daskhub/Chart.yaml
+++ b/helm-charts/daskhub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # in the deployer's CLI
     # https://github.com/2i2c-org/infrastructure/blob/HEAD/deployer/deployer.py#L195
   - name: dask-gateway
-    version: "2023.1.0"
+    version: "2023.9.0"
     repository: "https://helm.dask.org/"


### PR DESCRIPTION
dask-gateway 2023.9.0 is released, see the changelog at https://gateway.dask.org/changelog.html. 

We shouldn't be affected by the breaking changes, and the dask-gateway client users may install in the user server images doesn't have to be of the same version as the dask-gateway-server, so they can use a version older that still supports Python 3.7-3.8.