### PR TITLE
[EVENT] CryoCloud Geosmart Hackweek - GPU profile setup

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -327,6 +327,23 @@ basehub:
           allowed_teams:
             - 2i2c-org:hub-access-for-2i2c-staff
             - CryoInTheCloud:ml-in-glaciology
+          profile_options:
+            image:
+              display_name: Image
+              unlisted_choice:
+                enabled: true
+                display_name: "Custom image"
+                validation_regex: "^.+:.+$"
+                validation_message: "Must be a publicly available docker image of form <image-name>:<tag>"
+                kubespawner_override:
+                  image: "{value}"
+              choices:
+                pytorch:
+                  display_name: Pangeo PyTorch ML Notebook
+                  default: true
+                  slug: "pytorch"
+                  kubespawner_override:
+                    image: "quay.io/pangeo/pytorch-notebook:2023.09.19"
           kubespawner_override:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -320,6 +320,22 @@ basehub:
         #     mem_limit: null
         #     node_selector:
         #       node.kubernetes.io/instance-type: r5.16xlarge
+
+        - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
+          description: "Start a container on a dedicated node with a GPU"
+          slug: "gpu"
+          allowed_teams:
+            - 2i2c-org:hub-access-for-2i2c-staff
+            - CryoInTheCloud:ml-in-glaciology
+          kubespawner_override:
+            environment:
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
+            mem_limit: null
+            mem_guarantee: 14G
+            node_selector:
+              node.kubernetes.io/instance-type: g4dn.xlarge
+            extra_resource_limits:
+              nvidia.com/gpu: "1"
     scheduling:
       userScheduler:
         enabled: true

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -28,6 +28,12 @@ local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
+    {
+        instanceType: "g4dn.xlarge",
+        tags+: {
+            "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
+        },
+    },
 ];
 
 local daskNodes = [


### PR DESCRIPTION
- related #3135

This PR implements the following:
- A change to the relevant jsonnet file to create a GPU nodepool
- Add a profile to uncover the GPU nodepool
  - **NOTE:** I was unsure how to translate node sharing for this, and we don't seem to have documentation for it. So just left it the same as the example for now: https://infrastructure.2i2c.org/howto/features/gpu/#setting-up-a-gpu-user-profile
- Who can see/access the GPUs is controlled by GitHub team membership
  - https://github.com/2i2c-org/infrastructure/issues/3135#issuecomment-1762121658
- The unlisted choice profile option for images is also enabled. I provided the originally requested image as a default just in case.
  - https://github.com/2i2c-org/infrastructure/issues/3135#issuecomment-1756067729

I have deployed this to staging and confirmed that GPUs are available and the unlisted image choice is also available, as per the screenshots below

<img width="480" alt="Screenshot 2023-10-16 at 12 19 42" src="https://github.com/2i2c-org/infrastructure/assets/44771837/43892142-0ee9-48ae-9911-c6d2248c0ed0">
<img width="289" alt="Screenshot 2023-10-16 at 11 58 48" src="https://github.com/2i2c-org/infrastructure/assets/44771837/91ae6bf7-eeb4-4688-9cbd-7d22ce0ec1f2">
