### PR TITLE
Mention that nfs.pv should also be set to false

### DIFF
--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -49,6 +49,9 @@ provide persistent storage. So we turn it all off - particularly the home direct
 ```yaml
 nfs:
   enabled: false
+  # Required until https://github.com/2i2c-org/infrastructure/issues/3654 is fixed
+  pv:
+    enabled: false
 
 jupyterhub:
   custom:


### PR DESCRIPTION
Until https://github.com/2i2c-org/infrastructure/issues/3654 gets fixed, we update the ephemeral hub docs so folks who are setting up an ephemeral hub can just copy paste