### PR TITLE
[showcase] Enable env var access to scratch bucket

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -48,6 +48,9 @@ basehub:
         Authenticator:
           enable_auth_state: true
     singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
+        PANGEO_SCRATCH: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
       profileList:
         - display_name: "NASA TOPS-T ScienceCore-ClimateRisk"
           description: "For collaborative work on 2i2c/MD's NASA TOPS-T ScienceCore Module"


### PR DESCRIPTION
requested in https://2i2c.freshdesk.com/a/tickets/1255

A scratch bucket already existed, but the env var wasn't set up to link it to the hub