### PR TITLE
Fix 29GB RAM profile option not starting in openscapes

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -63,8 +63,8 @@ basehub:
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 1992701952
-                    mem_limit: 1992701952
+                    mem_guarantee: 1991341312
+                    mem_limit: 1991341312
                     cpu_guarantee: 0.234375
                     cpu_limit: 3.75
                     node_selector:
@@ -73,8 +73,8 @@ basehub:
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 3985403904
-                    mem_limit: 3985403904
+                    mem_guarantee: 3982682624
+                    mem_limit: 3982682624
                     cpu_guarantee: 0.46875
                     cpu_limit: 3.75
                     node_selector:
@@ -82,8 +82,8 @@ basehub:
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 7970807808
-                    mem_limit: 7970807808
+                    mem_guarantee: 7965365248
+                    mem_limit: 7965365248
                     cpu_guarantee: 0.9375
                     cpu_limit: 3.75
                     node_selector:
@@ -91,8 +91,8 @@ basehub:
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 15941615616
-                    mem_limit: 15941615616
+                    mem_guarantee: 15930730496
+                    mem_limit: 15930730496
                     cpu_guarantee: 1.875
                     cpu_limit: 3.75
                     node_selector:
@@ -100,8 +100,8 @@ basehub:
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 31883231232
-                    mem_limit: 31883231232
+                    mem_guarantee: 31861460992
+                    mem_limit: 31861460992
                     cpu_guarantee: 3.75
                     cpu_limit: 3.75
                     node_selector:


### PR DESCRIPTION
Looks like the overhead of resources in AWS nodes has changed since we last set these, causing the largest pod on r5.xlarge to not fit anymore. We should eventually dynamically generate these
\- but in the meantime, I've just regenerated these numbers using our existing deployer command so mem_29_7 starts again.