### PR TITLE
nasa-veda: add bucket permissions to terraform added outside terraform

### DIFF
--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -58,7 +58,9 @@ hub_cloud_permissions = {
                     "arn:aws:s3:::maap-ops-workspace",
                     "arn:aws:s3:::maap-ops-workspace/*",
                     "arn:aws:s3:::nasa-maap-data-store",
-                    "arn:aws:s3:::nasa-maap-data-store/*"
+                    "arn:aws:s3:::nasa-maap-data-store/*",
+                    "arn:aws:s3:::sdap-dev-zarr",
+                    "arn:aws:s3:::sdap-dev-zarr/*"
                 ]
             },
             {
@@ -113,7 +115,9 @@ hub_cloud_permissions = {
                     "arn:aws:s3:::maap-ops-workspace",
                     "arn:aws:s3:::maap-ops-workspace/*",
                     "arn:aws:s3:::nasa-maap-data-store",
-                    "arn:aws:s3:::nasa-maap-data-store/*"
+                    "arn:aws:s3:::nasa-maap-data-store/*",
+                    "arn:aws:s3:::sdap-dev-zarr",
+                    "arn:aws:s3:::sdap-dev-zarr/*"
                 ]
             },
             {


### PR DESCRIPTION
@freitagb I detected a change in nasa-veda's cloud infra that wasn't reflected in our terraform configuration.

When re-generating credentials (#3723), I had to either delete what was added outside the terraform config in the terraform managed resource (bucket permissions), or I had to add it. I opted to add it to the terraform configuration, and while doing that I also added the same permission for the staging environment.

The change applied outside our terraform configuration was to make an IAM Policy allowing bucket access apply to the bucket `sdap-dev-zarr`.

@freitagb could you confirm its OK to persist this change to the terraform config for use in both staging/prod?