### PR TITLE
Use same home page branch for utoronto prod hub too

### DIFF
--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -17,9 +17,6 @@ jupyterhub:
           # that pods in `kube-system` will still schedule.
           # So even though this is under `userPlaceholder`, it really is operating as a `nodePlaceholder`
           memory: 57350076Ki
-  custom:
-    homepage:
-      gitRepoBranch: "utoronto-prod"
   hub:
     db:
       pvc:


### PR DESCRIPTION
Everything should use the `utoronto` branch now, as set in the common config file

Ref https://github.com/2i2c-org/infrastructure/issues/2729