### PR TITLE
[merge this on Dec 10 morning CET] Openscapes event

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -42,11 +42,15 @@ basehub:
           - name: home
             mountPath: /home/jovyan/shared
             subPath: _shared
-            readOnly: false
+            # To be changed back to r-w after Dec 10th
+            # https://2i2c.freshdesk.com/a/tickets/1121
+            readOnly: true
           - name: home
             mountPath: /home/rstudio/shared
             subPath: _shared
-            readOnly: false
+            # To be changed back to r-w after Dec 10th
+            # https://2i2c.freshdesk.com/a/tickets/1121
+            readOnly: true
           - name: home
             mountPath: /home/rstudio
             subPath: "{username}"

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -57,7 +57,9 @@ basehub:
                     cpu_guarantee: 1.875
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      # To be changed back to r5.xlarge after Dec 10th
+                      # https://2i2c.freshdesk.com/a/tickets/1121
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.75 CPUs
                   kubespawner_override:
@@ -66,7 +68,9 @@ basehub:
                     cpu_guarantee: 3.75
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      # To be changed back to r5.xlarge after Dec 10th
+                      # https://2i2c.freshdesk.com/a/tickets/1121
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.72 CPUs
                   kubespawner_override:


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/3430

- I didn't get a confirmation about changing the `shared` directory to `readonly` persistently on the hub, so I've assumed we should only do it for the duration of the event
- I've changed the node type from `r5.xlarge` to `r5.4xlarge` for the `14.8GB` profile to have the 50 expected users on ~7 nodes, this means only 14% of the users will experiment longer startup times due to a new node coming up as opposed to 50% of them with the original node type
- I've left the `7.4GB` profile on `r5.xlarge`, as this will mean the 50 expected users of the second event on ~13 nodes, which means ~26 users of the users will experiment longer startup time, which I believe is acceptable.