### PR TITLE
Stop overriding hub.readinessProbe to false

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -45,8 +45,6 @@ basehub:
         enabled: true
     hub:
       allowNamedServers: true
-      readinessProbe:
-        enabled: false
       config:
         JupyterHub:
           authenticator_class: cilogon

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -76,8 +76,6 @@ jupyterhub:
       pvc:
         # Default seems too slow for our database, causes very bad response times
         storageClassName: managed-premium
-    readinessProbe:
-      enabled: false
     config:
       JupyterHub:
         authenticator_class: cilogon


### PR DESCRIPTION
The hub should never enter a "unready" state after it has become ready, but its helpful if it doesn't end up ready before its actually ready as well.

In the past, we've disabled `hub.readinessProbe` because:
1. It could lead to cluttering of logs, but it doesn't any more with a modern jupyterhub version
2. It could fail and making the hub unavailable - even though there wasn't another hub pod replica to delegate traffic to instead etc. It [won't do this](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/78bec62d591b7a97560c37edd79c7a15186fcfe9/jupyterhub/values.yaml#L124-L141) anymore though - the livenessProbe would fail first if that was the case.

If a hub readinessProbe exists, it can help with wait conditions. For example if `helm` upgrades with `--wait`, it will ensure the container doesn't crash before it becomes ready - but without a readinessProbe its considered ready directly, so `helm` may think its fine even though it entered a crashloop.