### PR TITLE
Ignore some files during live build to avoid infinite loop rebuilding

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -25,14 +25,20 @@ def docs(session):
         session.posargs.pop(session.posargs.index("live"))
 
         # Add folders to ignore
-        AUTOBUILD_IGNORE = [
+        AUTOBUILD_IGNORE_DIRS = [
             "_build",
             "tmp",
         ]
+        # Add files to ignore
+        AUTOBUILD_IGNORE_FILES = [
+            "_static/*.json",
+        ]
 
         cmd = ["sphinx-autobuild"]
-        for folder in AUTOBUILD_IGNORE:
+        for folder in AUTOBUILD_IGNORE_DIRS:
             cmd.extend(["--ignore", f"*/{folder}/*"])
+        for file in AUTOBUILD_IGNORE_FILES:
+            cmd.extend(["--ignore", f"*/{file}"])
 
         # Find an open port to serve on
         cmd.extend(["--port", "0"])


### PR DESCRIPTION
There are some files in the `docs/_static` folder that get generated as part of the `sphinx build` process. This results in an infinite loop of rebuilding happening when using the live server option: `nox -s docs -- live`. This PR adds those files to an ignore list to break the infinite loop.