### PR TITLE
Add a short initial policy about k8s version used in our clusters

### DIFF
--- a/docs/howto/upgrade-cluster/index.md
+++ b/docs/howto/upgrade-cluster/index.md
@@ -5,12 +5,24 @@ How we upgrade a Kubernetes cluster is specific to the cloud provider. This
 section covers topics in upgrading an existing Kubernetes cluster.
 
 ```{warning}
-As of now, we have not yet established practices on when to upgrade our
-Kubernetes clusters. Establishing this is tracked in [this GitHub
-issue](https://github.com/2i2c-org/infrastructure/issues/412).
-
 As of now, we also only have written documentation for how to upgrade Kubernetes
 clusters on AWS.
+```
+
+## Upgrade policy
+
+We aim to ensure we use a k8s version for the control plane and node groups that is at least **five minor versions** behind the latest one available at any given time.
+
+Ideally, the following rules should also be respected:
+
+1. Every new cluster we deploy should be using the latest available kubernetes version.
+1. All of the clusters deployed in a cloud provider should be using the same version.
+1. Check if new upgrades are needed at least every 3 months.
+
+
+```{warning}
+As of now, we have not yet established practices on how to ensure these upgrades happen according to the policy above. Establishing this is tracked in [this GitHub
+issue](https://github.com/2i2c-org/infrastructure/issues/412).
 ```
 
 ```{toctree}


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3248

Related https://github.com/2i2c-org/infrastructure/issues/412. Not sure if this should be closed as well, since we still don't have a process for enforcing this policy.

<!-- readthedocs-preview 2i2c-pilot-hubs start -->
----
:books: Documentation preview :books:: https://2i2c-pilot-hubs--3511.org.readthedocs.build/en/3511/

<!-- readthedocs-preview 2i2c-pilot-hubs end -->