### PR TITLE
carbonplan, qcl, ubc-eoas: cleanup no longer needed pullPolicy

### DIFF
--- a/config/clusters/carbonplan/common.values.yaml
+++ b/config/clusters/carbonplan/common.values.yaml
@@ -35,10 +35,6 @@ basehub:
       serviceAccountName: cloud-user-sa
       image:
         name: carbonplan/trace-python-notebook
-        # pullPolicy set to "Always" because we use the changing over time tag
-        # "latest".
-        pullPolicy: Always
-        tag: "latest"
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods
         # on these nodes.

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -50,10 +50,6 @@ jupyterhub:
             # Cull idle kernels after 24h (24 * 60 * 60)
             # Ref https://2i2c.freshdesk.com/a/tickets/1120
             cull_idle_timeout: 86400
-    image:
-      # Required when using :latest, until https://github.com/jupyterhub/kubespawner/pull/807
-      # is merged
-      pullPolicy: Always
     profileList:
       # NOTE: About node sharing
       #

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -54,10 +54,6 @@ jupyterhub:
           - hmodzelewski # Technical representative, Henryk Modzelewski
 
   singleuser:
-    image:
-      # Required when using :latest, until https://github.com/jupyterhub/kubespawner/pull/807
-      # is merged
-      pullPolicy: Always
     defaultUrl: /lab
     memory:
       # https://2i2c.freshdesk.com/a/tickets/955


### PR DESCRIPTION
With KubeSpawner 6.2.0 we can cleanup declaring an explicit pullPolicy to revert KubeSpawner's previous behavior that was to explicitly set this to IfNotPresent and instead rely on the k8s default behavior of `Always` for all `:latest` tags. For details see https://github.com/jupyterhub/kubespawner/pull/807.