### PR TITLE
Collect service labels in order for kube_service_ metrics to be usable

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -83,6 +83,7 @@ prometheus:
     metricLabelsAllowlist:
       - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
       - nodes=[*]
+      - services=[app, component]
 
   # prometheus-node-exporter is an optional prometheus chart dependency that we
   # rely on to collect metrics about the nodes


### PR DESCRIPTION
I think I found the fix to https://github.com/2i2c-org/infrastructure/issues/3237.

The `$hub` variable used in Grafana is using a `label_values` query, on a service metric called [`kube_service_labels`](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/service-metrics.md). But for the service labels to be available, they need to be allowed listed, because starting with [kube-state-metrics > v2.0](https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/), by default, the metrics contains only name and namespace labels, and all other needed labels need to be explicitly allowed.

What I don't understand why it worked until a month ago, as the v2.0 was released for some time already, but I believe this requirement got tighter with https://github.com/kubernetes/kube-state-metrics/pull/2145 which was released more recently.

Anyway, I've test-deployed this and we got the `$hub` variable back into our dashboards 🎉 