### PR TITLE
terraform, gcp: enable specification of individual node pools version

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -247,7 +247,7 @@ resource "google_container_node_pool" "notebook" {
   cluster  = google_container_cluster.cluster.name
   project  = google_container_cluster.cluster.project
   location = google_container_cluster.cluster.location
-  version  = var.k8s_versions.notebook_nodes_version
+  version  = try(each.value.node_version, var.k8s_versions.notebook_nodes_version)
 
   # terraform treats null same as unset, so we only set the node_locations
   # here if it is explicitly overriden. If not, it will just inherit whatever

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -98,7 +98,8 @@ variable "notebook_nodes" {
       {}
     ),
     resource_labels : optional(map(string), {}),
-    zones : optional(list(string), [])
+    zones : optional(list(string), []),
+    node_version : optional(string, ""),
   }))
   description = "Notebook node pools to create"
   default     = {}


### PR DESCRIPTION
When upgrading GKE clusters, we have a `notebook_nodes_version` variable, but if not all node pools are unused, its useful to be able to specify exceptions to the k8s version for individual node pools. This PR adds that ability and upgrades a few unused nodes in QCL as well.

This is preparation work for how we document and handle GKE cluster upgrades in general as tracked by #3250.

<details>
<summary>QCL terraform change applied</summary>

```terraform
Terraform will perform the following actions:

  # google_container_node_pool.notebook["huge"] will be destroyed
  # (because key ["huge"] is not in for_each map)
  - resource "google_container_node_pool" "notebook" {
      - cluster                     = "qcl-cluster" -> null
      - id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-huge" -> null
      - initial_node_count          = 0 -> null
      - instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroupManagers/gke-qcl-cluster-nb-huge-f34309ad-grp",
        ] -> null
      - location                    = "europe-west1" -> null
      - managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroups/gke-qcl-cluster-nb-huge-f34309ad-grp",
        ] -> null
      - name                        = "nb-huge" -> null
      - node_count                  = 0 -> null
      - node_locations              = [
          - "europe-west1-d",
        ] -> null
      - project                     = "qcl-hub" -> null
      - version                     = "1.24.9-gke.3200" -> null

      - autoscaling {
          - location_policy      = "BALANCED" -> null
          - max_node_count       = 100 -> null
          - min_node_count       = 0 -> null
          - total_max_node_count = 0 -> null
          - total_min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-balanced" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - logging_variant   = "DEFAULT" -> null
          - machine_type      = "n2-standard-96" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - resource_labels   = {} -> null
          - service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com" -> null
          - spot              = false -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode = "GKE_METADATA" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }
    }

  # google_container_node_pool.notebook["huge-highcpu"] will be destroyed
  # (because key ["huge-highcpu"] is not in for_each map)
  - resource "google_container_node_pool" "notebook" {
      - cluster                     = "qcl-cluster" -> null
      - id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-huge-highcpu" -> null
      - initial_node_count          = 0 -> null
      - instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroupManagers/gke-qcl-cluster-nb-huge-highcpu-56ceaf12-grp",
        ] -> null
      - location                    = "europe-west1" -> null
      - managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroups/gke-qcl-cluster-nb-huge-highcpu-56ceaf12-grp",
        ] -> null
      - name                        = "nb-huge-highcpu" -> null
      - node_count                  = 0 -> null
      - node_locations              = [
          - "europe-west1-d",
        ] -> null
      - project                     = "qcl-hub" -> null
      - version                     = "1.24.9-gke.3200" -> null

      - autoscaling {
          - location_policy      = "BALANCED" -> null
          - max_node_count       = 100 -> null
          - min_node_count       = 0 -> null
          - total_max_node_count = 0 -> null
          - total_min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-balanced" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - logging_variant   = "DEFAULT" -> null
          - machine_type      = "n2-highcpu-96" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - resource_labels   = {} -> null
          - service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com" -> null
          - spot              = false -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode = "GKE_METADATA" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }
    }

  # google_container_node_pool.notebook["large"] will be destroyed
  # (because key ["large"] is not in for_each map)
  - resource "google_container_node_pool" "notebook" {
      - cluster                     = "qcl-cluster" -> null
      - id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-large" -> null
      - initial_node_count          = 0 -> null
      - instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroupManagers/gke-qcl-cluster-nb-large-edce8ced-grp",
        ] -> null
      - location                    = "europe-west1" -> null
      - managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroups/gke-qcl-cluster-nb-large-edce8ced-grp",
        ] -> null
      - name                        = "nb-large" -> null
      - node_count                  = 0 -> null
      - node_locations              = [
          - "europe-west1-d",
        ] -> null
      - project                     = "qcl-hub" -> null
      - version                     = "1.24.9-gke.3200" -> null

      - autoscaling {
          - location_policy      = "BALANCED" -> null
          - max_node_count       = 100 -> null
          - min_node_count       = 0 -> null
          - total_max_node_count = 0 -> null
          - total_min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-balanced" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - logging_variant   = "DEFAULT" -> null
          - machine_type      = "n2-standard-48" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - resource_labels   = {} -> null
          - service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com" -> null
          - spot              = false -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode = "GKE_METADATA" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }
    }

  # google_container_node_pool.notebook["large-highcpu"] will be destroyed
  # (because key ["large-highcpu"] is not in for_each map)
  - resource "google_container_node_pool" "notebook" {
      - cluster                     = "qcl-cluster" -> null
      - id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-large-highcpu" -> null
      - initial_node_count          = 0 -> null
      - instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroupManagers/gke-qcl-cluster-nb-large-highcpu-9a199cd3-grp",
        ] -> null
      - location                    = "europe-west1" -> null
      - managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroups/gke-qcl-cluster-nb-large-highcpu-9a199cd3-grp",
        ] -> null
      - name                        = "nb-large-highcpu" -> null
      - node_count                  = 0 -> null
      - node_locations              = [
          - "europe-west1-d",
        ] -> null
      - project                     = "qcl-hub" -> null
      - version                     = "1.24.9-gke.3200" -> null

      - autoscaling {
          - location_policy      = "BALANCED" -> null
          - max_node_count       = 100 -> null
          - min_node_count       = 0 -> null
          - total_max_node_count = 0 -> null
          - total_min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-balanced" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - logging_variant   = "DEFAULT" -> null
          - machine_type      = "n2-highcpu-32" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - resource_labels   = {} -> null
          - service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com" -> null
          - spot              = false -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode = "GKE_METADATA" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }
    }

  # google_container_node_pool.notebook["medium"] will be destroyed
  # (because key ["medium"] is not in for_each map)
  - resource "google_container_node_pool" "notebook" {
      - cluster                     = "qcl-cluster" -> null
      - id                          = "projects/qcl-hub/locations/europe-west1/clusters/qcl-cluster/nodePools/nb-medium" -> null
      - initial_node_count          = 0 -> null
      - instance_group_urls         = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroupManagers/gke-qcl-cluster-nb-medium-491012d1-grp",
        ] -> null
      - location                    = "europe-west1" -> null
      - managed_instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/qcl-hub/zones/europe-west1-d/instanceGroups/gke-qcl-cluster-nb-medium-491012d1-grp",
        ] -> null
      - name                        = "nb-medium" -> null
      - node_count                  = 0 -> null
      - node_locations              = [
          - "europe-west1-d",
        ] -> null
      - project                     = "qcl-hub" -> null
      - version                     = "1.24.9-gke.3200" -> null

      - autoscaling {
          - location_policy      = "BALANCED" -> null
          - max_node_count       = 100 -> null
          - min_node_count       = 0 -> null
          - total_max_node_count = 0 -> null
          - total_min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - network_config {
          - create_pod_range     = false -> null
          - enable_private_nodes = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-balanced" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - logging_variant   = "DEFAULT" -> null
          - machine_type      = "n2-highmem-16" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - resource_labels   = {} -> null
          - service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com" -> null
          - spot              = false -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - mode = "GKE_METADATA" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
          - strategy        = "SURGE" -> null
        }
    }

  # google_container_node_pool.notebook["n2-highcpu-32"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highcpu-32"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highcpu-32"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highcpu-96"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highcpu-96"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highcpu-96"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-highmem-16"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-highmem-16"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-highmem-16"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-standard-48"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-standard-48"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-standard-48"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }

  # google_container_node_pool.notebook["n2-standard-96"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster                     = "qcl-cluster"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "europe-west1"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "nb-n2-standard-96"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = (known after apply)
      + operation                   = (known after apply)
      + project                     = "qcl-hub"
      + version                     = (known after apply)

      + autoscaling {
          + location_policy = (known after apply)
          + max_node_count  = 100
          + min_node_count  = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-balanced"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + logging_variant   = "DEFAULT"
          + machine_type      = "n2-standard-96"
          + metadata          = (known after apply)
          + min_cpu_platform  = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "qcl-cluster-sa@qcl-hub.iam.gserviceaccount.com"
          + spot              = false
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }
    }
```
</details>