### PR TITLE
Update cryptonono's location

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -33,7 +33,7 @@ jobs:
             chart_urls: '{"binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml"}'
           - name: "support"
             chart_path: "helm-charts/support/Chart.yaml"
-            chart_urls: '{"cryptnono": "https://yuvipanda.github.io/cryptnono/index.yaml", "cluster-autoscaler": "https://kubernetes.github.io/autoscaler/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx/index.yaml", "grafana": "https://grafana.github.io/helm-charts/index.yaml", "prometheus": "https://prometheus-community.github.io/helm-charts/index.yaml"}'
+            chart_urls: '{"cryptnono": "https://cryptnono.github.io/cryptnono/index.yaml", "cluster-autoscaler": "https://kubernetes.github.io/autoscaler/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx/index.yaml", "grafana": "https://grafana.github.io/helm-charts/index.yaml", "prometheus": "https://prometheus-community.github.io/helm-charts/index.yaml"}'
 
     steps:
       # We want tests to be run on the Pull Request that gets opened by the next step,

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -40,8 +40,8 @@ dependencies:
     condition: cluster-autoscaler.enabled
 
   # cryptnono, counters crypto mining
-  # Source code: https://github.com/yuvipanda/cryptnono/
+  # Source code: https://github.com/cryptnono/cryptnono/
   - name: cryptnono
     version: "0.3.1-0.dev.git.107.heb504bc"
-    repository: https://yuvipanda.github.io/cryptnono/
+    repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled


### PR DESCRIPTION
The repo has moved under a new account: https://github.com/cryptnono/cryptnono (see https://github.com/cryptnono/cryptnono/pull/25#issuecomment-1889099710)