### PR TITLE
victor, all hubs: remove ignored singleuser.image config for clarity

### DIFF
--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -81,9 +81,6 @@ basehub:
             node_selector:
               node.kubernetes.io/instance-type: m5.8xlarge
       defaultUrl: /lab
-      image:
-        name: pangeo/pangeo-notebook
-        tag: "2022.09.21"
     scheduling:
       userScheduler:
         enabled: true


### PR DESCRIPTION
Victor is actively using the configurator, so this image isn't relevant.