### PR TITLE
Add gh-scoped-creds environment variables.

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -52,6 +52,8 @@ basehub:
         SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: s3://2i2c-aws-us-persistent-showcase/$(JUPYTERHUB_USER)
+        GH_SCOPED_CREDS_CLIENT_ID: Iv1.f9261c4c78b4dfdd
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/2i2c-community-showcase-hub
       profileList:
         - display_name: "NASA TOPS-T ScienceCore-ClimateRisk"
           description: "For collaborative work on 2i2c/MD's NASA TOPS-T ScienceCore Module"


### PR DESCRIPTION
Set environment variables for `gh-scoped-creds` for the Community Showcase Hub following the instructions from the [Infrastrucure Guide](https://infrastructure.2i2c.org/howto/features/github/#allow-users-to-push-to-github).

Public link for the GH App: [2i2c Community Showcase Hub](https://github.com/organizations/2i2c-org/settings/apps/2i2c-community-showcase-hub).