### PR TITLE
Add gh-scoped-creds env vars for openscapes hubs

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -37,6 +37,9 @@ basehub:
     singleuser:
       serviceAccountName: cloud-user-sa
       defaultUrl: /lab
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.6981e043b45f042f"
+        GH_SCOPED_CREDS_ALL_URL: https://github.com/apps/openscapes-github-push-access
       profileList:
         - display_name: Python
           description: Python datascience environment

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -39,7 +39,7 @@ basehub:
       defaultUrl: /lab
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.6981e043b45f042f"
-        GH_SCOPED_CREDS_ALL_URL: https://github.com/apps/openscapes-github-push-access
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/openscapes-github-push-access
       profileList:
         - display_name: Python
           description: Python datascience environment


### PR DESCRIPTION
- related https://github.com/2i2c-org/infrastructure/issues/3693

This is not deployed yet as I did not want to overwrite the change in #3705 