### PR TITLE
docs: how to deploy with external aws account

### DIFF
--- a/docs/hub-deployment-guide/new-cluster/external-account.md
+++ b/docs/hub-deployment-guide/new-cluster/external-account.md
@@ -1,21 +1,21 @@
 # AWS with external account
 
-In some cases, the organization has its own AWS account and is provided it to us to deploy the cluster.
+In some cases, the organization has its own AWS account that is provided to us to deploy the cluster.
 This method is far simpler as we don't have to handle cloud billing, since it is handled by the organization.
 
 There are some steps to do before the deploy:
 
 1. Instruct the external organization to create one AWS IAM account with full permissions.
    Since we will have one account per engineer,
-   this should be for a specific engineer who is responsible for setting up the hub.
+   this initial account should be created for the specific engineer who is responsible for setting up the hub.
 
 1. The organization sends the credentials for this account to `support@2i2c.org`,
    [encrypted using age encryption method](inv:dc#support:encrypt).
 
 1. The engineer accesses this information and [decrypts it using the provided instructions](/sre-guide/support/decrypt-age).
 
-1. This engineer can use the IAM service in the AWS Console to create accounts for each engineer
-   and then sends the credentials to each engineer, for example, through Slack.
+1. This engineer can use the IAM service in the AWS Console to create accounts for each of the other engineers
+   and then sends the credentials to each, for example, through Slack.
    
    ```{tip}
    Create a **User group** with admin permissions.

--- a/docs/hub-deployment-guide/new-cluster/external-account.md
+++ b/docs/hub-deployment-guide/new-cluster/external-account.md
@@ -1,0 +1,25 @@
+# AWS with external account
+
+In some cases, the organization has its own AWS account and is provided it to us to deploy the cluster.
+This method is far simpler as we don't have to handle cloud billing, since it is handled by the organization.
+
+There are some steps to do before the deploy:
+
+1. Instruct the external organization to create one AWS IAM account with full permissions.
+   Since we will have one account per engineer,
+   this should be for a specific engineer who is responsible for setting up the hub.
+
+1. The organization sends the credentials for this account to `support@2i2c.org`,
+   [encrypted using age encryption method](inv:dc#support:encrypt).
+
+1. The engineer accesses this information and [decrypts it using the provided instructions](/sre-guide/support/decrypt-age).
+
+1. This engineer can use the IAM service in the AWS Console to create accounts for each engineer
+   and then sends the credentials to each engineer, for example, through Slack.
+   
+   ```{tip}
+   Create a **User group** with admin permissions.
+   ```
+
+1. Continue with the cluster setup as usual (following [new cluster on AWS](aws)).
+   On the section [](new-cluster:aws-setup-credentials) follow the steps for "For accounts without AWS SSO".

--- a/docs/hub-deployment-guide/new-cluster/index.md
+++ b/docs/hub-deployment-guide/new-cluster/index.md
@@ -31,4 +31,5 @@ Deploying Kubernetes to AWS has a distinctly different workflow than GCP or Azur
 new-cluster.md
 aws.md
 smce.md
+external-account.md
 ```


### PR DESCRIPTION
I am creating a new page because I believe it doesn't fit well within the current pages and their sections.

Please let me know if it would be more suitable to place it on another page.

ref: #3527 

<!-- readthedocs-preview 2i2c-pilot-hubs start -->
----
📚 Documentation preview 📚: https://2i2c-pilot-hubs--3594.org.readthedocs.build/en/3594/

<!-- readthedocs-preview 2i2c-pilot-hubs end -->