### PR TITLE
Give everyone on the VEDA hub access to imagebuilding-demo

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -136,6 +136,10 @@ jupyterhub:
         allowed_organizations:
           - 2i2c-org:hub-access-for-2i2c-staff
           - 2i2c-imagebuilding-hub-access
+          - veda-analytics-access:all-users
+          - veda-analytics-access:collaborator-access
+          - 2i2c-org:hub-access-for-2i2c-staff
+          - CYGNSS-VEDA:cygnss-iwg
         scope:
           - read:org
 


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/issues/3167