### PR TITLE
Revert "[Merge Jan 9] utoronto: Enable automatic login on utoronto hubs"

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -74,12 +74,6 @@ jupyterhub:
         concurrent_spawn_limit: 100
         # We wanna keep logs long term, primarily for analytics
         extra_log_file: /srv/jupyterhub/jupyterhub.log
-      Authenticator:
-        # If users come directly to jupyter.utoronto.ca or any of the other hub landing pages,
-        # we don't actually want to show them the landing page - just auth them if needed and
-        # send them over to wherever they need to go. This is because there is an *external* home
-        # page that is sending people to appropriate locations with /hub/user-redirect.
-        auto_login: true
       CILogonOAuthenticator:
         allowed_idps:
           https://idpz.utorauth.utoronto.ca/shibboleth:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#3531

More detail in https://github.com/2i2c-org/infrastructure/issues/2729#issuecomment-1883571591.

We don't want to *unconditionally* autologin. We want to autologin when nbgitpuller is being
used, and to redirect to datatools.utoronto.ca any other time. This is now handled by the JS
in https://github.com/2i2c-org/default-hub-homepage/pull/28

Ref https://github.com/2i2c-org/infrastructure/issues/2729