### PR TITLE
Make sure the configurator is disabled when appropriate

### DIFF
--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -243,7 +243,7 @@ def configurator_config(
     """
     For each hub of a specific cluster:
      - It asserts that when the singleuser configuration overrides the same fields like the configurator,
-       the later must be disabled.
+       the latter must be disabled.
        An error is raised otherwise.
     """
     _prepare_helm_charts_dependencies_and_schemas()

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -293,8 +293,6 @@ def configurator_config(
                 except KeyError:
                     pass
 
-        # If the authenticator class is github, then raise an error
-        # if `Authenticator.allowed_users` is set
         if configurator_enabled == True and singleuser_overrides == True:
             raise ValueError(
                 f"""

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -69,6 +69,17 @@ def _prepare_helm_charts_dependencies_and_schemas():
     subprocess.check_call(["helm", "dep", "up", support_dir])
 
 
+def get_list_of_hubs_to_operate_on(cluster_name, hub_name):
+    config_file_path = find_absolute_path_to_cluster_file(cluster_name)
+    with open(config_file_path) as f:
+        cluster = Cluster(yaml.load(f), config_file_path.parent)
+
+    if hub_name:
+        return [h for h in cluster.hubs if h.spec["name"] == hub_name]
+
+    return cluster.hubs
+
+
 @validate_app.command()
 def cluster_config(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
@@ -99,14 +110,8 @@ def hub_config(
     _prepare_helm_charts_dependencies_and_schemas()
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
-    with open(config_file_path) as f:
-        cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    hubs = []
-    if hub_name:
-        hubs = [h for h in cluster.hubs if h.spec["name"] == hub_name]
-    else:
-        hubs = cluster.hubs
+    hubs = get_list_of_hubs_to_operate_on(cluster_name, hub_name)
 
     for i, hub in enumerate(hubs):
         print_colour(
@@ -185,14 +190,8 @@ def authenticator_config(
     _prepare_helm_charts_dependencies_and_schemas()
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
-    with open(config_file_path) as f:
-        cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    hubs = []
-    if hub_name:
-        hubs = [h for h in cluster.hubs if h.spec["name"] == hub_name]
-    else:
-        hubs = cluster.hubs
+    hubs = get_list_of_hubs_to_operate_on(cluster_name, hub_name)
 
     for i, hub in enumerate(hubs):
         print_colour(
@@ -250,14 +249,8 @@ def configurator_config(
     _prepare_helm_charts_dependencies_and_schemas()
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
-    with open(config_file_path) as f:
-        cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    hubs = []
-    if hub_name:
-        hubs = [h for h in cluster.hubs if h.spec["name"] == hub_name]
-    else:
-        hubs = cluster.hubs
+    hubs = get_list_of_hubs_to_operate_on(cluster_name, hub_name)
 
     for i, hub in enumerate(hubs):
         print_colour(

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -242,7 +242,7 @@ def configurator_config(
 ):
     """
     For each hub of a specific cluster:
-     - It asserts that when the singleuser configuration overrides the same fields like the configurator,
+     - It asserts that when the singleuser configuration overrides the same fields like the configurator, specifically kubespawner_override and profile_options,
        the latter must be disabled.
        An error is raised otherwise.
     """


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3635

> In our [schema](https://github.com/2i2c-org/infrastructure/blob/285faeb899b7e10623e9464269d90497d8a97a13/helm-charts/basehub/values.schema.yaml#L496), I believe we can set it up so that jupyterConfigurator can be true only if singleuser.profileList is empty or unset (via one of the methods described in https://stackoverflow.com/a/38781027). This should ensure that we can't have both profile lists and the configurator enabled at the same time.

Unfortunately I couldn't implement @yuvipanda's suggestion above because we do not do any validation for the jupyterhub config and we rely on it's own schema. So instead I wrote this function which is also how we validate some of the authentication configuration. 

Does this make sense or should I continue to try and fiddle around with the actual schema?