### PR TITLE
Bump qcl homedir capacity

### DIFF
--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -15,7 +15,7 @@ core_node_machine_type = "n2-highmem-2"
 enable_network_policy  = true
 
 enable_filestore      = true
-filestore_capacity_gb = 2048
+filestore_capacity_gb = 2560
 
 user_buckets = {
   "scratch-staging" : {


### PR DESCRIPTION
Alert triggered: https://2i2c-org.pagerduty.com/incidents/Q0MH4BIV11IA1M?utm_campaign=channel&utm_source=slack

Already updated in the console.