### PR TITLE
cilogon hubs: declare first allowed_idps entry as default

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -83,6 +83,7 @@ jupyterhub:
         oauth_callback_url: https://cosmicds.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:
+            default: true
             username_derivation:
               username_claim: "preferred_username"
             allow_all: true

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -41,5 +41,6 @@ jupyterhub:
         oauth_callback_url: "https://staging.uk.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"

--- a/config/clusters/2i2c/aup.values.yaml
+++ b/config/clusters/2i2c/aup.values.yaml
@@ -40,6 +40,7 @@ jupyterhub:
         oauth_callback_url: "https://aup.pilot.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://github.com/login/oauth/authorize:
+            default: true
             username_derivation:
               username_claim: "preferred_username"
       OAuthenticator:

--- a/config/clusters/2i2c/binder-staging.values.yaml
+++ b/config/clusters/2i2c/binder-staging.values.yaml
@@ -74,6 +74,7 @@ binderhub:
           oauth_callback_url: "https://binder-staging.hub.2i2c.cloud/hub/oauth_callback"
           allowed_idps:
             http://google.com/accounts/o8/id:
+              default: true
               username_derivation:
                 username_claim: "email"
         Authenticator:

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -47,5 +47,6 @@ basehub:
           oauth_callback_url: "https://dask-staging.2i2c.cloud/hub/oauth_callback"
           allowed_idps:
             http://google.com/accounts/o8/id:
+              default: true
               username_derivation:
                 username_claim: "email"

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -34,6 +34,7 @@ jupyterhub:
         allowed_idps:
           # UTexas hub
           https://enterprise.login.utexas.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "eppn"
             allow_all: true

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -38,6 +38,7 @@ jupyterhub:
         allowed_idps:
           # Allow MTU to login via Shibboleth
           https://sso.mtu.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/2i2c/neurohackademy.values.yaml
+++ b/config/clusters/2i2c/neurohackademy.values.yaml
@@ -59,6 +59,7 @@ jupyterhub:
         oauth_callback_url: https://neurohackademy.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:
+            default: true
             username_derivation:
               username_claim: "preferred_username"
       OAuthenticator:

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -58,5 +58,6 @@ jupyterhub:
         oauth_callback_url: "https://staging.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -51,6 +51,7 @@ jupyterhub:
         oauth_callback_url: https://temple.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://fim.temple.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "eppn"
             allow_all: true

--- a/config/clusters/2i2c/ucmerced-common.values.yaml
+++ b/config/clusters/2i2c/ucmerced-common.values.yaml
@@ -19,28 +19,19 @@ jupyterhub:
           name: University of California, Merced
           url: http://www.ucmerced.edu/
   hub:
-    extraConfig:
-      100-cilogon-ordering: |
-        # Explicitly specify allowed_idps here, so their sort order is
-        # preserved. Otherwise, the keys get sorted lexicographically,
-        # and Google comes before UC Merced
-        # https://github.com/2i2c-org/infrastructure/issues/3267
-        c.CILogonOAuthenticator.allowed_idps = {
-          "urn:mace:incommon:ucmerced.edu": {
-            "username_derivation": {
-              "username_claim": "eppn"
-            },
-            "allow_all": True
-          },
-          "http://google.com/accounts/o8/id": {
-            "username_derivation": {
-              "username_claim": "email"
-            }
-          }
-        }
     config:
       JupyterHub:
         authenticator_class: cilogon
+      CILogonOAuthenticator:
+        allowed_idps:
+          urn:mace:incommon:ucmerced.edu:
+            default: true
+            username_derivation:
+              username_claim: "eppn"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
       Authenticator:
         admin_users:
           - schadalapaka@ucmerced.edu

--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -141,6 +141,7 @@ jupyterhub:
           - "106951135662332329542" # Elmar Bouwer (Cybera)
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "oidc"
             allowed_domains: &allowed_domains

--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -190,6 +190,7 @@ basehub:
         CILogonOAuthenticator:
           allowed_idps:
             http://github.com/login/oauth/authorize:
+              default: true
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:

--- a/config/clusters/catalystproject-africa/nm-aist.values.yaml
+++ b/config/clusters/catalystproject-africa/nm-aist.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://nm-aist.af.catalystproject.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: email
             allowed_domains:

--- a/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
+++ b/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://unitefa-conicet.latam.catalystproject.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/bcc.values.yaml
+++ b/config/clusters/cloudbank/bcc.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://bcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: "https://ccsf.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://csm.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/csulb.values.yaml
+++ b/config/clusters/cloudbank/csulb.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://csulb.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://its-shib.its.csulb.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/csum.values.yaml
+++ b/config/clusters/cloudbank/csum.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: "https://csum.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           https://cma-shibboleth.csum.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -40,6 +40,7 @@ jupyterhub:
         oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       Authenticator:

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -35,6 +35,7 @@ jupyterhub:
         oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -36,6 +36,7 @@ jupyterhub:
         oauth_callback_url: "https://elcamino.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/evc.values.yaml
+++ b/config/clusters/cloudbank/evc.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://evc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://fresno.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://glendale.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/howard.values.yaml
+++ b/config/clusters/cloudbank/howard.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://howard.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -40,6 +40,7 @@ jupyterhub:
         oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://sso.humboldt.edu/idp/metadata:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://lacc.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://laney.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/mills.values.yaml
+++ b/config/clusters/cloudbank/mills.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://datahub.mills.edu/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://miracosta.fedgw.com/gateway:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://norco.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://palomar.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://pasadena.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/sacramento.values.yaml
+++ b/config/clusters/cloudbank/sacramento.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://sacramento.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://sbcc-dev.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           https://idp.sbcc.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
           http://google.com/accounts/o8/id:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           https://idp.sbcc.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
           http://google.com/accounts/o8/id:

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: https://sjcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -40,6 +40,7 @@ jupyterhub:
         oauth_callback_url: https://sjsu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp01.sjsu.edu/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://skyline.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
             allowed_domains:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://staging.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
         oauth_callback_url: "https://tuskegee.cloudbank.2i2c.cloud/hub/oauth_callback"
         allowed_idps:
           http://google.com/accounts/o8/id:
+            default: true
             username_derivation:
               username_claim: "email"
       OAuthenticator:

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -125,6 +125,7 @@ basehub:
         CILogonOAuthenticator:
           allowed_idps:
             http://github.com/login/oauth/authorize:
+              default: true
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -215,6 +215,7 @@ basehub:
         CILogonOAuthenticator:
           allowed_idps:
             http://github.com/login/oauth/authorize:
+              default: true
               username_derivation:
                 username_claim: "preferred_username"
         OAuthenticator:

--- a/config/clusters/pangeo-hubs/coessing.values.yaml
+++ b/config/clusters/pangeo-hubs/coessing.values.yaml
@@ -40,6 +40,7 @@ basehub:
           oauth_callback_url: "https://coessing.2i2c.cloud/hub/oauth_callback"
           allowed_idps:
             http://google.com/accounts/o8/id:
+              default: true
               username_derivation:
                 username_claim: "email"
         OAuthenticator:

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -39,6 +39,7 @@ jupyterhub:
       CILogonOAuthenticator:
         allowed_idps:
           https://authentication.ubc.ca:
+            default: true
             username_derivation:
               username_claim: email
               action: strip_idp_domain

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -82,6 +82,7 @@ jupyterhub:
       CILogonOAuthenticator:
         allowed_idps:
           https://idpz.utorauth.utoronto.ca/shibboleth:
+            default: true
             username_derivation:
               username_claim: "email"
             allow_all: true

--- a/docs/hub-deployment-guide/configure-auth/cilogon.md
+++ b/docs/hub-deployment-guide/configure-auth/cilogon.md
@@ -75,6 +75,7 @@ jupyterhub:
           # In this example, all authenticated users are authorized via the idp
           # specific allow_all config.
           https://idp2.anu.edu.au/idp/shibboleth:
+            default: true
             username_derivation:
               username_claim: email
             allow_all: true # authorize all users authenticated by the idp
@@ -132,6 +133,7 @@ jupyterhub:
         oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:
+            default: true
             username_derivation:
               username_claim: "preferred_username"
 ```


### PR DESCRIPTION
Based on #3452.

Configures the first entry to be the default CILogon authenticator as the default for all hubs. This entry should also be the community specific entry. I've historically attempted to sort them with this in mind.

- Fixes #3267

