### PR TITLE
victor: fix deployer's grafana service account credentials

### DIFF
--- a/config/clusters/victor/enc-grafana-token.secret.yaml
+++ b/config/clusters/victor/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:Yu7cScQuAbZs4oKvaImqG1ESHKk7P6wWQn2EoN5A5LYOUK9VBCgApvHxk2NQl5W0LgNzWPhdOBef0BK2LmF7RwSV+1XVeIq3YTyjy4id+ukqn15CeFnu3Gq2qQM=,iv:RFAJsZqu5G4V1Cp9IrOS2f8ASJQMgHiZNRLqOadWTs4=,tag:uUpShf5F+ftdQqfhcoi5+Q==,type:str]
+grafana_token: ENC[AES256_GCM,data:OTBQAgpyShzEm+eHfQJVtEr83tJf8psaFPkjqTPozEaRpMqCGG7a3hE4+h79/g==,iv:hN3AirWeW8IdHG76reiCyUl/91PgQyBWpCU8qZGiuMQ=,tag:e+QQnBwSz4sAO4bXSjJ8Wg==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2022-11-07T15:23:55Z"
-          enc: CiQA4OM7eCbs52mBqdLkb3wr7m5ZiLV9dgZkhwwNNSBEizf4I/ASSQDuy/p8w13ge4Uz3wqQ0O7bqevUT5U0wZseugHVGpSfOT1kCuPHcvMY+Z4rsM7zEvCQSIx6E5Mynj10u4Qfn3DhiQ3DgOwbzg0=
+          created_at: "2024-02-29T21:51:08Z"
+          enc: CiUA4OM7eNjdvopHWnFtTnpID9wlVgIAwCva6LeATWpgvbD6J7VREkkAXoW3JpUHvVrB4am3g31cx/R/jYY/fzECxMnu2Q74CsSj6ZBQnogOpebaoFniyFkxFOTkoJKjC7FggJEufVHYcVOtpEwZjE3P
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-11-07T15:34:41Z"
-    mac: ENC[AES256_GCM,data:IjlnKN7F6A7yMFhLXEhePMhaWV9ObtWtiy2tyyHlCZWL/6SpKXmJ2pKyZgjgdvsQaOP204IpWdGnO83fQjEVybI1VpEWClah9kuCkNm4Roycr7YQo9vg6vTNXalBcVx9MszcACHo0cGf/QtSK4bd3puBkp59pC5/jIaJ+XGvx7w=,iv:TczwA2PGl/KR90BQ/pqKGCosPAbxEmYtGNl8LIHwRC0=,tag:s5Da4zddFgCjsRGEXkWsFw==,type:str]
+    lastmodified: "2024-02-29T21:51:08Z"
+    mac: ENC[AES256_GCM,data:h1MwQnXBeF6ge1BUhSfFLpicY3YLg2WK1wAVztEv6yfXf8kAVboPOFy0TBzToUXRmMqgSjcjXLOBoEIuuTjUNkseZjaZ1dRC3/z7XF8n2OzvaCaW6vR19LoKA4IrmWh4Agh8ImQ7ISFabN3MDpeJVOjx1xW83/pC4b1qYG+l88I=,iv:jqQ4U+ZZ22We+kbUFP/ZkOWEviybAZXDvou7pjEiPv0=,tag:0RK4MbWsJtUIHpxBw5BLJQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1


### PR DESCRIPTION
I redeployed dashboards since https://github.com/jupyterhub/grafana-dashboards/pull/100 was merged, but saw a permission error for victor. Maybe a new service account was created without being stored into this repo for version control?