### PR TITLE
Add documentation about regeneration deployer creds for SMCE accounts

### DIFF
--- a/docs/hub-deployment-guide/new-cluster/smce.md
+++ b/docs/hub-deployment-guide/new-cluster/smce.md
@@ -54,7 +54,7 @@ The `hub-continuous-deployer` has an access key and secret associated with it, t
 authenticates with AWS to perform actions. SMCE accounts have a 60 day password/access key
 regeneration policy and so we need to prepare to regularly regenerate this access key.
 
-We track which clusters have had their `hub-continuous-dpeloyer` access key regenerated
+We track which clusters have had their `hub-continuous-deployer` access key regenerated
 and when in this issue <https://github.com/2i2c-org/infrastructure/issues/2434> which
 also includes the steps for regeneration. Make sure to add the new cluster to this issue.
 


### PR DESCRIPTION
References the process to regenerate credentials for SMCE accounts in #2434 

<!-- readthedocs-preview 2i2c-pilot-hubs start -->
----
:books: Documentation preview :books:: https://2i2c-pilot-hubs--3504.org.readthedocs.build/en/3504/

<!-- readthedocs-preview 2i2c-pilot-hubs end -->