### PR TITLE
openscapes: Fix extraVolumeMounts being overriden

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -36,10 +36,19 @@ basehub:
       defaultUrl: /lab
       storage:
         extraVolumeMounts:
+          # Copy paste from basehub/values.yaml because we want
+          # `shared` to be readwrite for *everyone*
           - name: home
             mountPath: /home/jovyan/shared
             subPath: _shared
             readOnly: false
+          - name: home
+            mountPath: /home/rstudio
+            subPath: "{username}"
+          - name: home
+            mountPath: /home/rstudio/shared
+            subPath: _shared
+            readOnly: true
     scheduling:
       userScheduler:
         enabled: true


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3388, which otherwise basically just didn't mount home directories at all!

Fixes https://github.com/2i2c-org/infrastructure/pull/3388