### PR TITLE
2i2c-aws-us, cosmicds: cleanup not needed trick for repo2docker logs

### DIFF
--- a/config/clusters/2i2c-aws-us/cosmicds.values.yaml
+++ b/config/clusters/2i2c-aws-us/cosmicds.values.yaml
@@ -37,9 +37,6 @@ jupyterhub:
           name: Cosmic DS, Harvard
           url: https://www.cosmicds.cfa.harvard.edu/
   singleuser:
-    # Unset cmd so repo2docker-entrypoint gets used, and logs actually work
-    # Ref https://github.com/2i2c-org/infrastructure/issues/3109
-    cmd: null
     # No persistent storage should be kept to reduce any potential data
     # retention & privacy issues.
     # Ref https://github.com/2i2c-org/infrastructure/issues/2128#issuecomment-1635107926


### PR DESCRIPTION
I've confirmed that this isn't needed, practically checking that I get logs at `/srv/repo/.jupyter-server-log.txt` even when we leave `singleuser.cmd` set to jupyterhub-singleuser, which overrides the docker image's `CMD` (but not `ENTRYPOINT`).

repo2docker sets ENTRYPOINT (k8s command) and CMD (k8s args, and singleuser.cmd mapping to KubeSpawner.cmd) like this, as seen from `docker inspect  quay.io/nmearl/hubble-user-image:294205fdd286`:

```
            "Cmd": [
                "jupyter",
                "notebook",
                "--ip",
                "0.0.0.0"
            ],

            "Entrypoint": [
                "/usr/local/bin/repo2docker-entrypoint"
            ],
```

With this, #3805, and #3797, we no longer set `cmd` explicitly for any community, and rely systematically on the z2jh defaults of specifying `singleuser.cmd`. In practice, images `ENTRYPOINT` are systematically untouched, and images `CMD` are systematically replaced with `jupyterhub-singleuser`.