### PR TITLE
nasa-veda and nasa-ghg: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:RO5oHd6XJHR7gglQc9bQX5GiNOA=,iv:UhCnTfLfgfAKwxbuf5Qb+ztFriG9jyBs2YfmBN1kNR8=,tag:ZmufjCjL8Xg5h//TDTTdEg==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:50qpWADGewOLKsHTXr8cte0nDUWrsuWUZk9ArtnYgOU5ZQv5vlPV3Q==,iv:gp7KaSukU8110Q0piCtHoTsSnPgjegUEhwjthE88aDI=,tag:ZxKeG2i5QDYRS9HN/Lby+Q==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:jv1sm8OY1G+cN02Rb9dIDi+VK2sk7lU=,iv:ACf/x/BkkiJJcptexVixbJHNC2F2Yq3YZ2wjhS5l8YI=,tag:8k9jsReG7AYGbSMtkCOkxA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:qMunDZWHlI0up+d8T3QL8tGyrlU=,iv:RmbwXuuYz7GDEUeaWS5kB9jprQjkxRoKlkgFolNzrt0=,tag:POHzqzr3C4ynvA1aeU2N9Q==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:XGrQIdXfwDZ1bHGC9cGwyc9zE6hZFjJmFpGk5PfCDFSF9q43MrRsZg==,iv:n8qCgLDnpshgY+3xE2zYakJ2618tQ4+tpU4J6htSon0=,tag:Hv2JGZH8Qz4xiD177984fA==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:A+1ZcIrJFGFVA7+VbVvfiwvBzwkFgVI=,iv:joLvfo4bZJ7K3D5bchRnMFe42GEGQRg6Qzl5SpaqJm4=,tag:rcRKICnKUuw+zWLM+KQ/Hg==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-10-04T09:00:18Z",
-				"enc": "CiUA4OM7eDNwEoj9sW1cHS5uSQm7Q+YMaUEn48/qR6Jz7rIc5kh0EkkAq2nhVSKLV85r8rrHID/f9RLgzjOtV07cdTro/PW68LL+lMPDrljexkTRFoBuQt7g8+22D0SXfxjmc7mgyubmfVSdB527qYSf"
+				"created_at": "2023-11-19T18:59:51Z",
+				"enc": "CiUA4OM7eDGvjTNhZ63YMiU2KGZGeyGmQU8lonyhY95PlmVDvXdSEkkAjTWv+mHfwcNgPyz2iNvtJwt6lCVZKKLoYtdZqY3W6MiJrRXo4QjUg+t6tZ+y8GgbarwZTmzGu5uVtEWUtGIda3Zt85POOFQS"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-10-04T09:00:19Z",
-		"mac": "ENC[AES256_GCM,data:Eexw+Z4H9zLAJZ//C1hgdu8pG/QpSmUDQwu9sz+C0eoDsxPh0tRQGdV884DFNzMkaM+DbEHJfdP0J1ZsH8OG6iYdeYojpkss+1IIaa5TpfTTRmlILH+0rcbKEAaQp+r4uIHYJypM2KkZSOFT1mnScmjOUg9+5pVFCDxc58A8QZY=,iv:YJek86/pB5mADUXeo/GQuajlT9vPjJ6B9WQMsIUy3PY=,tag:f0eSvRqgHZoWuJSFL25uSw==,type:str]",
+		"lastmodified": "2023-11-19T18:59:51Z",
+		"mac": "ENC[AES256_GCM,data:ssY1powc8j6WidDT6WlzyQRboKGjqtpkLIm3mAzcqOqXFT2QwpbYHCc/LQZ/recD4Q9by7ehR7iBv9OVJE/Kv9xNozT6MTuhPE+vxTglhU4kHxm3uXRF6eq58PilC7AQv3iOxanWMxh/fXzAmF2QlWZH1bwjFoB+MYek8xQu/XU=,iv:tBGQ5lJlmpRtoY4FNQZFG0x4le1dHbqatVbtROwfWNY=,tag:Af1H3bFrirGtzlGCvlNclA==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"

--- a/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:qb+aa28S6XWWiCa9ho7edw4qfiM=,iv:PoRjK2pWvBdxbysD5RmsqL2wb4SmUS9v1Ojw/Dzu1+4=,tag:yvpD46F1qpHkSFP41Er8cQ==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:zcDUqz2Wsw95wUUpPj17noioCF0tvU2/kn0h/b9rMvhH5g1N/fKiIw==,iv:4adnU7Npm09u+RrcD8aFeUAc+Y2XP/sItLaJXFlVF+g=,tag:pyZWn65DP8uIkbhLM79yTQ==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:f2ovvm7GODiz82K9ep/LYsinPa/xwHM=,iv:63J+AzG0uQbxfb7sQaaOL8IB6QFwyg9OFLcpOOwDWoA=,tag:ZRoKKq6PvhtPKSZNv90NZA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:rIqVNArcN/4vj8eG4/1HJ4xPZjE=,iv:iudNRsrku2pcXmIPEQUzBfYJxvRe7rgamFj6S6M8EfA=,tag:POog+wkldH2pDmi3Ntmkmw==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:psDIfR5S6hHnvixmw5r9EUFq+WEkU2+bryB2h3s1uRLhnV6wCUn0uQ==,iv:Vd1ZiEOfWEcWndpjJDRdvTT9UNV/OiFeE5/fHLv+6CE=,tag:tS1xGtUQZj2buGPZF2l5vg==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:XgAZKbm5tHpbJBdtc+sR+pqRxwD+M4s=,iv:Cih/A/BloUOICV/ZGI0UvSu7OWCHbiyT6Anr1ByPAso=,tag:xBkwA822p4ljwKc82nda0w==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-10-04T08:15:59Z",
-				"enc": "CiUA4OM7eGA/8w8F0XhHq9EjzEJibgVZl4KEGdc+AW0Mi2suSUciEkkAq2nhVfCw6bdqrLb6tuaTPSirwitMPg8GchYprUVSvAPxBB4blq64I71yuB8A8mwhZsV+oXRslbD2+sz67+HyePQcCTS5ec5M"
+				"created_at": "2023-11-19T18:59:44Z",
+				"enc": "CiUA4OM7eKWO7OEo5U2nvjefm0zav25flhEpLHYyaPQVTTmnKuNkEkkAjTWv+uptb2rKL07ZsO4iH9/KRO//1D9YgmC02hnbyrUq+cNM3o5W7Q8VA3b44pnv+glk1D5AaGx/MQ9+xiZMv8RYwt+AyTq8"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-10-04T08:15:59Z",
-		"mac": "ENC[AES256_GCM,data:RKt/1FmbrrfbQDJXu/U22iUbY+TLoS3WUlzRboK/uh/w/YKPxusLR6J9pxuPEJ7/ikKUs9oQ73ybO8qYMaYgveU9rx20ljuHchNCvDrDCZwL/hNUFiiZZwqTNH4j3T0163fJZqFJWsU1iNiTYy3LbCTXPpUaNtb/OWyt8tMOURs=,iv:93fZZHa4lYntLKjbbVfWWajmujRmHIYlvkanfRVHwJw=,tag:j4sYc2sDuMNmLcoFNLc+PQ==,type:str]",
+		"lastmodified": "2023-11-19T18:59:45Z",
+		"mac": "ENC[AES256_GCM,data:A6kwseUQtrhc56do4RzL/GuISS9UnWQeH+sAPjJ8hl15mlx8JL5IrEyKSXZNLnj+AaCnzHSEBGO6/NFyobPF7NgeEhjLOvWNs4/pKJ9ED4+UrK7JoShLUOzFEwGZiDH2Cafv4qu1MST8L2/u8JWenkIUXhRRHEklsvR/nhAJkfA=,iv:5bXso/vSfDAcKAo44ckUZf/kD92gloWzbaMP/qY9I4U=,tag:KYFWTI09w2GvTnxBHS930w==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.2"


### PR DESCRIPTION
With this we won't have to think about this until after the chrismas holidays. I'll go for a self-merge here to ensure this won't cause failures for others using the deployer, either locally or via the CI system.

- See #2434 for details about what this is about.