### PR TITLE
leap, 2i2c, cloudbank: Cleanup some unused nodepools

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -218,7 +218,7 @@ resource "google_container_node_pool" "core" {
     # Faster disks provide faster image pulls!
     disk_type = "pd-balanced"
 
-    resource_labels = var.temp_opt_out_node_purpose_label_core_nodes ? {} : {
+    resource_labels = {
       "node-purpose" : "core"
     }
 

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -339,7 +339,7 @@ resource "google_container_node_pool" "notebook" {
       "https://www.googleapis.com/auth/cloud-platform"
     ]
 
-    resource_labels = each.value.temp_opt_out_node_purpose_label ? each.value.resource_labels : merge({
+    resource_labels = merge({
       "node-purpose" : "notebook"
     }, each.value.resource_labels)
 
@@ -417,7 +417,7 @@ resource "google_container_node_pool" "dask_worker" {
       "https://www.googleapis.com/auth/cloud-platform"
     ]
 
-    resource_labels = each.value.temp_opt_out_node_purpose_label ? each.value.resource_labels : merge({
+    resource_labels = merge({
       "node-purpose" : "dask-worker"
     }, each.value.resource_labels)
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -12,11 +12,7 @@ k8s_versions = {
   dask_nodes_version : "1.27.5-gke.200",
 }
 
-# FIXME: n2-highmem-2 is a better fit for cloudbank as they are currently
-#        limited by the number of pods per node and don't use dask-gateway
-#        that otherwise can make prothemeus server need more memory than a
-#        n2-highmem-2 node can provide.
-core_node_machine_type = "n2-highmem-4"
+core_node_machine_type = "n2-highmem-2"
 enable_network_policy  = true
 
 enable_filestore      = true

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -23,14 +23,6 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
-  # FIXME: Delete this node pool when its empty, its replaced by n2-highmem-4
-  "user" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-highmem-4",
-    node_version : "1.26.4-gke.1400",
-    temp_opt_out_node_purpose_label = true,
-  },
   "n2-highmem-4" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -80,14 +80,6 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  # FIXME: Delete this node pool when its empty, its replaced by n2-highmem-16
-  "medium" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-16",
-    node_version : "1.25.6-gke.1000",
-    temp_opt_out_node_purpose_label : true
-  },
   "n2-highmem-16" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -19,13 +19,6 @@ enable_filestore      = true
 filestore_capacity_gb = 5120
 
 notebook_nodes = {
-  # FIXME: Delete this node pool when its empty, its replaced by n2-highmem-4-b
-  "n2-highmem-4" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-4",
-    temp_opt_out_node_purpose_label : true,
-  },
   "n2-highmem-4-b" : {
     min : 0,
     max : 100,
@@ -40,24 +33,6 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-  },
-  # Nodepool for neurohackademy. Tracking issue: https://github.com/2i2c-org/infrastructure/issues/2681
-  "neurohackademy" : {
-    # We expect around 120 users
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-16",
-    labels : {
-      "2i2c.org/community" : "neurohackademy"
-    },
-    taints : [{
-      key : "2i2c.org/community",
-      value : "neurohackademy",
-      effect : "NO_SCHEDULE"
-    }],
-    resource_labels : {
-      "community" : "neurohackademy"
-    },
   },
   # Nodepool for temple university. https://github.com/2i2c-org/infrastructure/issues/3158
   # FIXME: Delete this node pool when its empty, its replaced by temple-b

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -35,29 +35,6 @@ notebook_nodes = {
     machine_type : "n2-highmem-64",
   },
   # Nodepool for temple university. https://github.com/2i2c-org/infrastructure/issues/3158
-  # FIXME: Delete this node pool when its empty, its replaced by temple-b
-  "temple" : {
-    # Expecting upto ~120 users at a time
-    min : 0,
-    max : 100,
-    # Everyone gets a 256M guarantee, and n2-highmem-8 has about 60GB of RAM.
-    # This fits upto 100 users on the node, as memory guarantee isn't the constraint.
-    # This works ok.
-    machine_type : "n2-highmem-8",
-    node_version : "1.26.4-gke.1400",
-    temp_opt_out_node_purpose_label : true,
-    labels : {
-      "2i2c.org/community" : "temple"
-    },
-    taints : [{
-      key : "2i2c.org/community",
-      value : "temple",
-      effect : "NO_SCHEDULE"
-    }],
-    resource_labels : {
-      "community" : "temple"
-    },
-  },
   "temple-b" : {
     # Expecting upto ~120 users at a time
     min : 0,

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -102,9 +102,6 @@ variable "notebook_nodes" {
       }),
       {}
     ),
-    # FIXME: Remove temp_opt_out_node_purpose_label when its no longer referenced.
-    #        See https://github.com/2i2c-org/infrastructure/issues/3405.
-    temp_opt_out_node_purpose_label : optional(bool, false),
     resource_labels : optional(map(string), {}),
     zones : optional(list(string), []),
     node_version : optional(string, ""),
@@ -138,9 +135,6 @@ variable "dask_nodes" {
       }),
       {}
     ),
-    # FIXME: Remove temp_opt_out_node_purpose_label when its no longer referenced.
-    #        See https://github.com/2i2c-org/infrastructure/issues/3405.
-    temp_opt_out_node_purpose_label : optional(bool, false),
     resource_labels : optional(map(string), {}),
     zones : optional(list(string), [])
     node_version : optional(string, ""),

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -240,13 +240,6 @@ variable "core_node_max_count" {
   EOT
 }
 
-# FIXME: Remove temp_opt_out_node_purpose_label_core_nodes when its no longer referenced.
-#        See https://github.com/2i2c-org/infrastructure/issues/3405.
-variable "temp_opt_out_node_purpose_label_core_nodes" {
-  type    = bool
-  default = false
-}
-
 variable "enable_network_policy" {
   type        = bool
   default     = false


### PR DESCRIPTION
- Also removes the temp opt out variable in use
- Also handles a FIXME about core node size on cloudbank. This brought us from 2
  n2-highmem-4 nodes to 3 n2-highmem-2 nodes, which is cheaper by 25%!

Fixes https://github.com/2i2c-org/infrastructure/issues/3405

These changes have all been applied