### PR TITLE
Add ephemeral spyglass hub to the hhmi cluster

### DIFF
--- a/config/clusters/hhmi/cluster.yaml
+++ b/config/clusters/hhmi/cluster.yaml
@@ -32,3 +32,10 @@ hubs:
       - common.values.yaml
       - prod.values.yaml
       - enc-prod.secret.values.yaml
+  - name: spyglass
+    display_name: "HHMI Spyglass (ephemeral)"
+    domain: spyglass.hhmi.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - spyglass.values.yaml
+      - enc-spyglass.secret.values.yaml

--- a/config/clusters/hhmi/enc-spyglass.secret.values.yaml
+++ b/config/clusters/hhmi/enc-spyglass.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:tRMrV5gjq/CVdXVDLXV7GZ9CVbpuvqso6YqG/uGmiSf41tHm/JhhB3wK8KsF8PR1WhSX,iv:pNzlRpFjfuKhhy2yY4tjgno/loUJ1fILm4QyG4RTfQo=,tag:p4PvWRRHVrQ2T5636SeQvA==,type:str]
+                client_secret: ENC[AES256_GCM,data:/7S4rIlrctYvslOgQT3ca4ccnSHF91CgZWa/BFqoaS/+bM90JQXOOG+Ym16QOGaMAmz3nHTbb1Wcw97XEVA2QojSoXFolPSLW48SIu4DYXvNOhCDbvs=,iv:uNYsw9FEIrdYapjqu3iaxajjKi2EMS2HuoTDGoaYwM8=,tag:AyY2wBdTTcU06YD4suqfeA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-01-29T11:47:45Z"
+          enc: CiUA4OM7eH7LaSZsJNEg4vcii34JBUu7DausMz17GSm8D1aEF+3gEkkAjTWv+irAbeNsrWhiyLRJkjvnjtp+Exfp4PnP//gxEfQY/l3yWzokRL2dH7i2pPcA0ZXBFpoh61y96zOawKhugploAubWVThg
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-01-29T11:47:45Z"
+    mac: ENC[AES256_GCM,data:+Sh6T1SAZXwtLAIwisQESaC8CrERYfdiwEMxHXUesaep5hf1rYR4dYp7+I8U07b+gHKES/t2m8AGNtFsndikEXCLfRAZ4vM2EQDXaf4CiZuMxFzLhoF3qSqp/0UC8Bh/ipqyTlKhCh/Gj1Ri93VVWtnSQeZRSvcJJfOzMtFzyRI=,iv:KSRpgoAozq4NpsYYYz1iM9fEk3sRtCVO3jfjnyihMjs=,tag:MavUCCPfDR2TgHj1FGz2XQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -9,6 +9,8 @@ jupyterhub:
         hosts:
           - spyglass.hhmi.2i2c.cloud
   custom:
+    jupyterhubConfigurator:
+      enabled: false
     singleuserAdmin:
       # Turn off trying to mount shared-readwrite folder for admins
       extraVolumeMounts: []

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -1,13 +1,5 @@
 nfs:
-  enabled: true
-  dirsizeReporter:
-    enabled: true
-  pv:
-    mountOptions:
-      - soft
-      - noatime
-    serverIP: 10.55.112.74
-    baseShareName: /homes/
+  enabled: false
 jupyterhub:
   ingress:
     hosts:

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -33,6 +33,9 @@ jupyterhub:
           name: ""
           url: ""
           custom_html: <a href="https://www.hhmi.org/">HHMI</a> and <a href="https://strategiesos.org/about/">Stratos</a>
+  prePuller:
+    hook:
+      enabled: true
   singleuser:
     initContainers: []
     storage:

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -1,0 +1,84 @@
+nfs:
+  enabled: true
+  dirsizeReporter:
+    enabled: true
+  pv:
+    mountOptions:
+      - soft
+      - noatime
+    serverIP: 10.55.112.74
+    baseShareName: /homes/
+jupyterhub:
+  ingress:
+    hosts:
+      - spyglass.hhmi.2i2c.cloud
+    tls:
+      - secretName: https-auto-tls
+        hosts:
+          - spyglass.hhmi.2i2c.cloud
+  custom:
+    singleuserAdmin:
+      # Turn off trying to mount shared-readwrite folder for admins
+      extraVolumeMounts: []
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    homepage:
+      templateVars:
+        org:
+          name: "HHMI"
+          url: https://www.hhmi.org/
+          logo_url: https://github.com/2i2c-org/infrastructure/assets/1879041/76419ba9-6d1a-41fe-b9b7-56fd89e0da40
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: ""
+          url: ""
+          custom_html: <a href="https://www.hhmi.org/">HHMI</a> and <a href="https://strategiesos.org/about/">Stratos</a>
+  singleuser:
+    initContainers: []
+    storage:
+      # No persistent storage should be kept to reduce any potential data
+      # retention & privacy issues.
+      type: none
+      extraVolumeMounts: []
+    defaultUrl: /lab
+    image:
+      name: quay.io/lorenlab/hhmi-spyglass-image
+      tag: "c307f9418a60"
+    extraContainers:
+      - name: mysql
+        image: datajoint/mysql # following the spyglass tutorial at https://lorenfranklab.github.io/spyglass/latest/notebooks/00_Setup/#existing-database
+        ports:
+          - name: mysql
+            containerPort: 3306
+        resources:
+          limits:
+            # Best effort only. No more than 1 CPU, and if mysql uses more than 4G, restart it
+            memory: 4Gi
+            cpu: 1.0
+          requests:
+            # If we don't set requests, k8s sets requests == limits!
+            # So we set something tiny
+            memory: 64Mi
+            cpu: 0.01
+        env:
+          # Configured using the env vars documented in https://lorenfranklab.github.io/spyglass/latest/notebooks/00_Setup/#existing-database
+          - name: MYSQL_ROOT_PASSWORD
+            value: "tutorial"
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: cilogon
+      CILogonOAuthenticator:
+        oauth_callback_url: https://spyglass.hhmi.2i2c.cloud/hub/oauth_callback
+        allowed_idps:
+          http://github.com/login/oauth/authorize:
+            default: true
+            username_derivation:
+              username_claim: "preferred_username"
+            allow_all: true

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -1,5 +1,7 @@
 nfs:
   enabled: false
+  pv:
+    enabled: false
 jupyterhub:
   ingress:
     hosts:


### PR DESCRIPTION
- ref: https://github.com/2i2c-org/infrastructure/issues/3643

hub can be tested at https://spyglass.hhmi.2i2c.cloud