### PR TITLE
Bump binderhub-service version

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
     version: 3.1.0
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.80.h358d32f
+    version: 0.1.0-0.dev.git.110.hd833d08
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled


### PR DESCRIPTION
Brings in https://github.com/2i2c-org/binderhub-service/pull/65

Ref https://github.com/2i2c-org/infrastructure/issues/3286