### PR TITLE
2i2c-aws-us, showcase: Add 2i2c-community-showcase:access-2i2c-showcase to allowed orgs

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -41,6 +41,7 @@ basehub:
           populate_teams_in_auth_state: true
           allowed_organizations:
             - 2i2c-org:research-delight-team
+            - 2i2c-community-showcase:access-2i2c-showcase
             - 2i2c-demo-hub-access:showcase-topst
             - ScienceCore
           scope:

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -40,7 +40,6 @@ basehub:
           oauth_callback_url: "https://showcase.2i2c.cloud/hub/oauth_callback"
           populate_teams_in_auth_state: true
           allowed_organizations:
-            - 2i2c-org:research-delight-team
             - 2i2c-community-showcase:access-2i2c-showcase
             - 2i2c-demo-hub-access:showcase-topst
             - ScienceCore
@@ -122,7 +121,7 @@ basehub:
           description: "A shared machine, the recommended option until you experience a limitation."
           allowed_teams: &allowed_teams
             - 2i2c-org:hub-access-for-2i2c-staff
-            - 2i2c-org:research-delight-team
+            - 2i2c-community-showcase:access-2i2c-showcase
           profile_options: &profile_options
             image:
               display_name: Image
@@ -209,7 +208,6 @@ basehub:
           slug: gpu
           allowed_teams:
             - 2i2c-org:hub-access-for-2i2c-staff
-            - 2i2c-org:research-delight-gpu-team
           description: "Start a container on a dedicated node with a GPU"
           profile_options:
             image:


### PR DESCRIPTION
Update access to the Showcase Hub using the [2i2c-community-showcase](https://github.com/orgs/2i2c-community-showcase/teams/access-2i2c-showcase) org.

- Owners of this org can invite Hub Admins to the `access-2i2c-showcase` team with maintainer rights
- Owners of this org can invite hub community users/test users as general members of the org (but not members of the `access-2i2c-showcase` team in the first instance)
- Hub Admins can **then** add community users/test users to the `access-2i2c-showcase` team using their maintainer rights to _practise_ granting access to the Showcase Hub as part of their hub champion training

@jmunroe can you double-check that this is the expected procedure before approving this request? Also, do we need to update existing access for:

- ~~`2i2c-org:research-delight-team`?~~
- `2i2c-demo-hub-access:showcase-topst`?
- `ScienceCore`?

EDIT: from issue https://github.com/2i2c-org/community-showcase/issues/66 I can see that we will remove`2i2c-org:research-delight-team` entirely. I would still like confirmation that access to the Showcase Hub for `2i2c-demo-hub-access:showcase-topst` and `ScienceCore` can be removed.

EDIT 2: `2i2c-demo-hub-access:showcase-topst` and `ScienceCore` to remain as is.