### PR TITLE
utoronto: reduce prometheus requested memory to fit better on smaller nodes

### DIFF
--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -23,10 +23,11 @@ prometheus:
           hosts:
             - prometheus.utoronto.2i2c.cloud
     resources:
+      # utoronto's prometheus seems to lie stable below 10Gi at around 6Gi
       requests:
-        memory: 16Gi
+        memory: 12Gi
       limits:
-        memory: 16Gi
+        memory: 12Gi
 
 grafana:
   grafana.ini:


### PR DESCRIPTION
While we can't change the node type currently in utoronto's k8s clusters core node pool, this is a pre-requisite to using 2 CPU / 16 GB RAM nodes (Standard_E2s_v5).

Prometheus memory footprint looks like this the last 6 months, so on average ~6 Gi used, and always below 10Gi, so it should be robust to declare a maximum of 12Gi.
![image](https://github.com/2i2c-org/infrastructure/assets/3837114/38a30094-8013-4163-9fbc-f2f405852675)
