### PR TITLE
eksctl: set nodegroup name based on namePrefix, nameBase, and nameSuffix

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -84,8 +84,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/2i2c-aws-us.key.pub'
@@ -99,10 +101,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -122,10 +122,8 @@ local daskNodes = [
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -101,8 +101,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/carbonplan.key.pub'
@@ -116,10 +118,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -138,10 +138,8 @@ local daskNodes = [
 
         } + n for n in notebookNodes
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -65,8 +65,10 @@ local daskNodes = [];
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/catalystproject-africa.key.pub'
@@ -80,10 +82,8 @@ local daskNodes = [];
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -102,10 +102,8 @@ local daskNodes = [];
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -94,8 +94,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/gridsst.key.pub'
@@ -109,10 +111,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: n.minSize,
             maxSize: 500,
@@ -130,10 +130,8 @@ local daskNodes = [
             },
         } + n for n in notebookNodes
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -108,8 +108,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/jupyter-meets-the-earth.key.pub'
@@ -123,10 +125,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -145,10 +145,8 @@ local daskNodes = [
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/libsonnet/nodegroup.jsonnet
+++ b/eksctl/libsonnet/nodegroup.jsonnet
@@ -10,10 +10,15 @@
 
 // Exported object
 {
-  // If using spot instances where a Auto Scaling Group (ASG) has multiple
-  // instances associated with it, label using the first instance type.
-  // FIXME: Clarify the limitations of picking one of multiple instance types
+  // Note that spot instances configured via an Auto Scaling Group (ASG) can have
+  // multiple instance types associated with it (with the same CPU/RAM/GPU), we
+  // label them using the first instance type in the ASG as a compromise.
+  //
+  // More details at:
+  // https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-mixed-instances-policies-and-spot-instances
+  //
   local instanceType = if 'instanceType' in $ then $.instanceType else $.instancesDistribution.instanceTypes[0],
+  // NodeGroup names can't have a '.' in them as instanceTypes has
   local escapedInstanceType = std.strReplace(instanceType, ".", "-"),
 
   // The cluster autoscaler reads specific tags on a Auto Scaling Group's default

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -89,8 +89,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-cryo.key.pub'
@@ -104,10 +106,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -126,10 +126,8 @@ local daskNodes = [
 
         } + n for n in notebookNodes
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -77,8 +77,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-ghg.key.pub'
@@ -92,10 +94,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -114,10 +114,8 @@ local daskNodes = [
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -78,8 +78,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/nasa-veda.key.pub'
@@ -93,10 +95,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -115,10 +115,8 @@ local daskNodes = [
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -92,8 +92,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [n + {clusterName:: $.metadata.name} for n in [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/openscapes.key.pub'
@@ -112,10 +114,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -133,10 +133,8 @@ local daskNodes = [
             },
         } + n for n in notebookNodes
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -83,8 +83,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-b',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'b',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/smithsonian.key.pub'
@@ -98,10 +100,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -120,10 +120,8 @@ local daskNodes = [
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -96,8 +96,10 @@ local daskNodes = [];
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/<< cluster_name >>.key.pub'
@@ -111,10 +113,8 @@ local daskNodes = [];
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: 'nb',
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -133,10 +133,8 @@ local daskNodes = [];
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: 'dask',
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -67,8 +67,10 @@ local daskNodes = [];
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/ubc-eoas.key.pub'
@@ -87,10 +89,8 @@ local daskNodes = [];
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -110,10 +110,8 @@ local daskNodes = [];
         } + n for n in notebookNodes
     ] + ( if daskNodes != null then
         [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -82,8 +82,10 @@ local daskNodes = [
         },
     ],
     nodeGroups: [
-        ng {
-            name: 'core-a',
+        ng + {
+            namePrefix: 'core',
+            nameSuffix: 'a',
+            nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
                 publicKeyPath: 'ssh-keys/victor.key.pub'
@@ -97,10 +99,8 @@ local daskNodes = [
             },
         },
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
+        ng + {
+            namePrefix: "nb",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -119,10 +119,8 @@ local daskNodes = [
 
         } + n for n in notebookNodes
     ] + [
-        ng {
-            // NodeGroup names can't have a '.' in them, while
-            // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(n.instancesDistribution.instanceTypes[0], ".", "-"),
+        ng + {
+            namePrefix: "dask",
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,


### PR DESCRIPTION
This feature enables us to create new node pools of the same instance type, allowing us to create a new node pool while waiting for another to become phased out. I wanted this for `nasa-cryo` to finalize a k8s upgrade.

### No phaseout guarantee

To add a new side by side with an old isn't enough, we would want to _ensure that the next scale up happens on the new node pool rather than the old_. I tried finding a way to guarantee this for a long time unsuccessfully using `tags` on AWS auto scaling groups, launch templates, and launch template versions. It is possible to constrain the old node pool by declaring `maxSize` to its current size, but that just stops it from growning and doesn't guarantee it shrinks but I'm not sure what else can be done.

### Misc refactors for jsonnet beginners like myself

As part of this, I also learned a lot about jsonnet and tried to help make the .jsonnet files a bit more easy to understand going onwards for jsonnet newbies like me.

### Related

- https://github.com/2i2c-org/infrastructure/issues/1924