### PR TITLE
utoronto, default and r hubs: update to use rebuilt images

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: "b4104c211e98"
+      tag: "8c7ba58b8bb0"
   hub:
     config:
       Authenticator:

--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -14,4 +14,4 @@ jupyterhub:
     defaultUrl: /rstudio
     image:
       name: quay.io/2i2c/utoronto-r-image
-      tag: "eebaeecd1987"
+      tag: "5e7aea3c30ff"


### PR DESCRIPTION
Bumps to the rebuilds triggered by these PRs:
- https://github.com/2i2c-org/utoronto-image/pull/61
- https://github.com/2i2c-org/utoronto-r-image/pull/18

Fixes https://github.com/2i2c-org/meta/issues/932

I'm not around until tuesday, please feel free to merge this!