### PR TITLE
[Catalyst-Africa] New lot of hubs (kush, wits and molerhealth)

### DIFF
--- a/config/clusters/catalystproject-africa/cluster.yaml
+++ b/config/clusters/catalystproject-africa/cluster.yaml
@@ -42,3 +42,11 @@ hubs:
       - common.values.yaml
       - uvri.values.yaml
       - enc-uvri.secret.values.yaml
+  - name: wits
+    display_name: "Catalyst Project, Africa - WITS"
+    domain: wits.af.catalystproject.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - common.values.yaml
+      - wits.values.yaml
+      - enc-wits.secret.values.yaml

--- a/config/clusters/catalystproject-africa/cluster.yaml
+++ b/config/clusters/catalystproject-africa/cluster.yaml
@@ -58,3 +58,11 @@ hubs:
       - common.values.yaml
       - kush.values.yaml
       - enc-kush.secret.values.yaml
+  - name: molerhealth
+    display_name: "Catalyst Project, Africa - MolerHealth "
+    domain: molerhealth.af.catalystproject.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - common.values.yaml
+      - molerhealth.values.yaml
+      - enc-molerhealth.secret.values.yaml

--- a/config/clusters/catalystproject-africa/cluster.yaml
+++ b/config/clusters/catalystproject-africa/cluster.yaml
@@ -50,3 +50,11 @@ hubs:
       - common.values.yaml
       - wits.values.yaml
       - enc-wits.secret.values.yaml
+  - name: kush
+    display_name: "Catalyst Project, Africa - KUSH"
+    domain: kush.af.catalystproject.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - common.values.yaml
+      - kush.values.yaml
+      - enc-kush.secret.values.yaml

--- a/config/clusters/catalystproject-africa/enc-kush.secret.values.yaml
+++ b/config/clusters/catalystproject-africa/enc-kush.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:Gkmq+33RgGILWWMxNBBSanflwwE=,iv:hps2UpDP6V8lppuKb9RnIWLTJ0PvtpTZiRrlxpzBkJ4=,tag:aIgWTM58Co8jnS1XY+Prog==,type:str]
+                client_secret: ENC[AES256_GCM,data:qhC0EQqw/xMn6MoLX/Qg5490EKs1gAn2vMjbFbyjkz8MLkIyD7IPeg==,iv:qtcya1NLgQqrIVvpQjk7nD6pYopoihApH56nG+BwGds=,tag:SJXcutZaLIG0aJuTh2O9MA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-03-16T18:56:57Z"
+          enc: CiUA4OM7eC6pPiGwZPvMCnBtZyxMHkHbqj83JS4/nUqeByc90ku6EkkAXoW3JmO+LiuyXhEwZw2g6VZx+pclkjt791ly42bEOuJ54S21YpSROCZbn2UtwQ6X5K2BcPlUjiGs+/YmFcXQn0SkxtP5T1/Q
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-16T18:56:59Z"
+    mac: ENC[AES256_GCM,data:DvnKusaKQFCAWMPWEWPNA9EfBQQ1pBJ82hiNvGn/DIBwlHRf1E4QBV+ZiajPSdLGMSl+Fi1aPPsLYwmK7Kn/oH5zERWnzNFFMwbdobUetrz/AOExKHWztPKqj9Ckf/k5trN3Jc4B9bpvsQuj9jLP9kVVQX7L4Sv4x6OSH2U45BI=,iv:oY/fSrjgTgl7HkaoblGjfH64GYRh254oBzEoaf5o/jc=,tag:VPPCYnzbl4xa2TTTXkef6A==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/catalystproject-africa/enc-molerhealth.secret.values.yaml
+++ b/config/clusters/catalystproject-africa/enc-molerhealth.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:9LqPZVvDDjL9yTYm7vyPTowA+uM=,iv:7q7PhCj5WuS2/UEqjKmeqY+xliv865Q3OUO78DI0ETo=,tag:dIUB4Jo3LMjb6eEvKxii0A==,type:str]
+                client_secret: ENC[AES256_GCM,data:y/fXvq5IlCVsP8KY4ix1/KXoaH9eJw9k3fwGbczcheHzANC1IlT6kw==,iv:CDokEvuSGOKKM7f9lUyu3kqPw3FFtkR7TGbG4QH0RIM=,tag:JXfQLCDBZ3L9h74Ld5qYtw==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-03-16T19:10:31Z"
+          enc: CiUA4OM7eH/kl/O91dxTRQFjbMaOGogUIJKSl5pn8Y1u9ffhNVOzEkkAXoW3JlzJ8d8nmYdsLHn5MrYSm8ikApQ415l4Zvchcom2dCGTgT3U92U/4Jk+qu8DUO1BNEH5ZyZxvAmOSWwJRvAB11c4XcJH
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-16T19:10:32Z"
+    mac: ENC[AES256_GCM,data:CSjKR1oQP/Ua21HOEGGc6l1vFN41/hgTSOu7WrANAy88PzffHW+Q2M5+AASHE0udrO4E4+TKKQ7R2h1xFyGil/b3U0545CRT1imtgX7Ixin/vqLjFT/f6hGfvyQ9UM7FfDsTWbaeZylGPekuTenmsI4gz1Uwrxz1pCjSP0wJo5k=,iv:JDBCbX6740RJsvo4A06/hEhXNg+QOupkRRihsaOjfpg=,tag:XmoSINsm1cxJKP3ipySD5A==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/catalystproject-africa/enc-wits.secret.values.yaml
+++ b/config/clusters/catalystproject-africa/enc-wits.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            GitHubOAuthenticator:
+                client_id: ENC[AES256_GCM,data:pJQFrWrenwY7jHiFBGTVCMZLu5w=,iv:MLrLiqdz5iHDsKwjsw77zU9kULxdmIOmOQgjh++Cook=,tag:64gcyzERRwSKbJkplC9ukw==,type:str]
+                client_secret: ENC[AES256_GCM,data:Bl/t9kN0Pynlg6rTzR2PZ8OawzxYCpmYb1qXvz4M4lbQjPQht8xyuA==,iv:dwot4RZoaMRKNdF/BHytae7Vj6FVleifQcpa+XFiHaU=,tag:vQVA1olAuQ8Dk7uoGVE1Bg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-03-16T18:43:27Z"
+          enc: CiUA4OM7eEOOAxlm3aaJ0/2+Bli6lMIms5g1F1McTvczHLD5E2JXEkkAXoW3JjnvcvLqZazPKNcY4tnlJ0iQEDal1Ij1TrN/eoLguy7dvBhuBctyeYbgaHBjOfQMIOq2T+UAaEF3Kqs7gM542nJjC66Q
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-16T18:43:28Z"
+    mac: ENC[AES256_GCM,data:VDU1vuVnL8SJXHdnlYGW4RWGZHfA/VKI3UpdH8v8sMynHTJsNa/4jsuWMapx9/3mEwJJ4gxsZFTkQ4I2U8SH4O3oIM1SZTIyAjn8ZfKk4UQrUXYiqGR/lwJVP7XBNpIj4XFDkjMCt7K/3YwgmHiorX8mLopCjsHhNO6WAUqGCDw=,iv:Go+Y30GoGswvkFNVb3rizc/DXB8iikSs8lYBqMCm8zY=,tag:83a8GVibHY+y4Pp5OqfnOg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/catalystproject-africa/kush.values.yaml
+++ b/config/clusters/catalystproject-africa/kush.values.yaml
@@ -1,0 +1,31 @@
+jupyterhub:
+  ingress:
+    hosts: [kush.af.catalystproject.2i2c.cloud]
+    tls:
+      - hosts: [kush.af.catalystproject.2i2c.cloud]
+        secretName: https-auto-tls
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
+    homepage:
+      templateVars:
+        org:
+          name: Catalyst Project, Africa - KUSH
+          url: https://catalystproject.cloud/
+          logo_url: https://catalystproject.cloud/_images/catalyst-icon-dark.png
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        oauth_callback_url: https://kush.af.catalystproject.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - CatalystProject-Hubs:kush
+        scope:
+          - read:org
+      Authenticator:
+        admin_users:
+          - Fadlelmola

--- a/config/clusters/catalystproject-africa/molerhealth.values.yaml
+++ b/config/clusters/catalystproject-africa/molerhealth.values.yaml
@@ -1,0 +1,31 @@
+jupyterhub:
+  ingress:
+    hosts: [molerhealth.af.catalystproject.2i2c.cloud]
+    tls:
+      - hosts: [molerhealth.af.catalystproject.2i2c.cloud]
+        secretName: https-auto-tls
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
+    homepage:
+      templateVars:
+        org:
+          name: Catalyst Project, Africa - MolerHealth
+          url: https://catalystproject.cloud/
+          logo_url: https://catalystproject.cloud/_images/catalyst-icon-dark.png
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        oauth_callback_url: https://molerhealth.af.catalystproject.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - CatalystProject-Hubs:molerhealth
+        scope:
+          - read:org
+      Authenticator:
+        admin_users:
+          - Monsurat-Onabajo

--- a/config/clusters/catalystproject-africa/wits.values.yaml
+++ b/config/clusters/catalystproject-africa/wits.values.yaml
@@ -1,0 +1,31 @@
+jupyterhub:
+  ingress:
+    hosts: [wits.af.catalystproject.2i2c.cloud]
+    tls:
+      - hosts: [wits.af.catalystproject.2i2c.cloud]
+        secretName: https-auto-tls
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "github"
+    jupyterhubConfigurator:
+      enabled: false
+    homepage:
+      templateVars:
+        org:
+          name: Catalyst Project, Africa - WITS
+          url: https://catalystproject.cloud/
+          logo_url: https://catalystproject.cloud/_images/catalyst-icon-dark.png
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: github
+      GitHubOAuthenticator:
+        oauth_callback_url: https://wits.af.catalystproject.2i2c.cloud/hub/oauth_callback
+        allowed_organizations:
+          - CatalystProject-Hubs:wits
+        scope:
+          - read:org
+      Authenticator:
+        admin_users:
+          - gentlelab2016


### PR DESCRIPTION
ref: #3740 (wits)
url: https://wits.af.catalystproject.2i2c.cloud

ref: #3770 (kush)
url: https://kush.af.catalystproject.2i2c.cloud

ref: #3771 (molerhealth)
url: https://molerhealth.af.catalystproject.2i2c.cloud

Note: Some administrators still need to create a GitHub account and accept the invitation.