### PR TITLE
Check for technical support contacts as part of new hub turn-up

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -23,6 +23,20 @@ body:
     validations:
       required: true
 
+  - type: checkboxes
+    attributes:
+      label: Technical support contacts listed
+      description: |
+        Technical contacts are the folks who are authorized to open support tickets about this hub.
+        The source of truth is maintained in [this airtable](https://airtable.com/appxk7c9WUsDjSi0Q/tbl3CWOgyoEtuGuIw/viwtpo7RxkYv63hiD?blocks=hide).
+
+        Validate that there is at least one technical contact listed in the airtable for this hub. If not, ping
+        partnerships to ensure they find out who that is and fill that information in.
+      options:
+        - label: Technical contact present
+    validations:
+      required: true
+
   - type: textarea
     attributes:
       label: Hub important dates
@@ -171,20 +185,6 @@ body:
         - label: Scalable Dask Cluster
     validations:
       required: false
-
-  - type: checkboxes
-    attributes:
-      label: Technical support contacts listed
-      description: |
-        Technical contacts are the folks who are authorized to open support tickets about this hub.
-        The source of truth is maintained in [this airtable](https://airtable.com/appxk7c9WUsDjSi0Q/tbl3CWOgyoEtuGuIw/viwtpo7RxkYv63hiD?blocks=hide).
-
-        Validate that there is at least one technical contact listed in the airtable for this hub. If not, ping
-        partnerships to ensure they find out who that is and fill that information in.
-      options:
-        - label: Technical contact present
-    validations:
-      required: true
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-hub-provide-info.yml
@@ -172,6 +172,20 @@ body:
     validations:
       required: false
 
+  - type: checkboxes
+    attributes:
+      label: Technical support contacts listed
+      description: |
+        Technical contacts are the folks who are authorized to open support tickets about this hub.
+        The source of truth is maintained in [this airtable](https://airtable.com/appxk7c9WUsDjSi0Q/tbl3CWOgyoEtuGuIw/viwtpo7RxkYv63hiD?blocks=hide).
+
+        Validate that there is at least one technical contact listed in the airtable for this hub. If not, ping
+        partnerships to ensure they find out who that is and fill that information in.
+      options:
+        - label: Technical contact present
+    validations:
+      required: true
+
   - type: dropdown
     attributes:
       label: (Optional) Preferred cloud provider


### PR DESCRIPTION
As part of https://github.com/2i2c-org/infrastructure/issues/3048#issuecomment-1907195217, we now have an airtable be the 'source of truth' for who is allowed to initiate support requests. This PR adds an item in the checklist for new hub turn up, making sure we validate that there *is* a technical contact for this hub.

The airtable in use may change soon as well as the terminology (as partnerships works on it https://github.com/2i2c-org/infrastructure/issues/3048#issuecomment-1909011115). But it is important to have a verification step here, so we don't let whatever airtable it is be out of date.

Ref https://github.com/2i2c-org/infrastructure/issues/3048#issuecomment-1907335901