### PR TITLE
cloudbank: Explicitly specify what nodepools users should go to

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -9,12 +9,15 @@ nfs:
 jupyterhub:
   singleuser:
     cpu:
-      # Each node has about 8 CPUs total, and if we limit users to no more than
-      # 4, no single user can take down a full node by themselves. We have to
+      # Each node has about 4 CPUs total, and if we limit users to no more than
+      # 2, no single user can take down a full node by themselves. We have to
       # set the guarantee to *something*, otherwise it is set to be equal
       # to the limit! We don't explicitly set a guarantee, because there is
       # a guarantee of 0.05 set in basehub/values.yaml
-      limit: 4
+      limit: 2
     image:
       name: quay.io/2i2c/cloudbank-data8-image
       tag: d2746e55a4ee
+    nodeSelector:
+      # Put everything on the most appropriate nodepool for these users
+      cloud.google.com/gke-nodepool: nb-n2-highmem-4


### PR DESCRIPTION
Otherwise, they still end up on the old 'user' nodepool, and it can not be decomissioned. With this, they will end up on the equivalent 'new' nodepool, and then I can get rid of the old one.

I have also had to adjust the CPU limit, as at some point I suppose we switched from 8 CPU nodes to 4 but did not adjust this.