### PR TITLE
Grant access for 2i2c members only via admin_users

### DIFF
--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -37,7 +37,6 @@ basehub:
           authenticator_class: "github"
         GitHubOAuthenticator:
           oauth_callback_url: "https://dask-staging.aws.2i2c.cloud/hub/oauth_callback"
-          allowed_organizations:
-            - 2i2c-org
+          allowed_organizations: []
           scope:
             - read:org

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -37,6 +37,3 @@ basehub:
           authenticator_class: "github"
         GitHubOAuthenticator:
           oauth_callback_url: "https://dask-staging.aws.2i2c.cloud/hub/oauth_callback"
-          allowed_organizations: []
-          scope:
-            - read:org

--- a/config/clusters/2i2c-aws-us/go-bgc.values.yaml
+++ b/config/clusters/2i2c-aws-us/go-bgc.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://go-bgc.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - go-bgc
         scope:
           - read:org

--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://itcoocean.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - Hackweek-ITCOocean:itcoocean-hackweek-2023
         scope:
           - read:org

--- a/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
+++ b/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
@@ -34,7 +34,6 @@ basehub:
         GitHubOAuthenticator:
           oauth_callback_url: https://ncar-cisl.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
-            - 2i2c-org
             - NCAR:2i2c-cloud-users
           scope:
             - read:org

--- a/config/clusters/2i2c-aws-us/researchdelight.values.yaml
+++ b/config/clusters/2i2c-aws-us/researchdelight.values.yaml
@@ -37,7 +37,6 @@ basehub:
         GitHubOAuthenticator:
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - 2i2c-org:research-delight-team
           scope:
             - read:org

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -32,6 +32,3 @@ jupyterhub:
         authenticator_class: "github"
       GitHubOAuthenticator:
         oauth_callback_url: "https://staging.aws.2i2c.cloud/hub/oauth_callback"
-        allowed_organizations: []
-        scope:
-          - read:org

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -32,7 +32,6 @@ jupyterhub:
         authenticator_class: "github"
       GitHubOAuthenticator:
         oauth_callback_url: "https://staging.aws.2i2c.cloud/hub/oauth_callback"
-        allowed_organizations:
-          - 2i2c-org
+        allowed_organizations: []
         scope:
           - read:org

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -52,7 +52,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: "https://ds.lis.2i2c.cloud/hub/oauth_callback"
         allowed_organizations:
-          - 2i2c-org
           - lisacuk
         scope:
           - read:org

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -43,5 +43,3 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"

--- a/config/clusters/2i2c/binder-staging.values.yaml
+++ b/config/clusters/2i2c/binder-staging.values.yaml
@@ -76,17 +76,14 @@ binderhub:
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"
-              allowed_domains:
-                - "2i2c.org"
         Authenticator:
           admin_users:
             - choldgraf@2i2c.org
             - colliand@2i2c.org
-            - erik@2i2c.org
             - damianavila@2i2c.org
+            - erik@2i2c.org
             - georgianaelena@2i2c.org
             - jmunroe@2i2c.org
-            - pnasrat@2i2c.org
             - sgibson@2i2c.org
             - yuvipanda@2i2c.org
     singleuser:

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -97,7 +97,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://climatematch.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org
           - ClimateMatchAcademy:2023students
         scope:
           - read:org

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -49,5 +49,3 @@ basehub:
             http://google.com/accounts/o8/id:
               username_derivation:
                 username_claim: "email"
-              allowed_domains:
-                - "2i2c.org"

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -41,5 +41,4 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "rmbl.org"
+              - rmbl.org

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -138,11 +138,9 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://imagebuilding-demo.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - 2i2c-imagebuilding-hub-access
           - veda-analytics-access:all-users
           - veda-analytics-access:collaborator-access
-          - 2i2c-org:hub-access-for-2i2c-staff
           - CYGNSS-VEDA:cygnss-iwg
         scope:
           - read:org

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -36,18 +36,16 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: "https://mtu.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
-          # Allow 2i2c staff to login with Google
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
           # Allow MTU to login via Shibboleth
           https://sso.mtu.edu/idp/shibboleth:
             username_derivation:
               username_claim: "email"
             allowed_domains:
               - "mtu.edu"
+          # Allow 2i2c staff to login with Google accounts
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - "dbkc@mtu.edu"

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -89,7 +89,6 @@ basehub:
         GitHubOAuthenticator:
           oauth_callback_url: https://oceanhackweek.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - oceanhackweek:ohw23-organizers
             - oceanhackweek:ohw23-participants-australia
             - oceanhackweek:ohw23-participants-seattle

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -60,5 +60,3 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -57,8 +57,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
       Authenticator:
         admin_users:
           - jmsmith1@temple.edu

--- a/config/clusters/2i2c/ucmerced-common.values.yaml
+++ b/config/clusters/2i2c/ucmerced-common.values.yaml
@@ -31,8 +31,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
-            allowed_domains:
-              - "2i2c.org"
       Authenticator:
         admin_users:
           - schadalapaka@ucmerced.edu

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -35,7 +35,6 @@ basehub:
           authenticator_class: github
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org
             - alabamawaterinstitute
             - NOAA-OWP
           scope:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -19,6 +19,9 @@ jupyterhub:
       enabled: true
   custom:
     2i2c:
+      # add_staff_user_ids_to_admin_users is disabled because the usernames
+      # aren't github id or email based, individual 2i2c members have added
+      # their user to admin_users manually instead.
       add_staff_user_ids_to_admin_users: false
       # add_staff_user_ids_of_type: "google"
     homepage:

--- a/config/clusters/catalystproject-africa/staging.values.yaml
+++ b/config/clusters/catalystproject-africa/staging.values.yaml
@@ -30,7 +30,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.af.catalystproject.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - czi-catalystproject
         scope:
           - read:org

--- a/config/clusters/catalystproject-latam/staging.values.yaml
+++ b/config/clusters/catalystproject-latam/staging.values.yaml
@@ -30,7 +30,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.latam.catalystproject.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - czi-catalystproject
         scope:
           - read:org

--- a/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
+++ b/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
@@ -34,10 +34,9 @@ jupyterhub:
             username_derivation:
               username_claim: "email"
             allowed_domains:
-              - "2i2c.org"
-              - "unc.edu.ar"
-              - "mi.unc.edu.ar"
-              - "famaf.unc.edu.ar"
+              - unc.edu.ar
+              - mi.unc.edu.ar
+              - famaf.unc.edu.ar
       Authenticator:
         admin_users:
           - aquevedo@unc.edu.ar

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -65,7 +65,6 @@ basehub:
           allowed_organizations:
             - leap-stc:leap-pangeo-base-access
             - leap-stc:leap-pangeo-full-access
-            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
         Authenticator:

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -35,7 +35,6 @@ basehub:
           authenticator_class: github
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org
             - LinkedEarth
           scope:
             - read:org

--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -44,7 +44,6 @@ basehub:
         GitHubOAuthenticator:
           allowed_organizations:
             - m2lines
-            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
         Authenticator:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -92,7 +92,6 @@ basehub:
         - display_name: "Small"
           default: true
           allowed_teams: &allowed_teams_normal_use
-            - 2i2c-org:hub-access-for-2i2c-staff
             - meom-group:hub-users # long term users
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
@@ -147,7 +146,6 @@ basehub:
         GitHubOAuthenticator:
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - meom-group:hub-users # long term users
             - demo-dask-grenoble2023:demo # temporary users for event
           scope:

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -92,6 +92,7 @@ basehub:
         - display_name: "Small"
           default: true
           allowed_teams: &allowed_teams_normal_use
+            - 2i2c-org:hub-access-for-2i2c-staff
             - meom-group:hub-users # long term users
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -44,7 +44,6 @@ basehub:
           # so need to populate the teams in the auth state
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:cryoclouduser
             - CryoInTheCloud:cryocloudadvanced
           scope:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -38,7 +38,6 @@ basehub:
           authenticator_class: github
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - US-GHG-Center:ghgc-hub-access
           scope:
             - read:org

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -43,7 +43,6 @@ basehub:
           allowed_organizations:
             - veda-analytics-access:all-users
             - veda-analytics-access:collaborator-access
-            - 2i2c-org:hub-access-for-2i2c-staff
             - CYGNSS-VEDA:cygnss-iwg
           scope:
             - read:org

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -43,7 +43,6 @@ basehub:
         GitHubOAuthenticator:
           allowed_organizations:
             - pangeo-data:us-central1-b-gcp
-            - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
         Authenticator:

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -40,7 +40,6 @@ jupyterhub:
         authenticator_class: github
       GitHubOAuthenticator:
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - QuantifiedCarbon:jupyterhub
         scope:
           - read:org

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -39,8 +39,7 @@ basehub:
           authenticator_class: github
         GitHubOAuthenticator:
           populate_teams_in_auth_state: true
-          allowed_organizations: &allowed_github_orgs
-            - 2i2c-org
+          allowed_organizations:
             - smithsonian
             - sidatasciencelab
             - Smithsonian-SDCH
@@ -76,7 +75,6 @@ basehub:
           description: &profile_list_description "Start a container with at least a chosen share of capacity on a node of this type"
           slug: small
           default: true
-          allowed_teams: *allowed_github_orgs
           profile_options:
             image: &profile_options_image
               display_name: Image

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -47,8 +47,6 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: email
-            allowed_domains:
-              - 2i2c.org
       Authenticator:
         admin_users:
           - ckrzysik # Technical representative, Charles Krzysik

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -38,7 +38,6 @@ basehub:
           authenticator_class: github
         GitHubOAuthenticator:
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - VICTOR-Community:victoraccess
           scope:
             - read:org

--- a/docs/hub-deployment-guide/configure-auth/cilogon.md
+++ b/docs/hub-deployment-guide/configure-auth/cilogon.md
@@ -60,27 +60,30 @@ To get the value of the key that must go in the `allowed_idp` dict for a specifi
 
 ```yaml
 jupyterhub:
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: google
   hub:
     config:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
         oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
-        # Google and ANU's are configured as the hubs identity providers (idps)
         allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              # Use the email as the hub username
-              username_claim: "email"
-            # Authorize any user with a @2i2c.org email in this idp
-            allowed_domains:
-              - "2i2c.org"
+          # Community specific idp - enables community members to authenticate.
+          # In this example, all authenticated users are authorized via the idp
+          # specific allow_all config.
           https://idp2.anu.edu.au/idp/shibboleth:
             username_derivation:
-              # Use the email as the hub username
-              username_claim: "email"
-            # Authorize all users in this idp
-            allow_all: true
+              username_claim: email
+            allow_all: true # authorize all users authenticated by the idp
+          # Google (or GitHub) idp - enables 2i2c admin users to authenticate.
+          # The basehub chart config "custom.2i2c.add_staff_user_ids..." expands
+          # admin_users to authorize specific 2i2c staff members.
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: email
       Authenticator:
         admin_users:
           - admin@anu.edu.au

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -73,6 +73,10 @@ You can remove yourself from the org once you have confirmed that login is worki
 
     ```yaml
     jupyterhub:
+      custom:
+        2i2c:
+          add_staff_user_ids_to_admin_users: true
+          add_staff_user_ids_of_type: github
       hub:
         config:
           JupyterHub:
@@ -80,7 +84,6 @@ You can remove yourself from the org once you have confirmed that login is worki
           GitHubOAuthenticator:
             oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
             allowed_organizations:
-              - 2i2c-org
               - ORG_NAME
             scope:
               - read:user
@@ -90,6 +93,10 @@ You can remove yourself from the org once you have confirmed that login is worki
 
     ```yaml
     jupyterhub:
+      custom:
+        2i2c:
+          add_staff_user_ids_to_admin_users: true
+          add_staff_user_ids_of_type: github
       hub:
         config:
           JupyterHub:

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -97,7 +97,6 @@ You can remove yourself from the org once you have confirmed that login is worki
           GitHubOAuthenticator:
             oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
             allowed_organizations:
-              - 2i2c-org:hub-access-for-2i2c-staff
               - ORG_NAME:TEAM_NAME
             scope:
               - read:org
@@ -220,6 +219,7 @@ To enable this access,
               mem_limit: 4G
     ```
 
-    Users who are a part of *any* of the listed teams will be able to access that profile.
-    Add `2i2c-org:teach-team` to all `allowed_teams` so 2i2c engineers can log in to debug
-    issues. If `allowed_teams` is not set, that profile is not available to anyone.
+    Users who are a part of *any* of the listed teams will be able to access
+    that profile. Add `2i2c-org:hub-access-for-2i2c-staff` to all
+    `allowed_teams` so 2i2c engineers can log in to debug issues. If
+    `allowed_teams` is not set, that profile is not available to anyone.

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -93,8 +93,8 @@ jupyterhub:
       staff_google_ids:
         - choldgraf@2i2c.org
         - colliand@2i2c.org
-        - erik@2i2c.org
         - damianavila@2i2c.org
+        - erik@2i2c.org
         - georgianaelena@2i2c.org
         - jmunroe@2i2c.org
         - sgibson@2i2c.org


### PR DESCRIPTION
With oauthenticator 16, being listed in `admin_users` makes 2i2c members have access even if they are now listed in `allowed_domains` or `allowed_organizations`. Due to this, we can avoid the need to declare `2i2c.org` and `2i2c-org` there and rely on being listed in `admin_users`.

I've provided a few comments, one per kind of change made.

## Related

- This is done for cloudbank cluster's hub in #3232
- #3144 