### PR TITLE
Adjust memory requests so largest instances spawn on r5.4xlarge

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -103,17 +103,17 @@ jupyterhub:
               mem_60_6:
                 display_name: 60.6 GB RAM, upto 15.72 CPUs
                 kubespawner_override:
-                  mem_guarantee: 65105797120
-                  mem_limit: 65105797120
+                  mem_guarantee: 65094813696
+                  mem_limit: 65094813696
                   cpu_guarantee: 7.86
                   cpu_limit: 15.72
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
-              mem_121_3:
-                display_name: 121.3 GB RAM, upto 15.72 CPUs
+              mem_121_2:
+                display_name: 121.2 GB RAM, upto 15.72 CPUs
                 kubespawner_override:
-                  mem_guarantee: 130211594240
-                  mem_limit: 130211594240
+                  mem_guarantee: 130189627392
+                  mem_limit: 130189627392
                   cpu_guarantee: 15.72
                   cpu_limit: 15.72
                   node_selector:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -151,23 +151,22 @@ basehub:
                     cpu_limit: 3.75
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
-
-                mem_60_7:
-                  display_name: 60.7 GB RAM, upto 15.725 CPUs
+                mem_60_6:
+                  display_name: 60.6 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65147242496
-                    mem_limit: 65147242496
-                    cpu_guarantee: 7.8625
-                    cpu_limit: 15.725
+                    mem_guarantee: 65094813696
+                    mem_limit: 65094813696
+                    cpu_guarantee: 7.86
+                    cpu_limit: 15.72
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
-                mem_121_3:
-                  display_name: 121.3 GB RAM, upto 15.725 CPUs
+                mem_121_2:
+                  display_name: 121.2 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130294484992
-                    mem_limit: 130294484992
-                    cpu_guarantee: 15.725
-                    cpu_limit: 15.725
+                    mem_guarantee: 130189627392
+                    mem_limit: 130189627392
+                    cpu_guarantee: 15.72
+                    cpu_limit: 15.72
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
         - display_name: "Rocker Geospatial with RStudio"

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -70,17 +70,17 @@ basehub:
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65105797120
-                    mem_limit: 65105797120
+                    mem_guarantee: 65094813696
+                    mem_limit: 65094813696
                     cpu_guarantee: 7.86
                     cpu_limit: 15.72
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
-                mem_121_3:
-                  display_name: 121.3 GB RAM, upto 15.72 CPUs
+                mem_121_2:
+                  display_name: 121.2 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130211594240
-                    mem_limit: 130211594240
+                    mem_guarantee: 130189627392
+                    mem_limit: 130189627392
                     cpu_guarantee: 15.72
                     cpu_limit: 15.72
                     node_selector:

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -83,17 +83,17 @@ basehub:
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65105797120
-                    mem_limit: 65105797120
+                    mem_guarantee: 65094813696
+                    mem_limit: 65094813696
                     cpu_guarantee: 7.86
                     cpu_limit: 15.72
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
-                mem_121_3:
-                  display_name: 121.3 GB RAM, upto 15.72 CPUs
+                mem_121_2:
+                  display_name: 121.2 GB RAM, upto 15.72 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130211594240
-                    mem_limit: 130211594240
+                    mem_guarantee: 130189627392
+                    mem_limit: 130189627392
                     cpu_guarantee: 15.72
                     cpu_limit: 15.72
                     node_selector:


### PR DESCRIPTION
Brings in the new memory / cpu limits set up for
https://github.com/2i2c-org/infrastructure/pull/3572 - without that, the largest set up size doesn't actually spawn on r5.4xlarge due to insufficient memory.