### PR TITLE
docs: Fix make live command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ help:
 .PHONY: help Makefile
 
 live:
-	sphinx-autobuild --ignore */_build/* --ignore */tmp/* -b html -n . _build/html 
+	sphinx-autobuild --ignore */_build/* --ignore */tmp/* --ignore */_static/hub-*.json -b dirhtml -n . _build/dirhtml
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for MyST -------------------------------------------------
 panels_add_bootstrap_css = False
+myst_footnote_transition = False
 myst_enable_extensions = [
     "colon_fence",
     "deflist",

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -3,7 +3,7 @@
 
 Much of our active infrastructure is configured and automatically updated via CI/CD pipelines.
 This means that changes in this repository often immediately impact the infrastructure that we run.
-As such, we follow team policies for review/merge that are more specific [than our general development merge policies](tc:development:merge-policy).
+As such, we follow team policies for review/merge that are more specific [than our general development merge policies](inv:tc#development:merge-policy).
 
 This document codifies our guidelines for doing code review and merging pull requests on active infrastructure (ie, anything in the `infrastructure/` codebase).
 

--- a/docs/howto/prepare-for-events/exam.md
+++ b/docs/howto/prepare-for-events/exam.md
@@ -39,7 +39,7 @@ This page documents what we do to prep, based on our prior experiences.
    If the hub has a profile list enabled, based on the instance types setup for
    the hub, you can find the new allocation options by running:
 
-   ```{bash}
+   ```bash
    deployer generate resource-allocation choices <instance-type>
    ```
 

--- a/docs/hub-deployment-guide/hubs/other-hub-ops/move-hubs/across-clusters.md
+++ b/docs/hub-deployment-guide/hubs/other-hub-ops/move-hubs/across-clusters.md
@@ -5,7 +5,7 @@ to ensure data is preserved.
 
 ## 1. Setup a new hub
 
-Setup [a new hub](../../../topic/infrastructure/config.md) in the target cluster, mimicking
+Setup [a new hub](config) in the target cluster, mimicking
 the config of the old hub as much as possible.
 
 (copy-home-dirs)=

--- a/docs/topic/access-creds/secrets.md
+++ b/docs/topic/access-creds/secrets.md
@@ -50,7 +50,7 @@ For example, if a service we use has become compromised, and we need to generate
 To rotate our secrets, take these steps:
 
 1. Determine which configuration file you'd like to update. See [](secrets:locations).
-2. Unencrypt the configuration file. See [the team compass documentation](tc:secrets:sops) for instructions on unencrypting.
+2. Unencrypt the configuration file. See [the team compass documentation](inv:tc#secrets:sops) for instructions on unencrypting.
 3. Generate a new key with `openssl`:
 
    ```


### PR DESCRIPTION
Running `make live`  from `docs` directory causes `sphinx-autobuild` to enter an infinite loop, constantly rebuilding the docs.

This happens because `conf.py` runs `helper-programs/generate-general-info-table-about-hubs.py`, which generates the file `_static/hub-stats.json` that triggers a rebuild.

I also fixed some warnings.

<!-- readthedocs-preview 2i2c-pilot-hubs start -->
----
📚 Documentation preview 📚: https://2i2c-pilot-hubs--3590.org.readthedocs.build/en/3590/

<!-- readthedocs-preview 2i2c-pilot-hubs end -->