### PR TITLE
Explicitly allow self-merging spell check fixes

### DIFF
--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -55,7 +55,8 @@ any approval.
 6. Emergency (eg exam, outage) related resource bumps
 7. *Cleanly* reverting a change that failed CI
 8. Updating soon to be expired credentials
-  
+9. Spelling and grammar error fixes in documentation or code comments
+
 ## Self-merging as a community partner
 
 As part of our [shared responsibility model](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html), we may grant merge rights to partner engineers.


### PR DESCRIPTION
After self-merging https://github.com/2i2c-org/infrastructure/pull/3678 I realized we don't explicitly list that as a self-mergeable PR. I think we should.

I explicitly mention documentation and code comments, as config spelling changes may have unintended consequences.