### PR TITLE
Add GitHub Actions workflow to automatically provide readthedocs preview links in PRs that touch docs

### DIFF
--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,0 +1,21 @@
+name: Add readthedocs preview link to pull requests
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          # The project slug in RTD still has the old repo name
+          project-slug: "2i2c-pilot-hubs"

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,11 +1,7 @@
 name: Add readthedocs preview link to pull requests
 
 on:
-  pull_request:
-    types:
-      - opened
-    branches:
-      - master
+  pull_request_target:
     paths:
       - "docs/**"
 

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
     branches:
-      - main
+      - master
     paths:
       - "docs/**"
 


### PR DESCRIPTION
This PR adds a GitHub Action workflow that will automatically add a link to the readthedocs preview to PR descriptions when we make changes within the `docs/` folder. An example PR can be seen here: https://github.com/sgibson91/test-multilingual-sphinx/pull/4