### PR TITLE
nasa-cryo: phase out outdated node pool to finalize k8s upgrade

### DIFF
--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -25,9 +25,11 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    # FIXME: The r5.xlarge node group is still at version 1.25 and should be
-    #        upgraded by deleting it and adding it back when possible.
+    # FIXME: Delete the r5.xlarge node group when empty. It has an old k8s
+    #        version and is tainted to prevent it from scaling up or scheduling
+    #        new pods on it.
     { instanceType: "r5.xlarge" },
+    { instanceType: "r5.xlarge", nameSuffix: "b" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
     {


### PR DESCRIPTION
This is a followup to #3445 where we make use of the added `nameSuffix` to create a new node pool of the same isntance type for users while the currently running users are given time to stop their servers.

```shell
CLUSTER_NAME=nasa-cryo

# I added a node pool in nasa-cryo.jsonnet
jsonnet $CLUSTER_NAME.jsonnet > $CLUSTER_NAME.eksctl.yaml
eksctl create nodegroup --config-file=$CLUSTER_NAME.eksctl.yaml --include="*"
```

```shell
# after the new node pool was created, I tainted the one to phase out
# this seems to influence the cluster-autoscaler while setting cloud tags doesn't
# because it favors information from existing nodes over the cloud tags it seems
kubectl taint node -l alpha.eksctl.io/nodegroup-name=nb-r5-xlarge k8s-upgrade-rolling-phaseout:NoSchedule
```