### PR TITLE
Swap 2i2c-imagebuilding-hub-access to 2i2c-demo-hub-access

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -138,7 +138,7 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://imagebuilding-demo.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-imagebuilding-hub-access
+          - 2i2c-demo-hub-access
           - veda-analytics-access:all-users
           - veda-analytics-access:collaborator-access
           - CYGNSS-VEDA:cygnss-iwg


### PR DESCRIPTION
I have just changed the name of this org as per https://github.com/2i2c-org/team-compass/issues/773 and so this PR ensures members of that org retain access.