### PR TITLE
dask-gateway: bump from 2023.9.0 to 2024.1.0

### DIFF
--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -97,7 +97,7 @@ def deploy(
         help="Name of hub to operate deploy. Omit to deploy all hubs on the cluster",
     ),
     dask_gateway_version: str = typer.Option(
-        "2023.9.0", help="Version of dask-gateway to install CRDs for"
+        "2024.1.0", help="Version of dask-gateway to install CRDs for"
     ),
     debug: bool = typer.Option(
         False,

--- a/helm-charts/daskhub/Chart.yaml
+++ b/helm-charts/daskhub/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     # in the deployer's CLI
     # https://github.com/2i2c-org/infrastructure/blob/HEAD/deployer/deployer.py#L195
   - name: dask-gateway
-    version: "2023.9.0"
+    version: "2024.1.0"
     repository: "https://helm.dask.org/"


### PR DESCRIPTION
This makes `latest` tag not come with `IfNotPreset` pull policies, which easily could cause issues if a `latest` tag was used. That in turn is something I want before suggesting use of `latest` tag in https://2i2c.freshdesk.com/a/tickets/794 as a compromise.