### PR TITLE
Add jackeddy hub

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -128,3 +128,13 @@ hubs:
       - basehub-common.values.yaml
       - mtu.values.yaml
       - enc-mtu.secret.values.yaml
+  - name: jackeddy
+    display_name: "Jack Eddy Symposium"
+    domain: jackeddy.2i2c.cloud
+    helm_chart: daskhub
+    auth0:
+      enabled: false
+    helm_chart_values_files:
+      - daskhub-common.values.yaml
+      - jackeddy.values.yaml
+      - enc-jackeddy.secret.values.yaml

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -132,8 +132,6 @@ hubs:
     display_name: "Jack Eddy Symposium"
     domain: jackeddy.2i2c.cloud
     helm_chart: daskhub
-    auth0:
-      enabled: false
     helm_chart_values_files:
       - daskhub-common.values.yaml
       - jackeddy.values.yaml

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -15,6 +15,13 @@ basehub:
         replicas: 0
       userScheduler:
         enabled: false
+    ingress:
+      hosts:
+        - jackeddy.2i2c.cloud
+      tls:
+        - secretName: https-auto-tls
+          hosts:
+            - jackeddy.2i2c.cloud
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -160,11 +160,6 @@ basehub:
       image:
         name: quay.io/2i2c/unlisted-choice-experiment
         tag: "0.0.1-0.dev.git.7130.h0bdc2d30"
-      networkPolicy:
-        # FIXME: For dask gateway
-        enabled: false
-      readinessProbe:
-        enabled: false
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -1,0 +1,184 @@
+basehub:
+  userServiceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: pilot-hubs-jackeddy@two-eye-two-see.iam.gserviceaccount.com
+  jupyterhub:
+    # https://infrastructure.2i2c.org/howto/features/ephemeral/#pre-pulled-images
+    prePuller:
+      continuous:
+        enabled: true
+    # FIXME: document this feature
+    scheduling:
+      userPlaceholder:
+        # Needed for continuous prePuller to work
+        enabled: true
+        replicas: 0
+      userScheduler:
+        enabled: false
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: true
+        add_staff_user_ids_of_type: "github"
+      homepage:
+        templateVars:
+          org:
+            name: Jack Eddy Symposium
+            url: https://cpaess.ucar.edu/meetings/4th-eddy-cross-disciplinary-symposium
+            logo_url: https://cpaess.ucar.edu/sites/default/files/styles/extra_large/public/2023-08/EddySymposium-900x400.jpg?itok=8qG7Dqi3
+          designed_by:
+            name: 2i2c
+            url: https://2i2c.org
+          operated_by:
+            name: 2i2c
+            url: https://2i2c.org
+          funded_by:
+            name: ""
+            url: ""
+            # FIXME: document this feature https://github.com/2i2c-org/default-hub-homepage/pull/25
+            custom_html: <a href="https://science.nasa.gov/heliophysics/programs/living-with-a-star/">NASA's Living with a Star program</a> and <a href="https://cpaess.ucar.edu/">UCAR/CPAESS</a>
+    singleuser:
+      extraFiles:
+        # FIXME: document this feature
+        # Currently only documented in the context of culling https://infrastructure.2i2c.org/sre-guide/manage-k8s/culling/#kernel-culling-configuration
+        jupyter_notebook_config.json:
+          data:
+            # Allow jupyterlab option to show hidden files in browser
+            ContentsManager:
+              allow_hidden: true
+      profileList:
+        requests:
+          #     Configuration setup based on https://github.com/2i2c-org/infrastructure/issues/2121.
+          #     Allocate resources from a n2-highmem-16 node, instead of a
+          #     n2-highmem-4 node to help reduce startup times.
+          #     Based on past usages of this hub, it is highly possible it will use notable
+          #     amounts of RAM.
+          #     The choice of this node, will avoid putting only two users requesting ~16 GB on
+          #     a ~32 GB node (if we went with a n2-highmem-4) and will instead allow for
+          #     at least eight users to fit per node on a n2-highmem-16 machine.
+          #     ref: https://github.com/2i2c-org/infrastructure/issues/3166#issuecomment-1755630637
+          display_name: Resource Allocation
+          choices:
+            mem_1_9:
+              display_name: 1.9 GB RAM, upto 3.75 CPUs
+              description: Fastest spinup time
+              kubespawner_override:
+                mem_guarantee: 1992701952
+                mem_limit: 1992701952
+                cpu_guarantee: 0.234375
+                cpu_limit: 3.75
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+              default: true
+            mem_3_7:
+              display_name: 3.7 GB RAM, upto 3.75 CPUs
+              kubespawner_override:
+                mem_guarantee: 3985403904
+                mem_limit: 3985403904
+                cpu_guarantee: 0.46875
+                cpu_limit: 3.75
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+            mem_7_4:
+              display_name: 7.4 GB RAM, upto 3.75 CPUs
+              kubespawner_override:
+                mem_guarantee: 7970807808
+                mem_limit: 7970807808
+                cpu_guarantee: 0.9375
+                cpu_limit: 3.75
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+            mem_14_8:
+              display_name: 14.8 GB RAM, upto 3.75 CPUs
+              kubespawner_override:
+                mem_guarantee: 15941615616
+                mem_limit: 15941615616
+                cpu_guarantee: 1.875
+                cpu_limit: 3.75
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+            mem_29_7:
+              display_name: 29.7 GB RAM, upto 3.75 CPUs
+              kubespawner_override:
+                mem_guarantee: 31883231232
+                mem_limit: 31883231232
+                cpu_guarantee: 3.75
+                cpu_limit: 3.75
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+            mem_60_6:
+              display_name: 60.6 GB RAM, upto 15.72 CPUs
+              kubespawner_override:
+                mem_guarantee: 65105797120
+                mem_limit: 65105797120
+                cpu_guarantee: 7.86
+                cpu_limit: 15.72
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+            mem_121_3:
+              display_name: 121.3 GB RAM, upto 15.72 CPUs
+              kubespawner_override:
+                mem_guarantee: 130211594240
+                mem_limit: 130211594240
+                cpu_guarantee: 15.72
+                cpu_limit: 15.72
+                node_selector:
+                  node.kubernetes.io/instance-type: n2-highmem-16
+        image: &profile_list_profile_options_image
+          display_name: Image
+          # https://infrastructure.2i2c.org/howto/features/allow-unlisted-profile-choice/
+          unlisted_choice: &profile_list_unlisted_choice
+            enabled: True
+            display_name: "Custom image"
+            validation_regex: "^.+:.+$"
+            validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+            kubespawner_override:
+              image: "{value}"
+          choices:
+            pangeo:
+              display_name: Base Pangeo Notebook
+              default: true
+              slug: "pangeo"
+              kubespawner_override:
+                image: "pangeo/pangeo-notebook:2023.10.03"
+      # https://infrastructure.2i2c.org/howto/features/dedicated-nodepool/
+      nodeSelector:
+        # Applied to all profile options
+        2i2c.org/community: jackeddy
+      defaultUrl: /lab
+      extraEnv:
+        # https://infrastructure.2i2c.org/howto/features/buckets/
+        SCRATCH_BUCKET: gcs://pilot-hubs-jackeddy-scratch/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gcs://pilot-hubs-jackeddy-scratch/$(JUPYTERHUB_USER)
+        # https://infrastructure.2i2c.org/howto/features/github
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.37646d01f3f58a80"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/jack-eddy-jupyterhub-push-access
+    hub:
+      config:
+        JupyterHub:
+          authenticator_class: github
+        GitHubOAuthenticator:
+          oauth_callback_url: https://jackeddy.2i2c.cloud/hub/oauth_callback
+          allowed_organizations:
+            - jack-eddy-symposium
+          scope:
+            - read:org
+        Authenticator:
+          # This hub uses GitHub Orgs/Teams auth and so we do not set
+          # allowed_users in order to not deny access to valid members of
+          # the listed Orgs/Teams. The following people should have admin
+          # access though.
+          admin_users:
+            - dan800 # Dan Marsh
+            - rmcgranaghan # Ryan McGranaghan
+      allowNamedServers: true
+      networkPolicy:
+        # FIXME: For dask gateway
+        enabled: false
+      readinessProbe:
+        enabled: false
+dask-gateway:
+  gateway:
+    extraConfig:
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -7,14 +7,6 @@ basehub:
     prePuller:
       continuous:
         enabled: true
-    # FIXME: document this feature
-    scheduling:
-      userPlaceholder:
-        # Needed for continuous prePuller to work
-        enabled: true
-        replicas: 0
-      userScheduler:
-        enabled: false
     ingress:
       hosts:
         - jackeddy.2i2c.cloud

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -33,7 +33,6 @@ basehub:
           funded_by:
             name: ""
             url: ""
-            # FIXME: document this feature https://github.com/2i2c-org/default-hub-homepage/pull/25
             custom_html: <a href="https://science.nasa.gov/heliophysics/programs/living-with-a-star/">NASA's Living with a Star program</a> and <a href="https://cpaess.ucar.edu/">UCAR/CPAESS</a>
     singleuser:
       extraFiles:

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -48,6 +48,11 @@ basehub:
       nodeSelector:
         # Applied to all profile options
         2i2c.org/community: jackeddy
+    extraTolerations:
+      - key: "2i2c.org/community"
+        operator: "Equal"
+        value: "jackeddy"
+        effect: "NoSchedule"
       defaultUrl: /lab
       extraEnv:
         # https://infrastructure.2i2c.org/howto/features/buckets/

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -176,10 +176,6 @@ basehub:
           scope:
             - read:org
         Authenticator:
-          # This hub uses GitHub Orgs/Teams auth and so we do not set
-          # allowed_users in order to not deny access to valid members of
-          # the listed Orgs/Teams. The following people should have admin
-          # access though.
           admin_users:
             - dan800 # Dan Marsh
             - rmcgranaghan # Ryan McGranaghan

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -45,101 +45,6 @@ basehub:
             # Allow jupyterlab option to show hidden files in browser
             ContentsManager:
               allow_hidden: true
-      profileList:
-        requests:
-          #     Configuration setup based on https://github.com/2i2c-org/infrastructure/issues/2121.
-          #     Allocate resources from a n2-highmem-16 node, instead of a
-          #     n2-highmem-4 node to help reduce startup times.
-          #     Based on past usages of this hub, it is highly possible it will use notable
-          #     amounts of RAM.
-          #     The choice of this node, will avoid putting only two users requesting ~16 GB on
-          #     a ~32 GB node (if we went with a n2-highmem-4) and will instead allow for
-          #     at least eight users to fit per node on a n2-highmem-16 machine.
-          #     ref: https://github.com/2i2c-org/infrastructure/issues/3166#issuecomment-1755630637
-          display_name: Resource Allocation
-          choices:
-            mem_1_9:
-              display_name: 1.9 GB RAM, upto 3.75 CPUs
-              description: Fastest spinup time
-              kubespawner_override:
-                mem_guarantee: 1992701952
-                mem_limit: 1992701952
-                cpu_guarantee: 0.234375
-                cpu_limit: 3.75
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-              default: true
-            mem_3_7:
-              display_name: 3.7 GB RAM, upto 3.75 CPUs
-              kubespawner_override:
-                mem_guarantee: 3985403904
-                mem_limit: 3985403904
-                cpu_guarantee: 0.46875
-                cpu_limit: 3.75
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-            mem_7_4:
-              display_name: 7.4 GB RAM, upto 3.75 CPUs
-              kubespawner_override:
-                mem_guarantee: 7970807808
-                mem_limit: 7970807808
-                cpu_guarantee: 0.9375
-                cpu_limit: 3.75
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-            mem_14_8:
-              display_name: 14.8 GB RAM, upto 3.75 CPUs
-              kubespawner_override:
-                mem_guarantee: 15941615616
-                mem_limit: 15941615616
-                cpu_guarantee: 1.875
-                cpu_limit: 3.75
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-            mem_29_7:
-              display_name: 29.7 GB RAM, upto 3.75 CPUs
-              kubespawner_override:
-                mem_guarantee: 31883231232
-                mem_limit: 31883231232
-                cpu_guarantee: 3.75
-                cpu_limit: 3.75
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-            mem_60_6:
-              display_name: 60.6 GB RAM, upto 15.72 CPUs
-              kubespawner_override:
-                mem_guarantee: 65105797120
-                mem_limit: 65105797120
-                cpu_guarantee: 7.86
-                cpu_limit: 15.72
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-            mem_121_3:
-              display_name: 121.3 GB RAM, upto 15.72 CPUs
-              kubespawner_override:
-                mem_guarantee: 130211594240
-                mem_limit: 130211594240
-                cpu_guarantee: 15.72
-                cpu_limit: 15.72
-                node_selector:
-                  node.kubernetes.io/instance-type: n2-highmem-16
-        image: &profile_list_profile_options_image
-          display_name: Image
-          # https://infrastructure.2i2c.org/howto/features/allow-unlisted-profile-choice/
-          unlisted_choice: &profile_list_unlisted_choice
-            enabled: True
-            display_name: "Custom image"
-            validation_regex: "^.+:.+$"
-            validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
-            kubespawner_override:
-              image: "{value}"
-          choices:
-            pangeo:
-              display_name: Base Pangeo Notebook
-              default: true
-              slug: "pangeo"
-              kubespawner_override:
-                image: "pangeo/pangeo-notebook:2023.10.03"
       # https://infrastructure.2i2c.org/howto/features/dedicated-nodepool/
       nodeSelector:
         # Applied to all profile options
@@ -152,7 +57,115 @@ basehub:
         # https://infrastructure.2i2c.org/howto/features/github
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.37646d01f3f58a80"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/jack-eddy-jupyterhub-push-access
+      profileList:
+        - display_name: "Image and resource allocation"
+          description: "Choose the user image and what resources to be allocated for the server"
+          slug: only-choice
+          profile_options:
+            requests:
+              #     Configuration setup based on https://github.com/2i2c-org/infrastructure/issues/2121.
+              #     Allocate resources from a n2-highmem-16 node, instead of a
+              #     n2-highmem-4 node to help reduce startup times.
+              #     Based on past usages of this hub, it is highly possible it will use notable
+              #     amounts of RAM.
+              #     The choice of this node, will avoid putting only two users requesting ~16 GB on
+              #     a ~32 GB node (if we went with a n2-highmem-4) and will instead allow for
+              #     at least eight users to fit per node on a n2-highmem-16 machine.
+              #     ref: https://github.com/2i2c-org/infrastructure/issues/3166#issuecomment-1755630637
+              display_name: Resource Allocation
+              choices:
+                mem_1_9:
+                  display_name: 1.9 GB RAM, upto 3.75 CPUs
+                  description: Fastest spinup time
+                  kubespawner_override:
+                    mem_guarantee: 1992701952
+                    mem_limit: 1992701952
+                    cpu_guarantee: 0.234375
+                    cpu_limit: 3.75
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                  default: true
+                mem_3_7:
+                  display_name: 3.7 GB RAM, upto 3.75 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 3985403904
+                    mem_limit: 3985403904
+                    cpu_guarantee: 0.46875
+                    cpu_limit: 3.75
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                mem_7_4:
+                  display_name: 7.4 GB RAM, upto 3.75 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 7970807808
+                    mem_limit: 7970807808
+                    cpu_guarantee: 0.9375
+                    cpu_limit: 3.75
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                mem_14_8:
+                  display_name: 14.8 GB RAM, upto 3.75 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 15941615616
+                    mem_limit: 15941615616
+                    cpu_guarantee: 1.875
+                    cpu_limit: 3.75
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                mem_29_7:
+                  display_name: 29.7 GB RAM, upto 3.75 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 31883231232
+                    mem_limit: 31883231232
+                    cpu_guarantee: 3.75
+                    cpu_limit: 3.75
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                mem_60_6:
+                  display_name: 60.6 GB RAM, upto 15.72 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 65105797120
+                    mem_limit: 65105797120
+                    cpu_guarantee: 7.86
+                    cpu_limit: 15.72
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+                mem_121_3:
+                  display_name: 121.3 GB RAM, upto 15.72 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 130211594240
+                    mem_limit: 130211594240
+                    cpu_guarantee: 15.72
+                    cpu_limit: 15.72
+                    node_selector:
+                      node.kubernetes.io/instance-type: n2-highmem-16
+            image:
+              display_name: Image
+              # https://infrastructure.2i2c.org/howto/features/allow-unlisted-profile-choice/
+              unlisted_choice:
+                enabled: True
+                display_name: "Custom image"
+                validation_regex: "^.+:.+$"
+                validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+                kubespawner_override:
+                  image: "{value}"
+              choices:
+                pangeo:
+                  display_name: Base Pangeo Notebook
+                  default: true
+                  slug: "pangeo"
+                  kubespawner_override:
+                    image: "pangeo/pangeo-notebook:2023.10.03"
     hub:
+      allowNamedServers: true
+      image:
+        name: quay.io/2i2c/unlisted-choice-experiment
+        tag: "0.0.1-0.dev.git.7130.h0bdc2d30"
+      networkPolicy:
+        # FIXME: For dask gateway
+        enabled: false
+      readinessProbe:
+        enabled: false
       config:
         JupyterHub:
           authenticator_class: github
@@ -170,12 +183,6 @@ basehub:
           admin_users:
             - dan800 # Dan Marsh
             - rmcgranaghan # Ryan McGranaghan
-      allowNamedServers: true
-      networkPolicy:
-        # FIXME: For dask gateway
-        enabled: false
-      readinessProbe:
-        enabled: false
 dask-gateway:
   gateway:
     extraConfig:

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -157,9 +157,6 @@ basehub:
                     image: "pangeo/pangeo-notebook:2023.10.03"
     hub:
       allowNamedServers: true
-      image:
-        name: quay.io/2i2c/unlisted-choice-experiment
-        tag: "0.0.1-0.dev.git.7130.h0bdc2d30"
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -47,11 +47,11 @@ basehub:
       nodeSelector:
         # Applied to all profile options
         2i2c.org/community: jackeddy
-    extraTolerations:
-      - key: "2i2c.org/community"
-        operator: "Equal"
-        value: "jackeddy"
-        effect: "NoSchedule"
+      extraTolerations:
+        - key: "2i2c.org/community"
+          operator: "Equal"
+          value: "jackeddy"
+          effect: "NoSchedule"
       defaultUrl: /lab
       extraEnv:
         # https://infrastructure.2i2c.org/howto/features/buckets/

--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -3,10 +3,6 @@ basehub:
     annotations:
       iam.gke.io/gcp-service-account: pilot-hubs-jackeddy@two-eye-two-see.iam.gserviceaccount.com
   jupyterhub:
-    # https://infrastructure.2i2c.org/howto/features/ephemeral/#pre-pulled-images
-    prePuller:
-      continuous:
-        enabled: true
     ingress:
       hosts:
         - jackeddy.2i2c.cloud

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -79,6 +79,23 @@ notebook_nodes = {
       "community" : "temple"
     },
   }
+  # Nodepool for jackeddy symposium. https://github.com/2i2c-org/infrastructure/issues/3166
+  "jackeddy" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+    labels : {
+      "2i2c.org/community" : "jackeddy"
+    },
+    taints : [{
+      key : "2i2c.org/community",
+      value : "jackeddy",
+      effect : "NO_SCHEDULE"
+    }],
+    resource_labels : {
+      "community" : "jackeddy"
+    }
+  }
 }
 
 # Setup a single node pool for dask workers.
@@ -94,7 +111,11 @@ dask_nodes = {
   },
 }
 
-user_buckets = {}
+user_buckets = {
+  "jackeddy-scratch" : {
+    "delete_after" : 7
+  }
+}
 
 
 hub_cloud_permissions = {
@@ -113,6 +134,11 @@ hub_cloud_permissions = {
     requestor_pays : true,
     bucket_admin_access : [],
     hub_namespace : "catalyst-cooperative"
+  },
+  "jackeddy" : {
+    requestor_pays : true,
+    bucket_admin_access : ["jackeddy-scratch"],
+    hub_namespace : "jackeddy"
   },
 }
 


### PR DESCRIPTION
For https://github.com/2i2c-org/infrastructure/issues/3166

It enables the same features the previous hub from https://github.com/2i2c-org/infrastructure/pull/1466 had + `unlisted_choice` and node sharing.

Note, that out of curiosity, I tried to link each "not-standard" config I found there to the engineering docs that explain them. This is why, there are some fixme comments and links to infra docs.

### The **documented** features this hub has:

- [setup custom, free-form user profile choices](https://infrastructure.2i2c.org/howto/features/allow-unlisted-profile-choice)
- [dedicated nodepool for a hub on a shared cluster](https://infrastructure.2i2c.org/howto/features/dedicated-nodepool/)
- [scratch buckets](https://infrastructure.2i2c.org/howto/features/buckets)
- [requestor Pays’ access to Google Cloud Storage buckets](https://infrastructure.2i2c.org/topic/features/#requestor-pays-access-to-google-cloud-storage-buckets)
- [gh-scoped-creds](https://infrastructure.2i2c.org/howto/features/github)
### Identified as not documented on the infra docs
- `custom_html` feature from https://github.com/2i2c-org/default-hub-homepage/pull/25
- allow jupyterlab option to show hidden files in browser
```yaml
    singleuser:
      extraFiles:
        jupyter_notebook_config.json:
          data:
            # Allow jupyterlab option to show hidden files in browser
            ContentsManager:
              allow_hidden: true
```
### Re-use
- Note that this hub will use the GitHubOAuthenticator and the credentials of the oauth app still existed in the repo under `enc-jackeddy.secret.values.yaml`
- Also, the GitHub app needed for gh-scoped-creds was still existing, so we are reusing that as well