### PR TITLE
Fix crashing docker daemon in binderhub-staging

### DIFF
--- a/config/clusters/2i2c/binder-staging.values.yaml
+++ b/config/clusters/2i2c/binder-staging.values.yaml
@@ -8,6 +8,18 @@ binderhub:
           - binder-staging.2i2c.cloud
   registry:
     url: https://us-central1-docker.pkg.dev
+
+  dind:
+    daemonset:
+      image:
+        name: docker.io/library/docker
+        # Temporarily pinned, until https://github.com/2i2c-org/infrastructure/issues/3588 is fixed
+        tag: "24.0.6-dind"
+    # We may have multiple dind docker daemons in the same node, and they all need to be
+    # using different paths for storing their socket & lib directories. Otherwise, they
+    # will race and crash.
+    hostSocketDir: /var/run/dind/binderhub-staging
+    hostLibDir: /var/lib/dind/binderhub-staging
   config:
     DockerRegistry:
       token_url: https://us-central1-docker.pkg.dev/v2/token?service=


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/3588