### PR TITLE
Make all GCP clusters support the instance types 4, 16, and 64 CPU highmem nodes

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -21,8 +21,18 @@ filestore_capacity_gb = 1024
 notebook_nodes = {
   "user" : {
     min : 0,
-    max : 20,
+    max : 100,
     machine_type : "n2-highmem-4"
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -24,16 +24,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
+    machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 user_buckets = {}

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -19,20 +19,21 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "user" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -36,16 +36,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4"
   },
-  "n2-highmem-16" : {
+  "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16"
   },
-  "n2-highmem-64" : {
+  "large" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64"
-  }
+  },
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -36,16 +36,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64"
-  },
+  }
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -31,20 +31,23 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
+  # FIXME: Rename this to "n2-highmem-64" when given the chance and no such nodes are running
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/basehub-template.tfvars
+++ b/terraform/gcp/projects/basehub-template.tfvars
@@ -27,17 +27,17 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/basehub-template.tfvars
+++ b/terraform/gcp/projects/basehub-template.tfvars
@@ -24,21 +24,21 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
-  "small" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4",
+    machine_type : "n2-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
+    machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 user_buckets = {}

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -21,8 +21,18 @@ filestore_capacity_gb = 1024
 notebook_nodes = {
   "user" : {
     min : 0,
-    max : 20,
+    max : 100,
     machine_type : "n2-highmem-4"
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -24,16 +24,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
+    machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 user_buckets = {}

--- a/terraform/gcp/projects/callysto.tfvars
+++ b/terraform/gcp/projects/callysto.tfvars
@@ -19,20 +19,21 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "user" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -17,16 +17,19 @@ filestore_capacity_gb = 1024
 core_node_machine_type = "n2-highmem-2"
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "small" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
   },
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
+  # FIXME: Rename this to "n2-highmem-64" when given the chance and no such nodes are running
   "large" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -27,16 +27,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n1-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
+    machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -22,20 +22,21 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "user" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4"
+    machine_type : "n1-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -24,8 +24,18 @@ filestore_capacity_gb = 1024
 notebook_nodes = {
   "user" : {
     min : 0,
-    max : 20,
+    max : 100,
     machine_type : "n1-highmem-4"
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -45,17 +45,17 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -42,21 +42,21 @@ hub_cloud_permissions = {
 
 # Setup notebook node pools
 notebook_nodes = {
-  "small" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4",
+    machine_type : "n2-highmem-4"
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16",
+    machine_type : "n2-highmem-16"
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -22,10 +22,20 @@ hub_cloud_permissions = {}
 
 # Setup notebook node pools
 notebook_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+  },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -22,21 +22,21 @@ hub_cloud_permissions = {}
 
 # Setup notebook node pools
 notebook_nodes = {
-  "small" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-4",
-  },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
-  "large" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
+    machine_type : "n2-highmem-4"
   },
+  "n2-highmem-64" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64"
+  }
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -22,6 +22,7 @@ hub_cloud_permissions = {}
 
 # Setup notebook node pools
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     min : 0,
     max : 100,
@@ -30,12 +31,12 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -73,8 +73,9 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -70,12 +70,22 @@ hub_cloud_permissions = {
 
 # Setup notebook node pools
 notebook_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+  },
   "medium" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.
     min : 1,
     max : 100,
     machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
   "gpu-t4" : {
     min : 0,

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -70,10 +70,10 @@ hub_cloud_permissions = {
 
 # Setup notebook node pools
 notebook_nodes = {
-  "small" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4",
+    machine_type : "n2-highmem-4"
   },
   "medium" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
@@ -82,11 +82,11 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-16",
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
   "gpu-t4" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -29,20 +29,23 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
+  # FIXME: Rename this to "n2-highmem-64" when given the chance and no such nodes are running
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
 }
 

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -39,11 +39,11 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-16",
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -37,7 +37,12 @@ notebook_nodes = {
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
 }
 

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -46,6 +46,21 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
+  "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4"
+  },
+  "n2-highmem-16" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16"
+  },
+  "n2-highmem-64" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64"
+  },
   "small" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/m2lines.tfvars
+++ b/terraform/gcp/projects/m2lines.tfvars
@@ -49,17 +49,17 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   },
   "small" : {
     min : 0,

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -18,17 +18,17 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   },
   "small" : {
     min : 0,

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -53,17 +53,17 @@ notebook_nodes = {
   "n2-highmem-4" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-4"
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-16"
+    machine_type : "n2-highmem-16",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   },
   "small" : {
     min : 0,

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -50,6 +50,21 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
+  "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4"
+  },
+  "n2-highmem-16" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16"
+  },
+  "n2-highmem-64" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64"
+  },
   "small" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -21,8 +21,18 @@ filestore_capacity_gb = 5120
 notebook_nodes = {
   "user" : {
     min : 0,
-    max : 20,
+    max : 100,
     machine_type : "n2-highmem-4",
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
   },
   "climatematch" : {
     min : 0,

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -19,6 +19,7 @@ enable_filestore      = true
 filestore_capacity_gb = 5120
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "user" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -24,16 +24,16 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-  },
+  }
   "climatematch" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -42,6 +42,11 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-standard-48",
   },
+  "larger" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-64",
+  },
   "huge" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -27,16 +27,19 @@ user_buckets = {
 }
 
 notebook_nodes = {
+  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
   "small" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
   },
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
+  # FIXME: Rename this to "n2-highmem-48" when given the chance and no such nodes are running
   "large" : {
     min : 0,
     max : 100,
@@ -45,7 +48,7 @@ notebook_nodes = {
   "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64"
+    machine_type : "n2-highmem-64",
   }
   "huge" : {
     min : 0,

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -42,11 +42,11 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-standard-48",
   },
-  "larger" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
-    machine_type : "n2-highmem-64",
-  },
+    machine_type : "n2-highmem-64"
+  }
   "huge" : {
     min : 0,
     max : 100,


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3304
Fixes https://github.com/2i2c-org/infrastructure/issues/3256

### TODO
Run `terraform plan & apply for`:

- [x] 2i2c-uk.tfvars
<details>
<summary>terraform plan -var-file=projects/callysto.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "two-eye-two-see-uk-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west2"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "two-eye-two-see-uk"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "two-eye-two-see-uk-cluster-sa@two-eye-two-see-uk.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "two-eye-two-see-uk-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west2"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "two-eye-two-see-uk"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "two-eye-two-see-uk-cluster-sa@two-eye-two-see-uk.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["user"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/two-eye-two-see-uk/locations/europe-west2/clusters/two-eye-two-see-uk-cluster/nodePools/nb-user"
        name                        = "nb-user"
        # (9 unchanged attributes hidden)

      ~ autoscaling {
          ~ max_node_count       = 20 -> 100
            # (4 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```
</details>

- [x] callysto.tfvars
<details>
<summary>terraform plan -var-file=projects/callysto.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "callysto-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "northamerica-northeast1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "callysto-202316"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "callysto-cluster-sa@callysto-202316.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "callysto-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "northamerica-northeast1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "callysto-202316"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "callysto-cluster-sa@callysto-202316.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["user"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/callysto-202316/locations/northamerica-northeast1/clusters/callysto-cluster/nodePools/nb-user"
        name                        = "nb-user"
        # (9 unchanged attributes hidden)

      ~ autoscaling {
          ~ max_node_count       = 20 -> 100
            # (4 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```

</details>

- [x] cloudbank.tfvars
<details>
<summary>terraform plan -var-file=projects/cloudbank.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "cb-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "cb-1003-1696"
      + version                     = "1.26.4-gke.1400"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "cb-cluster-sa@cb-1003-1696.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "cb-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "cb-1003-1696"
      + version                     = "1.26.4-gke.1400"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "cb-cluster-sa@cb-1003-1696.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["user"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/cb-1003-1696/locations/us-central1-b/clusters/cb-cluster/nodePools/nb-user"
        name                        = "nb-user"
        # (9 unchanged attributes hidden)

      ~ autoscaling {
          ~ max_node_count       = 20 -> 100
            # (4 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```
</details>

- [x] hhmi.tfvars
<details>
<summary>terraform plan -var-file=projects/hhmi.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-4"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "hhmi-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west2"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-4"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "hhmi-398911"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-4"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "hhmi-cluster-sa@hhmi-398911.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "hhmi-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west2"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "hhmi-398911"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "hhmi-cluster-sa@hhmi-398911.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
</details>

- [x] linked-earth.tfvars
<details>
<summary>terraform plan -var-file=projects/linked-earth.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "linked-earth-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "linked-earth-hubs"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "linked-earth-cluster-sa@linked-earth-hubs.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
</details>

- [x] m2lines.tfvars
<details>
<summary>terraform plan -var-file=projects/m2lines.tfvars</summary>

```bash
  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "m2lines-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "m2lines-hub"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "m2lines-cluster-sa@m2lines-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-4"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "m2lines-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-4"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "m2lines-hub"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-4"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "m2lines-cluster-sa@m2lines-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "m2lines-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "m2lines-hub"
      + version                     = "1.27.4-gke.900"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "m2lines-cluster-sa@m2lines-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

</details>

- [x] pilot-hubs.tfvars
<details>
<summary>terraform plan -var-file=projects/pilot-hubs.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "pilot-hubs-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "two-eye-two-see"
      + version                     = "1.26.4-gke.1400"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "pilot-hubs-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "two-eye-two-see"
      + version                     = "1.26.4-gke.1400"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["user"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-user"
        name                        = "nb-user"
        # (9 unchanged attributes hidden)

      ~ autoscaling {
          ~ max_node_count       = 20 -> 100
            # (4 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```
</details>

- [ ] leap.tfvars !!! 
<details>
<summary>terraform plan -var-file=projects/leap.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_cluster.cluster will be updated in-place
  ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/leap-pangeo/locations/us-central1/clusters/leap-cluster"
        name                        = "leap-cluster"
        # (27 unchanged attributes hidden)

      ~ cluster_autoscaling {
          ~ enabled             = true -> false
            # (1 unchanged attribute hidden)

          - resource_limits {
              - maximum       = 26112 -> null
              - minimum       = 1 -> null
              - resource_type = "memory" -> null
            }
          - resource_limits {
              - maximum       = 3264 -> null
              - minimum       = 1 -> null
              - resource_type = "cpu" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-a100" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-k80" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-p100" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-p4" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-t4" -> null
            }
          - resource_limits {
              - maximum       = 1024 -> null
              - minimum       = 1 -> null
              - resource_type = "nvidia-tesla-v100" -> null
            }

            # (1 unchanged block hidden)
        }

        # (23 unchanged blocks hidden)
    }

  # google_container_node_pool.notebook["n2-highmem-4"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "leap-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-4"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "leap-pangeo"
      + version                     = "1.25.6-gke.1000"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-4"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "leap-cluster-sa@leap-pangeo.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "leap-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "leap-pangeo"
      + version                     = "1.25.6-gke.1000"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "leap-cluster-sa@leap-pangeo.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```
</details>


- [x] qcl.tfvars !!!!
<details>
<summary>terraform plan -var-file=projects/qcl.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_container_cluster.cluster will be updated in-place
  ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster"
      + min_master_version          = "1.25.10-gke.2700"
        name                        = "qcl-cluster"
        # (26 unchanged attributes hidden)

        # (26 unchanged blocks hidden)
    }

  # google_container_node_pool.notebook["huge"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-huge"
        name                        = "nb-huge"
      ~ version                     = "1.24.11-gke.1000" -> "1.24.9-gke.3200"
        # (8 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

  # google_container_node_pool.notebook["large"] will be updated in-place
  ~ resource "google_container_node_pool" "notebook" {
        id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-large"
        name                        = "nb-large"
      ~ version                     = "1.24.11-gke.1000" -> "1.24.9-gke.3200"
        # (8 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = "1.24.9-gke.3200"

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 1 to add, 3 to change, 0 to destroy.

Changes to Outputs:
  ~ regular_channel_latest_k8s_versions = {
      ~ "1."    = "1.27.3-gke.1700" -> "1.27.4-gke.900"
      ~ "1.24." = "1.24.15-gke.1700" -> "1.24.16-gke.500"
      ~ "1.25." = "1.25.11-gke.1700" -> "1.25.12-gke.500"
      ~ "1.26." = "1.26.6-gke.1700" -> "1.26.7-gke.500"
      ~ "1.27." = "1.27.3-gke.1700" -> "1.27.4-gke.900"
    }

```
</details>

- [x] pangeo-hubs.tfvars
<details>
<summary>terraform plan -var-file=projects/pangeo-hubs.tfvars</summary>

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform planned the following actions, but then encountered a problem:

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "pangeo-hubs-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "pangeo-integration-te-3eea"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-4"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "pangeo-hubs-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-4"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "pangeo-integration-te-3eea"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-4"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-64"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "pangeo-hubs-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-central1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-64"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "pangeo-integration-te-3eea"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-64"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
╷
│ Warning: Failed to decode resource from state
│ 
│ Error decoding "google_monitoring_alert_policy.disk_space_full_alert" from prior state: unsupported attribute "condition_prometheus_query_language"
╵
╷
│ Error: Failed to get the data key required to decrypt the SOPS file.
│ 
│ Group 0: FAILED
│   projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs: FAILED
│     - | Error decrypting key: googleapi: Error 403: Permission
│       | 'cloudkms.cryptoKeyVersions.useToDecrypt' denied on resource
│       | 'projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs'
│       | (or it may not exist)., forbidden
│ 
│ Recovery failed because no master key was able to decrypt the file. In
│ order for SOPS to recover the file, at least one key has to be successful,
│ but none were.
│ 
│   with data.sops_file.pagerduty_service_integration_keys,
│   on pagerduty.tf line 13, in data "sops_file" "pagerduty_service_integration_keys":
│   13: data "sops_file" "pagerduty_service_integration_keys" {
│ 
```
</details>