### PR TITLE
qcl, awi-ciroh, leap, 2i2c: gke k8s clusters upgraded to 1.27

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -12,13 +12,13 @@ on:
     branches:
       - master
     paths:
+      # Include changes to the deployer script's folder, but exclude some parts
       - deployer/**
-      # Exclude changes to the tests directory from
-      # triggering this workflow
-      - "!deployer/health_check_tests/**"
-      # Exclude changes to the README from triggering
-      # this workflow
       - "!deployer/README.md"
+      - "!deployer/health_check_tests/**"
+      - "!deployer/commands/generate/billing/**"
+      - "!deployer/commands/generate/dedicated_cluster/**"
+      - "!deployer/commands/generate/resource_allocation/**"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**
@@ -27,13 +27,13 @@ on:
     branches:
       - master
     paths:
+      # Include changes to the deployer script's folder, but exclude some parts
       - deployer/**
-      # Exclude changes to the tests directory from
-      # triggering this workflow
-      - "!deployer/health_check_tests/**"
-      # Exclude changes to the README from triggering
-      # this workflow
       - "!deployer/README.md"
+      - "!deployer/health_check_tests/**"
+      - "!deployer/commands/generate/billing/**"
+      - "!deployer/commands/generate/dedicated_cluster/**"
+      - "!deployer/commands/generate/resource_allocation/**"
       - requirements.txt
       - .github/actions/setup-deploy/**
       - helm-charts/**

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -21,11 +21,11 @@
 #
 gke:
   2i2c:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: binder-staging-dind,binder-staging-image-cleaner,continuous-image-puller,imagebuilding-demo-binderhub-service-docker-api,netd
-    cpu_requests: 342m
-    memory_requests: 566Mi
-    k8s_version: v1.26.5-gke.2100
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 344m
+    memory_requests: 596Mi
+    k8s_version: v1.27.4-gke.900
   2i2c-uk:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -33,11 +33,11 @@ gke:
     memory_requests: 596Mi
     k8s_version: v1.27.4-gke.900
   awi-ciroh:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: netd
-    cpu_requests: 342m
-    memory_requests: 566Mi
-    k8s_version: v1.25.10-gke.2700
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 344m
+    memory_requests: 596Mi
+    k8s_version: v1.27.4-gke.900
   callysto:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -63,11 +63,11 @@ gke:
     memory_requests: 480Mi
     k8s_version: v1.27.3-gke.100
   leap:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: netd
-    cpu_requests: 342m
-    memory_requests: 566Mi
-    k8s_version: v1.25.10-gke.2700
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 344m
+    memory_requests: 596Mi
+    k8s_version: v1.27.4-gke.900
   linked-earth:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -93,11 +93,11 @@ gke:
     memory_requests: 566Mi
     k8s_version: v1.26.5-gke.2100
   qcl:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: continuous-image-puller,continuous-image-puller,netd
-    cpu_requests: 336m
-    memory_requests: 466Mi
-    k8s_version: v1.25.10-gke.2700
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 338m
+    memory_requests: 496Mi
+    k8s_version: v1.27.4-gke.900
 eks:
   2i2c-aws-us:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -8,10 +8,10 @@ enable_filestore       = true
 filestore_capacity_gb  = 1536
 
 k8s_versions = {
-  min_master_version : "1.25.8-gke.500",
-  core_nodes_version : "1.25.6-gke.1000",
-  notebook_nodes_version : "1.25.6-gke.1000",
-  dask_nodes_version : "1.25.6-gke.1000",
+  min_master_version : "1.27.4-gke.900",
+  core_nodes_version : "1.27.4-gke.900",
+  notebook_nodes_version : "1.27.4-gke.900",
+  dask_nodes_version : "1.27.4-gke.900",
 }
 
 user_buckets = {
@@ -31,20 +31,17 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
-  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
-  "small" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
   },
-  # FIXME: Rename this to "n2-highmem-64" when given the chance and no such nodes are running
-  "large" : {
+  "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
@@ -57,7 +54,7 @@ notebook_nodes = {
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 200,
     machine_type : "n2-highmem-16"

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -5,10 +5,10 @@ project_id = "leap-pangeo"
 core_node_machine_type = "n2-highmem-4"
 
 k8s_versions = {
-  min_master_version : "1.25.6-gke.1000",
-  core_nodes_version : "1.25.6-gke.1000",
-  notebook_nodes_version : "1.25.6-gke.1000",
-  dask_nodes_version : "1.25.6-gke.1000",
+  min_master_version : "1.27.4-gke.900",
+  core_nodes_version : "1.27.4-gke.900",
+  notebook_nodes_version : "1.27.4-gke.900",
+  dask_nodes_version : "1.27.4-gke.900",
 }
 
 # GPUs not available in us-central1-b
@@ -76,22 +76,26 @@ notebook_nodes = {
     machine_type : "n2-highmem-4",
   },
   # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
+  # FIXME: Remove node pool specific node_version pin when given the chance and no such nodes are running
   "medium" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.
     min : 1,
     max : 100,
     machine_type : "n2-highmem-16",
+    node_version : "1.25.6-gke.1000",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64"
   }
+  # FIXME: Remove node pool specific node_version pin when given the chance and no such nodes are running
   "gpu-t4" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
+    node_version : "1.25.6-gke.1000",
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",
@@ -114,7 +118,7 @@ notebook_nodes = {
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 200,
     # Disable preemptive nodes for dask so we can remove possible complications

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -26,6 +26,13 @@ region                 = "us-central1"
 core_node_machine_type = "n2-highmem-8"
 enable_private_cluster = true
 
+k8s_versions = {
+  min_master_version : "1.26.5-gke.2100",
+  core_nodes_version : "1.26.4-gke.1400",
+  notebook_nodes_version : "1.26.4-gke.1400",
+  dask_nodes_version : "1.26.4-gke.1400",
+}
+
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy = true
 
@@ -69,45 +76,21 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n1-standard-2",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-4",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
   "huge" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
-    labels : {},
-    gpu : {
-      enabled : false,
-      type : "",
-      count : 0
-    }
   },
 }
 
@@ -117,6 +100,7 @@ notebook_nodes = {
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
+  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
   "worker" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -18,6 +18,7 @@
 #
 #     terraform apply --var-file projects/pangeo-hubs.tfvars
 #
+# FIXME: core_node_machine_type should be set to n2-highmem-4 as its enough
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
 billing_project_id     = "pangeo-integration-te-3eea"

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -6,10 +6,10 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
-  min_master_version : "1.26.5-gke.2100",
-  core_nodes_version : "1.26.5-gke.2100",
-  notebook_nodes_version : "1.26.4-gke.1400",
-  dask_nodes_version : "1.26.5-gke.1400",
+  min_master_version : "1.27.4-gke.900",
+  core_nodes_version : "1.27.4-gke.900",
+  notebook_nodes_version : "1.27.4-gke.900",
+  dask_nodes_version : "1.27.4-gke.900",
 }
 
 core_node_machine_type = "n2-highmem-4"
@@ -19,11 +19,11 @@ enable_filestore      = true
 filestore_capacity_gb = 5120
 
 notebook_nodes = {
-  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
-  "user" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
+    node_version : "1.27.4-gke.900",
   },
   "n2-highmem-16" : {
     min : 0,
@@ -34,7 +34,7 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-  }
+  },
   # Nodepool for neurohackademy. Tracking issue: https://github.com/2i2c-org/infrastructure/issues/2681
   "neurohackademy" : {
     # We expect around 120 users
@@ -52,8 +52,9 @@ notebook_nodes = {
     resource_labels : {
       "community" : "neurohackademy"
     },
-  }
+  },
   # Nodepool for temple university. https://github.com/2i2c-org/infrastructure/issues/3158
+  # FIXME: Remove node pool specific node_version pin when given the chance and no such nodes are running
   "temple" : {
     # Expecting upto ~120 users at a time
     min : 0,
@@ -62,6 +63,7 @@ notebook_nodes = {
     # This fits upto 100 users on the node, as memory guarantee isn't the constraint.
     # This works ok.
     machine_type : "n2-highmem-8",
+    node_version : "1.26.4-gke.1400",
     labels : {
       "2i2c.org/community" : "temple"
     },
@@ -73,7 +75,7 @@ notebook_nodes = {
     resource_labels : {
       "community" : "temple"
     },
-  }
+  },
   # Nodepool for jackeddy symposium. https://github.com/2i2c-org/infrastructure/issues/3166
   "jackeddy" : {
     min : 0,
@@ -89,8 +91,8 @@ notebook_nodes = {
     }],
     resource_labels : {
       "community" : "jackeddy"
-    }
-  }
+    },
+  },
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -99,7 +99,7 @@ notebook_nodes = {
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
-  "worker" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,7 +23,6 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    node_version : "1.27.4-gke.900",
   },
   "n2-highmem-16" : {
     min : 0,

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -6,9 +6,9 @@ region           = "europe-west1"
 regional_cluster = true
 
 k8s_versions = {
-  min_master_version : "1.25.10-gke.2700",
-  core_nodes_version : "1.24.9-gke.3200",
-  notebook_nodes_version : "1.24.9-gke.3200",
+  min_master_version : "1.27.4-gke.900",
+  core_nodes_version : "1.27.4-gke.900",
+  notebook_nodes_version : "1.27.4-gke.900",
 }
 
 core_node_machine_type = "n2-highmem-2"
@@ -27,40 +27,37 @@ user_buckets = {
 }
 
 notebook_nodes = {
-  # FIXME: Rename this to "n2-highmem-4" when given the chance and no such nodes are running
-  "small" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
-  "medium" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-  },
-  # FIXME: Rename this to "n2-highmem-48" when given the chance and no such nodes are running
-  "large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-standard-48",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
   }
-  "huge" : {
+  "n2-standard-48" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-standard-48",
+  },
+  "n2-standard-96" : {
     min : 0,
     max : 100,
     machine_type : "n2-standard-96",
   },
-  "large-highcpu" : {
+  "n2-highcpu-32" : {
     min : 0,
     max : 100,
     machine_type : "n2-highcpu-32",
   },
-  "huge-highcpu" : {
+  "n2-highcpu-96" : {
     min : 0,
     max : 100,
     machine_type : "n2-highcpu-96",


### PR DESCRIPTION
These clusters were opportunistically upgraded as part of me trying to gain experience to document an upgrade policy for GKE clusters (#3250).

### Semi-related extras

388eae8 - I used `deployer generate resource-allocation daemonset-requests <cluster name>` to update information about daemonsets' resource requests in clusters as well

d1e193d - I made the deploy hubs workflow not redeploy all hubs because of changes to unrelated `generate` commands not used in the workflow