### PR TITLE
Fix extra case sensitivity in GitHub teams check

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -868,7 +868,9 @@ jupyterhub:
                 raise web.HTTPError(403)
 
             # Format user's teams in auth_state to "org:team"
-            teams = set([f'{team["organization"]["login"]}:{team["slug"]}' for team in auth_state["teams"]])
+            # casefold them so we can do case insensitive comparisons, as github itself is case insensitive (but preserving)
+            # for orgs and teams
+            teams = set([f'{team["organization"]["login"]}:{team["slug"]}'.casefold() for team in auth_state["teams"]])
             print(f"User {spawner.user.name} is part of teams {' '.join(teams)}")
 
             # Filter out profiles with allowed_teams set if the user isn't part
@@ -882,8 +884,10 @@ jupyterhub:
 
                 # allowed_teams can be "org" or "org:team", and we check
                 # membership just in time for orgs if needed
-                allowed_orgs = set([o for o in allowed_teams if ':' not in o])
-                allowed_teams = set([t for t in allowed_teams if ':' in t])
+                # casefold them so we can do case insensitive comparisons, as github itself is case insensitive (but preserving)
+                # for orgs and teams
+                allowed_orgs = set([o.casefold() for o in allowed_teams if ':' not in o])
+                allowed_teams = set([t.casefold() for t in allowed_teams if ':' in t])
 
                 if allowed_teams & teams:
                     print(f"Allowing profile {profile['display_name']} for user {spawner.user.name} based on team membership")


### PR DESCRIPTION
The community reproted an issue with people from the new organization being unable to login. This was the error message, only found in the logs.

> Your GitHub team membership is insufficient to launch any server profiles.
>
> GitHub teams you are a member of that this JupyterHub knows about are
> nasa-openscapes-workshops:workshopaccess-2i2c, <others>
>
> If you are part of additional teams, log out of this JupyterHub and
> log back in to refresh that information

Looking at the *case* of the error message, we see that our config specifies `nasa-openscapes-workshops:WorkshopAccess-2i2c` while the team name returned to us by GitHub is all lower case instead.

GitHub orgs are [not case sensitive](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#get-an-organization), and it was not clear to me if *teams* are or are not. Nevertheless, I verified that you can not actually create a different team in the same org with the same name but different case.

This patch casefolds all the team and org names we use, so comparisons are case insensitive. casefold works for all languages, while calling `.lower()` only works for a subset of languages.

Ref https://github.com/2i2c-org/infrastructure/issues/3695