### PR TITLE
utoronto: Don't force usage of notebookapp

### DIFF
--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -1,12 +1,4 @@
 jupyterhub:
-  singleuser:
-    extraEnv:
-      # Required to get jupyter-contrib-nbextensions to work, until
-      # https://github.com/2i2c-org/utoronto-image/pull/58 can land. An image
-      # including that is already in the staging hub, but not in the prod
-      # hub. This config can be removed when we promote that image to
-      # production.
-      JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
   ingress:
     hosts: [jupyter.utoronto.ca]
     tls:


### PR DESCRIPTION
https://github.com/2i2c-org/infrastructure/pull/3582 has been merged, so we can stop forcing NotebookApp in prod.

Without this, JupyterLab actually fails to launch, fixed upstream in https://github.com/jupyter-server/jupyter_server/pull/1384

Ref https://github.com/2i2c-org/infrastructure/issues/2729