### PR TITLE
Stop using continuous prePuller

### DIFF
--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -1,11 +1,7 @@
 jupyterhub:
-  # pre-puller is necessary as the image is pretty big, and
-  # pulling during first user spawn might cause timeouts and poor user
-  # experience. Also helps with node pre-warming. This works ok here
-  # because they have a dedicated nodepool.
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   singleuser:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -9,12 +9,9 @@ nfs:
     # Name of Google Filestore share
     baseShareName: /homes/
 jupyterhub:
-  # pre-puller is necessary as the image is pretty big, and
-  # pulling during first user spawn might cause timeouts and poor user
-  # experience. Also helps with node pre-warming.
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   custom:

--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -13,9 +13,7 @@ jupyterhub:
     allowNamedServers: true
   singleuser:
     image:
-      # This image specification is likeley overridden via the configurator, so
-      # use of prePuller is probably going to pull this instead of the
-      # configured image and just slow users down.
+      # This image specification is likely overridden via the configurator.
       #
       # jupyter/scipy-notebook is maintained at: https://github.com/jupyter/docker-stacks
       # tags can be viewed at: https://hub.docker.com/r/jupyter/scipy-notebook/tags

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -5,8 +5,8 @@ jupyterhub:
       - hosts: [demo.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   singleuser:

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -5,8 +5,8 @@ jupyterhub:
       - hosts: [humboldt.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   singleuser:

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -5,8 +5,8 @@ jupyterhub:
       - hosts: [sjsu.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   singleuser:

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -12,9 +12,6 @@ basehub:
       serverIP: fs-05f68d7e096d7cf16.efs.us-west-2.amazonaws.com
       baseShareName: /
   jupyterhub:
-    prePuller:
-      continuous:
-        enabled: true
     custom:
       2i2c:
         add_staff_user_ids_to_admin_users: true

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -10,8 +10,8 @@ nfs:
     baseShareName: /homes/
 jupyterhub:
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   custom:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -13,12 +13,9 @@ jupyterhub:
   scheduling:
     userScheduler:
       enabled: true
-  # pre-puller is necessary as the image is pretty big, and
-  # pulling during first user spawn might cause timeouts and poor user
-  # experience. Also helps with node pre-warming.
   prePuller:
-    continuous:
-      enabled: true
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image
     hook:
       enabled: true
   custom:

--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -107,34 +107,19 @@ jupyterhub:
 ```
 
 
-## Pre-pulled images
+## Image configuration in chart
 
-We want *consistently* faster startups wherever possible, as inconsistent start
-times is one of the big issues with folks using mybinder.org for events and
-workshops. So we enable the [pre-puller](https://z2jh.jupyter.org/en/latest/administrator/optimization.html#pulling-images-before-users-arrive)
-functionality to make startups faster and more consistent.
-
-This requires the user image is also set in config (and not via the JupyterHub
-configurator). But `tmpauthenticator` doesn't support admin accounts anyway,
-so this is fine.
+The image needs to be specified in the chart directly and not via the JupyterHub
+configurator because with `tmpauthenticator` we can't distinguish admin users to
+have such rights without providing it to every user.
 
 ```yaml
 jupyterhub:
   singleuser:
+    # image could also be configured via singleuser.profileList configuration
     image:
       name: <image-name>
       tag: <tag>
-      
-  prePuller:
-    # Startup performance is important for this event, and so we use
-    # pre-puller to make sure the images are already present on the
-    # nodes. This means image *must* be set in config, and not the configurator.
-    # tmpauthenticator doesn't support admin access anyway, so images
-    # must be set in config regardless.
-    hook:
-      enabled: true
-    continuous:
-      enabled: true
 ```
 
 ## Disabling home page customizations

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -143,9 +143,34 @@ jupyterhub:
           memory: 64Mi
         limits:
           memory: 1G
+  # prePuller is about pulling a one or more images identified via chart
+  # configuration, including singleuser.image, singleuser.profileList entries
+  # with a dedicated image, but not profileList entries with images' specified
+  # via profile_options.
   prePuller:
+    # continuous prePuller leads to the creation of a DaemonSet that starts a
+    # pod on each node to pull images.
+    #
+    # It is disabled as its only relevant for nodes started before user pods
+    # gets scheduled on them, in other cases it could delay startup and isn't
+    # expected to reduce startup times.
+    #
     continuous:
       enabled: false
+    # hook prePuller leads to the creation of a temporary DaemonSet and a pod
+    # awaiting pulling to complete before `helm upgrade` starts its main work.
+    #
+    # It is disabled as it adds notable complexity for a smaller benefit when
+    # correctly adopted. The added complexity includes:
+    #
+    # - risk of misconfiguration making image pulls not actually needed
+    # - risk of broken expectations and additional cognitive load
+    # - risk of causing significantly longer `helm upgrade` commands slowing
+    #   down our CI system
+    # - ClusterRoleBinding resources are needed for the image-awaiter Pod
+    #   involved, a resource that requires the highest k8s cluster permission
+    #   otherwise possibly not needed to deploy basehub
+    #
     hook:
       enabled: false
   proxy:
@@ -267,7 +292,7 @@ jupyterhub:
           MappingKernelManager: *server_config_mapping_kernel_manager
           NotebookApp: *server_config_server_app
           BaseFileIdManager: *server_config_base_file_id_manager
-    startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
+    startTimeout: 600 # 10 mins, node startup + image pulling makes it relevant
     defaultUrl: /tree
     image:
       name: jupyter/scipy-notebook

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -292,7 +292,7 @@ jupyterhub:
           MappingKernelManager: *server_config_mapping_kernel_manager
           NotebookApp: *server_config_server_app
           BaseFileIdManager: *server_config_base_file_id_manager
-    startTimeout: 600 # 10 mins, node startup + image pulling makes it relevant
+    startTimeout: 600 # 10 mins, node startup + image pulling sometimes takes more than the default 5min
     defaultUrl: /tree
     image:
       name: jupyter/scipy-notebook


### PR DESCRIPTION
## Update 2023-10-30

Based on feedback from Yuvi in https://github.com/2i2c-org/infrastructure/pull/3313#issuecomment-1777280535, I've pivoted to only disable the continuous prePuller in this PR, and not also the hook prePuller. I'm opening a followup PR to this to constrain the use of hook prePuller in another PR to help us avoid issues with it.

## Original PR

Fixes #2344 by inlining comments in basehub's default config that already disables prePuller logic by default, and by disabling both continous and hook prePuller where it is enabled for individual hubs.

---

prePuller is a somewhat complex machinery to reduce startup times in favorable conditions - conditions that also could change outside our chart configuration via the configurator for example. In unfavorable conditions, use of prePuller could instead increase startup times. This fragility and complexity has caused me some stress and cognitive load that I don't want to introduce to others, but instead help us all avoid.

This make me think __*the right call is to systematically disable both use of continious prePuller and hook prePuller*__.

<details>
<summary>Continue reading for some additional details</summary>

### Disabling continuous pulling

The continuous prePuller could be beneficial if nodes are pre-started before a user pod arrives to them. It was initially designed with intent to be used with `user-placeholder` / `node-placeholder` pods, something we are not using in any of our clusters.

We have successfully made use of the continuous prePuller in the past when pre-starting many nodes for events. With the introduction of the practice to schedule multiple users per node, this is not as relevant. I think if we want to use it for that time, we can do a one off image pull just after pre-starting nodes instead of having it enabled by default - this is to be clarified by #2541.

### Disabling hook pulling

The hook puller is active during `helm ugprade`, blocking the actual upgrade until pulling has been completed. I see some value in it compared to the current use of the continuous prePuller, but I think we are better off avoiding its complexity we introduce.

Read the [inlined config notes about disabling it](https://github.com/2i2c-org/infrastructure/pull/3313/files#diff-301db94aa87a33a484be445796919615b3eecdc883900e976be6870e645f6d48R160-R173) for some additional details.

### After disabling, these are no longer relevant caveats

When I've heard "slow startup" be mentioned in support tickets etc, I've often ended up considering caveats below to ensure use of prePuller wasn't causing it. If we disable prePulling systematically with this PR, none of us need to consider caveats like below going onwards to be the cause of slow startups! We could focus on fixing issues caused by other things without even first ruling out its the prePuller causing it.

- prePuller (continuous mainly) used for a hub scheduling user pods on nodes used by other hubs is likely to disturb other hubs, using a dedicated node pool has other caveats
- prePuller doesn't pull all images we configure for use - not those via the configurator or profile_options in some profile lists
- continuous prePuller pulling multiple images can even when pulling the right images delay startup times for non-pre-started nodes
- hook prePuller requires use of ClusterRoleBinding resources, something that some k8s admins isn't granted if they exercise the right to replicate in a cluster they only control a namespace within

</details>