### PR TITLE
nasa-veda: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:F6m+8lmvbz1MBU4J7/uHkWKxnx8=,iv:Y2pPaX+K+oQNVK6u8H4LvLA3phX5ytkmlCdXH7tTsts=,tag:iuhWm+gtWyU8kwXCdMgkJg==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:cxgMvRANqnwrR/xLZhid5dEJj09qGM2eIX/lwUWyCiRbQ4ZvfH5++g==,iv:w8W05bg5PyS3M0Ws3DQDJ6lq+SwAb7E33lahB7Zv6JA=,tag:Dlgv/GvezZfy/S16i5p/uA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:z7EyJ11GJ1H1ZlOAhSQmvfpdDOneVN8=,iv:ZoiS003GUh52qMrWnkkFWyYA2t0Wnh8+6lKDnK7mgEc=,tag:8Lyisxr2H3e6ExbSQdu+dA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:qb+aa28S6XWWiCa9ho7edw4qfiM=,iv:PoRjK2pWvBdxbysD5RmsqL2wb4SmUS9v1Ojw/Dzu1+4=,tag:yvpD46F1qpHkSFP41Er8cQ==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:zcDUqz2Wsw95wUUpPj17noioCF0tvU2/kn0h/b9rMvhH5g1N/fKiIw==,iv:4adnU7Npm09u+RrcD8aFeUAc+Y2XP/sItLaJXFlVF+g=,tag:pyZWn65DP8uIkbhLM79yTQ==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:f2ovvm7GODiz82K9ep/LYsinPa/xwHM=,iv:63J+AzG0uQbxfb7sQaaOL8IB6QFwyg9OFLcpOOwDWoA=,tag:ZRoKKq6PvhtPKSZNv90NZA==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-08-04T03:56:02Z",
-				"enc": "CiUA4OM7eFskpMIr9pMAXINSm2H8iNLDNRwXTGEjgg7v+IgyZo1rEkkAyiwFHEtmMTs4Hcg+lpn3ZX2xddcb37EudGfGLtqo+I0mYqsdB4wuAbL1FstcjGcE5nv/slD+uLUAOwK9WvYmm11YiC42+jmg"
+				"created_at": "2023-10-04T08:15:59Z",
+				"enc": "CiUA4OM7eGA/8w8F0XhHq9EjzEJibgVZl4KEGdc+AW0Mi2suSUciEkkAq2nhVfCw6bdqrLb6tuaTPSirwitMPg8GchYprUVSvAPxBB4blq64I71yuB8A8mwhZsV+oXRslbD2+sz67+HyePQcCTS5ec5M"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-08-04T03:56:03Z",
-		"mac": "ENC[AES256_GCM,data:udi/6EvTjCagNMUDlXZ0GIKMlWaVBDpkoJSpa3JZ+ThK2c4RsZJs5VXlM7narjfnkDGQS9ltPeHvVAscpOdVIKLG1eqOX9JhMZGuA4Pyd866cuQdSqiG6ICXzMh0NC7REYqcQTYjp+nGzFVwqzUzKsQDJwK4KDiKkAkhJtorr1M=,iv:Bgi8jyzFadgfsVAf/vnHumNJ5patvbEirpMGiOaiypo=,tag:y93hjgo39a001I0i5oaXHw==,type:str]",
+		"lastmodified": "2023-10-04T08:15:59Z",
+		"mac": "ENC[AES256_GCM,data:RKt/1FmbrrfbQDJXu/U22iUbY+TLoS3WUlzRboK/uh/w/YKPxusLR6J9pxuPEJ7/ikKUs9oQ73ybO8qYMaYgveU9rx20ljuHchNCvDrDCZwL/hNUFiiZZwqTNH4j3T0163fJZqFJWsU1iNiTYy3LbCTXPpUaNtb/OWyt8tMOURs=,iv:93fZZHa4lYntLKjbbVfWWajmujRmHIYlvkanfRVHwJw=,tag:j4sYc2sDuMNmLcoFNLc+PQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.3"
+		"version": "3.7.2"
 	}
 }


### PR DESCRIPTION
I've regenerated the nasa-veda deployer script credentials using @yuvipanda great summary at https://github.com/2i2c-org/infrastructure/issues/2434