### PR TITLE
Configure jupyter_server instead of notebook when configuring kernel culling

### DIFF
--- a/config/clusters/m2lines/common.values.yaml
+++ b/config/clusters/m2lines/common.values.yaml
@@ -53,7 +53,7 @@ basehub:
             - jbusecke
     singleuser:
       extraFiles:
-        jupyter_notebook_config.json:
+        jupyter_server_config.json:
           data:
             MappingKernelManager:
               # Cull idle kernels after 24h (24 * 60 * 60), to see if that

--- a/docs/sre-guide/manage-k8s/culling.md
+++ b/docs/sre-guide/manage-k8s/culling.md
@@ -25,7 +25,7 @@ More culling options and information about them can be found in the [idle-culler
 
 ## Kernel culling configuration
 
-The kernel culling options are configured through the `jupyter_notebook_config.json` file, located at `/usr/local/etc/jupyter/jupyter_notebook_config.json` in the user pod. This file is injected into the pod’s container on startup, by defining its location and content under [`singleuser.extraFiles`](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#singleuser-extrafiles) dictionary.
+The kernel culling options are configured through the `jupyter_server_config.json` file, located at `/usr/local/etc/jupyter/jupyter_server_config.json` in the user pod. This file is injected into the pod’s container on startup, by defining its location and content under [`singleuser.extraFiles`](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#singleuser-extrafiles) dictionary.
 
 You can modify the current culling options values, under `singleuser.extraFiles.data`, in the `helm-charts/basehub/values.yaml` file.
 
@@ -34,8 +34,8 @@ Example:
 ```yaml
 singleuser:
   extraFiles:
-    jupyter_notebook_config.json:
-      mountPath: /usr/local/etc/jupyter/jupyter_notebook_config.json
+    jupyter_server_config.json:
+      mountPath: /usr/local/etc/jupyter/jupyter_server_config.json
       data:
         MappingKernelManager:
           # shutdown kernels after no activity


### PR DESCRIPTION
This influences our docs and m2lines. m2lines is not being actively used and should to my knowledge be decommissioned, but it is updated anyhow to avoid retaining an outdated configuration that could be seen as an example to be copied to other hub configs.