### PR TITLE
openscapes: Remove extra volumemounts

### DIFF
--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -92,17 +92,6 @@ basehub:
             # Ensures container working dir is homedir
             # https://github.com/2i2c-org/infrastructure/issues/2559
             working_dir: /home/rstudio
-            # Because this is a list, it will override our default volume mounts
-            volume_mounts:
-              # Mount the user home directory
-              - name: home
-                mountPath: /home/rstudio
-                subPath: "{username}"
-              # Mount the shared readonly directory
-              - name: home
-                mountPath: /home/rstudio/shared
-                subPath: _shared
-                readOnly: true
           profile_options: *profile_options
         - display_name: Matlab
           description: Matlab environment

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -113,18 +113,6 @@ basehub:
                     # Ensures container working dir is homedir
                     # https://github.com/2i2c-org/infrastructure/issues/2559
                     working_dir: /home/rstudio
-                    # Because this is a list, it will override our default volume mounts
-                    volume_mounts:
-                      # Mount the user home directory
-                      - name: home
-                        mountPath: /home/rstudio
-                        subPath: "{username}"
-                      # Mount the shared readonly directory
-                      - name: home
-                        mountPath: /home/rstudio/shared
-                        subPath: _shared
-                        readOnly: true
-
             requests: *requests_profile_options
         - display_name: Matlab
           description: Matlab environment


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3246, as https://github.com/2i2c-org/infrastructure/pull/3347 was merged in the meantime.

Fixes https://github.com/2i2c-org/infrastructure/issues/3242