### PR TITLE
2i2c-aws-us, cosmicds: disable microsoft/google auth

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -79,16 +79,6 @@ jupyterhub:
             username_derivation:
               username_claim: "preferred_username"
             allow_all: true
-          # Temporarily enable Google & Microsoft accounts again
-          # Disable again first week of november
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
       Authenticator:
         admin_users:
           - nmearl


### PR DESCRIPTION
This PR resolve this comment for 2i2c-aws-us/cosmicds hub:

```
          # Temporarily enable Google & Microsoft accounts again
          # Disable again first week of november
```

This still doesn't resolve https://github.com/2i2c-org/meta/issues/681 though.