### PR TITLE
eksctl: declare an addon version to latest, so it can get updated

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -77,6 +77,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -94,6 +94,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -37,7 +37,8 @@ local daskNodes = [];
     kind: 'ClusterConfig',
     metadata+: {
         name: "catalystproject-africa",
-        region: clusterRegion,        version: '1.27'
+        region: clusterRegion,
+        version: '1.27'
     },
     availabilityZones: masterAzs,
     iam: {
@@ -57,6 +58,7 @@ local daskNodes = [];
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -78,6 +78,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -98,6 +98,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -80,6 +80,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -70,6 +70,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -71,6 +71,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -85,6 +85,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -76,6 +76,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -89,6 +89,7 @@ local daskNodes = [];
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -60,6 +60,7 @@ local daskNodes = [];
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -72,6 +72,7 @@ local daskNodes = [
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },


### PR DESCRIPTION
Specifying "latest" here only influences us when we do `eksctl update addon --config-file=...`, then it will update to the latest version instead of doing nothing.

Note that just because it was set to `latest` doesn't mean it gets updated at all times, only when `eksctl update addon` is called, not for example when doing a node pool upgrade or cluster upgrade. This aligns with how `eksctl` typically works with the cluster config file - only reading whats relevant to the specific command, where no command is applying the whole config.
