### PR TITLE
pangeo-hubs: upgrade k8s cluster, use smaller core nodes

### DIFF
--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -18,20 +18,19 @@
 #
 #     terraform apply --var-file projects/pangeo-hubs.tfvars
 #
-# FIXME: core_node_machine_type should be set to n2-highmem-4 as its enough
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
 billing_project_id     = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
-core_node_machine_type = "n2-highmem-8"
+core_node_machine_type = "n2-highmem-4"
 enable_private_cluster = true
 
 k8s_versions = {
-  min_master_version : "1.26.5-gke.2100",
-  core_nodes_version : "1.26.4-gke.1400",
-  notebook_nodes_version : "1.26.4-gke.1400",
-  dask_nodes_version : "1.26.4-gke.1400",
+  min_master_version : "1.27.5-gke.200",
+  core_nodes_version : "1.27.5-gke.200",
+  notebook_nodes_version : "1.27.5-gke.200",
+  dask_nodes_version : "1.27.5-gke.200",
 }
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
@@ -101,8 +100,7 @@ notebook_nodes = {
 # node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
 #
 dask_nodes = {
-  # FIXME: Rename this to "n2-highmem-16" when given the chance and no such nodes are running
-  "worker" : {
+  "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",


### PR DESCRIPTION
This isn't something I can apply myself, but I think now is a great time to apply these changes.

1. pangeo-hubs doesn't need n2-highmem-8 core nodes, n2-highmem-4 are sufficient. There is currently a single core node, and it has 30% and 35% requests, which would become ~60% and ~70% on a half as large node.
   ```
   Resource           Requests           Limits
   --------           --------           ------
   cpu                2422m (30%)        5103m (64%)
   memory             22117127808 (35%)  33818Mi (57%)
   ```
2. pangeo-hubs currently only has a single core node active, no user pods etc!