### PR TITLE
basehub: default to nfs.enabled / nfs.pv.enabled to false

### DIFF
--- a/config/clusters/2i2c-aws-us/basehub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/basehub-common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
+  enabled: true
   pv:
+    enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
     mountOptions:
       - rsize=1048576

--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -1,5 +1,6 @@
 nfs:
-  # No persistent storage for cosmicds
+  # nfs functionality explicitly disabled in case a common.values.yaml
+  # file is used to enable it for all hubs in the cluster
   enabled: false
   pv:
     enabled: false

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/2i2c/basehub-common.values.yaml
+++ b/config/clusters/2i2c/basehub-common.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/2i2c/daskhub-common.values.yaml
+++ b/config/clusters/2i2c/daskhub-common.values.yaml
@@ -2,6 +2,7 @@ basehub:
   nfs:
     enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -2,6 +2,7 @@ basehub:
   nfs:
     enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
+  enabled: true
   pv:
+    enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
     mountOptions:
       - rsize=1048576

--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
+  enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/gridsst/common.values.yaml
+++ b/config/clusters/gridsst/common.values.yaml
@@ -1,9 +1,11 @@
 basehub:
   nfs:
+    enabled: true
     # FIXME: Enable after https://github.com/yuvipanda/prometheus-dirsize-exporter/pull/7 is used
     dirsizeReporter:
       enabled: false
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -4,6 +4,7 @@ basehub:
     dirsizeReporter:
       enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -1,8 +1,6 @@
 basehub:
   nfs:
     enabled: true
-    dirsizeReporter:
-      enabled: true
     pv:
       enabled: true
       mountOptions:

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -1,6 +1,8 @@
 nfs:
   enabled: true
   dirsizeReporter:
+    # We don't need to report directory sizes here, as it's already being reported on by
+    # the 'source' hub
     enabled: false
   pv:
     enabled: true

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -1,8 +1,8 @@
+# nfs functionality enabled for this ephemeral hub to mount
+# a shared folder from another hub in the cluster
 nfs:
   enabled: true
   dirsizeReporter:
-    # We don't need to report directory sizes here, as it's already being reported on by
-    # the 'source' hub
     enabled: false
   pv:
     enabled: true

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -2,6 +2,7 @@ basehub:
   nfs:
     enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/linked-earth/common.values.yaml
+++ b/config/clusters/linked-earth/common.values.yaml
@@ -2,6 +2,7 @@ basehub:
   nfs:
     enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/meom-ige/common.values.yaml
+++ b/config/clusters/meom-ige/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
+  enabled: true
   pv:
+    enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
     mountOptions:
       - rsize=1048576

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -1,9 +1,11 @@
 basehub:
   nfs:
+    enabled: true
     # FIXME: Enable after https://github.com/yuvipanda/prometheus-dirsize-exporter/pull/7 is used
     dirsizeReporter:
       enabled: false
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -1,9 +1,11 @@
 basehub:
   nfs:
+    enabled: true
     # FIXME: Enable after https://github.com/yuvipanda/prometheus-dirsize-exporter/pull/7 is used
     dirsizeReporter:
       enabled: false
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -2,6 +2,7 @@ basehub:
   nfs:
     enabled: true
     pv:
+      enabled: true
       mountOptions:
         - soft
         - noatime

--- a/config/clusters/qcl/common.values.yaml
+++ b/config/clusters/qcl/common.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     mountOptions:
       - soft
       - noatime

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/config/clusters/ubc-eoas/common.values.yaml
+++ b/config/clusters/ubc-eoas/common.values.yaml
@@ -1,8 +1,10 @@
 nfs:
+  enabled: true
   # FIXME: Enable after https://github.com/yuvipanda/prometheus-dirsize-exporter/pull/7 is used
   dirsizeReporter:
     enabled: false
   pv:
+    enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
     mountOptions:
       - rsize=1048576

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -1,6 +1,7 @@
 nfs:
   enabled: true
   pv:
+    enabled: true
     # Recommended options from the Azure Portal UI for mounting the share
     mountOptions:
       - vers=4

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
+    enabled: true
     pv:
+      enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html
       mountOptions:
         - rsize=1048576

--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -80,11 +80,11 @@ ephemeral hub's users.
    pointing to, with the following config:
 
    ```yaml
+   # nfs functionality enabled for this ephemeral hub to mount
+   # a shared folder from another hub in the cluster
    nfs:
      enabled: true
      dirsizeReporter:
-       # We don't need to report directory sizes here, as it's already being reported on by
-       # the 'source' hub
        enabled: false
      pv:
        enabled: true

--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -47,9 +47,10 @@ As users are temporary and can not be accessed again, there is no reason to
 provide persistent storage. So we turn it all off - particularly the home directories.
 
 ```yaml
+# nfs functionality explicitly disabled in case a common.values.yaml
+# file is used to enable it for all hubs in the cluster
 nfs:
   enabled: false
-  # Required until https://github.com/2i2c-org/infrastructure/issues/3654 is fixed
   pv:
     enabled: false
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -64,14 +64,14 @@ staticWebsite:
       privateKey: ""
 
 nfs:
-  enabled: true
+  enabled: false
   dirsizeReporter:
     enabled: true
   shareCreator:
     enabled: true
     tolerations: []
   pv:
-    enabled: true
+    enabled: false
     mountOptions:
       - soft
       - noatime


### PR DESCRIPTION
Closes #3654.

We are still not following the best practice of providing a chart (basehub) that works out of the box with its default config, because at least we still have `jupyterhub.singleuser.extraVolumeMounts` and `jupyterhub.custom.singleuserAdmin.extraVolumeMounts` that mounts NFS folders even if `nfs.enabled` and `nfs.pv.enabled` aren't true, which would make startup fail.

This PR does not revert #3656 because I think many clusters will have hubs enabling and configuring `nfs` stuff in a common.values.yaml, while individual hubs may then go back to opting out of it.

Overall, this is something I consider an improvement, but it isn't as clearcut as I initially thought.