### PR TITLE
utoronto: Bump image for R staging hub

### DIFF
--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -4,6 +4,9 @@ jupyterhub:
     tls:
       - hosts: [r-staging.datatools.utoronto.ca]
         secretName: https-auto-tls
+  singleuser:
+    image:
+      tag: "36c17e91963a"
   hub:
     db:
       pvc:


### PR DESCRIPTION
Brings in https://github.com/2i2c-org/utoronto-r-image/pull/13, 
https://github.com/2i2c-org/utoronto-r-image/pull/14 and 
https://github.com/2i2c-org/utoronto-r-image/pull/15.

Ref https://github.com/2i2c-org/infrastructure/issues/2729