### PR TITLE
nox: add docstring about nox and list command how to use it

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,14 @@
+"""
+noxfile.py is a configuration file for the command-line tool nox that automates
+tasks in multiple Python environments. We use it to setup an environment to
+build our documentation.
+
+Config reference: https://nox.thea.codes/en/stable/config.html#noxfile
+
+Common tasks:
+- Install nox:                        pip install nox
+- Start a live reloading docs server: nox -- live
+"""
 import nox
 
 nox.options.reuse_existing_virtualenvs = True


### PR DESCRIPTION
I think its a great practice to ensure that various things in a github repo is somewhat self-explanatory as that helps anyone trying to onboard do it more efficiently. I didn't know how to use `nox` myself before doing this, and at one point I didn't know for what reason this file was around or how it was related to a repo I found it in.

A docstring like this can resolve such issues for us!

- Closes #1000