### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,6 +31,12 @@ updates:
     schedule:
       # Check for updates once a week. By default, this check happens on a Monday.
       interval: "monthly"
+    groups:
+      # Group all GHA updates together (to avoid desync in related actions e.g. upload-artifact, download-artifact)
+      # ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      actions:
+        patterns:
+          - "*"
     ignore:
       # Ignore patch upgrades to further reduce noise
       - update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Recently, the `upload-artifact` and `download-artifact` actions were updated, and dependabot opened a PR #3557. For repositories that use both the upload and download actions, this update caused CI breakages when the two packages were updated in separate PRs. Whilst we don't yet have any CI that uses `download-artifact`, it would be prudent in my view to take advantage of grouping all CI updates into a single PR.