### PR TITLE
Disable NFS completely when setting up ephemeral hub

### DIFF
--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -92,6 +92,9 @@ As users are temporary and can not be accessed again, there is no reason to
 provide persistent storage. So we turn it all off.
 
 ```yaml
+nfs:
+  enabled: false
+
 jupyterhub:
   custom:
     singleuserAdmin:


### PR DESCRIPTION
We disallow all persistent storage anyway, so we don't need the PersistentVolume and other base infrastructure setup by the nfs stanza