### PR TITLE
nasa smce clusters: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-esdis/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-esdis/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:oPKOsurPOC6y9M/1fC+zXWRPlLc=,iv:x/4c7QaVebYIgv1dRz+TrKi26SHx+4Du+6nveh1YCn4=,tag:f98HqtXCHLjwzMqakwJZew==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:2wgKlpvDw58nG8I8De1OGuY/iMRBI0YBuOT4PyrS+ftK1z3XaOHE2g==,iv:OjcEoj5TOw0CfgpP0JB3MIUsPX7BuD41UHeKN5X6mWU=,tag:qIPK9FshxAmxQR0eu43obA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:V3gK4fwvdg6S0Gqm+OMYYQ+CHPaHwx8=,iv:KgqXw4up32lco9+4FJug/59ZxPtp37OSsWeKKuFtM1E=,tag:Dl8I+Q9wZ3iG6vLqtBOuLA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:qFl+zOe2m7SnHq0c9nSOap+942U=,iv:m19mljbHzK5JgN7dzTgv6HZ+ughWP1NgJixRJx87hXw=,tag:UqZcqL2l8qpn6cMkadIf9Q==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:dYcC/STqxXdamGsD2EXA0av1JhQawniFMxpwTrppUanrVxm6UEQsyQ==,iv:xmgUAqlHfgIiDK9GKV2ehGz+9eomwz76Ac+XAzghKos=,tag:O0f7rym0GLJYOWCXCAU7hA==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:ckDpLNhDShNT10PvQAm9v+9AVx9ZSWk=,iv:PHNDSUAeoBeecRgEWLOrUjnNTd1pyyw6CzLWb/62DmU=,tag:yrl+cpujI9y0S4AQq8XkjA==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-01-04T23:28:35Z",
-				"enc": "CiUA4OM7eEbZmWcl3SiVG55lrCeNODpLG1k9+umcz3UTw5P2figfEkkAjTWv+piz7M8eFX8o1DVN9zQSgsExgMSC3Ht8Gfy+HQFZMzxSn996JakPNi8m94+LtpZS4cjbqi2jRIEnCMCFhZWNzDRbazvI"
+				"created_at": "2024-02-14T08:37:56Z",
+				"enc": "CiUA4OM7eI6f19C8pTp8BaZcdj00p3jDgRvefeB5v5VdgMIrmHAlEkkAXoW3JvAcx7P2IF4JUPEsq3itBPUjfKqOluTg+069G2tDwBdRUv+0lBYjv7EuSyRIbPNoLkMZHxfXCE7amiptD4jouY7UejUD"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-01-04T23:28:36Z",
-		"mac": "ENC[AES256_GCM,data:39hU3JfFxp0+s0adR2OPJv+QXVW81kYXXQ4BzUYAA7cCmRA4o9jQWE+9qAPBVmpWU0zi5WeSAsAJtRV28apcQGcNd4hqtB405dxxsX3cTIlviiAgPggsiS8ZEte5KutCa5BmKkXdMzMxZkMLgbj61K7YlCat82yi3dosHL1rSGA=,iv:jrx0m5+BJab3AeSay9mdZRSwlluDeMiZiVSM60HEUbM=,tag:nK4SFQWnGj+xtB1Jt1YXTw==,type:str]",
+		"lastmodified": "2024-02-14T08:37:56Z",
+		"mac": "ENC[AES256_GCM,data:ZcqsPCdH+dqcoEIl1PG/7t9ZWLEWdO5Ql4Li0UuffmEQ/5uDjsoemcS91z88M8WC33xm22BN3FbXzl7FlKroCg/rVbK81HS11Dnv2zuvs510rgcNXdQh8pEhXaesUQ208WTU1j0Yn614QrIs9fd+VOgqwkkUx7Hj4Fmq3x5Wz+Q=,iv:cIa4Dj5dyCAQ9ixCFn4fJo5fOrUYZY/eXUICh81a0sI=,tag:Gb4+ZGrPchM0xyRBaHUNIQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"

--- a/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:vXMsN91BXqgdF7KXxqX86p61aDo=,iv:P+RyTSlHiqSB9wu0lWJztJkuHwcPsmGQXNEzHM65XR4=,tag:Q/4fuVHgLFxXRNQ0LxCcvg==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:px56aI9GMUgkvcbYj001XHhxfMo1nWaWxiBuuIT1x1+N70fE8YFaIw==,iv:xmhfzt1JqlEHESWZnirojcVBvsJTk9hqF7Om3YKUHOs=,tag:y3PN+YRl50FDieRIl9QRyA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:pQeaY7atRNpI/i8ah9AKprHp194sbuA=,iv:74ae090GbgcxudUi/cDeV46CJX9v5qNBKK3+zk0HCu0=,tag:dT7+f0JuJC1NfaizUFbB9w==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:Gt1qbIr5LxRbyiXAsatdrnoXKE0=,iv:anT4NC8bEs2MSCOkb3PL+j0EWteLGJz2dfSl5b30js4=,tag:0TJ8Uz29W+mrTgu8toFeDw==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:J9JP9vHVPA6FO9gpORDDdttpLmIEPO33p3YghRs7RYRuzx3jO7hghA==,iv:wdG0no8rWt2lhN+I1Sw/bJr1Fm7JLIJ/AttFhBCTy1E=,tag:mtdhCuQDDz5Dt5GscBKVaw==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:3qXSpMQIG+hxZfTmEP18b8MbKIq9Qa8=,iv:Du4iyzxGWc92f2JIWZ2rnBxvquve28KYiKxSa3G3Nz0=,tag:U4pECdtiK5G8XMm5OzKbJQ==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-01-04T23:10:31Z",
-				"enc": "CiUA4OM7eKIg03EAlCM64KT1ZKrqMBL0QvL7zgFEAVQiIWcgjSWeEkkAjTWv+pfKWeZpLUe4MO5M3t7qdwzWD9mP7QpARXmCvwULPVP79EKzCHaErQHIa0Sq8g3ZvZHn2IpaSEGqvSg08rnL2UvPXWn2"
+				"created_at": "2024-02-14T08:37:35Z",
+				"enc": "CiUA4OM7eM5ZIXKj0JAXCpV7NLjQfnnLeUsxAoE5iX4w1HeQuaK2EkkAXoW3JuZcKpWFddOTHzGdV5hiwLyUqpsNzko+L7ydRFPPjmmc0SetkuqkeGG/chEsn7IbkDHUyUS4UAZ7qYNloZM2EA3leNG9"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-01-04T23:10:31Z",
-		"mac": "ENC[AES256_GCM,data:ThsEIM/YzZyCVCUsnSqoR3gMC+WDt6PyFHY4bSdI5zwD7gbW3V//GK/xUz0XcYsTmKqgL3b99mv3yK1EOyDlYj0LZoLOLZg8nh7Cc9JaiFA4fuvDu/b5r2hA1zYLERxJnJftlqG5sA4nDzv1wnNWf/LL0jzxApvlHty7g1Oa5BU=,iv:sp6AifQVyXgrHTVrIPEGzekhvyfA5syIA2YthhMuJsQ=,tag:k7L2uvgirZkoV5tG1aKLkA==,type:str]",
+		"lastmodified": "2024-02-14T08:37:36Z",
+		"mac": "ENC[AES256_GCM,data:fBdPDUC9r04k/P1iPu36sTn6jtzaC1dRWDtxt/i9ry2Uimyt9dX7zK+hNUkgQsixrwKF2SDcw1+G7q3CYmjgt/sw/1uLoJBdkxU1teE/dommdj6hw63ZfSycDFoO4EG6SM2iieiNxl3ivN1/Kyg8lO9EAO//5uRu9hZANHtrKGw=,iv:JV+G/2NAiCd8zdM5pm9XgrOaeMk/AyVrB3ncqUAJPOw=,tag:CmWySDChnR+w5ZLU66XHJQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"

--- a/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:3raNFoP4EOz5brXR10QdppGdRoQ=,iv:CHhvKsS+eZwCA+ryRkiHKGuyzH5YI1fCsChalBdm/3M=,tag:j92XTrA1OxZBQGZIj4eQSg==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:uJfSLuUpvtxEPQLV7AUY5+g948dr0kyMGcfSIqRDaCI1bGKOZjjx6g==,iv:lnlnK8ZcvAswaiE5U4qPE6LCTIubgPfWEoq9zIvvaRQ=,tag:0IwOhy99k21ifv0jzMwhMQ==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:uCxkY2QPKebMKHAnGRi0/LZg8vePcMI=,iv:+E1dTSDk93Gtsd9pPVoyFULI641SBkjFOaXeG5Z1J+o=,tag:gpNsfqEsqqGKLY1ytqMihw==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:B//0d0fUA5I29nngWNCXIahCA0o=,iv:1FLf+0o43t45GXWx8hkpHSnHXymuSp2J4xnUepSzsWk=,tag:vFe7Y2Ox+kNgfCpaQ5l/Iw==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:zB5rgp05IVWbzd/ZF8zYc0PCy3hPeJO7DTtp5QzkeB9Up/zIbN6XrQ==,iv:usRkrMXk7ZuD52E6jaZJnqK9fejKFJhI7QOTAHmd1Hs=,tag:IgRRfLc2HhPCXbWpvMrVQA==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:0ztpROiUhXLYefsxji94vPDsXU6J/M4=,iv:RHqWoHdWQdvdYzadQgbYHmkYbxPGAWPZrb7+i332jQA=,tag:k/ajOUWbKd/PZFdm13ZvXA==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-01-04T23:06:56Z",
-				"enc": "CiUA4OM7eM8HZ6FS+hnOqcl86XpGiYj9GeOW3aeoFnMpu6VkVoDsEkkAjTWv+iU0Yu+kXQ8FodYPhsM8asnqX1CjZ5pqIQCU0fY1qKxZ/SQNwL4rPb44VIWeYtnne3M6pZJOwtDQvtElowmuOkjEfrsz"
+				"created_at": "2024-02-14T08:36:56Z",
+				"enc": "CiUA4OM7eDh9sk57G2y6Mib1AIKRFjkjL6sX9ZqzhXI504Uzhya6EkkAXoW3JlP/CCOgdK7FC9JBC6KXZsH9sgca8WG+T9tpjrS9CL/uROoHn9LiQNM0R/72LyDil99hbEdwWwLcLt0zf4bKk7k3QLQ7"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-01-04T23:06:57Z",
-		"mac": "ENC[AES256_GCM,data:yU4oEi/fef0HKtezbjkjcNmKM/1LNUhdUPQMOHixsstaGoETva6BHYh+5YtHAdepDPfEd76y9vC4OeIZ2Aenilq6Qe3B2ar+lIGy0CA/Ph1KjS1+Q9/5v0vc9hlReNtpjoqz3xtx320sP0NwlIlKXNwg52xQQzQrvGOvFjzhLoA=,iv:GBR/zD7oynCaDSvF+Ec937VHKgNCcNIuuTO7EtKcfRg=,tag:EdbJ9VOE8/0TCA35SsMyKQ==,type:str]",
+		"lastmodified": "2024-02-14T08:36:57Z",
+		"mac": "ENC[AES256_GCM,data:UXLBG1lKAQl2UNb5QtBhHXZttfXpIyilC6XCVOQSN7zfO3dqPkRtZ8OKC54jp0Zs4+Fq5nGOPWhQhptCWFGDMKthFJ6uL4juVYuNOXbe6ouvSSCLKzdZKMXssgtp2GomU9MVR5SixEGXH3wrgQQvE7WCOUzDYGTdSYJkxJh9yRo=,iv:IlVFKWD4cC7nT5VGxnDbnBNctDtP1FgHKGG9sxNX/0I=,tag:0DhbeKEi84/Y1vRw5JVBWA==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"


### PR DESCRIPTION
The deployer access keys had been deleted, probably because NASA SMCE cluster's automation cleaning those older than 60 days. I think they expired unexpectedly because they wasn't correctly re-created last time, as the instructions for re-generating them only worked when they had expired. It looked like the previous instructions worked because the encrypted file showed changes, but I think that was because the encrypted file was re-generated using the same content rather than actually changed.

Notes about this in https://github.com/2i2c-org/infrastructure/issues/2434#issuecomment-1943294268, where the procedure for https://github.com/2i2c-org/infrastructure/issues/2434 has been updated so that we won't run into issues again.