### PR TITLE
terraform, azure and utoronto: an upgrade, misc to support it, and misc opportunistic details

### DIFF
--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -42,25 +42,9 @@ core_node_pool = {
 }
 
 user_node_pools = {
-  "default" : {
-    name : "nbdefault",
-    # NOTE: min-max below was set to 0-86 retroactively to align with
-    #       observed state without understanding on why 0-86 was picked.
-    min : 0,
-    max : 86,
-    # FIXME: upgrade user nodes vm_size to Standard_E8s_v5
-    vm_size : "Standard_E8s_v3",
-    # FIXME: remove this label
-    labels : {
-      "hub.jupyter.org/node-size" = "Standard_E8s_v3",
-    },
-    kubernetes_version : "1.26.3",
-    # FIXME: stop using persistent disks for the nodes, use Temporary instead
-    kubelet_disk_type : "OS",
-  },
   "usere8sv5" : {
     min : 0,
     max : 100,
     vm_size : "Standard_E8s_v5",
-  }
+  },
 }

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -20,10 +20,6 @@ core_node_pool = {
   #        reasons like three calico-typha pods. See
   #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
   #
-  #        Transitioning to E2s_v5 would require reducing the requested memory
-  #        by prometheus-server though, but that should be okay since
-  #        prometheus has reduced its memory profile significant enough recently.
-  #
   vm_size : "Standard_E4s_v3",
 
   # FIXME: stop using persistent disks for the nodes, use the variable default

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -1,3 +1,11 @@
+# IMPORTANT: Due to a restrictive network rule from storage.tf, we can't perform
+#            "terraform plan" or "terraform apply" without a workaround.
+#
+#            One known workaround is to allow your public IP temporarily as
+#            discussed in https://github.com/2i2c-org/infrastructure/issues/890#issuecomment-1879072422.
+#            This workaround is problematic as that may temporarily allow access
+#            to storage by other actors with the same IP.
+#
 tenant_id                      = "78aac226-2f03-4b4d-9037-b46d56c55210"
 subscription_id                = "ead3521a-d994-4a44-a68d-b16e35642d5b"
 resourcegroup_name             = "2i2c-utoronto-cluster"
@@ -16,17 +24,20 @@ node_pools = {
     {
       name : "core",
 
-      # FIXME: transition to "Standard_E2s_v5" nodes as they are large enough and
-      #        can more cheaply handle being forced to have 2-3 replicas for silly
-      #        reasons like three calico-typha pods. See
-      #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
+      # FIXME: Transition to "Standard_E2s_v5" nodes as they are large enough to
+      #        for the biggest workload (prometheus-server) and can handle high
+      #        availability requirements better.
+      #
+      #        We are currently forced to handle three calico-typha pods that
+      #        can't schedule on the same node, see https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
       #
       vm_size : "Standard_E4s_v3",
 
+      # core nodes doesn't need much disk space
       os_disk_size_gb : 40,
 
-      # FIXME: stop using persistent disks for the nodes, use the variable default
-      #        "Temporary" instead
+      # FIXME: Stop using persistent disks for the nodes, use the variable default
+      #        "Temporary" instead by removing this line.
       kubelet_disk_type : "OS",
 
       min : 1,

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -11,36 +11,38 @@ ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2
 # List available versions via: az aks get-versions --location westus2 -o table
 kubernetes_version = "1.28.3"
 
-core_node_pool = {
-  name : "core",
-  kubernetes_version : "1.28.3",
+node_pools = {
+  core : [
+    {
+      name : "core",
 
-  # FIXME: transition to "Standard_E2s_v5" nodes as they are large enough and
-  #        can more cheaply handle being forced to have 2-3 replicas for silly
-  #        reasons like three calico-typha pods. See
-  #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
-  #
-  vm_size : "Standard_E4s_v3",
+      # FIXME: transition to "Standard_E2s_v5" nodes as they are large enough and
+      #        can more cheaply handle being forced to have 2-3 replicas for silly
+      #        reasons like three calico-typha pods. See
+      #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
+      #
+      vm_size : "Standard_E4s_v3",
 
-  # FIXME: stop using persistent disks for the nodes, use the variable default
-  #        "Temporary" instead
-  kubelet_disk_type : "OS",
+      os_disk_size_gb : 40,
 
-  # FIXME: use a larger os_disk_size_gb than 40, like the default of 100, to
-  #        avoid running low when few replicas are used
-  os_disk_size_gb : 40,
+      # FIXME: stop using persistent disks for the nodes, use the variable default
+      #        "Temporary" instead
+      kubelet_disk_type : "OS",
 
-  # FIXME: its nice to use autoscaling, but we end up with three replicas due to
-  #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632
-  #        and its a waste at least using Standard_E4s_v3 machines.
-  enable_auto_scaling : false,
-  node_count : 2,
-}
+      min : 1,
+      max : 10,
+    },
+  ],
 
-user_node_pools = {
-  "usere8sv5" : {
-    min : 0,
-    max : 100,
-    vm_size : "Standard_E8s_v5",
-  },
+  user : [
+    {
+      name : "usere8sv5",
+      vm_size : "Standard_E8s_v5",
+      os_disk_size_gb : 200,
+      min : 0,
+      max : 100,
+    },
+  ],
+
+  dask : []
 }

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -11,7 +11,7 @@ ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2
 # FIXME: upgrade to 1.27.7, and then 1.28.3, based on the latest versions
 #        available via: az aks get-versions --location westus2 -o table
 #
-kubernetes_version = "1.26.3"
+kubernetes_version = "1.27.7"
 
 core_node_pool = {
   name : "core",

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -55,5 +55,5 @@ node_pools = {
     },
   ],
 
-  dask : []
+  dask : [],
 }

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -13,16 +13,31 @@ ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2
 #
 kubernetes_version = "1.26.3"
 
-# FIXME: upgrade core_node_vm_size to Standard_E4s_v5
-core_node_vm_size = "Standard_E4s_v3"
+core_node_pool = {
+  name : "core",
+  vm_size : "Standard_E4s_v3",
+  kubernetes_version : "1.26.3",
+}
 
 notebook_nodes = {
   "default" : {
+    name : "nbdefault",
     # NOTE: min-max below was set to 0-86 retroactively to align with
     #       observed state without understanding on why 0-86 was picked.
     min : 0,
     max : 86,
     # FIXME: upgrade user nodes vm_size to Standard_E8s_v5
     vm_size : "Standard_E8s_v3",
-  }
+    # FIXME: remove this label
+    labels : {
+      "hub.jupyter.org/node-size" = "Standard_E8s_v3",
+    },
+    kubernetes_version : "1.26.3",
+  },
+  #"usere8sv5" : {
+  #  min : 0,
+  #  max : 100,
+  #  vm_size : "Standard_E8s_v5",
+  #  kubernetes_version : "1.28.3",
+  #}
 }

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -8,18 +8,40 @@ location                       = "canadacentral"
 storage_size = 8192
 ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
 
-# FIXME: upgrade to 1.27.7, and then 1.28.3, based on the latest versions
-#        available via: az aks get-versions --location westus2 -o table
-#
-kubernetes_version = "1.27.7"
+# List available versions via: az aks get-versions --location westus2 -o table
+kubernetes_version = "1.28.3"
 
 core_node_pool = {
   name : "core",
+  kubernetes_version : "1.28.3",
+
+  # FIXME: transition to "Standard_E2s_v5" nodes as they are large enough and
+  #        can more cheaply handle being forced to have 2-3 replicas for silly
+  #        reasons like three calico-typha pods. See
+  #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632.
+  #
+  #        Transitioning to E2s_v5 would require reducing the requested memory
+  #        by prometheus-server though, but that should be okay since
+  #        prometheus has reduced its memory profile significant enough recently.
+  #
   vm_size : "Standard_E4s_v3",
-  kubernetes_version : "1.26.3",
+
+  # FIXME: stop using persistent disks for the nodes, use the variable default
+  #        "Temporary" instead
+  kubelet_disk_type : "OS",
+
+  # FIXME: use a larger os_disk_size_gb than 40, like the default of 100, to
+  #        avoid running low when few replicas are used
+  os_disk_size_gb : 40,
+
+  # FIXME: its nice to use autoscaling, but we end up with three replicas due to
+  #        https://github.com/2i2c-org/infrastructure/issues/3592#issuecomment-1883269632
+  #        and its a waste at least using Standard_E4s_v3 machines.
+  enable_auto_scaling : false,
+  node_count : 2,
 }
 
-notebook_nodes = {
+user_node_pools = {
   "default" : {
     name : "nbdefault",
     # NOTE: min-max below was set to 0-86 retroactively to align with
@@ -33,11 +55,12 @@ notebook_nodes = {
       "hub.jupyter.org/node-size" = "Standard_E8s_v3",
     },
     kubernetes_version : "1.26.3",
+    # FIXME: stop using persistent disks for the nodes, use Temporary instead
+    kubelet_disk_type : "OS",
   },
-  #"usere8sv5" : {
-  #  min : 0,
-  #  max : 100,
-  #  vm_size : "Standard_E8s_v5",
-  #  kubernetes_version : "1.28.3",
-  #}
+  "usere8sv5" : {
+    min : 0,
+    max : 100,
+    vm_size : "Standard_E8s_v5",
+  }
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -48,20 +48,6 @@ variable "kubernetes_version" {
 }
 
 
-variable "core_node_vm_size" {
-  type        = string
-  description = <<-EOT
-  VM Size to use for core nodes
-
-  Core nodes will always be on, and count as 'base cost'
-  for a cluster. We should try to run with as few of them
-  as possible.
-
-  WARNING: CHANGING THIS WILL DESTROY AND RECREATE THE CLUSTER!
-  EOT
-}
-
-
 variable "global_container_registry_name" {
   type        = string
   description = <<-EOT
@@ -92,8 +78,23 @@ variable "ssh_pub_key" {
   EOT
 }
 
+variable "core_node_pool" {
+  type = object({
+    name : optional(string, ""),
+    min : optional(number, 1),
+    max : optional(number, 10),
+    vm_size : string,
+    labels : optional(map(string), {}),
+    taints : optional(list(string), []),
+    os_disk_size_gb : optional(number, 40),
+    kubernetes_version : optional(string, "")
+  })
+  description = "Core node pool"
+}
+
 variable "notebook_nodes" {
   type = map(object({
+    name : optional(string, ""),
     min : number,
     max : number,
     vm_size : string,

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -81,18 +81,21 @@ variable "ssh_pub_key" {
 variable "core_node_pool" {
   type = object({
     name : optional(string, ""),
+    enable_auto_scaling = optional(bool, true),
     min : optional(number, 1),
     max : optional(number, 10),
+    node_count : optional(number),
     vm_size : string,
     labels : optional(map(string), {}),
     taints : optional(list(string), []),
-    os_disk_size_gb : optional(number, 40),
-    kubernetes_version : optional(string, "")
+    os_disk_size_gb : optional(number, 100),
+    kubernetes_version : optional(string, ""),
+    kubelet_disk_type : optional(string, "Temporary"),
   })
   description = "Core node pool"
 }
 
-variable "notebook_nodes" {
+variable "user_node_pools" {
   type = map(object({
     name : optional(string, ""),
     min : number,
@@ -100,20 +103,22 @@ variable "notebook_nodes" {
     vm_size : string,
     labels : optional(map(string), {}),
     taints : optional(list(string), []),
-    kubernetes_version : optional(string, "")
+    os_disk_size_gb : optional(number, 200),
+    kubernetes_version : optional(string, ""),
+    kubelet_disk_type : optional(string, "Temporary"),
   }))
-  description = "Notebook node pools to create"
+  description = "User node pools to create"
   default     = {}
 }
 
-variable "dask_nodes" {
+variable "dask_node_pools" {
   type = map(object({
     min : number,
     max : number,
     vm_size : string,
     labels : optional(map(string), {}),
     taints : optional(list(string), []),
-    kubernetes_version : optional(string, "")
+    kubernetes_version : optional(string, ""),
   }))
   description = "Dask node pools to create"
   default     = {}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -78,50 +78,25 @@ variable "ssh_pub_key" {
   EOT
 }
 
-variable "core_node_pool" {
-  type = object({
-    name : optional(string, ""),
-    enable_auto_scaling = optional(bool, true),
-    min : optional(number, 1),
-    max : optional(number, 10),
-    node_count : optional(number),
+variable "node_pools" {
+  type = map(list(object({
+    name : string,
     vm_size : string,
-    labels : optional(map(string), {}),
-    taints : optional(list(string), []),
     os_disk_size_gb : optional(number, 100),
-    kubernetes_version : optional(string, ""),
     kubelet_disk_type : optional(string, "Temporary"),
-  })
-  description = "Core node pool"
-}
-
-variable "user_node_pools" {
-  type = map(object({
-    name : optional(string, ""),
     min : number,
     max : number,
-    vm_size : string,
-    labels : optional(map(string), {}),
-    taints : optional(list(string), []),
-    os_disk_size_gb : optional(number, 200),
-    kubernetes_version : optional(string, ""),
-    kubelet_disk_type : optional(string, "Temporary"),
-  }))
-  description = "User node pools to create"
-  default     = {}
-}
-
-variable "dask_node_pools" {
-  type = map(object({
-    min : number,
-    max : number,
-    vm_size : string,
     labels : optional(map(string), {}),
     taints : optional(list(string), []),
     kubernetes_version : optional(string, ""),
-  }))
-  description = "Dask node pools to create"
-  default     = {}
+  })))
+  description = <<-EOT
+  Node pools to create to be listed under the keys 'core', 'user', and 'dask'.
+
+  There should be exactly one core node pool. The core node pool is given a
+  special treatment by being listed directly in the cluster resource's
+  'default_node_pool' field.
+  EOT
 }
 
 variable "create_service_principal" {


### PR DESCRIPTION
The terraform changes are applied already. I've done some things besides just upgrading the k8s cluster version that I believed were resonable to go for opportunistically.

### Changes overviewed

- a user node pool switch from `Standard_E8s_v3` to `_v5`, which is like `r3.2xlarge` to `r5.2xlarge` in AWS. This price of these are the same.
- a user node pool switch and a core node pool a prepared transition from use of persistent machine disks on user nodes to ephemeral machine disks (like in GKE also for example)
- (reverted, autoscaling and 3 replicas remains) a pinning of core node pool count to 2 in order to avoid paying for an empty core node pool due to #3592
- added resolution of configuration in order to
  - enable upgrade of control plan and node pools separately
  - enable a non-disruptive transitions from misc machine types
- misc fixme notes and comments with notable research behind them
- removal of no longer relevant label (`hub.jupyter.org/node-size`)
- an AKS transition towards referencing "notebook nodes" as "user nodes"
- (added post-review) refactored use of multiple node pool variables to a single variable to reduce duplication of node pool variable definitions