### PR TITLE
Update Showcase Hub Handbook Authoring image tag

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -129,7 +129,7 @@ basehub:
                   display_name: Handbook Authoring
                   slug: handbook
                   kubespawner_override:
-                    image: quay.io/2i2c/handbook-authoring-image:bbe4225a7940
+                    image: quay.io/2i2c/handbook-authoring-image:3559ba6430b3
                 pangeo:
                   display_name: Pangeo Notebook
                   default: true


### PR DESCRIPTION
I downgraded `docutils` to `v0.17.1` as advised in the [Jupyter Book docs](https://jupyterbook.org/en/stable/content/citations.html?highlight=docutils#citations-and-bibliographies) (see PR https://github.com/2i2c-org/community-showcase/pull/49) so that Citations and Bibliographies block would work properly in the Handbook Authoring image available on the Showcase Hub. 

This pull request changes the config file to deploy the updated image hosted on quay.io with the new tag.

Question: is this the correct process for all future changes to the profileList on the Showcase Hub? Thanks in advance!