### PR TITLE
Default to k8s 1.28 in new clusters (EKS, GKE)

### DIFF
--- a/eksctl/nasa-esdis.jsonnet
+++ b/eksctl/nasa-esdis.jsonnet
@@ -37,7 +37,8 @@ local daskNodes = [];
     kind: 'ClusterConfig',
     metadata+: {
         name: "nasa-esdis",
-        region: clusterRegion,        version: '1.27'
+        region: clusterRegion,
+        version: '1.27',
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-ghg-hub",
         region: clusterRegion,
-        version: '1.27'
+        version: '1.27',
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -67,9 +67,9 @@ local daskNodes = [];
         region: clusterRegion,
         {#
             version should be the latest support version by the eksctl CLI, see
-            https://eksctl.io/introduction/ for a list of supported versions.
+            https://eksctl.io/getting-started/ for a list of supported versions.
         -#}
-        version: "1.27",
+        version: "1.28",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -47,10 +47,8 @@ variable "k8s_version_prefixes" {
   # channel, so we may want to remove or add minor versions here over time.
   #
   default = [
-    "1.24.",
-    "1.25.",
-    "1.26.",
     "1.27.",
+    "1.28.",
     "1.",
   ]
   description = <<-EOT


### PR DESCRIPTION
This PR changes our EKS and GKE clusters templates to specify k8s 1.28 instead of k8s 1.27. I'm quite confident we are ready to adopt k8s 1.28, and its now part of Google's regular release channel.

Note that k8s 1.29 was released dec 13 2023, so its not bleeding fresh or similar, and z2jh's test suite works out fine against k8s 1.28 also.
