### PR TITLE
Use quay.io for jupyter/docker-stacks project's images

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -89,12 +89,12 @@ basehub:
                   display_name: Jupyter SciPy
                   slug: jupyter-scipy
                   kubespawner_override:
-                    image: jupyter/scipy-notebook:2023-06-27
+                    image: quay.io/jupyter/scipy-notebook:2024-03-18
                 jupyter-datascience:
                   display_name: Jupyter DataScience
                   slug: jupyter-datascience
                   kubespawner_override:
-                    image: jupyter/datascience-notebook:2023-06-27
+                    image: quay.io/jupyter/datascience-notebook:2024-03-18
                 rocker-geospatial:
                   display_name: Rocker Geospatial
                   slug: rocker-geospatial
@@ -149,12 +149,12 @@ basehub:
                   display_name: Jupyter SciPy
                   slug: jupyter-scipy
                   kubespawner_override:
-                    image: jupyter/scipy-notebook:2023-06-27
+                    image: quay.io/jupyter/scipy-notebook:2024-03-18
                 jupyter-datascience:
                   display_name: Jupyter DataScience
                   slug: jupyter-datascience
                   kubespawner_override:
-                    image: jupyter/datascience-notebook:2023-06-27
+                    image: quay.io/jupyter/datascience-notebook:2024-03-18
                 rocker-geospatial:
                   display_name: Rocker Geospatial
                   slug: rocker-geospatial

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -57,6 +57,7 @@ jupyterhub:
                 slug: geospatial
                 kubespawner_override:
                   image: rocker/binder:4.3
+                  image_pull_policy: Always
                   # Launch into RStudio after the user logs in
                   default_url: /rstudio
                   # Ensures container working dir is homedir
@@ -66,7 +67,7 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: jupyter/scipy-notebook:2023-06-26
+                  image: quay.io/jupyter/scipy-notebook:2024-03-18
           resources:
             display_name: Resource Allocation
             choices:

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -174,7 +174,7 @@ basehub:
                   display_name: Jupyter
                   slug: jupyter-scipy
                   kubespawner_override:
-                    image: jupyter/scipy-notebook:2023-06-27
+                    image: quay.io/jupyter/scipy-notebook:2024-03-18
                 rocker-geospatial:
                   display_name: RStudio
                   slug: rocker-geospatial

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -174,7 +174,8 @@ basehub:
                   display_name: Jupyter
                   slug: jupyter-scipy
                   kubespawner_override:
-                    image: quay.io/jupyter/scipy-notebook:2024-03-18
+                    # FIXME: use quay.io/ for tags after 2023-10-20
+                    image: jupyter/scipy-notebook:2023-06-27
                 rocker-geospatial:
                   display_name: RStudio
                   slug: rocker-geospatial

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -128,7 +128,8 @@ basehub:
                   display_name: Jupyter DockerStacks Julia Notebook
                   slug: "julia"
                   kubespawner_override:
-                    image: "quay.io/jupyter/julia-notebook:2024-03-18"
+                    # FIXME: use quay.io/ for tags after 2023-10-20
+                    image: "jupyter/julia-notebook:2023-07-05"
         - display_name: "4th of Medium: 1-4 CPU, 4-16 GB"
           description: "A shared machine."
           profile_options: *profile_options

--- a/config/clusters/jupyter-meets-the-earth/common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/common.values.yaml
@@ -128,7 +128,7 @@ basehub:
                   display_name: Jupyter DockerStacks Julia Notebook
                   slug: "julia"
                   kubespawner_override:
-                    image: "jupyter/julia-notebook:2023-07-05"
+                    image: "quay.io/jupyter/julia-notebook:2024-03-18"
         - display_name: "4th of Medium: 1-4 CPU, 4-16 GB"
           description: "A shared machine."
           profile_options: *profile_options

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -66,7 +66,8 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: quay.io/jupyter/scipy-notebook:2024-03-18
+                  # FIXME: use quay.io/ for tags after 2023-10-20
+                  image: jupyter/scipy-notebook:2023-06-26
           resources:
             display_name: Resource Allocation
             choices:

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -66,7 +66,7 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: jupyter/scipy-notebook:2023-06-26
+                  image: quay.io/jupyter/scipy-notebook:2024-03-18
           resources:
             display_name: Resource Allocation
             choices:

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -66,7 +66,8 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: quay.io/jupyter/scipy-notebook:2024-03-18
+                  # FIXME: use quay.io/ for tags after 2023-10-20
+                  image: jupyter/scipy-notebook:2023-06-26
           resources:
             display_name: Resource Allocation
             choices:

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -66,7 +66,7 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: jupyter/scipy-notebook:2023-06-26
+                  image: quay.io/jupyter/scipy-notebook:2024-03-18
           resources:
             display_name: Resource Allocation
             choices:

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -94,7 +94,7 @@ basehub:
                   display_name: Jupyter SciPy Notebook
                   slug: scipy
                   kubespawner_override:
-                    image: "jupyter/scipy-notebook:2023-09-04"
+                    image: "quay.io/jupyter/scipy-notebook:2024-03-18"
                 pangeo:
                   display_name: Pangeo Notebook
                   slug: pangeo

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -94,7 +94,8 @@ basehub:
                   display_name: Jupyter SciPy Notebook
                   slug: scipy
                   kubespawner_override:
-                    image: "quay.io/jupyter/scipy-notebook:2024-03-18"
+                    # FIXME: use quay.io/ for tags after 2023-10-20
+                    image: "jupyter/scipy-notebook:2023-09-04"
                 pangeo:
                   display_name: Pangeo Notebook
                   slug: pangeo

--- a/docs/howto/features/imagebuilding.md
+++ b/docs/howto/features/imagebuilding.md
@@ -66,7 +66,7 @@ jupyterhub:
                     display_name: Jupyter SciPy Notebook
                     slug: scipy
                     kubespawner_override:
-                      image: jupyter/scipy-notebook:2023-06-26
+                      image: quay.io/jupyter/scipy-notebook:2024-03-18
     ```
 
 ## Setup the image registry

--- a/docs/howto/features/rocker.md
+++ b/docs/howto/features/rocker.md
@@ -117,7 +117,7 @@ jupyterhub:
                 display_name: Jupyter SciPy Notebook
                 slug: scipy
                 kubespawner_override:
-                  image: jupyter/scipy-notebook:2023-06-26
+                  image: quay.io/jupyter/scipy-notebook:2024-03-18
 ```
 
 ## User installed packages

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -352,8 +352,8 @@ jupyterhub:
     startTimeout: 600 # 10 mins, node startup + image pulling sometimes takes more than the default 5min
     defaultUrl: /tree
     image:
-      name: jupyter/scipy-notebook
-      tag: "2023-06-19"
+      name: quay.io/jupyter/scipy-notebook
+      tag: "2024-03-18"
     storage:
       type: static
       static:


### PR DESCRIPTION
I've only bumped images that should be safe to bump, like in imagebuilding-demo, while the communities: earthscope, jmte, opensci, smithsonian got fixme notes instead to transition whenever bumping beyond the cutoff date 2023-10-20 where the images started publishing to quay.io instead of dockerhub.