### PR TITLE
Use images with nbgitpuller for UCMerced

### DIFF
--- a/config/clusters/2i2c/ucmerced-staging.values.yaml
+++ b/config/clusters/2i2c/ucmerced-staging.values.yaml
@@ -12,13 +12,15 @@ jupyterhub:
         description: Start a Python server with JupyterLab and scientific Python stack
         default: true
         kubespawner_override:
-          image: jupyter/scipy-notebook:2023-06-26
+          # From https://github.com/2i2c-org/scipy-notebook-with-nbgitpuller
+          image: quay.io/2i2c/scipy-notebook-with-nbgitpuller:99968bfe6916
           # Launch into JupyterLab after the user logs in
           default_url: /lab
       - display_name: R
         description: Start a R server with tidyverse & Geospatial tools
         kubespawner_override:
-          image: rocker/binder:4.3.1
+          # From https://github.com/2i2c-org/rocker-with-nbgitpuller
+          image: quay.io/2i2c/rocker-with-nbgitpuller:287ea05b2809
           default_url: /lab
           # Ensures container working dir is homedir
           # https://github.com/2i2c-org/infrastructure/issues/2559

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -12,13 +12,15 @@ jupyterhub:
         description: Start a Python server with JupyterLab and scientific Python stack
         default: true
         kubespawner_override:
-          image: jupyter/scipy-notebook:2023-06-26
+          # From https://github.com/2i2c-org/scipy-notebook-with-nbgitpuller
+          image: quay.io/2i2c/scipy-notebook-with-nbgitpuller:99968bfe6916
           # Launch into JupyterLab after the user logs in
           default_url: /lab
       - display_name: R
         description: Start a R server with tidyverse & Geospatial tools
         kubespawner_override:
-          image: rocker/binder:4.3.1
+          # From https://github.com/2i2c-org/rocker-with-nbgitpuller
+          image: quay.io/2i2c/rocker-with-nbgitpuller:287ea05b2809
           default_url: /lab
           # Ensures container working dir is homedir
           # https://github.com/2i2c-org/infrastructure/issues/2559


### PR DESCRIPTION
Both the images in use at UCMerced don't have nbgitpuller installed in them, while the previous combined image did.

I've been working on getting nbgitpuller into upstream jupyter docker-stacks (https://github.com/jupyter/docker-stacks/pull/2000) for a while, but it looks like it'll take a bit longer. So I've temporarily created a repo (https://github.com/2i2c-org/scipy-notebook-with-nbgitpuller/) to use here. It's based on the same tag as before, but with nbgitpuller installed. We can get rid of this once nbgitpuller lands upstream.

I have created https://github.com/2i2c-org/rocker-with-nbgitpuller/ to do the same for use with rocker. This too is a temporary repo. I hopefully will have a better longer term solution speced out next week.

This unblocks ucmerced currently teaching.

Ref https://2i2c.freshdesk.com/a/tickets/1089