### PR TITLE
Add `us-ghg-center` github org for US GHG Center graphana access

### DIFF
--- a/config/clusters/nasa-ghg/support.values.yaml
+++ b/config/clusters/nasa-ghg/support.values.yaml
@@ -13,7 +13,7 @@ grafana:
       root_url: https://grafana.nasa-ghg.2i2c.cloud/
     auth.github:
       enabled: true
-      allowed_organizations: 2i2c-org
+      allowed_organizations: 2i2c-org us-ghg-center
   ingress:
     hosts:
       - grafana.nasa-ghg.2i2c.cloud


### PR DESCRIPTION
# Description

From the support email I sent:
>I'm trying to access the GHG Center Grafana dashboard at https://grafana.nasa-ghg.2i2c.cloud/, trying to sign in using my GitHub username "slesaad". But I am unable to. I've attached the error screenshot. I have already been added as an admin - see [here](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/nasa-ghg/common.values.yaml#L54-L59). Am I missing something?
> ![image](https://github.com/2i2c-org/infrastructure/assets/7830949/7beab8f1-8212-49c7-a3b1-b85f575ac8f2)


Looks like this was the missing part?