### PR TITLE
dynamic-image-building: bump jupyterhub-fancy-profiles

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -120,7 +120,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7130.h0bdc2d30"
+      tag: "0.0.1-0.dev.git.7563.he8470ee4"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -39,6 +39,8 @@ jupyterhub:
               display_name: "Custom image"
               validation_regex: "^.+:.+$"
               validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+              display_name_in_choices: "Specify an existing docker image"
+              description_in_choices: "Use a pre-existing docker image from a public docker registry (dockerhub, quay, etc)"
               kubespawner_override:
                 image: "{value}"
             choices:

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-git+https://github.com/yuvipanda/jupyterhub-fancy-profiles@b624031b661f71a278a37bb1fae0b8d6f316d6b3
+git+https://github.com/yuvipanda/jupyterhub-fancy-profiles@ef923e37eddc9284c7b4701c79e56f1cb3ca9a9d


### PR DESCRIPTION
dynamic-image-building: bump jupyterhub-fancy-profiles
    
Diff + commits brought in: https://github.com/yuvipanda/jupyterhub-fancy-profiles/compare/b624031b661f71a278a37bb1fae0b8d6f316d6b3...ef923e37eddc9284c7b4701c79e56f1cb3ca9a9d
    
- Depend on upstream, released version of `@jupyterhub/binderhub-client`
   instead of a submodule
- Cleanup state management to be much simpler, fixes a few bugs
- General cleanup
    
jupyterhub-fancy-profiles is getting to a stage where it's no longer
a prototype, and there is better tracking of features. But not quite
yet.
    
Ref https://github.com/2i2c-org/infrastructure/issues/3286