### PR TITLE
[2i2c-uk:lis] Enable profileList

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -45,10 +45,21 @@ jupyterhub:
       # https://hub.docker.com/r/lisacuk/lishub-base
       name: "lisacuk/lishub-base"
       tag: "581a714"
-    memory:
-      # increase as requested via https://2i2c.freshdesk.com/a/tickets/1066
-      guarantee: 512M
-      limit: 2G
+    # Added profileList per https://2i2c.freshdesk.com/a/tickets/1066
+    profileList:
+      - display_name: "Small: ~512 MB RAM / ~0.5 CPU"
+        slug: mem_512m
+        default: true
+        kubespawner_override:
+          # increase as requested via https://2i2c.freshdesk.com/a/tickets/1066
+          mem_guarantee: 512M
+          mem_limit: 1G
+      - display_name: "Large: ~1 GB RAM / ~0.5 CPU"
+        slug: mem_1g
+        kubespawner_override:
+          # increase as requested via https://2i2c.freshdesk.com/a/tickets/1066
+          mem_guarantee: 1G
+          mem_limit: 2G
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -47,19 +47,42 @@ jupyterhub:
       tag: "581a714"
     # Added profileList per https://2i2c.freshdesk.com/a/tickets/1066
     profileList:
-      - display_name: "Small: ~512 MB RAM / ~0.5 CPU"
-        slug: mem_512m
-        default: true
-        kubespawner_override:
-          # increase as requested via https://2i2c.freshdesk.com/a/tickets/1066
-          mem_guarantee: 512M
-          mem_limit: 1G
-      - display_name: "Large: ~1 GB RAM / ~0.5 CPU"
-        slug: mem_1g
-        kubespawner_override:
-          # increase as requested via https://2i2c.freshdesk.com/a/tickets/1066
-          mem_guarantee: 1G
-          mem_limit: 2G
+      - mem_0_4:
+          display_name: 0.4 GB RAM, upto 3.485 CPUs
+          kubespawner_override:
+            mem_guarantee: 457785792
+            mem_limit: 457785792
+            cpu_guarantee: 0.054453125
+            cpu_limit: 3.485
+            node_selector:
+              node.kubernetes.io/instance-type: n2-highmem-4
+      - mem_0_9:
+          display_name: 0.9 GB RAM, upto 3.485 CPUs
+          kubespawner_override:
+            mem_guarantee: 915571584
+            mem_limit: 915571584
+            cpu_guarantee: 0.10890625
+            cpu_limit: 3.485
+            node_selector:
+              node.kubernetes.io/instance-type: n2-highmem-4
+      - mem_1_7:
+          display_name: 1.7 GB RAM, upto 3.485 CPUs
+          kubespawner_override:
+            mem_guarantee: 1831143168
+            mem_limit: 1831143168
+            cpu_guarantee: 0.2178125
+            cpu_limit: 3.485
+            node_selector:
+              node.kubernetes.io/instance-type: n2-highmem-4
+      - mem_3_4:
+          display_name: 3.4 GB RAM, upto 3.485 CPUs
+          kubespawner_override:
+            mem_guarantee: 3662286336
+            mem_limit: 3662286336
+            cpu_guarantee: 0.435625
+            cpu_limit: 3.485
+            node_selector:
+              node.kubernetes.io/instance-type: n2-highmem-4
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -47,42 +47,43 @@ jupyterhub:
       tag: "581a714"
     # Added profileList per https://2i2c.freshdesk.com/a/tickets/1066
     profileList:
-      - mem_0_4:
-          display_name: 0.4 GB RAM, upto 3.485 CPUs
-          kubespawner_override:
-            mem_guarantee: 457785792
-            mem_limit: 457785792
-            cpu_guarantee: 0.054453125
-            cpu_limit: 3.485
-            node_selector:
-              node.kubernetes.io/instance-type: n2-highmem-4
-      - mem_0_9:
-          display_name: 0.9 GB RAM, upto 3.485 CPUs
-          kubespawner_override:
-            mem_guarantee: 915571584
-            mem_limit: 915571584
-            cpu_guarantee: 0.10890625
-            cpu_limit: 3.485
-            node_selector:
-              node.kubernetes.io/instance-type: n2-highmem-4
-      - mem_1_7:
-          display_name: 1.7 GB RAM, upto 3.485 CPUs
-          kubespawner_override:
-            mem_guarantee: 1831143168
-            mem_limit: 1831143168
-            cpu_guarantee: 0.2178125
-            cpu_limit: 3.485
-            node_selector:
-              node.kubernetes.io/instance-type: n2-highmem-4
-      - mem_3_4:
-          display_name: 3.4 GB RAM, upto 3.485 CPUs
-          kubespawner_override:
-            mem_guarantee: 3662286336
-            mem_limit: 3662286336
-            cpu_guarantee: 0.435625
-            cpu_limit: 3.485
-            node_selector:
-              node.kubernetes.io/instance-type: n2-highmem-4
+      - display_name: 0.4 GB RAM, upto 3.485 CPUs
+        default: true
+        slug: mem_0_4
+        kubespawner_override:
+          mem_guarantee: 457785792
+          mem_limit: 457785792
+          cpu_guarantee: 0.054453125
+          cpu_limit: 3.485
+          node_selector:
+            node.kubernetes.io/instance-type: n2-highmem-4
+      - display_name: 0.9 GB RAM, upto 3.485 CPUs
+        slug: mem_0_9
+        kubespawner_override:
+          mem_guarantee: 915571584
+          mem_limit: 915571584
+          cpu_guarantee: 0.10890625
+          cpu_limit: 3.485
+          node_selector:
+            node.kubernetes.io/instance-type: n2-highmem-4
+      - display_name: 1.7 GB RAM, upto 3.485 CPUs
+        slug: mem_1_7
+        kubespawner_override:
+          mem_guarantee: 1831143168
+          mem_limit: 1831143168
+          cpu_guarantee: 0.2178125
+          cpu_limit: 3.485
+          node_selector:
+            node.kubernetes.io/instance-type: n2-highmem-4
+      - display_name: 3.4 GB RAM, upto 3.485 CPUs
+        slug: mem_3_4
+        kubespawner_override:
+          mem_guarantee: 3662286336
+          mem_limit: 3662286336
+          cpu_guarantee: 0.435625
+          cpu_limit: 3.485
+          node_selector:
+            node.kubernetes.io/instance-type: n2-highmem-4
   hub:
     config:
       JupyterHub:

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -40,6 +40,6 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: "https://staging.uk.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
-          http://google.com/accounts/o8/id:
+          http://github.com/login/oauth/authorize:
             username_derivation:
-              username_claim: "email"
+              username_claim: "preferred_username"


### PR DESCRIPTION
### Update: waiting for feedback in https://2i2c.freshdesk.com/a/tickets/1066 before merging.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/3302, also for https://2i2c.freshdesk.com/a/tickets/1066.

Matthew from LIS requested a guarantee of 1GB as they are still experiencing crashes, even after the increase to 512GB of guarantee from https://github.com/2i2c-org/infrastructure/pull/3302.

This PR enables profileLists for the lis hub, adding the new guarantee and reducing the limit of the initial one of 512G one from 2GB to 1GB.

I think it would be useful for them to enable https://github.com/jupyter-server/jupyter-resource-usage so they can better understand they mem needs, especially since from the grafana below, it looks like only a few users actually required around or more than 1GB.

This is also why the new server size option, instead of increasing it again.

<img width="716" alt="Screenshot 2023-10-24 at 10 02 40" src="https://github.com/2i2c-org/infrastructure/assets/7579677/0888c826-8a13-4cb0-a410-b2ed973bc1d0">
