### PR TITLE
Add AMS workshop participants access

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -46,6 +46,7 @@ basehub:
             - US-GHG-Center:ghg-use-case-2
             - US-GHG-Center:ghg-use-case-3
             - US-GHG-Center:ghg-external-collaborators
+            - US-GHG-Center:ghg-ams-2024-workshop-access
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
# Changes
- Added access to a new GitHub team `US-GHG-Center:ghg-ams-2024-workshop-access` to provide temporary access to GHG AMS 2024 workshop participants

cc @freitagb 