### PR TITLE
Enable 'allusers' for smithsonian hubs

### DIFF
--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -19,6 +19,22 @@ basehub:
         add_staff_user_ids_of_type: "github"
       jupyterhubConfigurator:
         enabled: false
+
+      singleuserAdmin:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/allusers
+          - name: home
+            mountPath: /home/rstudio/allusers
+          # mounts below are copied from basehub's values that we override by
+          # specifying extraVolumeMounts (lists get overridden when helm values
+          # are combined)
+          - name: home
+            mountPath: /home/jovyan/shared-readwrite
+            subPath: _shared
+          - name: home
+            mountPath: /home/rstudio/shared-readwrite
+            subPath: _shared
       homepage:
         templateVars:
           org:

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -87,6 +87,10 @@ jupyterhub:
           mountPath: /home/jovyan/allusers
           # Uncomment the line below to make the directory readonly for admins
           # readOnly: true
+        - name: home
+          mountPath: /home/rstudio/allusers
+          # Uncomment the line below to make the directory readonly for admins
+          # readOnly: true
         # mounts below are copied from basehub's values that we override by
         # specifying extraVolumeMounts (lists get overridden when helm values
         # are combined)


### PR DESCRIPTION
Also amend the allusers config to have it setup in the rstudio home as well

Ref https://2i2c.freshdesk.com/a/tickets/1359