### PR TITLE
[cloudbank] Updated User Image Tag

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -17,4 +17,4 @@ jupyterhub:
       limit: 4
     image:
       name: quay.io/2i2c/cloudbank-data8-image
-      tag: 6286b77ae45c
+      tag: d2746e55a4ee


### PR DESCRIPTION
This is the image that uses the downgraded version, 1.22.0, of numpy.