### PR TITLE
Disable hook prePuller for three communites using the jupyterhub configurator

### DIFF
--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -1,9 +1,4 @@
 jupyterhub:
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   singleuser:
     memory:
       limit: 16G
@@ -16,9 +11,6 @@ jupyterhub:
         value: "climatematch"
         effect: "NoSchedule"
     defaultUrl: /lab
-    image:
-      name: wesleyban/climatematch-notebook
-      tag: v0.1
     # shared-public for collaboration
     # See https://github.com/2i2c-org/infrastructure/issues/2785
     storage:

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -9,11 +9,6 @@ nfs:
     # Name of Google Filestore share
     baseShareName: /homes/
 jupyterhub:
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   custom:
     2i2c:
       # add_staff_user_ids_to_admin_users is disabled because the usernames
@@ -37,9 +32,6 @@ jupyterhub:
           name: Callysto
           url: https://www.callysto.ca
   singleuser:
-    image:
-      name: callysto/2i2c
-      tag: 0.1.4
     extraFiles:
       tree.html:
         mountPath: /usr/local/share/jupyter/custom_template/tree.html

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -9,11 +9,6 @@ nfs:
     # Name of Google Filestore share
     baseShareName: /homes/
 jupyterhub:
-  prePuller:
-    # hook prePuller shouldn't be enabled when configuring images in any other
-    # way than singleuser.image
-    hook:
-      enabled: true
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
@@ -48,13 +43,6 @@ jupyterhub:
           - gizmo404
           - jtkmckenna
   singleuser:
-    image:
-      # pangeo/pangeo-notebook is maintained at: https://github.com/pangeo-data/pangeo-docker-images
-      name: pangeo/pangeo-notebook
-      # pullPolicy set to "Always" because we use the changing over time tag
-      # "latest".
-      pullPolicy: Always
-      tag: "latest"
     profileList:
       # NOTE: About node sharing
       #


### PR DESCRIPTION
Since callysto, qcl, and 2i2c/climatematch are all using the configurator, they don't have any benefit from the hook prePuller so this PR disables it for these hubs to reduce unessecary complexity and false expectations from the config.

These are commits extracted from #3341 that as a whole can't be merged short term