### PR TITLE
[nasa-veda] Regenerate deployer credentials

### DIFF
--- a/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:rIqVNArcN/4vj8eG4/1HJ4xPZjE=,iv:iudNRsrku2pcXmIPEQUzBfYJxvRe7rgamFj6S6M8EfA=,tag:POog+wkldH2pDmi3Ntmkmw==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:psDIfR5S6hHnvixmw5r9EUFq+WEkU2+bryB2h3s1uRLhnV6wCUn0uQ==,iv:Vd1ZiEOfWEcWndpjJDRdvTT9UNV/OiFeE5/fHLv+6CE=,tag:tS1xGtUQZj2buGPZF2l5vg==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:XgAZKbm5tHpbJBdtc+sR+pqRxwD+M4s=,iv:Cih/A/BloUOICV/ZGI0UvSu7OWCHbiyT6Anr1ByPAso=,tag:xBkwA822p4ljwKc82nda0w==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:snwBYJoxlHiqiy1Z5P+Te305S+o=,iv:mw8v47wbEFYFInVALmqai708PbcGilD9a2EooiqPj6I=,tag:wd9JeH7e6dsArPf2HFckvQ==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:Nm7cPP0TVZbXrB8dI1eBB5DdQndYsVjZwC6nzoMyehFLuH8MxA3A9w==,iv:nYWAH7JH9AGX7F7PRjp2uHvFM3GOHi4gx9Ofzdc8VEE=,tag:VwJK6wOFAZpvuTdf1cZe+g==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:0wO9NjNEYDI7VEwbaABNuflsbKHRcCI=,iv:UaQaXwPjgsnHObJWunkSrhxCb5jnlho4m1roMJuH/SY=,tag:pRz4GNk89O13KK0iL6J/kg==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-11-19T18:59:44Z",
-				"enc": "CiUA4OM7eKWO7OEo5U2nvjefm0zav25flhEpLHYyaPQVTTmnKuNkEkkAjTWv+uptb2rKL07ZsO4iH9/KRO//1D9YgmC02hnbyrUq+cNM3o5W7Q8VA3b44pnv+glk1D5AaGx/MQ9+xiZMv8RYwt+AyTq8"
+				"created_at": "2023-12-06T16:20:17Z",
+				"enc": "CiUA4OM7eGFJsgOtkHhpuwtBk7FVibsSQb/81TJhM3geXJ4yP0BZEkkAjTWv+tD1IGTInNdjJdb3sll1n9vPIEJ+EWnp53nRYe3+WBOV53BPZMOq1usbIBDMVkriNHw8YtIRO2lfNVBFKhKaUd5TCgPH"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-11-19T18:59:45Z",
-		"mac": "ENC[AES256_GCM,data:A6kwseUQtrhc56do4RzL/GuISS9UnWQeH+sAPjJ8hl15mlx8JL5IrEyKSXZNLnj+AaCnzHSEBGO6/NFyobPF7NgeEhjLOvWNs4/pKJ9ED4+UrK7JoShLUOzFEwGZiDH2Cafv4qu1MST8L2/u8JWenkIUXhRRHEklsvR/nhAJkfA=,iv:5bXso/vSfDAcKAo44ckUZf/kD92gloWzbaMP/qY9I4U=,tag:KYFWTI09w2GvTnxBHS930w==,type:str]",
+		"lastmodified": "2023-12-06T16:20:17Z",
+		"mac": "ENC[AES256_GCM,data:igdFyuAFjSfqiQVVIhQap23ODCDRe5azpaKKyGL5G1dQ34voJfUhAq0KR2bAlfHBGSAo6l9qI18vcdzSjHmkPsxu1sJWhN3H3l0C6HubIWbplXmlv0t7b8PuBASx0DSy9LxsIVPygXP9/88GyU+nP2ywwdgrVZ8fxxqS1YuYkDc=,iv:KmpCe1L4io1sDEWCCyqGS69bz7cNM2+/8DeJuVYyaeU=,tag:qF+TP2UjKp25GNBw7cQAhQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.2"
+		"version": "3.8.1"
 	}
 }


### PR DESCRIPTION
While completing #3480, I noticed that the deployer credentials had been deleted in terraform. I'm not sure how or why this has happened, but it was going to be regenerated when I ran the apply command anyway, so this PR is committing the new access creds to the repo so we maintain access for CI.