### PR TITLE
cosmicds: Fix logs not being generated

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -37,6 +37,9 @@ jupyterhub:
           name: Cosmic DS, Harvard
           url: https://www.cosmicds.cfa.harvard.edu/
   singleuser:
+    # Unset cmd so repo2docker-entrypoint gets used, and logs actually work
+    # Ref https://github.com/2i2c-org/infrastructure/issues/3109
+    cmd: null
     # No persistent storage should be kept to reduce any potential data
     # retention & privacy issues.
     # Ref https://github.com/2i2c-org/infrastructure/issues/2128#issuecomment-1635107926


### PR DESCRIPTION
Turns out us unconditionally setting `jupyterhub-singleuser` as `cmd` prevents repo2docker's automatic log generation from working!

It gets put under `REPO_DIR`, so it's under `/srv/repo/.jupyter-server-log.txt` now.

Fixes https://github.com/2i2c-org/infrastructure/issues/3109