### PR TITLE
LEAP: Disable public access on the LEAP buckets

### DIFF
--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -45,12 +45,10 @@ user_buckets = {
   "persistent-ro" : {
     "delete_after" : null,
     "extra_admin_members" : ["group:leap-persistent-bucket-writers@googlegroups.com"],
-    "public_access" : true
   },
   "persistent-ro-staging" : {
     "delete_after" : null,
     "extra_admin_members" : ["group:leap-persistent-bucket-writers@googlegroups.com"],
-    "public_access" : true
   }
 }
 


### PR DESCRIPTION
Ref https://2i2c.freshdesk.com/a/tickets/1105

I've manually done the things this needed.