### PR TITLE
[2i2c-uk : lis] Add a warning message for users selecting the large instance

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -63,7 +63,10 @@ jupyterhub:
           mem_limit: 2G
           mem_guarantee: 512M
       - display_name: Large Instance
-        description: "Provides 1G - 4G of RAM"
+        # Requested in https://2i2c.freshdesk.com/a/tickets/1348
+        description: |
+          Provides 1G - 4G of RAM</p>
+          <p> ⚠️ Please use this instance only if you know you need it, otherwise use the Regular Instance!
         kubespawner_override:
           mem_limit: 4G
           mem_guarantee: 1G


### PR DESCRIPTION
For https://2i2c.freshdesk.com/a/tickets/1348

Had to hack into how kubespawner renders the description text to be able to get the warning a new line  😅 Not sure if there's a better way to do it.

https://github.com/jupyterhub/kubespawner/blob/f99b98fc731517129ebfb7ef3fee293f28d75a75/kubespawner/templates/form.html#L16