### PR TITLE
[NASA-VEDA] feat: Add EIS-fire team to VEDA-Hub

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -47,6 +47,7 @@ basehub:
             - veda-analytics-access:collaborator-access
             - CYGNSS-VEDA:cygnss-iwg
             - veda-analytics-access:maap-biomass-team
+            - Earth-Information-System:eis-fire
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
Adding the EIS Fire team so they can self manage membership in NASA-VEDA Hub as needed.
https://github.com/Earth-Information-System
Primary contacts are @mccabete and @eorland

cc: @freitagb @ranchodeluxe 