### PR TITLE
cloudbank: revision of auth config

### DIFF
--- a/config/clusters/cloudbank/bcc.values.yaml
+++ b/config/clusters/cloudbank/bcc.values.yaml
@@ -39,7 +39,8 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains: ["2i2c.org", "berkeley.edu", "peralta.edu"]
+            allowed_domains:
+              - peralta.edu
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - mail.ccsf.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         allowed_users:
           - clare.alice.heimer@gmail.com

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -39,14 +39,14 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
+            allowed_domains:
+              - mail.ccsf.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
       Authenticator:
+        allowed_users:
+          - clare.alice.heimer@gmail.com
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
@@ -54,7 +54,6 @@ jupyterhub:
           - craig.persiko@mail.ccsf.edu
           - efuchs@mail.ccsf.edu
           - amy.mclanahan@mail.ccsf.edu
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@mail\.ccsf\.edu|clare\.alice\.heimer@gmail\.com|deployment-service-check)$'
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -36,9 +36,6 @@ jupyterhub:
             allowed_domains:
               - my.smccd.edu
               - smccd.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -34,14 +34,11 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "my.smccd.edu"
-              - "smccd.edu"
+              - my.smccd.edu
+              - smccd.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -39,7 +39,8 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains: ["2i2c.org", "berkeley.edu", "csulb.edu"]
+            allowed_domains:
+              - csulb.edu
           https://its-shib.its.csulb.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
@@ -47,7 +48,6 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -36,18 +36,15 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://csulb.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
+          https://its-shib.its.csulb.edu/idp/shibboleth:
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains:
               - csulb.edu
-          https://its-shib.its.csulb.edu/idp/shibboleth:
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/csum.values.yaml
+++ b/config/clusters/cloudbank/csum.values.yaml
@@ -53,6 +53,7 @@ jupyterhub:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - jteoh@csum.edu
+          - jsimons@csum.edu
     extraFiles:
       configurator-schema-default:
         data:

--- a/config/clusters/cloudbank/csum.values.yaml
+++ b/config/clusters/cloudbank/csum.values.yaml
@@ -39,7 +39,6 @@ jupyterhub:
           https://cma-shibboleth.csum.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
             allow_all: true
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:
@@ -49,8 +48,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -42,21 +42,17 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization for this hub because
-            # username_pattern configured and enforced also, allowing only users
-            # with *.edu suffixed domains besides specific admin users.
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - kalkeab@gmail.com
           - jhenryestrada@gmail.com
-        # We only want 2i2c users and users with .edu emails to sign up
-        # Protects against cryptominers - https://github.com/2i2c-org/infrastructure/issues/1216
-        # FIXME: This doesn't account for educational institutions that have emails that don't end in .edu,
-        # as is the case for some non-euroamerican universities.
-        username_pattern: '^(.+@2i2c\.org|.+\.edu|kalkeab@gmail\.com|jhenryestrada@gmail\.com|deployment-service-check)$'
+        # NOTE: This demo hub may be temporarily opened up for broad access by
+        #       declaring `allow_all: true` for the google idp. If that is done,
+        #       username_pattern can then be used to constrain access.
+        #
+        # username_pattern: '^(.+@2i2c\.org|.+\.edu|kalkeab@gmail\.com|jhenryestrada@gmail\.com|deployment-service-check)$'
   cull:
     # Cull after 30min of inactivity
     every: 300

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -42,13 +42,13 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
+            # allow_all is a partial authorization, username_pattern is enforced
+            # also to allow a subset of users, specifically *.edu suffixed
+            # domains in this case
             allow_all: true
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -42,15 +42,11 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced
-            # also to allow a subset of users, specifically *.edu suffixed
-            # domains in this case
+            # allow_all is a partial authorization for this hub because
+            # username_pattern configured and enforced also, allowing only users
+            # with *.edu suffixed domains besides specific admin users.
             allow_all: true
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
-        # These folks should still have admin tho
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -34,19 +34,16 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - dvc.edu
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:
               username_claim: "email"
             allowed_domains:
               - dvc.edu
-          urn:mace:incommon:berkeley.edu:
+          http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
+            allowed_domains:
+              - dvc.edu
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -37,16 +37,16 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains: ["2i2c.org", "berkeley.edu", "dvc.edu"]
+            allowed_domains:
+              - dvc.edu
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "dvc.edu"
+              - dvc.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       JupyterHub:
         authenticator_class: cilogon
       Authenticator:

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -40,9 +40,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - elcamino.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -38,11 +38,11 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains: ["2i2c.org", "berkeley.edu", "elcamino.edu"]
+            allowed_domains:
+              - elcamino.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/evc.values.yaml
+++ b/config/clusters/cloudbank/evc.values.yaml
@@ -47,9 +47,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/evc.values.yaml
+++ b/config/clusters/cloudbank/evc.values.yaml
@@ -40,20 +40,16 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "sjcc.edu"
-              - "stu.sjcc.edu"
-              - "stu.evc.edu"
-              - "evc.edu"
+              - sjcc.edu
+              - stu.sjcc.edu
+              - stu.evc.edu
+              - evc.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -37,9 +37,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - joellen.green@fresnocitycollege.edu

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -37,12 +37,9 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - joellen.green@fresnocitycollege.edu

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -36,9 +36,6 @@ jupyterhub:
             allowed_domains:
               - glendale.edu
               - student.glendale.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - simon@glendale.edu

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -34,14 +34,11 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "glendale.edu"
-              - "student.glendale.edu"
+              - glendale.edu
+              - student.glendale.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - simon@glendale.edu

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -33,9 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -43,9 +43,7 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "humboldt.edu"
+              - humboldt.edu
           https://sso.humboldt.edu/idp/metadata:
             username_derivation:
               username_claim: "email"
@@ -53,7 +51,6 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         # These folks should still have admin tho
         admin_users:

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -39,20 +39,16 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
+          https://sso.humboldt.edu/idp/metadata:
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
             allowed_domains:
               - humboldt.edu
-          https://sso.humboldt.edu/idp/metadata:
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
-        # These folks should still have admin tho
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -33,9 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -34,17 +34,14 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "cc.peralta.edu"
-              - "peralta.edu"
+              - cc.peralta.edu
+              - peralta.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -39,9 +39,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - mills.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - aculich@berkeley.edu

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -34,13 +34,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "mills.edu"
+              - mills.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - aculich@berkeley.edu

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains: ["2i2c.org"]
           https://miracosta.fedgw.com/gateway:
             username_derivation:
               username_claim: "email"
@@ -41,7 +40,6 @@ jupyterhub:
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - sfirouzian@miracosta.edu

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -30,14 +30,11 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
           https://miracosta.fedgw.com/gateway:
             username_derivation:
               username_claim: "email"
             allow_all: true
-          urn:mace:incommon:berkeley.edu:
+          http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -42,9 +42,6 @@ jupyterhub:
             allowed_domains:
               - missioncollege.edu
               - mywvm.wvm.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -40,14 +40,11 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "missioncollege.edu"
-              - "mywvm.wvm.edu"
+              - missioncollege.edu
+              - mywvm.wvm.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -34,18 +34,14 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "norcocollege.edu"
-              - "student.rccd.edu"
+              - norcocollege.edu
+              - student.rccd.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -39,9 +39,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -33,9 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - go.pasadena.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - yxchang@go.pasadena.edu

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -40,13 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "go.pasadena.edu"
+              - go.pasadena.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - yxchang@go.pasadena.edu

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -40,14 +40,11 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "scc.losrios.edu"
-              - "apps.losrios.edu"
+              - scc.losrios.edu
+              - apps.losrios.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -42,9 +42,6 @@ jupyterhub:
             allowed_domains:
               - scc.losrios.edu
               - apps.losrios.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - saddleback.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -40,13 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
-              - "saddleback.edu"
+              - saddleback.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -46,9 +46,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -40,19 +40,15 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "sccollege.edu"
-              - "student.sccollege.edu"
-              - "student.sac.edu"
+              - sccollege.edu
+              - student.sccollege.edu
+              - student.sac.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -30,13 +30,10 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc-dev.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
           https://idp.sbcc.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
+          http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -30,13 +30,10 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: "https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
           https://idp.sbcc.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
+          http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - christiaan.desmond@sjcc.edu

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -34,20 +34,16 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "sjcc.edu"
-              - "stu.sjcc.edu"
-              - "stu.evc.edu"
-              - "evc.edu"
+              - sjcc.edu
+              - stu.sjcc.edu
+              - stu.evc.edu
+              - evc.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
-              - "berkeley.edu"
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - christiaan.desmond@sjcc.edu

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -39,19 +39,16 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://sjsu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
           https://idp01.sjsu.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
             allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+          urn:mace:incommon:berkeley.edu:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -46,9 +46,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - my.smccd.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -40,12 +40,10 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "my.smccd.edu"
+              - my.smccd.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -39,17 +39,14 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
+            allowed_domains:
+              - santarosa.edu
           urn:mace:incommon:berkeley.edu:
             username_derivation:
               username_claim: "email"
-            # allow_all is a partial authorization, username_pattern is enforced also
-            allow_all: true
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - mmckeever@santarosa.edu
           - mjmckeever496@gmail.com
-        username_pattern: '^(.+@2i2c\.org|.+@berkeley\.edu|.+@santarosa\.edu|mjmckeever496@gmail\.com|deployment-service-check)$'

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
               username_claim: "email"
             allowed_domains:
               - santarosa.edu
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       Authenticator:
         admin_users:
           - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -33,9 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -33,9 +33,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-          urn:mace:incommon:berkeley.edu:
-            username_derivation:
-              username_claim: "email"
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as


### PR DESCRIPTION
This PR updates cloudbank cluster's hubs configuration of CILogonOAuthenticator, and various changes made here should also be made in other hubs in other clusters but this PR is scoped for cloudbank specifically for now.

## PR changes

### Now authorized _either by_ ...

With oauthenticator v16, a user can be authorized by different config and doesn't have to be authorized by all config. For example, `allowed_domains` previously rejected admin users signing in if it was configured, but in oauthenticator v16 you can be authorized by being part of either `allowed_domains` or `admin_users`.

### berkeley.edu and 2i2c.org users access reduced

Previously any user with a berkeley.edu email or 2i2c.org email was granted access by many hubs configurations via `allowed_domains`. This is now tightened to only allow specific berkeley.edu usernames and 2i2c.org usernames.

### Berkeley idp removed, Google idp is sufficient

Both berkeley and google has been configured as identity providers, where the berkeley idp was meant to provide access for admin users at berkeley and google idp was meant to provide access for admin users at 2i2c. Since the admin users of berkeley have google accounts as well, we can rely soley on the google idp instead to grant access to all admins.

To reduce the complexity of auth config and help us avoid granting more access than wanted, the berkeley idp is removed entirely.

### csum open access tightened

I saw that the csum hub was configured to grant access to all google users, this access is now reduced. This resolves the comment in https://github.com/2i2c-org/infrastructure/pull/3231#pullrequestreview-1659245312.

### Reordered entries allowed_idps entries

I moved the user relevant idp to the top, and the admin relevant idp to the bottom. This was done for consistency and in preparation for a future improvement about pre-selecting a choice in a CILogon dropdown list. This needs https://github.com/jupyterhub/oauthenticator/issues/690 to be resolved first though.

## Related

- Fixes #3196
- Followup to #3144