### PR TITLE
openscapes: Use a bigger node to account for future event expected usage

### DIFF
--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -57,7 +57,7 @@ basehub:
                     cpu_guarantee: 1.875
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.75 CPUs
                   kubespawner_override:
@@ -66,7 +66,7 @@ basehub:
                     cpu_guarantee: 3.75
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.72 CPUs
                   kubespawner_override:


### PR DESCRIPTION
For https://github.com/2i2c-org/infrastructure/issues/3217