### PR TITLE
[deployer] Don't allow overwriting existing cluster infrastructure files unless `--force` is used and working tree is clean

### DIFF
--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -15,7 +15,11 @@ import typer
 from deployer.utils.file_acquisition import REPO_ROOT_PATH
 from deployer.utils.rendering import print_colour
 
-from .common import force_overwrite, generate_config_directory, generate_support_files
+from .common import (
+    check_before_continuing_with_generate_command,
+    generate_config_directory,
+    generate_support_files,
+)
 from .dedicated_cluster_app import dedicated_cluster_app
 
 
@@ -24,6 +28,7 @@ def get_infra_files_to_be_created(cluster_name):
         REPO_ROOT_PATH / "eksctl" / f"{cluster_name}.jsonnet",
         REPO_ROOT_PATH / "terraform/aws/projects" / f"{cluster_name}.tfvars",
         REPO_ROOT_PATH / "eksctl/ssh-keys/secret" / f"{cluster_name}.key",
+        REPO_ROOT_PATH / "config/clusters" / cluster_name / "support.values.yaml",
         REPO_ROOT_PATH
         / "config/clusters"
         / cluster_name
@@ -112,16 +117,18 @@ def aws(
     Automatically generate the files required to setup a new cluster on AWS if they don't exist.
     Use --force to force existing configuration files to be overwritten by this command.
     """
-
     # These are the variables needed by the templates used to generate the cluster config file
     # and support files
+
     vars = {
         "cluster_name": cluster_name,
         "hub_type": hub_type,
         "cluster_region": cluster_region,
     }
 
-    if not force_overwrite(get_infra_files_to_be_created, cluster_name, force):
+    if not check_before_continuing_with_generate_command(
+        get_infra_files_to_be_created, cluster_name, force
+    ):
         raise typer.Abort()
 
     # If we are here, then either no existing infrastructure files for this cluster have been found

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -26,10 +26,13 @@ from .dedicated_cluster_app import dedicated_cluster_app
 def get_infra_files_to_be_created(cluster_name):
     return [
         REPO_ROOT_PATH / "eksctl" / f"{cluster_name}.jsonnet",
-        (REPO_ROOT_PATH / "terraform/aws/projects" / f"{cluster_name}.tfvars"),
-        (REPO_ROOT_PATH / "eksctl/ssh-keys/secret" / f"{cluster_name}.key",),
-        REPO_ROOT_PATH / "config/clusters/templates/common/support.values.yaml",
-        REPO_ROOT_PATH / "config/clusters/templates/common/support.secret.values.yaml",
+        REPO_ROOT_PATH / "terraform/aws/projects" / f"{cluster_name}.tfvars",
+        REPO_ROOT_PATH / "eksctl/ssh-keys/secret" / f"{cluster_name}.key",
+        REPO_ROOT_PATH
+        / "config/clusters/"
+        / cluster_name
+        / "enc-support.secret.values.yaml",
+        REPO_ROOT_PATH / "config/clusters" / cluster_name / "cluster.yaml",
     ]
 
 

--- a/deployer/commands/generate/dedicated_cluster/common.py
+++ b/deployer/commands/generate/dedicated_cluster/common.py
@@ -25,7 +25,7 @@ def check_git_status_clean(infra_files):
         full_filepath = REPO_ROOT_PATH / file
         if full_filepath in infra_files:
             print_colour(
-                f"{full_filepath} was not comitted. Commit or restore the file in order to proceed with the generation.",
+                f"{full_filepath} was not committed. Commit or restore the file in order to proceed with the generation.",
                 "yellow",
             )
             return False

--- a/deployer/commands/generate/dedicated_cluster/common.py
+++ b/deployer/commands/generate/dedicated_cluster/common.py
@@ -10,26 +10,6 @@ from deployer.utils.file_acquisition import REPO_ROOT_PATH
 from deployer.utils.rendering import print_colour
 
 
-def check_force_overwrite(cluster_name, force):
-    """
-    Check if the force flag is present and print relevant messages to stdout.
-    If  the --force flag was False, return False, otherwise, return True.
-    """
-    if not force:
-        print_colour(
-            f"Found existing infrastructure files for cluster {cluster_name}. Use --force if you want to allow this script to overwrite them.",
-            "red",
-        )
-        return False
-
-    print_colour(
-        f"Attention! Found existing infrastructure files for {cluster_name}. They will be overwritten by the --force flag!",
-        "red",
-    )
-
-    return True
-
-
 def check_git_status_clean(infra_files):
     """
     Check if running `git status` doesn't return any file that the generate command should create/update.
@@ -72,9 +52,17 @@ def check_before_continuing_with_generate_command(
     if not (any(os.path.exists(path) for path in infra_files)):
         return True
 
-    if not check_force_overwrite(cluster_name, force):
+    if not force:
+        print_colour(
+            f"Found existing infrastructure files for cluster {cluster_name}. Use --force if you want to allow this script to overwrite them.",
+            "red",
+        )
         return False
 
+    print_colour(
+        f"Attention! Found existing infrastructure files for {cluster_name}. They will be overwritten by the --force flag!",
+        "red",
+    )
     return True
 
 

--- a/deployer/commands/generate/dedicated_cluster/common.py
+++ b/deployer/commands/generate/dedicated_cluster/common.py
@@ -17,16 +17,35 @@ def infra_files_already_exist(get_infra_files_func, cluster_name):
     return False
 
 
+def force_overwrite(get_infra_files_func, cluster_name, force):
+    if infra_files_already_exist(get_infra_files_func, cluster_name):
+        if not force:
+            print_colour(
+                f"Found existing infrastructure files for cluster {cluster_name}. Use --force if you want to allow this script to overwrite them.",
+                "red",
+            )
+            return False
+        else:
+            print_colour(
+                f"Attention! Found existing infrastructure files for {cluster_name}. They will be overwritten by the --force flag!",
+                "red",
+            )
+    return True
+
+
 def generate_cluster_config_file(cluster_config_directory, provider, vars):
     """
     Generates the `config/<cluster_name>/cluster.yaml` config
     """
+    print_colour("Generating the cluster.yaml config file...", "yellow")
     with open(
         REPO_ROOT_PATH / f"config/clusters/templates/{provider}/cluster.yaml"
     ) as f:
         cluster_yaml_template = jinja2.Template(f.read())
-    with open(cluster_config_directory / "cluster.yaml", "w") as f:
+    cluster_yaml_file = cluster_config_directory / "cluster.yaml"
+    with open(cluster_yaml_file, "w") as f:
         f.write(cluster_yaml_template.render(**vars))
+        print_colour(f"{cluster_yaml_file} created")
 
 
 def generate_support_files(cluster_config_directory, vars):

--- a/deployer/commands/generate/dedicated_cluster/common.py
+++ b/deployer/commands/generate/dedicated_cluster/common.py
@@ -9,6 +9,14 @@ from deployer.utils.file_acquisition import REPO_ROOT_PATH
 from deployer.utils.rendering import print_colour
 
 
+def infra_files_already_exist(get_infra_files_func, cluster_name):
+    infra_files = get_infra_files_func(cluster_name)
+    if any(os.path.exists(path) for path in infra_files):
+        return True
+
+    return False
+
+
 def generate_cluster_config_file(cluster_config_directory, provider, vars):
     """
     Generates the `config/<cluster_name>/cluster.yaml` config

--- a/deployer/commands/generate/dedicated_cluster/gcp.py
+++ b/deployer/commands/generate/dedicated_cluster/gcp.py
@@ -17,7 +17,7 @@ from deployer.utils.file_acquisition import REPO_ROOT_PATH
 from deployer.utils.rendering import print_colour
 
 from .common import (
-    force_overwrite,
+    check_before_continuing_with_generate_command,
     generate_cluster_config_file,
     generate_config_directory,
     generate_support_files,
@@ -98,7 +98,9 @@ def gcp(
         "hub_name": hub_name,
     }
 
-    if not force_overwrite(get_infra_files_to_be_created, cluster_name, force):
+    if not check_before_continuing_with_generate_command(
+        get_infra_files_to_be_created, cluster_name, force
+    ):
         raise typer.Abort()
 
     # If we are here, then either no existing infrastructure files for this cluster have been found

--- a/deployer/commands/generate/dedicated_cluster/gcp.py
+++ b/deployer/commands/generate/dedicated_cluster/gcp.py
@@ -17,11 +17,24 @@ from deployer.utils.file_acquisition import REPO_ROOT_PATH
 from deployer.utils.rendering import print_colour
 
 from .common import (
+    force_overwrite,
     generate_cluster_config_file,
     generate_config_directory,
     generate_support_files,
 )
 from .dedicated_cluster_app import dedicated_cluster_app
+
+
+def get_infra_files_to_be_created(cluster_name):
+    return [
+        REPO_ROOT_PATH / "terraform/gcp/projects" / f"{cluster_name}.tfvars",
+        REPO_ROOT_PATH / "config/clusters" / cluster_name / "support.values.yaml",
+        REPO_ROOT_PATH
+        / "config/clusters"
+        / cluster_name
+        / "enc-support.secret.values.yaml",
+        REPO_ROOT_PATH / "config/clusters" / cluster_name / "cluster.yaml",
+    ]
 
 
 def generate_terraform_file(vars):
@@ -63,9 +76,17 @@ def gcp(
     hub_type: Annotated[
         str, typer.Option(prompt="Please insert the hub type of the first hub")
     ] = "basehub",
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Whether or not to force the override of the files that already exist",
+        ),
+    ] = False,
 ):
     """
-    Automatically generates the initial files, required to setup a new cluster on GCP
+    Automatically generates the initial files, required to setup a new cluster on GCP if they don't exist.
+    Use --force to force existing configuration files to be overwritten by this command.
     """
     # These are the variables needed by the templates used to generate the cluster config file
     # and support files
@@ -76,6 +97,12 @@ def gcp(
         "project_id": project_id,
         "hub_name": hub_name,
     }
+
+    if not force_overwrite(get_infra_files_to_be_created, cluster_name, force):
+        raise typer.Abort()
+
+    # If we are here, then either no existing infrastructure files for this cluster have been found
+    # or the `--force` flag was provided and we can override existing files.
 
     # Automatically generate the terraform config file
     generate_terraform_file(vars)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,11 @@ google-cloud-bigquery==3.13.*
 google-cloud-bigquery[pandas]==3.13.*
 gspread==5.12.*
 
-# requests is used by deployer/cilogon_app.py
+# requests is used by deployer/commands/cilogon.py
 requests==2.*
+
+# this is used by the generator of dedicated cluster files deployer/commands/dedicated_cluster
+GitPython
 
 # Used to parse units that kubernetes understands (like GiB)
 kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ gspread==5.12.*
 requests==2.*
 
 # this is used by the generator of dedicated cluster files deployer/commands/dedicated_cluster
-GitPython
+GitPython==3.1.40
 
 # Used to parse units that kubernetes understands (like GiB)
 kubernetes


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3294