### PR TITLE
Fix auth details for 2i2c-aws-us/showcase and two cloudbank hubs

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -38,7 +38,6 @@ basehub:
           oauth_callback_url: "https://showcase.2i2c.cloud/hub/oauth_callback"
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:hub-access-for-2i2c-staff
             - 2i2c-org:research-delight-team
             - 2i2c-demo-hub-access:showcase-topst
           scope:

--- a/config/clusters/cloudbank/lamission.values.yaml
+++ b/config/clusters/cloudbank/lamission.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "google"
+      add_staff_user_ids_of_type: "github"
     homepage:
       templateVars:
         org:
@@ -30,7 +30,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://lamission.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org
           - LAMC-Mathematics
         scope:
           - read:org

--- a/config/clusters/cloudbank/wlac.values.yaml
+++ b/config/clusters/cloudbank/wlac.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "google"
+      add_staff_user_ids_of_type: "github"
     homepage:
       templateVars:
         org:

--- a/config/clusters/cloudbank/wlac.values.yaml
+++ b/config/clusters/cloudbank/wlac.values.yaml
@@ -30,7 +30,6 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://wlac.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-org:hub-access-for-2i2c-staff
           - WLAC-CS
         scope:
           - read:org


### PR DESCRIPTION
[5d269bb](https://github.com/2i2c-org/infrastructure/pull/3358/commits/5d269bb6ac9129fe9ef4420f4e9e03fba7abc873) - Allowing the GitHub org 2i2c-org or a team in it isn't needed when specifying `allowed_organizations`, we are already added as individual accounts via `jupyterhub.custom.2i2c.add_staff_user_ids_to_admin_users` and `jupyterhub.custom.2i2c.add_staff_user_ids_of_type`. Before OAuthenticator 16, this was needed though because then you had to be part of both to become an admin user.

9d4e75b - cloudbank, lamission and wlac: fix auth for 2i2c team
