### PR TITLE
openscapes: Mount homedir for rocker profile under /home/rstudio

### DIFF
--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -89,6 +89,20 @@ basehub:
           description: R (with RStudio) + Python environment
           kubespawner_override:
             image: openscapes/rocker:a7596b5
+            # Ensures container working dir is homedir
+            # https://github.com/2i2c-org/infrastructure/issues/2559
+            working_dir: /home/rstudio
+            # Because this is a list, it will override our default volume mounts
+            volume_mounts:
+              # Mount the user home directory
+              - name: home
+                mountPath: /home/rstudio
+                subPath: "{username}"
+              # Mount the shared readonly directory
+              - name: home
+                mountPath: /home/rstudio/shared
+                subPath: _shared
+                readOnly: true
           profile_options: *profile_options
         - display_name: Matlab
           description: Matlab environment

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -110,6 +110,21 @@ basehub:
                   default: true
                   kubespawner_override:
                     image: openscapes/rocker:a7596b5
+                    # Ensures container working dir is homedir
+                    # https://github.com/2i2c-org/infrastructure/issues/2559
+                    working_dir: /home/rstudio
+                    # Because this is a list, it will override our default volume mounts
+                    volume_mounts:
+                      # Mount the user home directory
+                      - name: home
+                        mountPath: /home/rstudio
+                        subPath: "{username}"
+                      # Mount the shared readonly directory
+                      - name: home
+                        mountPath: /home/rstudio/shared
+                        subPath: _shared
+                        readOnly: true
+
             requests: *requests_profile_options
         - display_name: Matlab
           description: Matlab environment


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3242