### PR TITLE
terraform: default to k8s 1.29 for new GKE/EKS clusters

### DIFF
--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -69,7 +69,7 @@ local daskNodes = [];
             version should be the latest support version by the eksctl CLI, see
             https://eksctl.io/getting-started/ for a list of supported versions.
         -#}
-        version: "1.28",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -5,7 +5,6 @@
 # To get get the output of relevance, run:
 #
 #   terraform plan -var-file=projects/$CLUSTER_NAME.tfvars
-#   terraform output regular_channel_latest_k8s_versions
 #
 # data ref: https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_engine_versions
 data "google_container_engine_versions" "k8s_version_prefixes" {

--- a/terraform/gcp/projects/basehub-template.tfvars
+++ b/terraform/gcp/projects/basehub-template.tfvars
@@ -14,6 +14,21 @@ region = "{{ cluster_region }}"
 # Default to a HA cluster for reliability
 regional_cluster = true
 
+
+# TODO: Before applying this, identify a k8s version to specify. Pick the latest
+#       k8s version from GKE's regular release channel. Look at the output
+#       called `regular_channel_latest_k8s_versions` as seen when using
+#       `terraform plan -var-file=projects/{{ cluster_name }}.tfvars`.
+#
+#       Then use that version to explicitly set all k8s versions below, and
+#       finally decomment the k8s_versions section and removing this comment.
+#
+#k8s_versions = {
+#  min_master_version : "",
+#  core_nodes_version : "",
+#  notebook_nodes_version : "",
+#}
+
 core_node_machine_type = "n2-highmem-2"
 
 # For multi-tenant cluster, network policy is required to enforce separation between hubs

--- a/terraform/gcp/projects/daskhub-template.tfvars
+++ b/terraform/gcp/projects/daskhub-template.tfvars
@@ -14,6 +14,21 @@ region = "{{ cluster_region }}"
 # Default to a HA cluster for reliability
 regional_cluster = true
 
+# TODO: Before applying this, identify a k8s version to specify. Pick the latest
+#       k8s version from GKE's regular release channel. Look at the output
+#       called `regular_channel_latest_k8s_versions` as seen when using
+#       `terraform plan -var-file=projects/{{ cluster_name }}.tfvars`.
+#
+#       Then use that version to explicitly set all k8s versions below, and
+#       finally decomment the k8s_versions section and removing this comment.
+#
+#k8s_versions = {
+#  min_master_version : "",
+#  core_nodes_version : "",
+#  notebook_nodes_version : "",
+#  dask_nodes_version : "",
+#}
+
 core_node_machine_type = "n2-highmem-4"
 
 # Network policy is required to enforce separation between hubs on multi-tenant clusters

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -49,6 +49,7 @@ variable "k8s_version_prefixes" {
   default = [
     "1.27.",
     "1.28.",
+    "1.29.",
     "1.",
   ]
   description = <<-EOT


### PR DESCRIPTION
This is aligning with the policy on what k8s version to upgrade to in https://infrastructure.2i2c.org/howto/upgrade-cluster/#upgrade-policy.

At some point in time, we will trial use of a minor k8s version not already tried - I think the best time to do that is for new clusters as they don't have existing users. We can absolutely upgrade existing clusters to arrive at a new minor version never before used by us at 2i2c, but I figure we should be especially brave doing it for new clusters.