### PR TITLE
openscapes: Set readOnly to false on shared dir on rstudio as well

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -43,12 +43,12 @@ basehub:
             subPath: _shared
             readOnly: false
           - name: home
-            mountPath: /home/rstudio
-            subPath: "{username}"
-          - name: home
             mountPath: /home/rstudio/shared
             subPath: _shared
-            readOnly: true
+            readOnly: false
+          - name: home
+            mountPath: /home/rstudio
+            subPath: "{username}"
     scheduling:
       userScheduler:
         enabled: true


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3389

Fixes https://github.com/2i2c-org/infrastructure/pull/3388