### PR TITLE
[opesnci] Add a staging hub

### DIFF
--- a/config/clusters/opensci/cluster.yaml
+++ b/config/clusters/opensci/cluster.yaml
@@ -10,8 +10,19 @@ support:
     - support.values.yaml
     - enc-support.secret.values.yaml
 hubs:
+  - name: staging
+    display_name: "Opensci Staging"
+    domain: staging.opensci.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      # The order in which you list files here is the order the will be passed
+      # to the helm upgrade command in, and that has meaning. Please check
+      # that you intend for these files to be applied in this order.
+      - common.values.yaml
+      - staging.values.yaml
+      - enc-staging.secret.values.yaml
   - name: sciencecore
-    display_name: "Sciencecore "
+    display_name: "Sciencecore"
     domain: sciencecore.opensci.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:

--- a/config/clusters/opensci/enc-staging.secret.values.yaml
+++ b/config/clusters/opensci/enc-staging.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:dJMpxGNR8xE5PWZHA1XubT+3ts4=,iv:xbSZpzOLOjmdVffsV2ZARyfXCpdSPswpNaIncKQvXNs=,tag:cnKUDx2sUd7dM/A0fkc18w==,type:str]
+                client_secret: ENC[AES256_GCM,data:wSXfm0EmWmVWGYxKUpulkoJQEzuJDFZLsQlWrQVIdbByLsYET2shVg==,iv:qH/HLyi3q0eaCLDTGWjSqHoTqnUIK38vQBf8HGrqdSU=,tag:zCdElZl1KT/ac/ghhsfihw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2023-09-18T19:00:41Z"
+          enc: CiUA4OM7eFioG9yDgVwKtc0cYrU65GNcqMSDuUgnuXuq3KW9dRI6EkkAq2nhVV2TFrZOq5jktjMd4TQF1lwH/08tAyGd3vMfBmdd3Xdy3bAUUHhrPXcK6QabMRYdXPzQzgB+oBGaqOsJO7D7jT9NpeCn
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-06T10:50:04Z"
+    mac: ENC[AES256_GCM,data:x9UzSsYgmlPY8CybANIA2YLBEXHId1HlRSZClarY/9HEX+3UerJ8FimsQenxjm6u86aEmvfFQ24lCdEX8zaITRtLDZKhXxXD85J2bUHKB9b3jAv2KcVs20KKq4HlftRZ73hH0z8pqn/Cn2jwCknxEvqaNH/CFYv8QThBqpjg/Zs=,iv:v32MM0vhDkiGXRjQgvuAeOOYgXpEnkXIqNwdaYvDsO8=,tag:WxCN1yqm7VNjslHx1a2JVQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -1,0 +1,123 @@
+jupyterhub:
+  ingress:
+    hosts:
+      - staging.opensci.2i2c.cloud
+    tls:
+      - secretName: https-auto-tls
+        hosts:
+          - staging.opensci.2i2c.cloud
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
+    homepage:
+      templateVars:
+        org:
+          name: Staging
+          url: https://2i2c.org
+          logo_url: https://2i2c.org/media/logo.png
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        operated_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: ""
+          url: ""
+  singleuser:
+    profileList:
+      - display_name: "Only Profile Available, this info is not shown in the UI"
+        slug: only-choice
+        profile_options:
+          image:
+            display_name: Image
+            unlisted_choice: &profile_list_unlisted_choice
+              enabled: True
+              display_name: "Custom image"
+              validation_regex: "^.+:.+$"
+              validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+              display_name_in_choices: "Specify an existing docker image"
+              description_in_choices: "Use a pre-existing docker image from a public docker registry (dockerhub, quay, etc)"
+              kubespawner_override:
+                image: "{value}"
+            choices:
+              pangeo:
+                display_name: Pangeo Notebook Image
+                description: "Python image with scientific, dask and geospatial tools"
+                kubespawner_override:
+                  image: pangeo/pangeo-notebook:2023.09.11
+              geospatial:
+                display_name: Rocker Geospatial
+                description: "R image with RStudio, the tidyverse & Geospatial tools"
+                default: true
+                slug: geospatial
+                kubespawner_override:
+                  image: rocker/binder:4.3
+                  # Launch into RStudio after the user logs in
+                  default_url: /rstudio
+                  # Ensures container working dir is homedir
+                  # https://github.com/2i2c-org/infrastructure/issues/2559
+                  working_dir: /home/rstudio
+              scipy:
+                display_name: Jupyter SciPy Notebook
+                slug: scipy
+                kubespawner_override:
+                  image: jupyter/scipy-notebook:2023-06-26
+          resources:
+            display_name: Resource Allocation
+            choices:
+              mem_3_7:
+                display_name: 3.7 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 3982682624
+                  mem_limit: 3982682624
+                  cpu_guarantee: 0.46875
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+                default: true
+              mem_7_4:
+                display_name: 7.4 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 7965365248
+                  mem_limit: 7965365248
+                  cpu_guarantee: 0.9375
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_14_8:
+                display_name: 14.8 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 15930730496
+                  mem_limit: 15930730496
+                  cpu_guarantee: 1.875
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_29_7:
+                display_name: 29.7 GB RAM, upto 3.7 CPUs
+                kubespawner_override:
+                  mem_guarantee: 31861460992
+                  mem_limit: 31861460992
+                  cpu_guarantee: 3.75
+                  cpu_limit: 3.75
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.xlarge
+
+  hub:
+    allowNamedServers: true
+    image:
+      name: quay.io/2i2c/dynamic-image-building-experiment
+      tag: "0.0.1-0.dev.git.7567.ha4162031"
+    config:
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        oauth_callback_url: https://staging.opensci.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - 2i2c-demo-hub-access
+        scope:
+          - read:org


### PR DESCRIPTION
Ideally this would also be an imagebuilding style of hub, but without https://github.com/2i2c-org/binderhub-service/pull/77 we can't.

The binderhub-service chart version we are using atm does not have this change, as trying to use the latest version failed like this https://github.com/2i2c-org/binderhub-service/issues/89.

So this PR just adds a regular basehub staging hub to unblock the currently failing deployment workflow. 