### PR TITLE
cloudbank: upgrade k8s, adjust core node

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -6,32 +6,36 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
-  min_master_version : "1.26.5-gke.2100",
-  core_nodes_version : "1.26.5-gke.2100",
-  notebook_nodes_version : "1.26.4-gke.1400",
+  min_master_version : "1.27.5-gke.200",
+  core_nodes_version : "1.27.5-gke.200",
+  notebook_nodes_version : "1.27.5-gke.200",
+  dask_nodes_version : "1.27.5-gke.200",
 }
 
-# FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
-#        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
-temp_opt_out_node_purpose_label_core_nodes = true
-
-# FIXME: Transition to n2-highmem-4 when possible
-core_node_machine_type = "n1-highmem-4"
+# FIXME: n2-highmem-2 is a better fit for cloudbank as they are currently
+#        limited by the number of pods per node and don't use dask-gateway
+#        that otherwise can make prothemeus server need more memory than a
+#        n2-highmem-2 node can provide.
+core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
-  # FIXME: Update the machine type to "n2-highmem-4" and rename this node pool
-  #        when given the chance and no such nodes are running.
-  # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be
-  #        done. See https://github.com/2i2c-org/infrastructure/issues/3405.
+  # FIXME: Remove this node pool when unused, its been replaced by the
+  #        n2-highmem-4 node pool
   "user" : {
     min : 0,
     max : 100,
     machine_type : "n1-highmem-4",
-    temp_opt_out_node_purpose_label = true
+    node_version : "1.26.4-gke.1400",
+    temp_opt_out_node_purpose_label = true,
+  },
+  "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
     min : 0,


### PR DESCRIPTION
With this all GKE cluster's api-servers are at 1.27, but a few node pools may be behind still with associated FIXME notes to upgrade when given the chance.

I transitioned away from n1-highmem-4 as I was thinking we could fit everything in a single n2-highmem-4 etc, but I learned that the limiting factor was the number of pods for cloudbank. I've added a fixme note mentioning that the limiting factors are pods, and that dask-gateway isn't used in this cluster, which makes it a good candidate to use n2-highmem-2 nodes instead.