### PR TITLE
nasa-ghg: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:z1xLkTS0J/oYMh0ZVGRs/ua0DFg=,iv:AmPx76htI68uV0Up6W5UK8C1GG+Om3xeKGXKfiOxUpM=,tag:vEorWkH0iHopfhN20ccuwA==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:iHaXdV/p/cvOv15vJO3iHI7exHb925KAK3JmM/cwwFGwYSt5WAauyw==,iv:/2BAVt7T4MtP+7gJpeylHQ/L2dVzn6QQoXQJHRAZL24=,tag:Ec2jW2YNhFRfIUBO+HtfFA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:+QGRtxPxxVi3OhpYNoN7abSySKH3iBI=,iv:D+B/3Y2ws3epgtzDNOHrKL1HLkg8t2cUg1LjBeu8fZQ=,tag:jBQnX/u1sK0mjQQ93UYomw==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:RO5oHd6XJHR7gglQc9bQX5GiNOA=,iv:UhCnTfLfgfAKwxbuf5Qb+ztFriG9jyBs2YfmBN1kNR8=,tag:ZmufjCjL8Xg5h//TDTTdEg==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:50qpWADGewOLKsHTXr8cte0nDUWrsuWUZk9ArtnYgOU5ZQv5vlPV3Q==,iv:gp7KaSukU8110Q0piCtHoTsSnPgjegUEhwjthE88aDI=,tag:ZxKeG2i5QDYRS9HN/Lby+Q==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:jv1sm8OY1G+cN02Rb9dIDi+VK2sk7lU=,iv:ACf/x/BkkiJJcptexVixbJHNC2F2Yq3YZ2wjhS5l8YI=,tag:8k9jsReG7AYGbSMtkCOkxA==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-08-01T04:09:20Z",
-				"enc": "CiUA4OM7eEPg5xK/eAcpC3e6mMJAlrSjo4Nual1xPJq6Wic3ngCREkkAyiwFHBZZPcpY4dqPSLT2PXygtIRiGVktvokfXp0B+g0G1XZ9toL/BV8o/O84afw3VaimydZycw89sZx9kDw2G2LPJ4juTLJN"
+				"created_at": "2023-10-04T09:00:18Z",
+				"enc": "CiUA4OM7eDNwEoj9sW1cHS5uSQm7Q+YMaUEn48/qR6Jz7rIc5kh0EkkAq2nhVSKLV85r8rrHID/f9RLgzjOtV07cdTro/PW68LL+lMPDrljexkTRFoBuQt7g8+22D0SXfxjmc7mgyubmfVSdB527qYSf"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-08-01T04:09:20Z",
-		"mac": "ENC[AES256_GCM,data:zyodwbR9gSZZ+leHLgdQhed15nK5WD6mlfM9PSbzxZp5tZi+NWwkH7Yt+Xp7kp2YbV9bxowy0KNF+yhbHif8B/BUYxvhwWJOD3F9Xj9xU8tcK+yFC3a5KfwtQR/Sfxls2gkBqM2VmjrSeepzyZQ6YqOQl54aOaSjJkp+m4/68Hg=,iv:AWoZTJBIMKCJPou4GM+dkNvNBpazm/Hmy5rqVx85w+w=,tag:uLFRb3VY/Q+PWLi+0BMm1Q==,type:str]",
+		"lastmodified": "2023-10-04T09:00:19Z",
+		"mac": "ENC[AES256_GCM,data:Eexw+Z4H9zLAJZ//C1hgdu8pG/QpSmUDQwu9sz+C0eoDsxPh0tRQGdV884DFNzMkaM+DbEHJfdP0J1ZsH8OG6iYdeYojpkss+1IIaa5TpfTTRmlILH+0rcbKEAaQp+r4uIHYJypM2KkZSOFT1mnScmjOUg9+5pVFCDxc58A8QZY=,iv:YJek86/pB5mADUXeo/GQuajlT9vPjJ6B9WQMsIUy3PY=,tag:f0eSvRqgHZoWuJSFL25uSw==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.3"
+		"version": "3.7.2"
 	}
 }


### PR DESCRIPTION
I've regenerated the nasa-ghg deployer script credentials using @yuvipanda great summary at https://github.com/2i2c-org/infrastructure/issues/2434