### PR TITLE
Move the " UToronto JupyterHub Private Cloner"  GitHub app's details under the default hubs common

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -49,20 +49,6 @@ jupyterhub:
     memory:
       limit: 2G
       guarantee: 1G
-    extraFiles:
-      github-app-private-key.pem:
-        mountPath: /etc/github/github-app-private-key.pem
-        # stringData field will be set via encrypted values files but added here
-        # to meet the chart schema validation requirements without the need to
-        # use secret values during the validation.
-        stringData: "dummy"
-      gitconfig:
-        mountPath: /etc/gitconfig
-        # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner
-        stringData: |
-          [credential "https://github.com"]
-          helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
-          useHttpPath = true
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -3,6 +3,20 @@ jupyterhub:
     image:
       name: quay.io/2i2c/utoronto-image
       tag: "14320bae73a0"
+    extraFiles:
+      github-app-private-key.pem:
+        mountPath: /etc/github/github-app-private-key.pem
+        # stringData field will be set via encrypted values files but added here
+        # to meet the chart schema validation requirements without the need to
+        # use secret values during the validation.
+        stringData: "dummy"
+      gitconfig:
+        mountPath: /etc/gitconfig
+        # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner
+        stringData: |
+          [credential "https://github.com"]
+          helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
+          useHttpPath = true
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
The homepage URL of this app is set to https://jupyter.utoronto.ca, so I believe a separate one for the r hub is needed.