### PR TITLE
[Don't merge until Jan 9]Redirect all UToronto home pages to unified homepage

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -20,8 +20,11 @@ jupyterhub:
       enabled: true
   custom:
     homepage:
+      # Everyone hitting the home page directly is redirected to
+      # https://datatools.utoronto.ca as the unified home page. The various parameters
+      # here under templateVars are no-op - UToronto manages the unified homepage themselves.
+      gitRepoBranch: "utoronto"
       templateVars:
-        interface_selector: true
         org:
           name: University of Toronto
           logo_url: https://raw.githubusercontent.com/2i2c-org/default-hub-homepage/utoronto-prod/extra-assets/images/home-hero.png
@@ -35,26 +38,6 @@ jupyterhub:
         funded_by:
           name: University of Toronto
           url: https://www.utoronto.ca/
-        announcements:
-          - |
-            <div>
-              <h4>ARC will be making changes to our educational JupyterHub on January 9, 2023</h4>
-              
-              <p>R/RStudio will be moved off <a href="https://jupyter.utoronto.ca">jupyter.utoronto.ca</a>. R/RStudio will
-              continue to be available through <a href="https://r.datatools.utoronto.ca">r.datatools.utoronto.ca</a> – a
-              separate RStudio hub. To make access to JupyterHub easier than ever, we will also consolidate the landing
-              pages for our Jupyter Notebook and RStudio hubs into a single launch page:
-              <a href="https://datatools.utoronto.ca">datatools.utoronto.ca</a>.</p>
-
-              <p>For more information, please read <a href="https://act.utoronto.ca/jupyterhub-support/updates-to-our-educational-jupyterhub/">our announcement</a>.</p>
-            </div>
-          - |
-            <div>
-              <h4>* NEW * Jupyter Support Website</h4>
-
-              We have started a JupyterHub support website with documentation and tip sheets, and we will be adding more on an
-              ongoing basis. To reach the support site, please visit: <a href="https://act.utoronto.ca/jupyterhub-support">https://act.utoronto.ca/jupyterhub-support/</a>.
-            </div>
   singleuser:
     cpu:
       # Each node has about 8 CPUs total, and if we limit users to no more than

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -4,6 +4,9 @@ jupyterhub:
     tls:
       - hosts: [staging.utoronto.2i2c.cloud]
         secretName: https-auto-tls
+  singleuser:
+    image:
+      tag: "14320bae73a0"
   hub:
     config:
       CILogonOAuthenticator:

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -4,12 +4,6 @@ jupyterhub:
     tls:
       - hosts: [staging.utoronto.2i2c.cloud]
         secretName: https-auto-tls
-  custom:
-    homepage:
-      gitRepoBranch: "utoronto-staging"
-  singleuser:
-    image:
-      tag: "14320bae73a0"
   hub:
     config:
       CILogonOAuthenticator:


### PR DESCRIPTION
UToronto will have a new URL (to be determined...) that they will manage, and will act as the 'unified' home page. In https://2i2c.freshdesk.com/a/tickets/952 they have asked us to redirect anyone landing just on the home page of the hubs to this new URL. I've setup the [utoronto
branch](https://github.com/2i2c-org/default-hub-homepage/tree/utoronto) of the home pages repo to redirect to the new URL.

This just deploys that change. The new URL hasn't been provided to us yet, so the utoronto branch in the default-hub-homepage repo will need to be updated once that URL is present.

Ref https://github.com/2i2c-org/infrastructure/issues/2729