### PR TITLE
Cross-link setting up GPUs in AWS cluster creation

### DIFF
--- a/docs/howto/features/gpu.md
+++ b/docs/howto/features/gpu.md
@@ -100,6 +100,7 @@ series nodes.
 7. Ask for the increase, and wait. This can take *several working days*,
    so do it as early as possible!
 
+(howto:features:gpu:aws:nodegroup)=
 #### Setup GPU nodegroup on eksctl
 
 We use `eksctl` with `jsonnet` to provision our kubernetes clusters on

--- a/docs/hub-deployment-guide/new-cluster/aws.md
+++ b/docs/hub-deployment-guide/new-cluster/aws.md
@@ -72,6 +72,11 @@ This will generate the following files:
 4. `terraform/aws/projects/$CLUSTER_NAME.tfvars`, a terraform variables file that will setup
    most of the non EKS infrastructure.
 
+### Add GPU nodegroup if needed
+
+If this cluster is going to have GPUs, you should edit the generated jsonnet file
+to [include a GPU nodegroups](howto:features:gpu:aws:nodegroup).
+
 ### Create and render an eksctl config file
 
 We use an eksctl [config file](https://eksctl.io/usage/schema/) in YAML to specify


### PR DESCRIPTION
When we are *creating* an AWS cluster, if we already know that GPUs are needed, we should add the nodegroup at that point already. This cross-links that, to streamline new hub turn-ups.

Ref https://github.com/2i2c-org/meta/issues/897