### PR TITLE
Revert "openscapes: Setup GitHub Auth for openscapes staging"

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -47,16 +47,41 @@ basehub:
       allowNamedServers: true
       config:
         JupyterHub:
-          authenticator_class: github
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.openscapes.2i2c.cloud/hub/oauth_callback
-          allowed_organizations:
-            - NASA-Openscapes:workshopaccess-2i2c
-            - NASA-Openscapes:longtermaccess-2i2c
-            - NASA-Openscapes:championsaccess-2i2c
-          scope:
-            - read:org
+          authenticator_class: cilogon
+        CILogonOAuthenticator:
+          allowed_idps:
+            http://github.com/login/oauth/authorize:
+              username_derivation:
+                username_claim: "preferred_username"
+        OAuthenticator:
+          # WARNING: Don't use allow_existing_users with config to allow an
+          #          externally managed group of users, such as
+          #          GitHubOAuthenticator.allowed_organizations, as it breaks a
+          #          common expectations for an admin user.
+          #
+          #          The broken expectation is that removing a user from the
+          #          externally managed group implies that the user won't have
+          #          access any more. In practice the user will still have
+          #          access if it had logged in once before, as it then exists
+          #          in JupyterHub's database of users.
+          #
+          allow_existing_users: True
         Authenticator:
+          # WARNING: Removing a user from admin_users or allowed_users doesn't
+          #          revoke admin status or access.
+          #
+          #          OAuthenticator.allow_existing_users allows any user in the
+          #          JupyterHub database of users able to login. This includes
+          #          any previously logged in user or user previously listed in
+          #          allowed_users or admin_users, as such users are added to
+          #          JupyterHub's database on startup.
+          #
+          #          To revoke admin status or access for a user when
+          #          allow_existing_users is enabled, first remove the user from
+          #          admin_users or allowed_users, then deploy the change, and
+          #          finally revoke the admin status or delete the user via the
+          #          /hub/admin panel.
+          #
           admin_users:
             - amfriesz
             - jules32

--- a/config/clusters/openscapes/enc-staging.secret.values.yaml
+++ b/config/clusters/openscapes/enc-staging.secret.values.yaml
@@ -2,9 +2,6 @@ basehub:
     jupyterhub:
         hub:
             config:
-                GitHubOAuthenticator:
-                    client_id: ENC[AES256_GCM,data:OJ108MTcwcDD/p9A1g76jJV/IX4=,iv:jEoy+bDExh2STfYwGhuvPLivTSbDOYLAwJCp6cpN/kI=,tag:mhxy9BZKTam07MLOLgX6dQ==,type:str]
-                    client_secret: ENC[AES256_GCM,data:I5WJEZONBxsP+O6p+VJTCd08BasuQZuMAtENnk13rQfcUmDEbpAxfg==,iv:dt2zNgtFERpTe60UX8pzojEaa7M0X1AFtkD1CGTQORM=,tag:b/5qXuquAI+UT29nW5gxIQ==,type:str]
                 CILogonOAuthenticator:
                     client_id: ENC[AES256_GCM,data:EBaAMzaTvfRUNK6U4k+6TMCnIreSQo2BotapMjad9nS4YgD48XXmM/vx+3IOglx9HotA,iv:/a6xsdxpI+nDSSk2nPkAFGA6TKja7c8dHF4yXsFt0sY=,tag:sYoFNPe8b3KI/5BJ8MqusA==,type:str]
                     client_secret: ENC[AES256_GCM,data:hzatCTFx/dQNsedELDFYjug6g+Yfs1H8Q5JAJth9xLx/2Y9XcUAu0SzsDcL4M4CbeiN5wRYpvsyKz+6ygGsNtoo8n7MG427JxJPjz7uwm3IvQrauVJE=,iv:t5hn2DttsSpeU+bbF6OF3XLxekzj92eg2+fiwGWS/Kc=,tag:CcZnc+81ea+iQkHKrp7kVQ==,type:str]
@@ -17,8 +14,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-11-01T14:48:00Z"
-    mac: ENC[AES256_GCM,data:/uGQr8FOAHYN6IKA66vSGEF+0It7elmM8MV7TyWjWclyMg4A0GA/pCDXaxjx9Ao+piR2IIxCKxRMW9zDs3UqcUT6JjYBgZzH+exaAsYgONzIYRcdKN9JmZK3xGSUye5t5QDfzdAXLmNylR8228cTYZeg3SBZGATNr3FoUnTglZY=,iv:9lxleGE7BLOvVX6oYvC4TypOh/JVhIpHelKCxc+W0sY=,tag:tzDFJrVjJ0hD2Vap7j+6RQ==,type:str]
+    lastmodified: "2023-03-13T10:04:10Z"
+    mac: ENC[AES256_GCM,data:gNugXyk8VLkVL5+sRISipvrMD3dDP3O16Hr/PROtNp1DJjcYAmK6j1OQo/MtMho00zzycQIjI9NkYa+j99d/+cXgXJa0RRDhERBkW5OWT95cFFznJlR2vIK0sbD6UIBktVirUU6Mit3LfcB5CTzTky3ixFuoLwoG5Suqb7YfLug=,iv:S51lDAOUpTHmKa4B6WuludJTQurhqZCxHfNPj+D/M2g=,tag:aZkrbG7ZOvZft4ggZl87fA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#3357

Missed the fact that this was changing files in `common.yaml`
that should instead be changed in `staging.yaml`.

Reverting and cancelling the deploys to leave staging in current
state.

Ref https://github.com/2i2c-org/infrastructure/issues/3240