### PR TITLE
Bump utoronto staging image again

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -1,10 +1,5 @@
 jupyterhub:
   singleuser:
-    extraEnv:
-      # Required to get jupyter-contrib-nbextensions to work
-      # See https://github.com/2i2c-org/infrastructure/issues/2380
-      # Upstream issue at https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/153
-      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
     image:
       name: quay.io/2i2c/utoronto-image
       tag: "736072886c54"

--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -1,4 +1,12 @@
 jupyterhub:
+  singleuser:
+    extraEnv:
+      # Required to get jupyter-contrib-nbextensions to work, until
+      # https://github.com/2i2c-org/utoronto-image/pull/58 can land. An image
+      # including that is already in the staging hub, but not in the prod
+      # hub. This config can be removed when we promote that image to
+      # production.
+      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
   ingress:
     hosts: [jupyter.utoronto.ca]
     tls:

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -9,7 +9,7 @@ jupyterhub:
       gitRepoBranch: "utoronto-staging"
   singleuser:
     image:
-      tag: "6d72913197bf"
+      tag: "14320bae73a0"
   hub:
     config:
       CILogonOAuthenticator:


### PR DESCRIPTION
Brings in https://github.com/2i2c-org/utoronto-image/pull/58, so we no longer have to use the older notebook server.

Fixes https://github.com/2i2c-org/infrastructure/issues/2380 
Ref https://github.com/2i2c-org/infrastructure/issues/2729