### PR TITLE
[Support] Add a "bring your own image" profile to https://itcoocean.2i2c.cloud/

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -241,6 +241,92 @@ jupyterhub:
                   mem_guarantee: 115.549G
                   mem_limit: 128G
                   cpu_guarantee: 15.0
+      - display_name: "Bring your own image"
+        description: Specify your own docker image (must have python and jupyterhub installed in it)
+        slug: custom
+        allowed_teams:
+          # Requested in: https://2i2c.freshdesk.com/a/tickets/1320
+          - Hackweek-ITCOocean:itcoocean-hackweek-2023
+          - nmfs-opensci:2i2c-demo
+          - 2i2c-org:hub-access-for-2i2c-staff
+        profile_options:
+          image:
+            display_name: Image
+            unlisted_choice:
+              enabled: True
+              display_name: "Custom image"
+              validation_regex: "^.+:.+$"
+              validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+              kubespawner_override:
+                image: "{value}"
+            choices: {}
+          resource_allocation:
+            display_name: Resource Allocation
+            choices:
+              mem_1_9:
+                display_name: 1.9 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 1992701952
+                  mem_limit: 1992701952
+                  cpu_guarantee: 0.234375
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+                default: true
+              mem_3_7:
+                display_name: 3.7 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 3985403904
+                  mem_limit: 3985403904
+                  cpu_guarantee: 0.46875
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_7_4:
+                display_name: 7.4 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 7970807808
+                  mem_limit: 7970807808
+                  cpu_guarantee: 0.9375
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_14_8:
+                display_name: 14.8 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 15941615616
+                  mem_limit: 15941615616
+                  cpu_guarantee: 1.875
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_29_7:
+                display_name: 29.7 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 31883231232
+                  mem_limit: 31883231232
+                  cpu_guarantee: 3.75
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_60_6:
+                display_name: 60.6 GB RAM, upto 15.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 65094813696
+                  mem_limit: 65094813696
+                  cpu_guarantee: 7.86
+                  cpu_limit: 15.72
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.4xlarge
+              mem_121_2:
+                display_name: 121.2 GB RAM, upto 15.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 130189627392
+                  mem_limit: 130189627392
+                  cpu_guarantee: 15.72
+                  cpu_limit: 15.72
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.4xlarge
         kubespawner_override:
           cpu_limit: null
           mem_limit: null


### PR DESCRIPTION
Requested in https://2i2c.freshdesk.com/a/tickets/1320

Because the request was to have this feature on the itcoocean.2i2c.cloud hub in the same way that it is being done on the Openscapes hub, this PR copies the opescapes profile "bring your own image", including the resource allocation options there. Only the `allowed_teams` is specific to this hub.

