### PR TITLE
Allow ESDIS hub access to S3

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -47,6 +47,10 @@ jupyterhub:
           - freitagb # Brian Freitag
           - slesaad # Slesa Adhikari
   singleuser:
+    # We want to access IAM roles here, even though this is not set up to use dask
+    cloudMetadata:
+      blockWithIptables: false
+    serviceAccountName: user-sa
     defaultUrl: /lab
     profileList:
       - display_name: "Modified Pangeo Notebook"


### PR DESCRIPTION
We were setting up the name of the service account in daskhub/values.yaml, so hubs that were set up without dask don't actually have access to the IAM roles set up for them!