### PR TITLE
leap and carbonplan: tune hub/proxy pods' requests/limits

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -170,19 +170,19 @@ basehub:
       chp:
         resources:
           requests:
-            cpu: 0.5
+            cpu: 100m
             memory: 256Mi
           limits:
             cpu: 1
-            memory: 4Gi
+            memory: 512Mi
     hub:
       resources:
         requests:
-          cpu: 0.5
-          memory: 256Mi
+          cpu: 100m
+          memory: 512Mi
         limits:
           cpu: 1
-          memory: 4Gi
+          memory: 1Gi
       allowNamedServers: true
       config:
         JupyterHub:

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -27,11 +27,6 @@ basehub:
           limits:
             cpu: 1
             memory: 512Mi
-    singleuser:
-      extraEnv:
-        SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)
-        PERSISTENT_BUCKET: gs://leap-persistent/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: gs://leap-scratch/$(JUPYTERHUB_USER)
     hub:
       resources:
         requests:
@@ -43,3 +38,8 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://leap.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: gs://leap-persistent/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: gs://leap-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -22,8 +22,11 @@ basehub:
       chp:
         resources:
           requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
             cpu: 1
-            memory: 1Gi
+            memory: 512Mi
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)
@@ -32,8 +35,11 @@ basehub:
     hub:
       resources:
         requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
           cpu: 1
-          memory: 2Gi
+          memory: 1Gi
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://leap.2i2c.cloud/hub/oauth_callback


### PR DESCRIPTION
Fixes #3376 by tuning proxy/hub pods' resources requests/limits for cpu/memory that has been increased historically to ensure it won't be a problem. This tunes those conservative requests/limits based on data to help us avoid setting a too conservative precedent for other hubs and potentially reducing cloud costs.
- still requesting more memory than has ever been seen used, and allowing the limit of memory to be 2x of that request
- still requesting more CPU than has been seen the last 90 days, and allowing the limit of CPU to 10x of that request