### PR TITLE
nasa and hhmi hubs: update QGIS image

### DIFF
--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -174,15 +174,10 @@ basehub:
                   display_name: Linux desktop
                   slug: desktop
                   kubespawner_override:
-                    # Explicitly unset this - we set this to 'jupyterhub-singleuser'
-                    # in basehub/values.yaml. We instead want to leave this unset,
-                    # so the default command for the docker image is used instead.
-                    # This is required for .desktop files to show up correctly.
-                    cmd: null
                     # Launch people directly into the Linux desktop when they start
                     default_url: /desktop
                     # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-                    image: "quay.io/jupyter-remote-desktop-proxy/qgis:2023-09-27"
+                    image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
     hub:
       allowNamedServers: true
       config:

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -133,13 +133,8 @@ jupyterhub:
       - display_name: QGIS
         description: QGIS environment
         kubespawner_override:
-          # Explicitly unset this - we set this to 'jupyterhub-singleuser'
-          # in basehub/values.yaml. We instead want to leave this unset,
-          # so the default command for the docker image is used instead.
-          # This is required for .desktop files to show up correctly.
-          cmd: null
           # Launch people directly into the Linux desktop when they start
           default_url: /desktop
           # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-          image: "quay.io/jupyter-remote-desktop-proxy/qgis:2023-09-27"
+          image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
         profile_options: *profile_options

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -150,15 +150,9 @@ basehub:
           slug: qgis
           description: Linux desktop in the browser, with qgis installed
           kubespawner_override:
-            # Explicitly unset this - we set this to 'jupyterhub-singleuser'
-            # in basehub/values.yaml. We instead want to leave this unset,
-            # so the default command for the docker image is used instead.
-            # This is required for .desktop files to show up correctly.
-            cmd: null
-            # Launch people directly into the Linux desktop when they start
             default_url: /desktop
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: "quay.io/2i2c/nasa-qgis-image:78d96c092f8e"
+            image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -187,15 +187,10 @@ basehub:
           slug: qgis
           description: Linux desktop in the browser, with qgis installed
           kubespawner_override:
-            # Explicitly unset this - we set this to 'jupyterhub-singleuser'
-            # in basehub/values.yaml. We instead want to leave this unset,
-            # so the default command for the docker image is used instead.
-            # This is required for .desktop files to show up correctly.
-            cmd: null
             # Launch people directly into the Linux desktop when they start
             default_url: /desktop
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: "quay.io/2i2c/nasa-qgis-image:78d96c092f8e"
+            image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)


### PR DESCRIPTION
Bumps to the image built via https://github.com/2i2c-org/nasa-qgis-image/pull/10.

- Fixes https://github.com/2i2c-org/meta/issues/931
- Removes a workaround to set `singleuser.cmd: null`
  This can be done as the docker image, based on quay.io/jupyter/minimal-notebook, since 2024-01-22 declares an ENTRYPOINT that includes executing the `start.sh` script.
  
  A Dockerfile's `ENTRYPOINT` / `CMD` can be overridden by specifying `command` / `args` in a k8s pod's container specification. The z2jh charts `singleuser.cmd` maps to `KubeSpawner.cmd`, and that configuration together with `KubeSpawner.args` is combined to set k8s pod's container `args`. This means KubeSpawner doesn't touch `ENTRYPOINT` aka. `command` in k8s specifications, making the `start.sh` script still be executed, while when it was set in jupyter/docker-stacks images `CMD` before 2024-01-22 it would get overridden.