### PR TITLE
Regenerate ghg grafana token

### DIFF
--- a/config/clusters/nasa-ghg/enc-grafana-token.secret.yaml
+++ b/config/clusters/nasa-ghg/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:/aUJUK4JYe9StYl6GFgdSDr4U0Gu/hWYrZFPrHiwakte522qWcLi41GlFtDcLg==,iv:5vHDygc6p4Z7KeaLtMAnRooUZXpM60YtWtYGAinvr7o=,tag:DhzypLdZH3Xj2rIAcY0NtQ==,type:str]
+grafana_token: ENC[AES256_GCM,data:ihqjjOd72G4hmfEFbUvjqyW37toAyED1bAvexOSLi1sx0XoQ8d9nrOW4c6UtVg==,iv:I2NWn3h7ZRcYBpUJ+qlgRLj005Kp3/94YMvrvojhpRk=,tag:Qwk5kApDfracK+j7aWG+jA==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-08-01T04:13:35Z"
-          enc: CiUA4OM7eMF/JSawr4Gq4HWeu9qf8hXfRVMstEX5E0q2y2Oi4pxUEkkAyiwFHMPa7FIjUnCClxQkvPyFEp0gHa9g4N83mh6hLpTXcca9gE0MT/uHL+VU70osF0VGlJasDTPygGqcQlBkNjQsZrsLKCOf
+          created_at: "2024-02-09T10:34:14Z"
+          enc: CiUA4OM7eA1BDaIYR2kxnolHFaWLLlf+ZVjdmws2WpD2XdW0WpdxEkkAjTWv+jNxFWkW6Z05+jf+nJY9orGIzSyfX1BkxP/RFWYsar4WEizgP6upIlSVy+4IOtev1mwnyMO9COqTtnh+qSkqFvUJagb4
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-01T04:13:35Z"
-    mac: ENC[AES256_GCM,data:bTYLCJokBwKg5PmG1Myys++tIuXGF9jpLfQxCCAvUg5VkFp/8SX4RpHcph2xUJqkXT9aELTnwGo5CcZurpCcXgcxN/FRWProRbO7i9oFTC2fbZg7MP7lrnOAy0quQ6CFPe15XYlGFSDdeabLX3RRDQ3j14vacPlwfI4r2jhY4L0=,iv:V/B1EYeD8qbPEzsvNYBy1mEkyHdX1ZkYr8j3qSTDopQ=,tag:mcKaH15YDZMewlV9Iyr4Hw==,type:str]
+    lastmodified: "2024-02-09T10:34:14Z"
+    mac: ENC[AES256_GCM,data:juFIE8Gf7IemXeQI488EGO1B+1BfWT/xsXS48bv5mpR/IRD1pbEeXdYMUfSac5LVaT7iZL0YzDEFoz756oxpxy04ob09xdtk/YYpdt2e9Gudi/F1skve7iPH12tN5aVaxuwqkRuT/ICcYYB6OKbAgF2wIZpdkqCFD7bDF/ul6KI=,iv:O/2Hz6QuohlVuG+4SbBWOS8WEhZ07Yyqdlscd1WyM8E=,tag:T90pbkmdC7fQbhymrwbklQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
For https://2i2c.freshdesk.com/a/tickets/1300

Deploying the jupyterhub dashboards with the cmd below threw a 401 unauthorized error (probably the token expired or something):

``` 
deployer grafana deploy-dashboards nasa-ghg 
```

So, I've regenerated the token with:

```
deployer grafana new-token nasa-ghg  
```

Then redone the deploy and it worked.