### PR TITLE
hhmi:spyglass change available RAM on spyglass to 3.4GB

### DIFF
--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -66,6 +66,15 @@ jupyterhub:
     image:
       name: quay.io/2i2c/hhmi-spyglass-image
       tag: "67523d9ea855"
+    profileList:
+      - display_name: "Spyglass"
+        description: "3.4GB RAM environment for spyglass notebooks"
+        default: true
+        kubespawner_override:
+          mem_guarantee: 3.4G
+          mem_limit: 3.4G
+          node_selector:
+            node.kubernetes.io/instance-type: n2-highmem-4
     extraContainers:
       - name: mysql
         image: datajoint/mysql # following the spyglass tutorial at https://lorenfranklab.github.io/spyglass/latest/notebooks/00_Setup/#existing-database

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -66,15 +66,12 @@ jupyterhub:
     image:
       name: quay.io/2i2c/hhmi-spyglass-image
       tag: "67523d9ea855"
-    profileList:
-      - display_name: "Spyglass"
-        description: "3.4GB RAM environment for spyglass notebooks"
-        default: true
-        kubespawner_override:
-          mem_guarantee: 3.4G
-          mem_limit: 3.4G
-          node_selector:
-            node.kubernetes.io/instance-type: n2-highmem-4
+    profileList: null
+    memory:
+      limit: 3.4G
+      guarantee: 3.4G
+    nodeSelector:
+      node.kubernetes.io/instance-type: n2-highmem-4
     extraContainers:
       - name: mysql
         image: datajoint/mysql # following the spyglass tutorial at https://lorenfranklab.github.io/spyglass/latest/notebooks/00_Setup/#existing-database

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -66,7 +66,6 @@ jupyterhub:
     image:
       name: quay.io/2i2c/hhmi-spyglass-image
       tag: "67523d9ea855"
-    profileList: null
     memory:
       limit: 3.4G
       guarantee: 3.4G


### PR DESCRIPTION
I've added an `kubespawner_override`  to that the memory is set to 3.4GB.  It looks like `kubespawner_override` has to be under a `profile_list` but i this application, there is only one item in that list.  

Is there a way for skipping the UI that shows the list of profile options and defaulting to this one and only option?
