### PR TITLE
openscapes: Use GitHubOAuthenticator for prod as well

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -49,7 +49,6 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
-          oauth_callback_url: https://staging.openscapes.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
             - NASA-Openscapes:workshopaccess-2i2c
             - NASA-Openscapes:longtermaccess-2i2c

--- a/config/clusters/openscapes/enc-prod.secret.values.yaml
+++ b/config/clusters/openscapes/enc-prod.secret.values.yaml
@@ -2,6 +2,9 @@ basehub:
     jupyterhub:
         hub:
             config:
+                GitHubOAuthenticator:
+                    client_id: ENC[AES256_GCM,data:NFyGnKb5e+P780cU2D0YfEm0Hgg=,iv:W+UfR4CiLHsv+3KA1yk2Ifr4LuixqLrxvwKhg+ue1ow=,tag:4Rh68xpLMk1v0INqNz7Quw==,type:str]
+                    client_secret: ENC[AES256_GCM,data:ofz7XY4qnop7QYc5SrBWPoQ69eRtxve1RLGlvuRN2pxDBq1rMYOn2Q==,iv:hmY/aXhmxplZ754ETo6Z83bBZ2g9rAlzdjnkkulXd6Q=,tag:APg7/OtJx4dq6UsUiAtAvA==,type:str]
                 CILogonOAuthenticator:
                     client_id: ENC[AES256_GCM,data:PCbeuaL7ldU54DbnmVNW+q2a3wTP5qd6S3dQej1An2sLwVGj4i7bxEQQAWDNs84KNxsT,iv:Hd/mRDZDHPDVJ3tjy0Td+KZWeegEL0iFqrqaWLyotK0=,tag:D6olXkt8OIt2ZdOVomZxDA==,type:str]
                     client_secret: ENC[AES256_GCM,data:SI36RxfT1vtePE0pkQorVeNhkGTt6GpSEkIMjbKwlGyIPFezKqMRFPYJxAeV5tz0JgdGd59h1XQb9Jk0K0K8XlxTKfWZ/M19dMqWpjDlgM4Ur3mHoCQ=,iv:W4NoN8hMqioTK1WOQnQJH7IZvtHyHXvLyrGg3bjJqhE=,tag:kGmt3v+2GOZ77nUO3AiUIg==,type:str]
@@ -14,8 +17,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-13T10:03:40Z"
-    mac: ENC[AES256_GCM,data:ZpYHsxfzFLW2ua+A40no5U4kUKSv5Fo/qf9Ys2LEMZS2ASZ0V3J1fJH2Dz6xbveavwgxDBWU0N4+KdT+WUzlx6V1Z/REVdmzLYEADSe7vnZX2W6tDfuB/Rf8rReB8Ajb45mn2LLEgLBv+jB97QXf0ijcxi5q4Vie6qH3sZOOG/0=,iv:YQN4OTU4zYmV8uI8bmy5bXLvzyurYneO9n9hTWa7JAA=,tag:UKahoDg8DSvkq9+V7rWW8g==,type:str]
+    lastmodified: "2023-11-01T16:06:18Z"
+    mac: ENC[AES256_GCM,data:t8iIrVtfn2kWB9KgUJy1k/3uDD2qMdCMc0qRy8Cqnf6XlStBUnynXUCfSAc/3//PGALfjfHFHOiAq7Az0BYZ4wpLDR30ecUke5X58ZzU81wQOzIeBXqFa/pFGsx36idoVE5KsBlNqHcWyn/pWSS6d55NqjruZOnW4oFgZc1lJjA=,iv:uA6J/qPN65IHcXXM1W4U3rbwC7Si7H75bvW345ZQXMo=,tag:UjBmqruapnbVA9tB3pZW/A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -97,5 +97,7 @@ basehub:
           profile_options: *profile_options
     hub:
       config:
+        GitHubOAuthenticator:
+          oauth_callback_url: "https://openscapes.2i2c.cloud/hub/oauth_callback"
         CILogonOAuthenticator:
           oauth_callback_url: "https://openscapes.2i2c.cloud/hub/oauth_callback"

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -126,5 +126,7 @@ basehub:
             requests: *requests_profile_options
     hub:
       config:
+        GitHubOAuthenticator:
+          oauth_callback_url: "https://staging.openscapes.2i2c.cloud/hub/oauth_callback"
         CILogonOAuthenticator:
           oauth_callback_url: "https://staging.openscapes.2i2c.cloud/hub/oauth_callback"


### PR DESCRIPTION
This also fixes an issue in https://github.com/2i2c-org/infrastructure/pull/3357, where config that should've been in staging.values.yaml was instead in common.values.yaml. I cancelled the run even though I only caught it after I hit merge, so no harm done.

Ref https://github.com/2i2c-org/infrastructure/issues/3240