### PR TITLE
Constrain use of hook prePuller

### DIFF
--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -4,11 +4,6 @@ jupyterhub:
     tls:
       - hosts: [demo.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   singleuser:
     memory:
       guarantee: 512M

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -4,11 +4,6 @@ jupyterhub:
     tls:
       - hosts: [humboldt.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   singleuser:
     memory:
       guarantee: 512M

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -4,11 +4,6 @@ jupyterhub:
     tls:
       - hosts: [sjsu.cloudbank.2i2c.cloud]
         secretName: https-auto-tls
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   singleuser:
     memory:
       guarantee: 512M

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -23,6 +23,18 @@ jupyterhub:
         funded_by:
           name: 2i2c
           url: https://2i2c.org
+    jupyterhubConfigurator:
+      enabled: false
+  prePuller:
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image.
+    #
+    # All cloudbank hubs makes use of the same user nodes, so its sufficient if
+    # a single hub pulls an image defined in common.values.yaml, this staging
+    # hub is picked for that purpose as it will be updated before other hubs.
+    #
+    hook:
+      enabled: true
   hub:
     config:
       JupyterHub:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -13,11 +13,6 @@ jupyterhub:
   scheduling:
     userScheduler:
       enabled: true
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   custom:
     homepage:
       templateVars:

--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -20,6 +20,13 @@ jupyterhub:
   custom:
     homepage:
       gitRepoBranch: "utoronto-prod"
+    jupyterhubConfigurator:
+      enabled: false
+  prePuller:
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image.
+    hook:
+      enabled: true
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/r-prod.values.yaml
+++ b/config/clusters/utoronto/r-prod.values.yaml
@@ -4,6 +4,14 @@ jupyterhub:
     tls:
       - hosts: [r.datatools.utoronto.ca]
         secretName: https-auto-tls
+  custom:
+    jupyterhubConfigurator:
+      enabled: false
+  prePuller:
+    # hook prePuller shouldn't be enabled when configuring images in any other
+    # way than singleuser.image.
+    hook:
+      enabled: true
   hub:
     db:
       pvc:

--- a/helm-charts/basehub/templates/NOTES.txt
+++ b/helm-charts/basehub/templates/NOTES.txt
@@ -1,0 +1,20 @@
+{{- /*
+  Error during template rendering to avoid misconfigurations that are either too
+  complicated to forbid by the chart's schema, or that would benefit from a more
+  verbose error message.
+*/}}
+
+{{- $error := "" }}
+{{- $error_title := "\n" }}
+{{- $error_title = print $error_title "\n#################################################################################" }}
+{{- $error_title = print $error_title "\n######   ERROR: The basehub chart config values wasn't accepted! The        #####" }}
+{{- $error_title = print $error_title "\n######          messages below provides more details.                       #####" }}
+{{- $error_title = print $error_title "\n#################################################################################" }}
+
+{{- if and .Values.jupyterhub.prePuller.hook.enabled .Values.jupyterhub.custom.jupyterhubConfigurator.enabled }}
+{{- $error = print $error "\n\nPROHIBITED: jupyterhub.prePuller.hook.enabled isn't allowed to be configured with jupyterhub.custom.jupyterhubConfigurator.enabled to ensure we don't pull an image that isn't relevant." }}
+{{- end }}
+
+{{- if $error }}
+{{- fail (print $error_title $error "\n\n") }}
+{{- end }}


### PR DESCRIPTION
This is a followup on https://github.com/2i2c-org/infrastructure/pull/3313#issuecomment-1777280535 to still retain use of hook prePuller, but to constrain its use.

The use of hook image puller is constrained to:
- _Not using the jupyterhub-configurator at the same time_
  This is enforced by the chart schema.
- _Not using one or more images set in any other way than by singleuser.image_
  This isn't enforced as its hard to enforce surgically enough to not constrain use of `profileList` beyond what we want. Due to that, a comment is made next to prePuller.hook.enabled to help us keep track of this. I'm quite strongly opinionated that this comment is retained inline because I think its too hard for us to enforce this policy if its only declared in external docs.

## Opt-out of jupyterhub-configurator

With `jupyterhub.custom.jupyterhubConfigurator.enabled` individual hubs can opt-out of using it. When disabled, it won't present itself to users via the JupyterHub menu under services, and any options set historically when enabled are ignored.

## Hub specific changes

### Cloudbank

_No impact on the communities are expected **except** for the jupyterhub-configurator no longer being usable on the staging hub._

Hook prePuller was enabled for a few hubs but not all. Since they put users on the the same nodes, and all hubs configure the same singleuser.image, it doesn't help to have more than one hook prePuller as long as it does its work before hubs are upgraded. By enabling hook prePuller on the staging hub, we accomplish this.

With this, the jupyterhub-configurator is disabled for the staging hub though which in this case is an undesired consequence as its really pulling the image for other hubs, possibly using the configurator.

### UToronto

The hook prePuller was enabled on staging and prod hubs. Staging hubs benefit from the configurator, and the prod hubs doesn't. As long as hook prePuller is enabled on either staging or prod, they should be fine. This led to:

-|Staging|Prod
-|-|-
hook prePuller | now disabled | remains enabled
jupyterhub-configurator | remains enabled | now disabled
