### PR TITLE
Openscapes: Change the node selector instance type to r5.16xlarge for all profile options

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -69,7 +69,7 @@ basehub:
                     cpu_guarantee: 0.234375
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
@@ -79,7 +79,7 @@ basehub:
                     cpu_guarantee: 0.46875
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -88,7 +88,7 @@ basehub:
                     cpu_guarantee: 0.9375
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -97,7 +97,7 @@ basehub:
                     cpu_guarantee: 1.875
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -106,7 +106,7 @@ basehub:
                     cpu_guarantee: 3.75
                     cpu_limit: 3.75
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
@@ -115,7 +115,7 @@ basehub:
                     cpu_guarantee: 7.86
                     cpu_limit: 15.72
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.4xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
                 mem_121_2:
                   display_name: 121.2 GB RAM, upto 15.7 CPUs
                   kubespawner_override:
@@ -124,7 +124,7 @@ basehub:
                     cpu_guarantee: 15.72
                     cpu_limit: 15.72
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.4xlarge
+                      node.kubernetes.io/instance-type: r5.16xlarge
         - display_name: R
           description: R (with RStudio) + Python environment
           allowed_teams:


### PR DESCRIPTION
- addresses: https://github.com/2i2c-org/infrastructure/issues/3743

As discussed in https://github.com/2i2c-org/infrastructure/issues/3743#issuecomment-1989387520