### PR TITLE
Add  `emit-methane-plume-2024-03-14` team to Openscapes Hub

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -54,6 +54,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
             image: openscapes/python:4f340eb
           profile_options: &profile_options
@@ -136,6 +137,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
           kubespawner_override:
             image: openscapes/rocker:a7596b5
             # Ensures container working dir is homedir
@@ -154,6 +156,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
           kubespawner_override:
             image: openscapes/matlab:2023-11-28
           profile_options: *profile_options
@@ -199,6 +202,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
           scope:
             - read:org
         Authenticator:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -137,7 +137,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
-            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
             image: openscapes/rocker:a7596b5
             # Ensures container working dir is homedir
@@ -156,7 +156,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
-            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
             image: openscapes/matlab:2023-11-28
           profile_options: *profile_options
@@ -202,7 +202,7 @@ basehub:
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
             - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
-            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14            
+            - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
Hello @yuvipanda , from our [plan we discussed in today's hackday](https://github.com/NASA-Openscapes/2i2cAccessPolicies/issues/7#issuecomment-1989465680), here is a pull request to add  `emit-methane-plume-2024-03-14` team to Openscapes Hub. I added this Team everywhere except "bring your own image"

Would you be able to double-check that I did this correctly in all the places you expected? 

Thank you!



