### PR TITLE
leap: increase filestore capacity with 25% to 2.5TB

### DIFF
--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -21,7 +21,7 @@ enable_network_policy = true
 
 # Setup a filestore for in-cluster NFS
 enable_filestore      = true
-filestore_capacity_gb = 2048
+filestore_capacity_gb = 2560
 
 user_buckets = {
   "scratch-staging" : {


### PR DESCRIPTION
90% of the home directory / shared directory storage was used and we got a warning about running low. I've increased the 2TiB of storage to 2.5TiB now.

Ping @jbusecke for visibility.