### PR TITLE
Handle deployment-service-check user for auth0

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -87,12 +87,15 @@ basehub:
               return False
 
           def populate_token(spawner, auth_state):
-            token_env = {
-              'AUTH0_ACCESS_TOKEN': auth_state.get("access_token", ""),
-              'AUTH0_ID_TOKEN': auth_state.get("id_token", ""),
-              'AUTH0_REFRESH_TOKEN': auth_state.get('refresh_token', '')
-            }
-            spawner.environment.update(token_env)
+            # For our deployment-service-check health check user, there is no auth_state.
+            # So these env variables need not be set.
+            if auth_state:
+              token_env = {
+                'AUTH0_ACCESS_TOKEN': auth_state.get("access_token", ""),
+                'AUTH0_ID_TOKEN': auth_state.get("id_token", ""),
+                'AUTH0_REFRESH_TOKEN': auth_state.get('refresh_token', '')
+              }
+              spawner.environment.update(token_env)
 
           c.Spawner.auth_state_hook = populate_token
 


### PR DESCRIPTION
That user (which we use for our health checks) does not have any auth state, so this was causing health checks to fail.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/3618