### PR TITLE
Add 'runbook' for adding admin users from freshdesk

### DIFF
--- a/docs/sre-guide/support/admin-users.md
+++ b/docs/sre-guide/support/admin-users.md
@@ -32,7 +32,7 @@ Requests to make specific users admin are handled via Freshdesk.
 
 ## Caveats & future work
 
-We don't have a clearly stated policy on wether admin access should
+We don't have a clearly stated policy on whether admin access should
 be granted via config or via existing admins marking other users as
 admin. Marking other users as admins via the admin interface may
 cause them to lose that status if we ever have to nuke and redeploy

--- a/docs/sre-guide/support/admin-users.md
+++ b/docs/sre-guide/support/admin-users.md
@@ -3,7 +3,6 @@
 Requests to make specific users admin are handled via Freshdesk.
 
 1. Validate that the person asking is allowed to ask for this
-   TODO: Link to the team-compass page once that is merged
 
 2. Make sure that the username is in the correct format for the hub!
    This means GitHub handles for GitHub Auth, appropriate values based on

--- a/docs/sre-guide/support/admin-users.md
+++ b/docs/sre-guide/support/admin-users.md
@@ -1,0 +1,40 @@
+# Adding admin users based on a support request
+
+Requests to make specific users admin are handled via Freshdesk.
+
+1. Validate that the person asking is allowed to ask for this
+   TODO: Link to the team-compass page once that is merged
+
+2. Make sure that the username is in the correct format for the hub!
+   This means GitHub handles for GitHub Auth, appropriate values based on
+   `username_claim` for CILogon based setup, and look for examples under
+   existing admin list for any custom auth setups we may have.
+
+   If it looks like the username format is invalid, ask them to go to
+   `{{ hub-url }}/hub/home` and tell us the username they see on the top right.
+   This is always correct.
+
+3. Add the username provided to admin users, under `hub.config.Authenticator.admin_users`.
+   Add a comment linking to the freshdesk ticket that required us to add this next
+   to the username.
+
+4. Make a pull request with this change, and you can self merge this.
+
+5. Let the requestor know this has been deployed. You may use the following template:
+
+   > Hello {{ Name }}
+   >
+   > The usernames you provided have been made admins on the JupyterHub! You can verify
+   > this by going to the hub control panel at {{ hub-url }}/hub/home, and you should
+   > see an 'Admin' option in the top bar.
+   >
+   > Thanks!
+
+## Caveats & future work
+
+We don't have a clearly stated policy on wether admin access should
+be granted via config or via existing admins marking other users as
+admin. Marking other users as admins via the admin interface may
+cause them to lose that status if we ever have to nuke and redeploy
+the hub's database. This lack of clarity in our policy is why we don't
+just tell them to use the admin interface if they email support

--- a/docs/sre-guide/support/admin-users.md
+++ b/docs/sre-guide/support/admin-users.md
@@ -19,7 +19,7 @@ Requests to make specific users admin are handled via Freshdesk.
 
 4. Make a pull request with this change, and you can self merge this.
 
-5. Let the requestor know this has been deployed. You may use the following template:
+5. Let the requester know this has been deployed. You may use the following template:
 
    > Hello {{ Name }}
    >

--- a/docs/sre-guide/support/index.md
+++ b/docs/sre-guide/support/index.md
@@ -12,4 +12,5 @@ decrypt-age
 build-image-remotely
 credits
 grafana-account
+admin-users
 ```


### PR DESCRIPTION
Each time I handle a ticket on freshdesk, if one doesn't already exist, I'm going to try to write a clear, step by step 'runbook' that anyone doing support can follow whenever a specific kind of request comes in via freshdesk.

This is such a runbook for adding admins to a hub, for https://2i2c.freshdesk.com/a/tickets/1279 that led to https://github.com/2i2c-org/infrastructure/pull/3659