### PR TITLE
Deactivate the configurator where profileLists override same config

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -11,6 +11,8 @@ jupyterhub:
     2i2c:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
     homepage:
       templateVars:
         org:

--- a/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
+++ b/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
@@ -12,6 +12,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -15,6 +15,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -10,7 +10,8 @@ jupyterhub:
     2i2c:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "github"
-
+    jupyterhubConfigurator:
+      enabled: false
     homepage:
       templateVars:
         org:

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -66,6 +66,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -16,6 +16,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "google"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -19,6 +19,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -14,6 +14,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -18,6 +18,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -21,6 +21,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -16,6 +16,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -15,6 +15,8 @@ jupyterhub:
     2i2c:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
     homepage:
       templateVars:
         org:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -19,6 +19,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -19,6 +19,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -16,6 +16,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         gitRepoBranch: "openscapes"
         templateVars:

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -17,6 +17,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -19,6 +19,8 @@ jupyterhub:
     2i2c:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "google"
+    jupyterhubConfigurator:
+      enabled: false
     homepage:
       templateVars:
         org:


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/3349

The following configuration files where identified to be overriding the `image` in profileLists:

- [x] `clusters/nasa-ghg in file ->> common.values.yaml`
- [x] `clusters/2i2c-aws-us in file ->> showcase.values.yaml`
- [x] `clusters/2i2c-aws-us in file ->> ncar-cisl.values.yaml`
- [x] `clusters/2i2c-aws-us in file ->> itcoocean.values.yaml`
- [x] `clusters/nasa-veda in file ->> common.values.yaml`
- [x] `clusters/2i2c in file ->> imagebuilding-demo.values.yaml`
- [x] `clusters/2i2c in file ->> ohw.values.yaml`
- [x] `clusters/2i2c in file ->> ucmerced-staging.values.yaml`
- [x] `clusters/2i2c in file ->> ucmerced.values.yaml`
- [x] `clusters/smithsonian in file ->> common.values.yaml`
- [x] `clusters/openscapes in file ->> staging.values.yaml`
- [x] `clusters/openscapes in file ->> prod.values.yaml`
- [x] `clusters/jupyter-meets-the-earth in file ->> common.values.yaml`
- [x] `clusters/leap in file ->> common.values.yaml`
- [x] `clusters/nasa-cryo in file ->> common.values.yaml`
- [x] `clusters/hhmi in file ->> common.values.yaml`
- [x] `clusters/ubc-eoas in file ->> common.values.yaml`
- [x] `clusters/nasa-esdis in file ->> common.values.yaml`
- [x] `clusters/earthscope in file ->> common.values.yaml`
- [x] `clusters/gridsst in file ->> common.values.yaml`

<details>
  <summary>In case is of interest I used a python script to identify these.</summary>

  ```python
def get_profile_list(jupyterhub_config):
    try:
        profiles = jupyterhub_config.get("singleuser", {}).get("profileList", None)
        if profiles:
            for p in profiles:
                overrides = p.get("kubespawner_override", None)
                if overrides and overrides.get("image", None):
                    return True
                options = p.get("profile_options", None)
                if options:
                    if "image" in options:
                        return True
    except KeyError:
        return False
  ```
</details>