### PR TITLE
sops: configure indentation and get YAML valid .json output

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,3 +5,14 @@ creation_rules:
     gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
   - path_regex: deployer/keys/.*key.*
     gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+
+# stores configuration is supported by sops 3.9.0+ only
+stores:
+  # By configuring json indent, we get spaces instead of tabs for json files,
+  # which makes them valid YAML files as well.
+  json:
+    indent: 4
+  json_binary:
+    indent: 4
+  yaml:
+    indent: 2


### PR DESCRIPTION
Sops 3.9.0 (not yet released) will be able, with this configuration, to emit `.json` files that are also valid YAML files by no longer using tabs.

I've declared an indentation of 2 for emitted YAML files and an indentation of 4 for .json files. This aligns with misc other files we have in our repo.

### Related

- https://github.com/getsops/sops/issues/1028
- https://github.com/getsops/sops/pull/1273