### PR TITLE
k8s maintenance: upgrade EKS clusters from 1.24 and 1.25 to 1.27

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -57,7 +57,7 @@ local daskNodes = [
     metadata+: {
         name: "2i2c-aws-us",
         region: clusterRegion,
-        version: '1.25'
+        version: '1.27',
     },
     availabilityZones: masterAzs,
     iam: {
@@ -85,7 +85,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/2i2c-aws-us.key.pub'

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -25,10 +25,19 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+    # FIXME: Ensure gridsst wants minSize 1. Before an event it was set to 0,
+    #        but as part of scaling down after the event it stayed at one.
+    #
+    #        scale up:   https://github.com/2i2c-org/infrastructure/pull/1836
+    #        scale down: https://github.com/2i2c-org/infrastructure/pull/1844
+    #
     { instanceType: "m5.large", minSize: 1 },
     { instanceType: "m5.xlarge", minSize: 0 },
     { instanceType: "m5.2xlarge", minSize: 0 },
     { instanceType: "m5.8xlarge", minSize: 0 },
+    { instanceType: "r5.xlarge", minSize: 0 },
+    { instanceType: "r5.4xlarge", minSize: 0 },
+    { instanceType: "r5.16xlarge", minSize: 0 },
     {
         instanceType: "g4dn.xlarge", minSize: 0,
         tags+: {
@@ -58,7 +67,7 @@ local daskNodes = [
     metadata+: {
         name: "gridsst",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -86,7 +95,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/gridsst.key.pub'
@@ -119,7 +128,6 @@ local daskNodes = [
                 "hub.jupyter.org_dedicated": "user:NoSchedule",
                 "hub.jupyter.org/dedicated": "user:NoSchedule"
             },
-
         } + n for n in notebookNodes
     ] + [
         ng {

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -25,6 +25,9 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
     { instanceType: "m5.xlarge" },
     { instanceType: "m5.4xlarge" },
     { instanceType: "m5.16xlarge" },
@@ -78,7 +81,7 @@ local daskNodes = [
     metadata+: {
         name: "jupyter-meets-the-earth",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -106,7 +109,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/jupyter-meets-the-earth.key.pub'

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -25,6 +25,8 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+    # FIXME: The r5.xlarge node group is still at version 1.25 and should be
+    #        upgraded by deleting it and adding it back when possible.
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
@@ -60,7 +62,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-cryo",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -88,7 +90,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-cryo.key.pub'

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -51,7 +51,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-veda",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -79,7 +79,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-b',
+            name: 'core-a',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-veda.key.pub'

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -55,7 +55,7 @@ local daskNodes = [
     metadata+: {
         name: "openscapeshub",
         region: clusterRegion,
-        version: '1.24'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -56,7 +56,7 @@ local daskNodes = [
     metadata+: {
         name: "smithsonian",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -84,7 +84,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-a',
+            name: 'core-b',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/smithsonian.key.pub'

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -69,7 +69,7 @@ local daskNodes = [];
             version should be the latest support version by the eksctl CLI, see
             https://eksctl.io/introduction/ for a list of supported versions.
         -#}
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -65,10 +65,10 @@ local daskNodes = [];
     metadata+: {
         name: "<< cluster_name >>",
         region: clusterRegion,
-        {#-
+        {#
             version should be the latest support version by the eksctl CLI, see
             https://eksctl.io/introduction/ for a list of supported versions.
-        #}
+        -#}
         version: '1.25'
     },
     availabilityZones: masterAzs,

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -25,10 +25,10 @@ local nodeAz = "ca-central-1a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    # TODO: this m5 instance type is to be deleted when its no longer has user pods
-    #       running on it, we have transitioned to use r5 instance types (highmem)
-    { instanceType: "m5.large" },
+    { instanceType: "r5.xlarge" },
     { instanceType: "r5.2xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
 ];
 
 local daskNodes = [];
@@ -40,7 +40,7 @@ local daskNodes = [];
     metadata+: {
         name: "ubc-eoas",
         region: clusterRegion,
-        version: '1.24'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -29,6 +29,9 @@ local notebookNodes = [
     { instanceType: "m5.xlarge" },
     { instanceType: "m5.2xlarge" },
     { instanceType: "m5.8xlarge" },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
 ];
 
 local daskNodes = [
@@ -52,7 +55,7 @@ local daskNodes = [
     metadata+: {
         name: "victor",
         region: clusterRegion,
-        version: '1.25'
+        version: "1.27",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -80,7 +83,7 @@ local daskNodes = [
     ],
     nodeGroups: [
         ng {
-            name: 'core-b',
+            name: 'core-a',
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/victor.key.pub'


### PR DESCRIPTION
I took the chance to do some upgrades opportunistically now that they had very little activity, shifting a bit of work hours to this Sunday from the week to come.

- Closes #3249
  - 2i2c-aws-us v1.25.15-eks-4f4795d
  - gridsst v1.25.15-eks-4f4795d
  - jupyter-meets-the-earth v1.25.14-eks-f8587cb
  - nasa-cryo v1.25.15-eks-4f4795d
  - nasa-veda v1.25.15-eks-4f4795d
  - smithsonian v1.25.15-eks-4f4795d
  - victor v1.25.15-eks-4f4795d
- Closes #3224 together with upgrades made by @GeorgianaElena
  - openscapes v1.24.16-eks-2d98532
  - ubc-eoas v1.24.16-eks-2d98532

All EKS clusters are now `v1.27.7-eks-4f4795d`, and all GKE clusters are at `1.27.*`. Only our utoronto AKS clusters remains at 1.26 and is tracked via https://github.com/2i2c-org/infrastructure/issues/3412.