### PR TITLE
basehub: don't declare singleuser.cmd - its z2jh's default

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -276,10 +276,6 @@ jupyterhub:
           - name: home
             mountPath: /home/jovyan/shared
             subPath: _shared
-    cmd:
-      # Explicitly define this, as it's no longer set by z2jh
-      # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
-      - jupyterhub-singleuser
     extraEnv:
       # notebook writes secure files that don't need to survive a
       # restart here. Writing 'secure' files on some file systems (like


### PR DESCRIPTION
Its a breaking change for z2jh to change this, so if it changes we'll be
well aware about it from changelogs when upgrading.

I mainly want to remove the now outdated comment, but I also appreciate
not re-specifying defaults in general as that makes it easier to
overview and trust whats declared in basehub's default values are actual
changes from the default.