### PR TITLE
Use qgis image from new location

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -101,8 +101,8 @@ basehub:
                     cmd: null
                     # Launch people directly into the Linux desktop when they start
                     default_url: /desktop
-                    # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-                    image: "quay.io/jupyter-remote-desktop-proxy/qgis:2023-09-27"
+                    # Built from https://github.com/2i2c-org/nasa-qgis-image
+                    image: "quay.io/2i2c/nasa-qgis-image:78d96c092f8e"
             requests:
               # NOTE: Node share choices are in active development, see comment
               #       next to profileList: above.

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -192,8 +192,8 @@ basehub:
             cmd: null
             # Launch people directly into the Linux desktop when they start
             default_url: /desktop
-            # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-            image: "quay.io/jupyter-remote-desktop-proxy/qgis:2023-09-27"
+            # Built from https://github.com/2i2c-org/nasa-qgis-image
+            image: "quay.io/2i2c/nasa-qgis-image:78d96c092f8e"
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)


### PR DESCRIPTION
https://github.com/2i2c-org/nasa-qgis-image is the new home of this image, as the PR linked to has been closed.