### PR TITLE
2i2c-us: Reduce size of filestore for use as home directory

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -20,7 +20,7 @@ core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 enable_filestore      = true
-filestore_capacity_gb = 5120
+filestore_capacity_gb = 3072
 
 notebook_nodes = {
   # FIXME: Remove temp_opt_out_node_purpose_label when a node upgrade can be


### PR DESCRIPTION
We did a couple cleanups (AUP and Neurohackademy) that have brought usage down now to 2.4T only. This saves us approximately 600$ a month in cloud usage.