### PR TITLE
Always check for latest rocker/binder image as tags get rebuilt

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -100,6 +100,7 @@ basehub:
                   slug: rocker-geospatial
                   kubespawner_override:
                     image: rocker/binder:4.3
+                    image_pull_policy: Always
                     # Launch into RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir
@@ -159,6 +160,7 @@ basehub:
                   slug: rocker-geospatial
                   kubespawner_override:
                     image: rocker/binder:4.3
+                    image_pull_policy: Always
                     # Launch into RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir

--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -64,6 +64,7 @@ jupyterhub:
         slug: rocker
         kubespawner_override:
           image: rocker/binder:4.3
+          image_pull_policy: Always
           default_url: /rstudio
           working_dir: /home/rstudio # Ensures container working dir is homedir
           node_selector:

--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -50,6 +50,7 @@ jupyterhub:
         slug: rocker
         kubespawner_override:
           image: rocker/binder:4.3
+          image_pull_policy: Always
           default_url: /rstudio
           working_dir: /home/rstudio # Ensures container working dir is homedir
         profile_options: *profile_options

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -180,6 +180,7 @@ basehub:
                   slug: rocker-geospatial
                   kubespawner_override:
                     image: rocker/binder:4.3
+                    image_pull_policy: Always
                     # Launch into RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -165,6 +165,7 @@ basehub:
                   slug: rocker
                   kubespawner_override:
                     image: rocker/binder:4.3
+                    image_pull_policy: Always
                     # Launch RStudio after the user logs in
                     default_url: /rstudio
                     # Ensures container working dir is homedir

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -140,6 +140,7 @@ basehub:
           description: R environment with many geospatial libraries pre-installed
           kubespawner_override:
             image: rocker/binder:4.3
+            image_pull_policy: Always
             # Launch RStudio after the user logs in
             default_url: /rstudio
             # Ensures container working dir is homedir

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -177,6 +177,7 @@ basehub:
           description: R environment with many geospatial libraries pre-installed
           kubespawner_override:
             image: rocker/binder:4.3
+            image_pull_policy: Always
             # Launch RStudio after the user logs in
             default_url: /rstudio
             # Ensures container working dir is homedir

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -56,6 +56,7 @@ jupyterhub:
                 slug: geospatial
                 kubespawner_override:
                   image: rocker/binder:4.3
+                  image_pull_policy: Always
                   # Launch into RStudio after the user logs in
                   default_url: /rstudio
                   # Ensures container working dir is homedir

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -56,6 +56,7 @@ jupyterhub:
                 slug: geospatial
                 kubespawner_override:
                   image: rocker/binder:4.3
+                  image_pull_policy: Always
                   # Launch into RStudio after the user logs in
                   default_url: /rstudio
                   # Ensures container working dir is homedir

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -87,6 +87,7 @@ basehub:
                   slug: geospatial
                   kubespawner_override:
                     image: rocker/binder:4.3
+                    image_pull_policy: Always
                     working_dir: /home/rstudio
                     default_url: /rstudio
                 scipy:

--- a/docs/howto/features/rocker.md
+++ b/docs/howto/features/rocker.md
@@ -96,27 +96,28 @@ When using profileLists, it should probably look like this:
 jupyterhub:
   singleuser:
     profileList:
-    - display_name: "Some Profile Name"
-      profile_options:
-        image:
-          display_name: Image
-          choices:
-            geospatial:
-              display_name: Rocker Geospatial
-              default: true
-              slug: geospatial
-              kubespawner_override:
-                image: rocker/binder:4.3
-                # Launch into RStudio after the user logs in
-                default_url: /rstudio
-                # Ensures container working dir is homedir
-                # https://github.com/2i2c-org/infrastructure/issues/2559
-                working_dir: /home/rstudio
-            scipy:
-              display_name: Jupyter SciPy Notebook
-              slug: scipy
-              kubespawner_override:
-                image: jupyter/scipy-notebook:2023-06-26
+      - display_name: "Some Profile Name"
+        profile_options:
+          image:
+            display_name: Image
+            choices:
+              geospatial:
+                display_name: Rocker Geospatial
+                default: true
+                slug: geospatial
+                kubespawner_override:
+                  image: rocker/binder:4.3
+                  image_pull_policy: Always
+                  # Launch into RStudio after the user logs in
+                  default_url: /rstudio
+                  # Ensures container working dir is homedir
+                  # https://github.com/2i2c-org/infrastructure/issues/2559
+                  working_dir: /home/rstudio
+              scipy:
+                display_name: Jupyter SciPy Notebook
+                slug: scipy
+                kubespawner_override:
+                  image: jupyter/scipy-notebook:2023-06-26
 ```
 
 ## User installed packages


### PR DESCRIPTION
- Fixes https://github.com/2i2c-org/infrastructure/issues/3801

These images have tags that get updated over time, even 4.3.3 gets updated over time. Due to that, we should check against the container registry at all times if there is a new version to avoid old versions being used on long-running nodes. If that happens - we end up with multiple versions of the same image tag running, for example missing out on a security patch.

I verified this works in 2i2c-aws-us/showcase.