### PR TITLE
Update GitHub team name to be generic for workshops

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -48,7 +48,7 @@ basehub:
             - US-GHG-Center:ghg-use-case-2
             - US-GHG-Center:ghg-use-case-3
             - US-GHG-Center:ghg-external-collaborators
-            - US-GHG-Center:ghg-ams-2024-workshop-access
+            - US-GHG-Center:ghg-workshop-access
             - US-GHG-Center:ghg-trial-access
           scope:
             - read:org


### PR DESCRIPTION
# Change
Rename one of the GitHub teams to be a generic name for reuse between workshops
`US-GHG-Center:ghg-ams-2024-workshop-access` -> `US-GHG-Center:ghg-workshop-access`