### PR TITLE
nasa smce clusters: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-esdis/cluster.yaml
+++ b/config/clusters/nasa-esdis/cluster.yaml
@@ -1,5 +1,6 @@
 name: nasa-esdis
-provider: aws
+provider: aws # https://smce-esdis-hub.signin.aws.amazon.com/console
+account: smce-esdis-hub
 aws:
   key: enc-deployer-credentials.secret.json
   clusterType: eks

--- a/config/clusters/nasa-esdis/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-esdis/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:qFl+zOe2m7SnHq0c9nSOap+942U=,iv:m19mljbHzK5JgN7dzTgv6HZ+ughWP1NgJixRJx87hXw=,tag:UqZcqL2l8qpn6cMkadIf9Q==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:dYcC/STqxXdamGsD2EXA0av1JhQawniFMxpwTrppUanrVxm6UEQsyQ==,iv:xmgUAqlHfgIiDK9GKV2ehGz+9eomwz76Ac+XAzghKos=,tag:O0f7rym0GLJYOWCXCAU7hA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:ckDpLNhDShNT10PvQAm9v+9AVx9ZSWk=,iv:PHNDSUAeoBeecRgEWLOrUjnNTd1pyyw6CzLWb/62DmU=,tag:yrl+cpujI9y0S4AQq8XkjA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:psP/bPSRvG5KFa0IEtMRvDe1mGc=,iv:iDs1UK8XSYk0dhj61zQpOjRBKb3bu4iBJzyMOfdq1Mg=,tag:Rx1KttU/8zH5/KAnFcCTLQ==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:Re+uECrn6j2ekDmyIxL+3nrN0MqBxDgu6G0WTLFBWQKPCLpyG6VxFA==,iv:LZJl6TNA9m3brUOcqyM5ERIHAlrhuuH5kjklcpYf+5Y=,tag:xWdVeIbqJ4QyaHKJYYYIfw==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:jhym6NDkEHaajZSuUUfiAL9yL4L6W/4=,iv:BOaMYnMv4SsEiPfFhSBsVpzNbW17b8Yo2/Iie3CHceE=,tag:uDsXiAVDeEe2KPg5cJUM6g==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-02-14T08:37:56Z",
-				"enc": "CiUA4OM7eI6f19C8pTp8BaZcdj00p3jDgRvefeB5v5VdgMIrmHAlEkkAXoW3JvAcx7P2IF4JUPEsq3itBPUjfKqOluTg+069G2tDwBdRUv+0lBYjv7EuSyRIbPNoLkMZHxfXCE7amiptD4jouY7UejUD"
+				"created_at": "2024-02-28T20:39:12Z",
+				"enc": "CiUA4OM7eAhtQrxUtxwRPUfj4q9kuqwS6sx7Oq2VgeruQJlzB6+qEkkAXoW3JjfBbEdZgUuuQzuS7JqLzD15Q612clR10c05wB3bTy03tOKKuStcFSo00Dlm3Z2HmZ5yvv2+rXkgt+e+viRf+DsPTEPh"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-02-14T08:37:56Z",
-		"mac": "ENC[AES256_GCM,data:ZcqsPCdH+dqcoEIl1PG/7t9ZWLEWdO5Ql4Li0UuffmEQ/5uDjsoemcS91z88M8WC33xm22BN3FbXzl7FlKroCg/rVbK81HS11Dnv2zuvs510rgcNXdQh8pEhXaesUQ208WTU1j0Yn614QrIs9fd+VOgqwkkUx7Hj4Fmq3x5Wz+Q=,iv:cIa4Dj5dyCAQ9ixCFn4fJo5fOrUYZY/eXUICh81a0sI=,tag:Gb4+ZGrPchM0xyRBaHUNIQ==,type:str]",
+		"lastmodified": "2024-02-28T20:39:13Z",
+		"mac": "ENC[AES256_GCM,data:rTYO5MHI5ZS9w0MelEu8OKsGtlzRvTuxQswDHHPOiz9HDlLeY2Gdrl6j20Ak7wPNfsQ7e0ThdU0tOZOb8zZ3T0bKQxJL8UwMT40zRQRu2FK2sBHm/ZOyRtsSGNXfoN/JTjzpAeHZBZ4BHh1G0MBBBQ5RkfttnCoQp8vYq//CVv0=,iv:CTMEgJi0FK4DJ2qbIpjYbBLCoq5IZEYc6GeUDm2Bs+M=,tag:Xk+Z3j1RLv4eahGLxRwnyA==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"

--- a/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:Gt1qbIr5LxRbyiXAsatdrnoXKE0=,iv:anT4NC8bEs2MSCOkb3PL+j0EWteLGJz2dfSl5b30js4=,tag:0TJ8Uz29W+mrTgu8toFeDw==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:J9JP9vHVPA6FO9gpORDDdttpLmIEPO33p3YghRs7RYRuzx3jO7hghA==,iv:wdG0no8rWt2lhN+I1Sw/bJr1Fm7JLIJ/AttFhBCTy1E=,tag:mtdhCuQDDz5Dt5GscBKVaw==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:3qXSpMQIG+hxZfTmEP18b8MbKIq9Qa8=,iv:Du4iyzxGWc92f2JIWZ2rnBxvquve28KYiKxSa3G3Nz0=,tag:U4pECdtiK5G8XMm5OzKbJQ==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:JkX9tVCub2vX0VinLhkjl2c6KeA=,iv:WFhy2SSx42q3pwZPiNeNmkF6k465lvylRB77ymi6dTE=,tag:RfZ2WXIpks6juotbdcIqcg==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:91eD31K/GzC/8BapUHdAgMZeAGPxlBbNYu99bCo0gKacL/mO17RcBQ==,iv:k6NN56F7KJ8aIel7vmV+3/RwDnJmEbNtP1laTFSWeCc=,tag:9MJpxCt/JbXlsX5dPjum9A==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:G/+S+CnSM1+ZtM8ZFgieKnnJZ5HUAls=,iv:tYDBWoMu9Bl2H1q0+UchJq+JjCxyniAlAtb7FEEBjmI=,tag:jWVGh/6/tLu4CHzu3LoE0Q==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-02-14T08:37:35Z",
-				"enc": "CiUA4OM7eM5ZIXKj0JAXCpV7NLjQfnnLeUsxAoE5iX4w1HeQuaK2EkkAXoW3JuZcKpWFddOTHzGdV5hiwLyUqpsNzko+L7ydRFPPjmmc0SetkuqkeGG/chEsn7IbkDHUyUS4UAZ7qYNloZM2EA3leNG9"
+				"created_at": "2024-02-28T20:39:15Z",
+				"enc": "CiUA4OM7eDDxm3/aBXHrTXBCTmn7vg8Ps0d16T0COVBBjSAtCmn7EkkAXoW3JrXFkPG4Mo+P+hCaieWE1oDr7g72VsluhTxlJssLB8pGLhA662ugdXrOz3ai+GIGNf5MsE4EJ5pL8sdaZOjAORGp6wce"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-02-14T08:37:36Z",
-		"mac": "ENC[AES256_GCM,data:fBdPDUC9r04k/P1iPu36sTn6jtzaC1dRWDtxt/i9ry2Uimyt9dX7zK+hNUkgQsixrwKF2SDcw1+G7q3CYmjgt/sw/1uLoJBdkxU1teE/dommdj6hw63ZfSycDFoO4EG6SM2iieiNxl3ivN1/Kyg8lO9EAO//5uRu9hZANHtrKGw=,iv:JV+G/2NAiCd8zdM5pm9XgrOaeMk/AyVrB3ncqUAJPOw=,tag:CmWySDChnR+w5ZLU66XHJQ==,type:str]",
+		"lastmodified": "2024-02-28T20:39:15Z",
+		"mac": "ENC[AES256_GCM,data:f808UBO6BFjpVJZaqBN31bIV7Y5UkNsUyT+rLPY6vlz0kxtvU/7cWCs+zHeZIJ6S30A/3hBBB5d9n4tOAzl5WHfP+mKjuWP3m7y49+4PSwv2CHaYu7j7WydXYX3RW+oBA0nn7QILboAH0fiNeFK2R8cNX1xmaZvyTGNONpjUFCg=,iv:fvFiEWTZ0ts96yN2lj8Pwj3OJu5/ZYZaFpeIoxDhjsU=,tag:ZZT9za0Er5oIzwW/RyG1Mw==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"

--- a/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-veda/enc-deployer-credentials.secret.json
@@ -1,23 +1,23 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:B//0d0fUA5I29nngWNCXIahCA0o=,iv:1FLf+0o43t45GXWx8hkpHSnHXymuSp2J4xnUepSzsWk=,tag:vFe7Y2Ox+kNgfCpaQ5l/Iw==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:zB5rgp05IVWbzd/ZF8zYc0PCy3hPeJO7DTtp5QzkeB9Up/zIbN6XrQ==,iv:usRkrMXk7ZuD52E6jaZJnqK9fejKFJhI7QOTAHmd1Hs=,tag:IgRRfLc2HhPCXbWpvMrVQA==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:0ztpROiUhXLYefsxji94vPDsXU6J/M4=,iv:RHqWoHdWQdvdYzadQgbYHmkYbxPGAWPZrb7+i332jQA=,tag:k/ajOUWbKd/PZFdm13ZvXA==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:5yk5O+FY3YJNJljPOPyZh294Hco=,iv:XetK6Ntaj94k00obidcNvOKCSs5OrJIttiwI/Tv6TNc=,tag:mNz2/fWhPOSlSJ0ZrPjS0A==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:/vumRn493v9jwHVOlFswSkOpOYjiqj+FLwoJpl2fP7sYE9YPASw2Jw==,iv:OOP1U8ICup/8pkqcnpk+17r+ZyFIZlyrJ6DO51+i9dg=,tag:V4zitB5sPN5FrrP4HcMk5A==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:Dy0bxjbTQJcuui7QStEMNI/1kSUQ7YI=,iv:qLeUzBfOAYP230R+k59MEWo3rak+jngJwHjnWfZz9nI=,tag:2cpWcsUVDtuWpIPQksq8uA==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2024-02-14T08:36:56Z",
-				"enc": "CiUA4OM7eDh9sk57G2y6Mib1AIKRFjkjL6sX9ZqzhXI504Uzhya6EkkAXoW3JlP/CCOgdK7FC9JBC6KXZsH9sgca8WG+T9tpjrS9CL/uROoHn9LiQNM0R/72LyDil99hbEdwWwLcLt0zf4bKk7k3QLQ7"
+				"created_at": "2024-02-28T20:39:18Z",
+				"enc": "CiUA4OM7eKgrM9YWf0ijMlp4MqI++ADksTeHayNa48wBiTCjqdmPEkkAXoW3Jocmt7VRlzbfpKVKuCP6T+NP1MPYAUCLIDq4dntM3vr07RSPx856FpVqcVv+LxL7hWlSw2jl8AIJxUyQqXO2CXCin5n4"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-02-14T08:36:57Z",
-		"mac": "ENC[AES256_GCM,data:UXLBG1lKAQl2UNb5QtBhHXZttfXpIyilC6XCVOQSN7zfO3dqPkRtZ8OKC54jp0Zs4+Fq5nGOPWhQhptCWFGDMKthFJ6uL4juVYuNOXbe6ouvSSCLKzdZKMXssgtp2GomU9MVR5SixEGXH3wrgQQvE7WCOUzDYGTdSYJkxJh9yRo=,iv:IlVFKWD4cC7nT5VGxnDbnBNctDtP1FgHKGG9sxNX/0I=,tag:0DhbeKEi84/Y1vRw5JVBWA==,type:str]",
+		"lastmodified": "2024-02-28T20:39:19Z",
+		"mac": "ENC[AES256_GCM,data:sX66V+TN1gtw2nDFxTeehhfHQpUEzK7t2923qiM4iTOQ71YmTriLfwTqIRE+FF6TvWJVxtJZOmr+R3RK9HJEhbeUfHt52g7yvYE5FXNWXsmI+95qTWARrysBm7N03pmuw29ByZdhSFNbSSAMcJkxxW3UXb4miapny6Lplk2SUFA=,iv:SDgh19N8y5P5gO9ebNCGZqXQ1Kvw0Xp1fc2+wp6wTSk=,tag:P69Yrjsq03hckp5dDTDP/g==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"


### PR DESCRIPTION
- Scheduled chore work for #2434.

I'm also adding an `account:` field to nasa-esdis which missed it.