### PR TITLE
[CI/CD] Exclude changes to deployer/README from triggering the deploy

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -16,6 +16,9 @@ on:
       # Exclude changes to the tests directory from
       # triggering this workflow
       - "!deployer/health_check_tests/**"
+      # Exclude changes to the README from triggering
+      # this workflow
+      - "!deployer/README.md"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**
@@ -28,6 +31,9 @@ on:
       # Exclude changes to the tests directory from
       # triggering this workflow
       - "!deployer/health_check_tests/**"
+      # Exclude changes to the README from triggering
+      # this workflow
+      - "!deployer/README.md"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**


### PR DESCRIPTION
For PRs like https://github.com/2i2c-org/infrastructure/pull/3316, that just update the README, I don't believe deploying all hubs is necessary?