### PR TITLE
Include initContainers when calculating pod overhead

### DIFF
--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -22,7 +22,7 @@
 gke:
   2i2c:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: ""
+    other_daemon_sets: binder-staging-dind,binder-staging-image-cleaner,imagebuilding-demo-binderhub-service-docker-api
     cpu_requests: 344m
     memory_requests: 596Mi
     k8s_version: v1.27.4-gke.900
@@ -31,7 +31,7 @@ gke:
     other_daemon_sets: ""
     cpu_requests: 344m
     memory_requests: 596Mi
-    k8s_version: v1.27.4-gke.900
+    k8s_version: v1.27.7-gke.1056000
   awi-ciroh:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -43,25 +43,25 @@ gke:
     other_daemon_sets: ""
     cpu_requests: 344m
     memory_requests: 596Mi
-    k8s_version: v1.27.4-gke.900
+    k8s_version: v1.27.7-gke.1056000
   catalystproject-latam:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 338m
     memory_requests: 496Mi
-    k8s_version: v1.27.3-gke.100
+    k8s_version: v1.27.7-gke.1056000
   cloudbank:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: continuous-image-puller,continuous-image-puller,continuous-image-puller,netd
-    cpu_requests: 342m
-    memory_requests: 566Mi
-    k8s_version: v1.26.5-gke.2100
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 344m
+    memory_requests: 596Mi
+    k8s_version: v1.27.5-gke.200
   hhmi:
     requesting_daemon_sets: fluentbit-gke,gke-metadata-server,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 228m
     memory_requests: 480Mi
-    k8s_version: v1.27.3-gke.100
+    k8s_version: v1.27.7-gke.1056000
   leap:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -81,54 +81,60 @@ gke:
     memory_requests: 580Mi
     k8s_version: v1.27.4-gke.900
   pangeo-hubs:
-    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: netd
-    cpu_requests: 342m
-    memory_requests: 566Mi
-    k8s_version: v1.26.5-gke.2100
+    requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 344m
+    memory_requests: 596Mi
+    k8s_version: v1.27.5-gke.200
   qcl:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 338m
     memory_requests: 496Mi
-    k8s_version: v1.27.4-gke.900
+    k8s_version: v1.27.7-gke.1056000
 eks:
   2i2c-aws-us:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   catalystproject-africa:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.27.4-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   gridsst:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   jupyter-meets-the-earth:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   nasa-cryo:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
+  nasa-esdis:
+    requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
+    other_daemon_sets: ""
+    cpu_requests: 170m
+    memory_requests: 250Mi
+    k8s_version: v1.27.8-eks-8cb36c9
   nasa-ghg:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.27.4-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   nasa-veda:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -140,29 +146,29 @@ eks:
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.24.16-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   smithsonian:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   ubc-eoas:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.24.17-eks-f8587cb
+    k8s_version: v1.27.8-eks-8cb36c9
   victor:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
 aks:
   utoronto:
     requesting_daemon_sets: cloud-node-manager,csi-azuredisk-node,csi-azurefile-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: calico-node,continuous-image-puller,continuous-image-puller,continuous-image-puller,continuous-image-puller
+    other_daemon_sets: calico-node
     cpu_requests: 226m
     memory_requests: 300Mi
     k8s_version: v1.26.3

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -134,7 +134,7 @@ eks:
     other_daemon_sets: ""
     cpu_requests: 170m
     memory_requests: 250Mi
-    k8s_version: v1.25.12-eks-2d98532
+    k8s_version: v1.27.8-eks-8cb36c9
   openscapes:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/deployer/commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/commands/generate/resource_allocation/node-capacity-info.json
@@ -55,12 +55,12 @@
             "memory": 130451771392
         },
         "measured_overhead": {
-            "cpu": 0.165,
-            "memory": 157286400
+            "cpu": 0.17,
+            "memory": 262144000
         },
         "available": {
-            "cpu": 15.725,
-            "memory": 130294484992
+            "cpu": 15.72,
+            "memory": 130189627392
         }
     },
     "n2-highmem-32": {


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/pull/3569 changed the cryptnono daemonset to have different resource requests for the init containers as well as the container. While working on https://github.com/2i2c-org/infrastructure/pull/3566, I noticed this was generating wrong choices - the overhead was calculated wrong (too small).

We were intentionally ignoring init containers while calculating overhead, and turns out the scheduler and the autoscaler both do take it into consideration. The effective resource request for a pod is the higher of the resource requests for the containers *or* the init containers - this ensures that a pod with higher requests for init containers than containers (like our cryptnono pod!) will actually run. This is documented at
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resource-sharing-within-containers, and implemented in Kubernetes itself at
https://github.com/kubernetes/kubernetes/blob/9bd0ef5f173de3cc2d1d629a4aee499d53690aee/pkg/api/v1/resource/helpers.go#L50 (this is the library code that the cluster autoscaler uses).

This PR updates the two places we currently have that calculate effective resource requests (I assume eventually these will be merged into one - I haven't kept up with the team's work last quarter here).

I've updated the node-capacity-info.json file, which is what seems to be used by the generator script right now.