### PR TITLE
Pin deployer's billing dependencies to major-like versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,15 +31,14 @@ pandas
 pandera
 prometheus_pandas
 pytest-mock
-google-cloud-bigquery==3.13.*
-google-cloud-bigquery[pandas]==3.13.*
-gspread==5.12.*
+google-cloud-bigquery[pandas]==3.*
+gspread==5.*
 
 # requests is used by deployer/commands/cilogon.py
 requests==2.*
 
 # this is used by the generator of dedicated cluster files deployer/commands/dedicated_cluster
-GitPython==3.1.40
+GitPython==3.*
 
 # Used to parse units that kubernetes understands (like GiB)
 kubernetes


### PR DESCRIPTION
I think this gives us less dependabot PRs bumping billing dependencies that we approve and merge without testing anyhow. I think pinning to the major version strikes a reasonable balance.

When we merge one of these dependabot PRs, we make full re-deploys of all hubs as well, which is good for us to avoid doing unless needed.