### PR TITLE
terraform, gcp: fix removal of wrong commit in node-purpose infra labels pr

### DIFF
--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -18,18 +18,14 @@
 #
 #     terraform apply --var-file projects/pangeo-hubs.tfvars
 #
+# FIXME: core_node_machine_type should be set to n2-highmem-4 as its enough
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
 billing_project_id     = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
+core_node_machine_type = "n2-highmem-8"
 enable_private_cluster = true
-
-# FIXME: core_node_machine_type should be set to n2-highmem-4 as its enough
-# FIXME: Remove temp_opt_out_node_purpose_label_core_nodes when a node upgrade can be
-#        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
-core_node_machine_type                     = "n2-highmem-8"
-temp_opt_out_node_purpose_label_core_nodes = true
 
 k8s_versions = {
   min_master_version : "1.26.5-gke.2100",
@@ -62,49 +58,40 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
-  # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
-  #        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
   "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    temp_opt_out_node_purpose_label : true,
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    temp_opt_out_node_purpose_label : true,
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-    temp_opt_out_node_purpose_label : true,
   },
   "small" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-2",
-    temp_opt_out_node_purpose_label : true,
   },
   "medium" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-4",
-    temp_opt_out_node_purpose_label : true,
   },
   "large" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
-    temp_opt_out_node_purpose_label : true,
   },
   "huge" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-16",
-    temp_opt_out_node_purpose_label : true,
   },
 }
 
@@ -115,13 +102,10 @@ notebook_nodes = {
 #
 dask_nodes = {
   # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
-  # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
-  #        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
   "worker" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    temp_opt_out_node_purpose_label : true,
   },
 }
 

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -12,6 +12,10 @@ k8s_versions = {
   dask_nodes_version : "1.27.4-gke.900",
 }
 
+# FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
+#        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
+temp_opt_out_node_purpose_label_core_nodes = true
+
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
@@ -19,10 +23,13 @@ enable_filestore      = true
 filestore_capacity_gb = 5120
 
 notebook_nodes = {
+  # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
+  #        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
   "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
+    temp_opt_out_node_purpose_label : true,
   },
   "n2-highmem-16" : {
     min : 0,
@@ -54,6 +61,8 @@ notebook_nodes = {
   },
   # Nodepool for temple university. https://github.com/2i2c-org/infrastructure/issues/3158
   # FIXME: Remove node pool specific node_version pin when given the chance and no such nodes are running
+  # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
+  #        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
   "temple" : {
     # Expecting upto ~120 users at a time
     min : 0,
@@ -63,6 +72,7 @@ notebook_nodes = {
     # This works ok.
     machine_type : "n2-highmem-8",
     node_version : "1.26.4-gke.1400",
+    temp_opt_out_node_purpose_label : true,
     labels : {
       "2i2c.org/community" : "temple"
     },


### PR DESCRIPTION
This is a followup to #3405 where I by mistake removed a `pilot-hubs` commit instead of a `pangeo-hubs` commit.