### PR TITLE
leap, lis, and climatematch hubs: avoid overriding shared-readwrite mount

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -33,13 +33,22 @@ jupyterhub:
         funded_by:
           name: London Interdisciplinary School
           url: https://www.lis.ac.uk
-    # Extra mount point for admins to access to all users' home dirs
-    # Ref https://2i2c.freshdesk.com/a/tickets/228
     singleuserAdmin:
       extraVolumeMounts:
+        # /allusers is an extra mount point for admins to access to all users'
+        # home dirs, ref: https://2i2c.freshdesk.com/a/tickets/228.
         - name: home
           mountPath: /home/jovyan/allusers
           readOnly: false
+        # mounts below are copied from basehub's values that we override by
+        # specifying extraVolumeMounts (lists get overridden when helm values
+        # are combined)
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
+        - name: home
+          mountPath: /home/rstudio/shared-readwrite
+          subPath: _shared
   singleuser:
     image:
       # https://hub.docker.com/r/lisacuk/lishub-base

--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -52,6 +52,15 @@ jupyterhub:
         - name: home
           mountPath: /home/jovyan/allusers
           readOnly: true
+        # mounts below are copied from basehub's values that we override by
+        # specifying extraVolumeMounts (lists get overridden when helm values
+        # are combined)
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
+        - name: home
+          mountPath: /home/rstudio/shared-readwrite
+          subPath: _shared
     2i2c:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "github"

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -18,6 +18,15 @@ basehub:
           - name: home
             mountPath: /home/jovyan/allusers
             readOnly: true
+          # mounts below are copied from basehub's values that we override by
+          # specifying extraVolumeMounts (lists get overridden when helm values
+          # are combined)
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
+          - name: home
+            mountPath: /home/rstudio/shared-readwrite
+            subPath: _shared
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -87,6 +87,15 @@ jupyterhub:
           mountPath: /home/jovyan/allusers
           # Uncomment the line below to make the directory readonly for admins
           # readOnly: true
+        # mounts below are copied from basehub's values that we override by
+        # specifying extraVolumeMounts (lists get overridden when helm values
+        # are combined)
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
+        - name: home
+          mountPath: /home/rstudio/shared-readwrite
+          subPath: _shared
 ```
 
 #### A `shared-public` directory


### PR DESCRIPTION
Fix override of shared-readwrite mounting config

basehub defines the list `custom.singleuserAdmin.extraVolumeMounts` and
provides two entries to it.

If a hub re-specifies this list with a single new entry, it will end up
overriding entire list, making the two entries defined by default be
lost. This is a challenge with using helm values that are list, they
combine by replacing eachother rather than appending to each other.

Due to that, whenever we want to add a mount, we need to re-specify the
mounts that are in the list by default.

This commit impacts the following cluster, hubs:

- 2i2c-uk, lis
- 2i2c, climatematch
- leap, staging and prod

---

- Fixes #3738