### PR TITLE
Update nasa-veda-singleuser to newest image

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -68,7 +68,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:5068290376e8c3151d97a36ae6485bb7ff79650b94aecc93ffb2ea1b42d76460
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-07
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
Please apply these changes to staging and prod for nasa-veda.

Our new custom singleuser image now points to `pangeo-notebook:2024.01.23` via these images:

https://github.com/NASA-IMPACT/veda-jh-environments/blob/main/docker-images/custom/nasa-veda-singleuser/Dockerfile

https://github.com/NASA-IMPACT/veda-jh-environments/blob/main/docker-images/base/pangeo-notebook/Dockerfile#L1

