### PR TITLE
Use jupyterhub-fancy-profiles from PyPI

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -122,7 +122,7 @@ jupyterhub:
         url: http://imagebuilding-demo-binderhub-service:8090
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7563.he8470ee4"
+      tag: "0.0.1-0.dev.git.7567.ha4162031"
     config:
       JupyterHub:
         authenticator_class: github

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-git+https://github.com/yuvipanda/jupyterhub-fancy-profiles@ef923e37eddc9284c7b4701c79e56f1cb3ca9a9d
+jupyterhub-fancy-profiles==0.2.0


### PR DESCRIPTION
- `jupyterhub-fancy-profiles` is now published (with GitHub automation!) to [pypi](https://pypi.org/project/jupyterhub-fancy-profiles/)
- There's a preliminary changelog for 0.2.0 now, at https://github.com/yuvipanda/jupyterhub-fancy-profiles/releases/tag/v0.2.0
- Part of making jupyterhub-fancy-profiles more robust and available for use more broadly

Ref https://github.com/2i2c-org/infrastructure/issues/3286