### PR TITLE
Central grafana datasources and cli fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_decommission-hub.md
+++ b/.github/ISSUE_TEMPLATE/5_decommission-hub.md
@@ -44,6 +44,8 @@ Usually, it is because it was a hub that we created for a workshop/conference an
 
 _This phase is only necessary for single hub clusters._
 
+- [ ] Remove the cluster's datasource from the central Grafana with:
+  - `deployer grafana central-ds remove CLUSTER_NAME`
 - [ ] Run `terraform plan -destroy` and `terraform apply` from the [appropriate workspace](https://infrastructure.2i2c.org/en/latest/topic/terraform.html#workspaces), to destroy the cluster
 - [ ] Delete the terraform workspace: `terraform workspace delete <NAME>`
 - [ ] Remove the associated `config/clusters/<cluster_name>` directory and all its contents

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -32,7 +32,7 @@ grafana:
     # We delete the initial "prometheus" data source from the database to avoid confusion.
     # This is because the 2i2c grafana is the central one and we call this datasource "2i2c"
     # instead of "prometheus" to be more clear what's about.
-    # This config-added datasource can only be deleted link this,
+    # This config-added datasource can only be deleted like this,
     # the UI and API are disabled for this operation.
     deleteDatasources:
       - name: prometheus

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -29,11 +29,6 @@ grafana:
       allowed_organizations: 2i2c-org
     feature_toggles:
       enable: exploreMixedDatasource
-    # We delete the initial "prometheus" data source from the database to avoid confusion.
-    # This is because the 2i2c grafana is the central one and we call this datasource "2i2c"
-    # instead of "prometheus" to be more clear what's about.
-    # This config-added datasource can only be deleted like this,
-    # the UI and API are disabled for this operation.
   datasources:
     datasources.yaml:
       apiVersion: 1

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -45,7 +45,7 @@ grafana:
           # This is the name of the kubernetes service exposed by the prometheus server
           url: http://support-prometheus-server
           access: proxy
-          isDefault: true
+          isDefault: false
           editable: false
   ingress:
     hosts:

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -29,6 +29,14 @@ grafana:
       allowed_organizations: 2i2c-org
     feature_toggles:
       enable: exploreMixedDatasource
+    # We delete the initial "prometheus" data source from the database to avoid confusion.
+    # This is because the 2i2c grafana is the central one and we call this datasource "2i2c"
+    # instead of "prometheus" to be more clear what's about.
+    # This config-added datasource can only be deleted link this,
+    # the UI and API are disabled for this operation.
+    deleteDatasources:
+      - name: prometheus
+        orgId: 1
   ingress:
     hosts:
       - grafana.pilot.2i2c.cloud

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -34,9 +34,24 @@ grafana:
     # instead of "prometheus" to be more clear what's about.
     # This config-added datasource can only be deleted like this,
     # the UI and API are disabled for this operation.
-    deleteDatasources:
-      - name: prometheus
-        orgId: 1
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        # Add the prometheus server as a datasource in the same namespace as grafana.
+        # This is called "prometheus" in all other clusters, except of the 2i2c one,
+        # which is the central Grafana, where all clusters' prometheus instances
+        # are also linked as datasources.
+        # Having "2i2c" as the name, instead of the more generic "prometheus"
+        # will help to more easily know what cluster the datasource is mapping.
+        - name: 2i2c
+          orgId: 1
+          type: prometheus
+          # This is the name of the kubernetes service exposed by the prometheus server
+          url: http://support-prometheus-server
+          access: proxy
+          isDefault: true
+          editable: false
   ingress:
     hosts:
       - grafana.pilot.2i2c.cloud

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -317,11 +317,20 @@ If such a file doesn't already exist, it will be created by this function.
   Updates:
   - the content of `enc-grafana-token.secret.yaml` with the new token if one already existed
 
-#### `grafana update-central-datasources`
+#### The `grafana central-ds` sub-command
+This is a sub-command meant to help engineers to programmatically manage the datasources registered in the 2i2c central Grafana at https://grafana.pilot.2i2c.cloud.
 
-Ensures that the central grafana at https://grafana.pilot.2i2c.cloud is
-configured to use as datasource the authenticated prometheus instances of all
-the clusters that we run.
+##### `grafana central-ds add`
+Adds a new cluster as a datasource to the central Grafana.
+
+##### `grafana central-ds remove`
+Removes a datasource from the central Grafana. In the unlikely case, the datasource has a different name than the cluster's name, pass it through the optional `datasource-name` flag.
+
+##### `grafana central-ds get-add-candidates`
+Gets the clusters that are in the infrastructure repository but are NOT registered in central grafana as datasources. Usually this happens when a new clusters was added, but its prometheus server was not mapped to a datasource of the central 2i2c Grafana. This list can then be used to know which datasources to add.
+
+##### `grafana central-ds get-rm-candidates`
+Gets the list of datasources that are registered in central grafana but are NOT in the list of clusters in the infrastructure repository. Usually this happens when a clusters was decommissioned, but its prometheus server was not removed from the datasources of the central 2i2c Grafana. This list can then be used to know which datasources to remove.
 
 ### The `validate` sub-command
 

--- a/deployer/commands/grafana/central_grafana.py
+++ b/deployer/commands/grafana/central_grafana.py
@@ -28,12 +28,18 @@ from .utils import (
 yaml = YAML(typ="safe")
 
 
-def build_datasource_details(cluster_name):
+def central_grafana_datasource_endpoint(central_grafana_cluster_name="2i2c"):
+    grafana_url = get_grafana_url(central_grafana_cluster_name)
+    return f"{grafana_url}/api/datasources"
+
+
+def build_datasource_details(cluster_name, datasource_name=None):
     """
     Build the payload needed to create an authenticated datasource in Grafana for `cluster_name`.
 
     Args:
-        cluster_name: name of the cluster
+        cluster_name: name of the cluster who's prometheus instance will map to this datasource_name
+        datasource_name: name of the datasource
     Returns:
         dict object: req payload to be consumed by Grafana
     """
@@ -43,8 +49,9 @@ def build_datasource_details(cluster_name):
     # Get the credentials of this prometheus instance
     prometheus_creds = get_cluster_prometheus_creds(cluster_name)
 
+    datasource_name = cluster_name if not datasource_name else datasource_name
     datasource_details = {
-        "name": cluster_name,
+        "name": datasource_name,
         "type": "prometheus",
         "access": "proxy",
         "url": f"https://{datasource_url}",
@@ -56,14 +63,14 @@ def build_datasource_details(cluster_name):
     return datasource_details
 
 
-def build_datasource_request_headers(cluster_name):
+def build_datasource_request_headers(central_grafana_cluster_name="2i2c"):
     """
     Build the headers needed to send requests to the Grafana datasource endpoint.
 
     Returns:
         dict: "Accept", "Content-Type", "Authorization" headers
     """
-    token = get_grafana_token(cluster_name)
+    token = get_grafana_token(central_grafana_cluster_name)
 
     headers = {
         "Accept": "application/json",
@@ -74,7 +81,7 @@ def build_datasource_request_headers(cluster_name):
     return headers
 
 
-def get_clusters_used_as_datasources(cluster_name, datasource_endpoint):
+def get_clusters_used_as_datasources(central_grafana_cluster_name="2i2c"):
     """
     Get the list of cluster names that have prometheus instances
     already defined as datasources of the central Grafana.
@@ -82,14 +89,18 @@ def get_clusters_used_as_datasources(cluster_name, datasource_endpoint):
     Returns:
         list: the name of the clusters registered as central Grafana datasources
     """
-    headers = build_datasource_request_headers(cluster_name)
+    datasource_endpoint = central_grafana_datasource_endpoint(
+        central_grafana_cluster_name
+    )
+
+    headers = build_datasource_request_headers()
 
     # Get the list of all the currently existing datasources
     response = requests.get(datasource_endpoint, headers=headers)
 
     if not response.ok:
         print(
-            f"An error occured when retrieving the datasources from {datasource_endpoint}.\n"
+            f"An error occurred when retrieving the datasources from {datasource_endpoint}.\n"
             f"Error was {response.text}."
         )
         response.raise_for_status()
@@ -99,68 +110,126 @@ def get_clusters_used_as_datasources(cluster_name, datasource_endpoint):
 
 
 @grafana_app.command()
-def update_central_datasources(
-    central_grafana_cluster=typer.Option(
-        "2i2c", help="Name of cluster where the central grafana lives"
+def get_datasources_removal_candidates():
+    """
+    Get the datasources names that are registered in central grafana
+    but are NOT in the list of clusters in the infrastructure repository.
+    You might consider removing these datasources one by one, as they might link to
+    decommissioned clusters.
+    """
+    # Get a list of the clusters that already have their prometheus instances used as datasources
+    datasources = get_clusters_used_as_datasources()
+
+    # Get the list of the names of clusters in the infrastructure repository
+    cluster_files = get_all_cluster_yaml_files()
+    cluster_names = [cluster.parents[0].name for cluster in cluster_files]
+
+    rm_candidates = set(datasources).difference(cluster_names)
+
+    if not rm_candidates:
+        print_colour("Everything is up to date! :)")
+        return
+
+    print(
+        "These datasources don't map to an existing cluster. You might consider removing them."
     )
+    print_colour(f"{rm_candidates}", "yellow")
+
+
+@grafana_app.command()
+def get_datasources_add_candidates():
+    """
+    Get the clusters in the infrastructure repository but are NOT
+    registered in central grafana as datasources.
+    You might consider adding these datasources, as they might link to
+    new clusters that haven't been updated.
+    """
+
+    # Get a list of the clusters that already have their prometheus instances used as datasources
+    datasources = get_clusters_used_as_datasources()
+
+    # Get the list of the names of clusters in the infrastructure repository
+    cluster_files = get_all_cluster_yaml_files()
+    cluster_names = [cluster.parents[0].name for cluster in cluster_files]
+
+    add_candidates = set(cluster_names).difference(datasources)
+    if not add_candidates:
+        print_colour("Everything is up to date! :)")
+        return
+
+    print(
+        "These datasources don't map to an existing cluster. You might consider removing them."
+    )
+    print_colour(f"{add_candidates}", "yellow")
+
+
+@grafana_app.command()
+def add_cluster_as_datasource(
+    cluster_name=typer.Argument(
+        ..., help="Name of cluster to add as a datasource to the central 2i2c grafana."
+    ),
+    datasource_name=typer.Option(
+        "",
+        help="(Optional) The name of the datasource to add. Defaults to cluster_name.",
+    ),
+):
+    """
+    Add a new cluster to the central 2i2c grafana.
+    """
+    datasource_name = cluster_name if not datasource_name else datasource_name
+    datasource_endpoint = central_grafana_datasource_endpoint("2i2c")
+
+    # Get a list of the clusters that already have their prometheus instances used as datasources
+    datasources = get_clusters_used_as_datasources()
+    if cluster_name and cluster_name not in datasources:
+        print(f"Checking if {cluster_name} it can be added as datasource...")
+        datasource_details = build_datasource_details(cluster_name)
+        req_body = json.dumps(datasource_details)
+
+        # Tell Grafana to create and register a datasource for this cluster
+        headers = build_datasource_request_headers()
+        response = requests.post(datasource_endpoint, data=req_body, headers=headers)
+        if not response.ok:
+            print_colour(f"{response.reason}.{response.json()['message']}.", "red")
+            return
+
+        print_colour(f"Successfully created a new datasource for {cluster_name}!")
+
+
+@grafana_app.command()
+def rm_entry_from_datasources(
+    cluster_name=typer.Argument(
+        ...,
+        help="The name of cluster who's prometheus instance we're removing from the datasources in the central 2i2c grafana.",
+    ),
+    datasource_name=typer.Option(
+        "",
+        help="The name of the datasource we're removing. This is usually the same with the name of cluster.",
+    ),
 ):
     """
     Update the central grafana with datasources for all clusters prometheus instances
     """
-    grafana_url = get_grafana_url(central_grafana_cluster)
-    datasource_endpoint = f"{grafana_url}/api/datasources"
+    datasource_name = cluster_name if not datasource_name else datasource_name
+    datasource_endpoint = central_grafana_datasource_endpoint("2i2c")
+    datasource_delete_endpoint = f"{datasource_endpoint}/name/{datasource_name}"
 
     # Get a list of the clusters that already have their prometheus instances used as datasources
-    datasources = get_clusters_used_as_datasources(
-        central_grafana_cluster, datasource_endpoint
-    )
+    datasources = get_clusters_used_as_datasources()
 
-    # Get a list of filepaths to all cluster.yaml files in the repo
-    cluster_files = get_all_cluster_yaml_files()
+    if datasource_name in datasources:
+        print(f"Checking if {datasource_name} it can be deleted from datasources...")
+        # Build the datasource details for the instances that aren't configures as datasources
+        datasource_details = build_datasource_details(cluster_name, datasource_name)
+        req_body = json.dumps(datasource_details)
 
-    print("Searching for clusters that aren't Grafana datasources...")
-    # Count how many clusters we can't add as datasources for logging
-    exceptions = 0
-    for cluster_file in cluster_files:
-        # Read in the cluster.yaml file
-        with open(cluster_file) as f:
-            cluster_config = yaml.load(f)
-
-        # Get the cluster's name
-        cluster_name = cluster_config.get("name", {})
-        if cluster_name and cluster_name not in datasources:
-            print(f"Found {cluster_name} cluster. Checking if it can be added...")
-            # Build the datasource details for the instances that aren't configures as datasources
-            try:
-                datasource_details = build_datasource_details(cluster_name)
-                req_body = json.dumps(datasource_details)
-
-                # Tell Grafana to create and register a datasource for this cluster
-                headers = build_datasource_request_headers(central_grafana_cluster)
-                response = requests.post(
-                    datasource_endpoint, data=req_body, headers=headers
-                )
-                if not response.ok:
-                    print(
-                        f"An error occured when creating the datasource. \nError was {response.text}."
-                    )
-                    response.raise_for_status()
-                print_colour(
-                    f"Successfully created a new datasource for {cluster_name}!"
-                )
-            except Exception as e:
-                print_colour(
-                    f"An error occured for {cluster_name}.\nError was: {e}.\nSkipping...",
-                    "yellow",
-                )
-                exceptions += 1
-                pass
-
-    if exceptions:
-        print_colour(
-            f"Failed to add {exceptions} clusters as datasources. See errors above!",
-            "red",
+        # Tell Grafana to create and register a datasource for this cluster
+        headers = build_datasource_request_headers()
+        response = requests.delete(
+            datasource_delete_endpoint, data=req_body, headers=headers
         )
-    print_colour(
-        f"Successfully retrieved {len(datasources)} existing datasources! {datasources}"
-    )
+        if not response.ok:
+            print_colour(f"{response.reason}. {response.json()['message']}.", "red")
+            return
+
+        print_colour(f"Successfully deleted the datasource of {datasource_name}!")

--- a/deployer/commands/grafana/central_grafana.py
+++ b/deployer/commands/grafana/central_grafana.py
@@ -182,7 +182,7 @@ def add_cluster_as_datasource(
     # Get a list of the clusters that already have their prometheus instances used as datasources
     datasources = get_clusters_used_as_datasources()
     if cluster_name and cluster_name not in datasources:
-        print(f"Checking if {cluster_name} it can be added as datasource...")
+        print(f"Checking if {cluster_name} can be added as datasource...")
         datasource_details = build_datasource_details(cluster_name)
         req_body = json.dumps(datasource_details)
 
@@ -218,7 +218,7 @@ def rm_entry_from_datasources(
     datasources = get_clusters_used_as_datasources()
 
     if datasource_name in datasources:
-        print(f"Checking if {datasource_name} it can be deleted from datasources...")
+        print(f"Checking if {datasource_name} can be deleted from datasources...")
         # Build the datasource details for the instances that aren't configures as datasources
         datasource_details = build_datasource_details(cluster_name, datasource_name)
         req_body = json.dumps(datasource_details)

--- a/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
+++ b/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
@@ -1,6 +1,6 @@
 # Register the cluster's Prometheus server with the central Grafana
 
-Once you have [deployed the support chart](deploy-support-chart), you must also register this cluster as a datasource for the [central Grafana dashboard](grafana-dashboards:central). This will allow you to visualize cluster statistics not only from the cluster-specific Grafana deployement but also from the central dashboard, that aggregates data from all the clusters.
+Once you have [deployed the support chart](deploy-support-chart), you must also register this cluster as a datasource for the [central Grafana dashboard](grafana-dashboards:central). This will allow you to visualize cluster statistics not only from the cluster-specific Grafana deployment but also from the central dashboard, that aggregates data from all the clusters.
 
 ## Create a `support.secret.values.yaml` file
 
@@ -49,4 +49,8 @@ deployer deploy-support $CLUSTER_NAME
 
 ## Link the cluster's Prometheus server to the central Grafana
 
-Run `deployer grafana update-central-datasources` to register the new prometheus with the default central grafana.
+To register the new prometheus with the default central grafana, run the command below.
+
+```bash
+deployer grafana central-ds add $CLUSTER_NAME
+```

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -383,7 +383,7 @@ grafana:
           # This is the name of the kubernetes service exposed by the prometheus server
           url: http://support-prometheus-server
           access: proxy
-          isDefault: true
+          isDefault: false
           editable: false
 
 # cryptnono kills processes attempting to mine the cryptocurrency Monero in the


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/1510.

This PR:
- renames the `prometheus` datasource of the 2i2c's Grafana to `2i2c`
- creates a new deployer sub-command called `grafana central-ds` to manage the datasources in the central Grafana
- replaces the `deployer grafana update-central-datasources` command that added all clusters in the repo as datasources, in bulk to four individual commands:
   - one to add a cluster as datasource
   - one to delete a cluster from the datasources list
   - one to list all of the clusters that are not marked as datasources in the 2i2c grafana, but doesn't take any action
   - one to list all of the datasources in the central grafana that don;t have a cluster counterpart in this repo
- updates the add cluster / rm cluster with central grafana update steps.

Note, that "renaming" the `prometheus` data source was a bit tricky:

- this was a config that was provisioned through config, and it's marked as not editable in our support chart https://github.com/2i2c-org/infrastructure/blob/5e12d77b0037706f42cbba1ba88d96aa8794262b/helm-charts/support/values.yaml#L373-L386, so it had to be deleted through config
- Followed the docs at https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources to add a `deleteDatasources` list entry
- Then renamed the default provisioned datasource of the 2i2c cluster to be 2i2c instead of `prometheus`
- Then removed the  `deleteDatasources` entry.
- Note that the datasources in `deleteDatasources` are first deleted, then whatever is listed under `datasouces` is added.


<!-- readthedocs-preview 2i2c-pilot-hubs start -->
----
:books: Documentation preview :books:: https://2i2c-pilot-hubs--3450.org.readthedocs.build/en/3450/

<!-- readthedocs-preview 2i2c-pilot-hubs end -->