### PR TITLE
update image tag for nasa-singleuser image

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -54,7 +54,7 @@ jupyterhub:
         description: Pangeo based notebook with a Python environment
         default: true
         kubespawner_override:
-          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2023-03-20
+          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
           init_containers:
             # Need to explicitly fix ownership here, as otherwise these directories will be owned
             # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -54,7 +54,7 @@ jupyterhub:
         description: Pangeo based notebook with a Python environment
         default: true
         kubespawner_override:
-          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-07
+          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2023-03-20
           init_containers:
             # Need to explicitly fix ownership here, as otherwise these directories will be owned
             # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -66,7 +66,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:5068290376e8c3151d97a36ae6485bb7ff79650b94aecc93ffb2ea1b42d76460
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2023-03-20
           profile_options: &profile_options
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -66,7 +66,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2023-03-20
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
           profile_options: &profile_options
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -68,7 +68,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-07
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
Refs https://github.com/NASA-IMPACT/veda-jh-environments/issues/46

Updates the nasa-veda-singleuser image to an image that uses an updated version of the `pangeo-notebook` base image (now using `pangeo/pangeo-notebook:2024.03.13`)

This update is needed to address https://github.com/jupyterhub/jupyter-server-proxy/security/advisories/GHSA-w3vc-fx9p-wp4v

cc @yuvipanda @ranchodeluxe @wildintellect @abarciauskas-bgse