### PR TITLE
leap, all hubs: remove ignored singleuser.image config for clarity

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -76,9 +76,6 @@ basehub:
             - rabernat
             - jbusecke
     singleuser:
-      image:
-        name: pangeo/pangeo-notebook
-        tag: "2023.05.18"
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.0c7df3d4b3191b2f"
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/leap-hub-push-access


### PR DESCRIPTION
This is addressing #3703 for leap specifically.