### PR TITLE
Allow JupyterLab to show hidden files

### DIFF
--- a/config/clusters/2i2c/jackeddy.values.yaml
+++ b/config/clusters/2i2c/jackeddy.values.yaml
@@ -31,14 +31,6 @@ basehub:
             url: ""
             custom_html: <a href="https://science.nasa.gov/heliophysics/programs/living-with-a-star/">NASA's Living with a Star program</a> and <a href="https://cpaess.ucar.edu/">UCAR/CPAESS</a>
     singleuser:
-      extraFiles:
-        # FIXME: document this feature
-        # Currently only documented in the context of culling https://infrastructure.2i2c.org/sre-guide/manage-k8s/culling/#kernel-culling-configuration
-        jupyter_notebook_config.json:
-          data:
-            # Allow jupyterlab option to show hidden files in browser
-            ContentsManager:
-              allow_hidden: true
       # https://infrastructure.2i2c.org/howto/features/dedicated-nodepool/
       nodeSelector:
         # Applied to all profile options

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -35,14 +35,6 @@ basehub:
             url: https://jupytearth.org
 
     singleuser:
-      extraFiles:
-        jupyter_server_config.json:
-          mountPath: /etc/jupyter/jupyter_notebook_config.json
-          data:
-            # Allow jupyterlab option to show hidden files in browser
-            # https://github.com/berkeley-dsep-infra/datahub/issues/3160
-            ContentsManager:
-              allow_hidden: true
       initContainers:
         # Need to explicitly set this up and copy what's in basehub/values.yaml
         # as we have an extra 'shared-public' directory here.

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -62,14 +62,6 @@ basehub:
             - jomey
 
     singleuser:
-      extraFiles:
-        # jupyter_server_config.json is defined by basehub, this entry adds to it
-        jupyter_server_config.json:
-          data:
-            ContentsManager:
-              # Enable showing hidden files in JupyterLab
-              # https://github.com/CryoInTheCloud/hub-image/issues/3
-              allow_hidden: true
       defaultUrl: /lab
       storage:
         extraVolumes:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -233,6 +233,11 @@ jupyterhub:
         # as culling the kernel will register activity,
         # resetting the no_activity timer for the server as a whole
         data:
+          # Allow JupyterLab to show the 'View -> Show Hidden Files' option
+          # in the menu. Defaults are not changed.
+          # https://github.com/jupyterlab/jupyterlab/issues/11304#issuecomment-945466766
+          ContentsManager:
+            allow_hidden: true
           # MappingKernelManager configuration reference:
           # https://jupyter-server.readthedocs.io/en/latest/api/jupyter_server.services.kernels.html#jupyter_server.services.kernels.kernelmanager.MappingKernelManager
           #


### PR DESCRIPTION
This doesn't change any behavior, but just allows JupyterLab to show a 'View -> Show Hidden Files' option that folks can turn on. The only reason it isn't on by default is apparently a historical
accident (https://github.com/jupyterlab/jupyterlab/issues/11304#issuecomment-945466766)

Instead of turning it on piecemeal per-hub, this just turns it on for everyone. There's no reason to not.

Ref https://2i2c.freshdesk.com/a/tickets/1056