### PR TITLE
Round CPU display numbers in resource allocation list

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -55,7 +55,7 @@ jupyterhub:
             display_name: Resource Allocation
             choices:
               mem_1_9:
-                display_name: 1.9 GB RAM, upto 3.75 CPUs
+                display_name: 1.9 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 1992701952
                   mem_limit: 1992701952
@@ -65,7 +65,7 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_3_7:
-                display_name: 3.7 GB RAM, upto 3.75 CPUs
+                display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 3985403904
                   mem_limit: 3985403904
@@ -74,7 +74,7 @@ jupyterhub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
-                display_name: 7.4 GB RAM, upto 3.75 CPUs
+                display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 7970807808
                   mem_limit: 7970807808
@@ -83,7 +83,7 @@ jupyterhub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
-                display_name: 14.8 GB RAM, upto 3.75 CPUs
+                display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 15941615616
                   mem_limit: 15941615616
@@ -92,7 +92,7 @@ jupyterhub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_29_7:
-                display_name: 29.7 GB RAM, upto 3.75 CPUs
+                display_name: 29.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 31883231232
                   mem_limit: 31883231232
@@ -101,7 +101,7 @@ jupyterhub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_60_6:
-                display_name: 60.6 GB RAM, upto 15.72 CPUs
+                display_name: 60.6 GB RAM, upto 15.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 65094813696
                   mem_limit: 65094813696
@@ -110,7 +110,7 @@ jupyterhub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
               mem_121_2:
-                display_name: 121.2 GB RAM, upto 15.72 CPUs
+                display_name: 121.2 GB RAM, upto 15.7 CPUs
                 kubespawner_override:
                   mem_guarantee: 130189627392
                   mem_limit: 130189627392

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -106,7 +106,7 @@ basehub:
               display_name: Resource Allocation
               choices:
                 mem_1_9:
-                  display_name: 1.9 GB RAM, upto 3.75 CPUs
+                  display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 1991341312
                     mem_limit: 1991341312
@@ -116,7 +116,7 @@ basehub:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
-                  display_name: 3.7 GB RAM, upto 3.75 CPUs
+                  display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 3982682624
                     mem_limit: 3982682624
@@ -125,7 +125,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
-                  display_name: 7.4 GB RAM, upto 3.75 CPUs
+                  display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 7965365248
                     mem_limit: 7965365248
@@ -134,7 +134,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
-                  display_name: 14.8 GB RAM, upto 3.75 CPUs
+                  display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 15930730496
                     mem_limit: 15930730496
@@ -143,7 +143,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
-                  display_name: 29.7 GB RAM, upto 3.75 CPUs
+                  display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 31861460992
                     mem_limit: 31861460992
@@ -152,7 +152,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.72 CPUs
+                  display_name: 60.6 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 65094813696
                     mem_limit: 65094813696
@@ -161,7 +161,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.72 CPUs
+                  display_name: 121.2 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 130189627392
                     mem_limit: 130189627392

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -22,7 +22,7 @@ basehub:
               display_name: Resource Allocation
               choices:
                 mem_1_9:
-                  display_name: 1.9 GB RAM, upto 3.75 CPUs
+                  display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 1992701952
                     mem_limit: 1992701952
@@ -32,7 +32,7 @@ basehub:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
-                  display_name: 3.7 GB RAM, upto 3.75 CPUs
+                  display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 3985403904
                     mem_limit: 3985403904
@@ -41,7 +41,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
-                  display_name: 7.4 GB RAM, upto 3.75 CPUs
+                  display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 7970807808
                     mem_limit: 7970807808
@@ -50,7 +50,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
-                  display_name: 14.8 GB RAM, upto 3.75 CPUs
+                  display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 15941615616
                     mem_limit: 15941615616
@@ -59,7 +59,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
-                  display_name: 29.7 GB RAM, upto 3.75 CPUs
+                  display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 31883231232
                     mem_limit: 31883231232
@@ -68,7 +68,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.72 CPUs
+                  display_name: 60.6 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 65094813696
                     mem_limit: 65094813696
@@ -77,7 +77,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.72 CPUs
+                  display_name: 121.2 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 130189627392
                     mem_limit: 130189627392

--- a/config/clusters/openscapes/staging.values.yaml
+++ b/config/clusters/openscapes/staging.values.yaml
@@ -35,7 +35,7 @@ basehub:
               display_name: Resource Allocation
               choices:
                 mem_1_9:
-                  display_name: 1.9 GB RAM, upto 3.75 CPUs
+                  display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 1992701952
                     mem_limit: 1992701952
@@ -45,7 +45,7 @@ basehub:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
-                  display_name: 3.7 GB RAM, upto 3.75 CPUs
+                  display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 3985403904
                     mem_limit: 3985403904
@@ -54,7 +54,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
-                  display_name: 7.4 GB RAM, upto 3.75 CPUs
+                  display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 7970807808
                     mem_limit: 7970807808
@@ -63,7 +63,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
-                  display_name: 14.8 GB RAM, upto 3.75 CPUs
+                  display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 15941615616
                     mem_limit: 15941615616
@@ -72,7 +72,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
-                  display_name: 29.7 GB RAM, upto 3.75 CPUs
+                  display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 31883231232
                     mem_limit: 31883231232
@@ -81,7 +81,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.72 CPUs
+                  display_name: 60.6 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 65094813696
                     mem_limit: 65094813696
@@ -90,7 +90,7 @@ basehub:
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.72 CPUs
+                  display_name: 121.2 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
                     mem_guarantee: 130189627392
                     mem_limit: 130189627392

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -1,4 +1,5 @@
 import json
+import math
 import sys
 from enum import Enum
 from pathlib import Path
@@ -52,6 +53,11 @@ def proportional_memory_strategy(
     available_node_mem = nodeinfo["available"]["memory"]
     available_node_cpu = nodeinfo["available"]["cpu"]
 
+    # Only show one digit after . for CPU, but round *down* not up so we never
+    # say they are getting more CPU than our limit is set to. We multiply & divide
+    # with a floor, as otherwise 3.75 gets rounded to 3.8, not 3.7
+    cpu_display = math.floor(available_node_cpu * 10) / 10
+
     # We always start from the top, and provide a choice that takes up the whole node.
     mem_limit = available_node_mem
 
@@ -61,9 +67,9 @@ def proportional_memory_strategy(
         # This makes sure we utilize all the memory on a node all the time.
         cpu_guarantee = (mem_limit / available_node_mem) * available_node_cpu
 
-        # Memory is in bytes, let's convert it to GB to display
+        # Memory is in bytes, let's convert it to GB (with only 1 digit after .) to display
         mem_display = f"{mem_limit / 1024 / 1024 / 1024:.1f}"
-        display_name = f"{mem_display} GB RAM, upto {available_node_cpu} CPUs"
+        display_name = f"{mem_display} GB RAM, upto {cpu_display} CPUs"
 
         choice = {
             "display_name": display_name,


### PR DESCRIPTION
Brings it down to one digit after decimal, rather than 2.

Ref https://github.com/2i2c-org/infrastructure/issues/3584