### PR TITLE
UBC-EOAS: Explicitly set imagePullPolicy to "Always"

### DIFF
--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -54,6 +54,10 @@ jupyterhub:
           - hmodzelewski # Technical representative, Henryk Modzelewski
 
   singleuser:
+    image:
+      # Required when using :latest, until https://github.com/jupyterhub/kubespawner/pull/807
+      # is merged
+      pullPolicy: Always
     defaultUrl: /lab
     memory:
       # https://2i2c.freshdesk.com/a/tickets/955


### PR DESCRIPTION
Needed until this KubeSpawner bug fix is merged:
https://github.com/jupyterhub/kubespawner/pull/807

Ref https://2i2c.freshdesk.com/a/tickets/1100