### PR TITLE
Correct where the HHMI cloud costs go

### DIFF
--- a/config/clusters/hhmi/cluster.yaml
+++ b/config/clusters/hhmi/cluster.yaml
@@ -8,7 +8,7 @@ gcp:
   billing:
     paid_by_us: true
     bigquery:
-      project: hhmi
+      project: two-eye-two-see
       dataset: cloud_costs
       billing_id: 0157F7-E3EA8C-25AC3C
 support:


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3429. As part of that, I had redirected where the HHMI (and all other projects') cloud costs go, and this updates the cluster.yaml to point to the correct place.

Ref https://github.com/2i2c-org/infrastructure/issues/3350