### PR TITLE
[Support: Earthscope] Remove authentication special casing

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -22,7 +22,7 @@ basehub:
         templateVars:
           org:
             url: https://www.earthscope.org/
-            logo_url: https://drive.google.com/uc?export=view&id=1UUStqv7PBcxiIkzECUFKIdQKKIU8mXeb
+            logo_url: https://github.com/2i2c-org/infrastructure/assets/7579677/589da909-86c2-4440-a42b-e3f1b59f49d5
           designed_by:
             name: "2i2c"
             url: https://2i2c.org

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -82,18 +82,6 @@ basehub:
                     url = f"{url}?{params}"
                 return url
 
-            async def authenticate(self, *args, **kwargs):
-              auth_model = await super().authenticate(*args, **kwargs)
-              username = auth_model["name"]
-              # This is required until https://github.com/jupyterhub/oauthenticator/pull/717
-              # gets merged, can be removed after that.
-              if username.startswith("oauth2|cilogon"):
-                  cilogon_sub = username.rsplit("|", 1)[-1]
-                  cilogon_sub_parts = cilogon_sub.split("/")
-                  username = f"oauth2|cilogon|{cilogon_sub_parts[3]}|{cilogon_sub_parts[5]}"
-              auth_model["name"] = username
-              return auth_model
-
             async def check_allowed(self, username, auth_model):
               if await super().check_allowed(username, auth_model):
                   return True


### PR DESCRIPTION
According to https://2i2c.freshdesk.com/a/tickets/1416, earthscope's Auth0 integration with CILogon was updated and no longer returns `sub` claims like `oauth|CILogon|https://cilogon.com/serverA/users/BCDEF` but `oauth2|CILogon|ABCDEF`.

This means we can get rid of this special casing.