### PR TITLE
Automate triager project board tasks

### DIFF
--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -1,0 +1,46 @@
+name: Set project board status fields
+on: 
+  issues:
+    types:
+      - labeled
+
+jobs:
+  update-project-board-fields:
+    if: github.event.label.name == 'support'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse the ticket tracker issue template form
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/5_freshdesk-ticket.yml
+      - name: Get ticket impact from the form
+        shell: python
+        id: get-ticket-impact
+        run: |
+          import os
+
+          form = ${{ steps.issue-parser.outputs.jsonString }}
+          impact = form.get("ticket_impact")
+          # Export the `pending_info` string to GITHUB_OUTPUT to be used in following steps
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+              print(f"impact={impact}", file=f)
+      - name: Update the "Impact" field with info from the issue form
+        uses: EndBug/project-fields@v2
+        id: fields
+        with:
+          operation: set
+          fields: Impact
+          github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
+          project_url: https://github.com/orgs/2i2c-org/projects/22
+          values: "${{ steps.get-ticket-impact.outputs.impact }}"
+      - name: Update the "Type" field to "Support"
+        uses: EndBug/project-fields@v2
+        id: fields
+        with:
+          operation: set
+          fields: Type
+          github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
+          project_url: https://github.com/orgs/2i2c-org/projects/22
+          values: "Support"

--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -1,5 +1,5 @@
 name: Set project board status fields
-on: 
+on:
   issues:
     types:
       - labeled
@@ -27,7 +27,7 @@ jobs:
               print(f"impact={impact}", file=f)
       - name: Set the "Impact" project board field
         uses: EndBug/project-fields@v2
-        id: fields
+        id: impact-field
         with:
           operation: set
           fields: Impact
@@ -36,7 +36,7 @@ jobs:
           values: "${{ steps.get-ticket-impact.outputs.impact }}"
       - name: Set "Type" field of the project board to "Support"
         uses: EndBug/project-fields@v2
-        id: fields
+        id: type-field
         with:
           operation: set
           fields: Type

--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -25,21 +25,12 @@ jobs:
           # Export the `impact` string to GITHUB_OUTPUT to be used in following steps
           with open(os.environ["GITHUB_OUTPUT"], "a") as f :
               print(f"impact={impact}", file=f)
-      - name: Set the "Impact" project board field
+      - name: Set the "Impact" and "Type" project board fields
         uses: EndBug/project-fields@v2
-        id: impact-field
+        id: set-fields
         with:
           operation: set
-          fields: Impact
+          fields: Impact,Type
           github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           project_url: https://github.com/orgs/2i2c-org/projects/22
-          values: "${{ steps.get-ticket-impact.outputs.impact }}"
-      - name: Set "Type" field of the project board to "Support"
-        uses: EndBug/project-fields@v2
-        id: type-field
-        with:
-          operation: set
-          fields: Type
-          github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
-          project_url: https://github.com/orgs/2i2c-org/projects/22
-          values: "Support"
+          values: ${{ steps.get-ticket-impact.outputs.impact }},Support

--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -26,7 +26,7 @@ jobs:
           # Export the `pending_info` string to GITHUB_OUTPUT to be used in following steps
           with open(os.environ["GITHUB_OUTPUT"], "a") as f :
               print(f"impact={impact}", file=f)
-      - name: Update the "Impact" field with info from the issue form
+      - name: Set the "Impact" project board field
         uses: EndBug/project-fields@v2
         id: fields
         with:
@@ -35,7 +35,7 @@ jobs:
           github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           project_url: https://github.com/orgs/2i2c-org/projects/22
           values: "${{ steps.get-ticket-impact.outputs.impact }}"
-      - name: Update the "Type" field to "Support"
+      - name: Set "Type" field of the project board to "Support"
         uses: EndBug/project-fields@v2
         id: fields
         with:

--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Parse the ticket tracker issue template form
-        uses: stefanbuck/github-issue-praser@v3
+        uses: stefanbuck/github-issue-parser@v3
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/5_freshdesk-ticket.yml

--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -20,10 +20,9 @@ jobs:
         id: get-ticket-impact
         run: |
           import os
-
           form = ${{ steps.issue-parser.outputs.jsonString }}
           impact = form.get("ticket_impact")
-          # Export the `pending_info` string to GITHUB_OUTPUT to be used in following steps
+          # Export the `impact` string to GITHUB_OUTPUT to be used in following steps
           with open(os.environ["GITHUB_OUTPUT"], "a") as f :
               print(f"impact={impact}", file=f)
       - name: Set the "Impact" project board field


### PR DESCRIPTION
In the [Non-incident support process](https://compass.2i2c.org/projects/managed-hubs/support/#non-incident-response-process), the support triager is tasked with opening follow-up issues for the tickets they cannot resolve in the first 30m.

These issues will get into the [Engineering and Product Backlog](https://github.com/orgs/2i2c-org/projects/22) and after, the triager needs to manually set some fields about them like `type` and `impact` so they can be properly prioritized later.

This workflow automates these tasks as long as the support triager uses the ticket tracker issue form and fills in all the relevant information.


