### PR TITLE
2i2c-aws-us, showcase: fix bucket access after rename

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -4,7 +4,7 @@ basehub:
       # When we renamed this hub, we did so at a DNS level and not an infrastructure
       # level. No terraform config was touched. Hence the kubernetes annotations retain
       # the original hub name.
-      eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-researchdelight
+      eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-showcase
   jupyterhub:
     ingress:
       hosts: [showcase.2i2c.cloud]

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -40,7 +40,7 @@ hub_cloud_permissions = {
     bucket_admin_access : ["scratch-dask-staging"],
     extra_iam_policy : ""
   },
-  "researchdelight" : {
+  "showcase" : {
     requestor_pays : true,
     bucket_admin_access : [
       "scratch-researchdelight",


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3639 reported by @jnywong via freshdesk. There are some some debugging notes on how I arrived at this fix detailed in https://github.com/2i2c-org/infrastructure/issues/3639#issuecomment-1918793205.