### PR TITLE
2i2c, dask-staging: test against pangeo/pangeo-notebook:latest

### DIFF
--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -38,7 +38,7 @@ basehub:
     singleuser:
       image:
         name: pangeo/pangeo-notebook
-        tag: "2022.06.02"
+        tag: "latest"
     hub:
       config:
         JupyterHub:


### PR DESCRIPTION
I think we benefit from leaving this unpinned so that we could fail on changes introduced over time in pangeo/pangeo-notebook. I don't think this will cause us to see failures over time though, but its better we spot them here than our communities spot them I think.

To pin an image tag is more work but also gives us more control on what changes and when, but at the same time if we don't automatically bump the pinned version, we will run into issues over time as well. For example things may be broken between dask-gateway server being updated to modern versions and the dask-gateway client installed in a pinned image from 2022.

I'm open to pinning a 2024 version of pangeo-notebook, but I prefer to see us ping `latest` for this cluster's dask-staging to help us catch issues.