### PR TITLE
Mark auth_token as a string, not integer

### DIFF
--- a/deployer/cloud_access.py
+++ b/deployer/cloud_access.py
@@ -19,7 +19,7 @@ def exec_aws_shell(
     mfa_device_id: str = typer.Argument(
         ..., help="Full ARN of MFA Device the code is from"
     ),
-    auth_token: int = typer.Argument(
+    auth_token: str = typer.Argument(
         ..., help="6 digit 2 factor authentication code from the MFA device"
     ),
 ):


### PR DESCRIPTION
When marked as an integer, leading zeros get stripped.