### PR TITLE
basehub: update jupyterhub chart from 3.2.1 to 3.3.7 (Scheduled for 9nd April)

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -119,7 +119,7 @@ jupyterhub:
         display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7567.ha4162031"
+      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -119,7 +119,7 @@ jupyterhub:
         display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7567.ha4162031"
+      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -113,7 +113,7 @@ jupyterhub:
     allowNamedServers: true
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7567.ha4162031"
+      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -10,6 +10,8 @@ support:
 hubs:
   - name: staging
     display_name: "University of Toronto (staging)"
+    # to access this staging hub, visit this link directly
+    # https://staging.utoronto.2i2c.cloud/hub/home
     domain: staging.utoronto.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
@@ -28,6 +30,8 @@ hubs:
       - enc-default-prod.secret.values.yaml
   - name: r-staging
     display_name: "University of Toronto (r-staging)"
+    # to access this staging hub, visit this link directly
+    # https://r-staging.datatools.utoronto.ca/hub/home
     domain: r-staging.datatools.utoronto.ca
     helm_chart: basehub
     helm_chart_values_files:

--- a/docs/howto/custom-jupyterhub-image.md
+++ b/docs/howto/custom-jupyterhub-image.md
@@ -148,7 +148,7 @@ You will need to put a config similar to the one below in your hub configuration
 hub:
   image:
     name: quay.io/2i2c/new-experiment
-    tag: "0.0.1-0.dev.git.7130.h70e84dd2"
+    tag: "0.0.1-0.dev.git.8663.h049aa2c2"
 ```
 
 ```{important}

--- a/docs/howto/features/imagebuilding.md
+++ b/docs/howto/features/imagebuilding.md
@@ -20,7 +20,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.7567.ha4162031"
+      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
 ```
 
 ## Connect with `jupyterhub-fancy-profiles`

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 3.2.1
+    version: 3.3.7
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
     version: 0.1.0-0.dev.git.110.hd833d08

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -764,7 +764,7 @@ jupyterhub:
         admin: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.7670.hfd1b116d"
+      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -18,13 +18,11 @@ FROM jupyterhub/k8s-hub:3.2.1
 # requirements.txt file with dependencies, this build argument allows us to
 # reuse this Dockerfile for all images.
 ARG REQUIREMENTS_FILE
-
 COPY ${REQUIREMENTS_FILE} /tmp/
 
 USER root
 RUN pip install -r /tmp/${REQUIREMENTS_FILE}
 
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
-
-COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
+COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/
 USER $NB_USER

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,7 +12,7 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:3.2.1
+FROM jupyterhub/k8s-hub:3.3.7
 
 # chartpress.yaml defines multiple hub images differentiated only by a
 # requirements.txt file with dependencies, this build argument allows us to

--- a/helm-charts/images/hub/dynamic-image-building-requirements.txt
+++ b/helm-charts/images/hub/dynamic-image-building-requirements.txt
@@ -1,13 +1,13 @@
 # Image lives at quay.io/2i2c/dynamic-image-building-experiment
 
-# jupyterhub-configurator isn't version controlled, so we pin to a specific
-# commit currently. Available commits are found at
-# https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# jupyterhub-configurator isn't maintained and its not intended to be developed
+# further. We are using a branch that has forked from the main branch just
+# before a breaking change were made. This allows us to avoid migrating.
 #
-# FIXME: ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db is from Mar 26, 2021, but
-#        several commits has been made since.
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
 #
-git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
+git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
 jupyterhub-fancy-profiles==0.2.0

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -1,10 +1,10 @@
 # Image lives at quay.io/2i2c/pilot-hub
 
-# jupyterhub-configurator isn't version controlled, so we pin to a specific
-# commit currently. Available commits are found at
-# https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# jupyterhub-configurator isn't maintained and its not intended to be developed
+# further. We are using a branch that has forked from the main branch just
+# before a breaking change were made. This allows us to avoid migrating.
 #
-# FIXME: ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db is from Mar 26, 2021, but
-#        several commits has been made since.
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
 #
-git+https://github.com/yuvipanda/jupyterhub-configurator@ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
+git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility


### PR DESCRIPTION
This update brings in jupyterhub 4.1.0 and oauthenticator 16.3.0.

## Two bugfixes upstream

This early adoption of z2jh's new release led to catching two bugs.

- First 3.3.0 failed because of a pycurl regression (observed when using oauthenticator to sign in)
  https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3366
- Then 3.3.1 failed because of a iptables regression (observed when starting a user pod)
  https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3368

## Compatibility fix in jupyterhub-configurator

- [x] The jupyterhub-configurator's web-server made use of HubOAuthenticator that now requires xsrf tokens when receiving javascript fetch requests. This is resolved by https://github.com/yuvipanda/jupyterhub-configurator/pull/19 which is backported to an old enough commit in a branch we now build from. This branch can be adopted without introducing breaking changes.
- [x] Closes https://github.com/2i2c-org/infrastructure/issues/3197, let's not try to migrate to use the latest jupyterhub-configurator commit as it has introduced breaking changes that we would need to migrate config to handle.

## About JupyterHub 4.1.1 - 4.1.5 releases

Several (all?) of the issues patched related to `jupyterhub` code executed in the user servers, which are unaffected by this PRs upgrade of the server side part of jupyterhub.

- In 4.1.1, https://github.com/jupyterhub/jupyterhub/pull/4745
- In 4.1.2, https://github.com/jupyterhub/jupyterhub/pull/4750
- In 4.1.3, https://github.com/jupyterhub/jupyterhub/pull/4753
- In 4.1.4, https://github.com/jupyterhub/jupyterhub/pull/4759
- In 4.1.5, https://github.com/jupyterhub/jupyterhub/pull/4771

## Verifications

- [x] jupyterhub-configurator works
- [x] rstudio works
- [x] nbgitpuller works (nbgitpuller 1.2.1+ is required if jupyterhub 4.1 is used in the user env)
- [x] jupyter-resource-usage works
- [x] jupyter-remote-desktop-proxy works (2.0.0+ is required if jupyterhub 4.1 is used in the user env)
- [x] jupyter notebook 6
- [x] jupyter notebook 7 (jupyter_server based, like jupyter lab)


## Related

- z2jh changelog: https://z2jh.jupyter.org/en/stable/changelog.html
- jupyterhub changelog: https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html
- oauthenticator changelog: https://oauthenticator.readthedocs.io/en/latest/reference/changelog.html
