### PR TITLE
basehub: fix bug in profile list filtering influencing a few users

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -764,8 +764,15 @@ jupyterhub:
                     allowed_profiles.append(profile)
                     continue
 
-                access_token = auth_state["token_response"]["access_token"]
-                token_type = auth_state["token_response"]["token_type"]
+                if "token_response" in auth_state:
+                    access_token = auth_state["token_response"]["access_token"]
+                    token_type = auth_state["token_response"]["token_type"]
+                else:
+                    # token_response was introduced to auth_state in
+                    # oauthenticator 16, so this is adjusting to an auth_state
+                    # set by oauthenticator 15
+                    access_token = auth_state["access_token"]
+                    token_type = "token"
                 for allowed_org in allowed_orgs:
                     user_in_allowed_org = await spawner.authenticator._check_membership_allowed_organizations(
                         allowed_org, spawner.user.name, access_token, token_type


### PR DESCRIPTION
This is a followup to #3234 where I didn't account for auth_state could be retained from oauthenticator 15 even after we upgraded to oauthenticator 16.

The bug was reported by @jbusecke in https://2i2c.freshdesk.com/a/tickets/1037, thank you Julius!!!

I've deployed this to staging successfully, and then also deployed it to prod. Merging this ensures it remains in prod long term but otherwise we have time for more detailed review.

---

I think ths bug led to 500 errors if:

- GitHubOAuthenticator was used with the `allowed_teams` filtering of `profile_list` options
- A user had been logged in since oauthenticator 15 was used, needed to start a server and arrived to /hub/spawn, and didn't have access to all server options.