### PR TITLE
Allow specifying an archival policy for buckets

### DIFF
--- a/docs/howto/features/buckets.md
+++ b/docs/howto/features/buckets.md
@@ -15,6 +15,9 @@ on why users want this!
       },
       "bucket2": {
          "delete_after": null
+      },
+      "bucket3": {
+         "archival_storageclass_after": 3
       }
    }
    ```
@@ -27,6 +30,12 @@ on why users want this!
    time* the object will be automatically cleaned up - this is
    very helpful for 'scratch' buckets that are temporary. Set to
    `null` to prevent this cleaning up process from happening, e.g., if users want a persistent bucket.
+
+   `archival_storageclass_after` (available only for AWS currently) transitions objects
+   created in this bucket to a cheaper, slower archival class after the number of days
+   specified in this variable. This is helpful for archiving user home directories or similar
+   use cases, where data needs to be kept for a long time but rarely accessed. This should
+   not be used for frequently accessed or publicly accessible data.
 
 2. Enable access to these buckets from the hub or make them publicly accessible from outside
    by [editing `hub_cloud_permissions`](howto:features:cloud-access:access-perms)

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -16,6 +16,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "user_bucket_expiry" {
       days = each.value.delete_after
     }
   }
+
+  rule {
+    id     = "archival-storageclass"
+    status = each.value.delete_after != null ? "Enabled" : "Disabled"
+
+    transition {
+      # Transition this to much cheaper object storage after a few days
+      days = each.value.archival_storageclass_after
+      # Glacier Instant is fast enough while also being pretty cheap
+      storage_class = "GLACIER_IR"
+    }
+  }
 }
 
 locals {

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -11,6 +11,9 @@ user_buckets = {
   "scratch" : {
     "delete_after" : 7
   },
+  "prod-homedirs-archive" : {
+    "archival_storageclass_after" : 3
+  }
 }
 
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -20,7 +20,12 @@ variable "cluster_nodes_location" {
 }
 
 variable "user_buckets" {
-  type        = map(object({ delete_after : number }))
+  type = map(
+    object({
+      delete_after : optional(number, null),
+      archival_storageclass_after : optional(number, null)
+    })
+  )
   default     = {}
   description = <<-EOT
   S3 Buckets to be created.
@@ -28,9 +33,13 @@ variable "user_buckets" {
   The key for each entry will be prefixed with {var.prefix}- to form
   the name of the bucket.
 
-  The value is a map, with 'delete_after' the only accepted key in that
-  map - it lists the number of days after which any content in the
-  bucket will be deleted. Set to null to not delete data.
+  The value is a map, with the following accepted keys:
+
+  1. `delete_after` - number of days after *creation* an object in this
+     bucket will be automatically deleted. Set to null to not delete data.
+  2. `archival_storageclass_after` - number of days after *creation* an
+     object in this bucket will be automatically transitioned to a cheaper,
+     slower storageclass for cost savings. Set to null to not transition.
   EOT
 }
 


### PR DESCRIPTION
Only enables this for openscapes, which is using it as described in https://github.com/2i2c-org/infrastructure/issues/3562.