### PR TITLE
Minor doc fixes about setting up AWS clusters

### DIFF
--- a/docs/hub-deployment-guide/deploy-support/configure-support.md
+++ b/docs/hub-deployment-guide/deploy-support/configure-support.md
@@ -6,6 +6,12 @@ These tools are [`ingress-nginx`](https://kubernetes.github.io/ingress-nginx/), 
 
 This section will walk you through how to deploy the support chart on a cluster.
 
+```{attention}
+If you ran `deployer generate dedicated-cluster ...` during the [new cluster setup](new-cluster),
+then a lot of these files will have already been created for you and you do not
+need to recreate them, only update them if required.
+```
+
 ## Create a `support.values.yaml` file in your chosen cluster folder
 
 In the `infrastructure` repo, the full filepath should be: `config/clusters/<cluster_name>/support.values.yaml`.

--- a/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
+++ b/docs/hub-deployment-guide/deploy-support/register-central-grafana.md
@@ -2,6 +2,12 @@
 
 Once you have [deployed the support chart](deploy-support-chart), you must also register this cluster as a datasource for the [central Grafana dashboard](grafana-dashboards:central). This will allow you to visualize cluster statistics not only from the cluster-specific Grafana deployment but also from the central dashboard, that aggregates data from all the clusters.
 
+```{attention}
+If you ran `deployer generate dedicated-cluster ...` during the [new cluster setup](new-cluster),
+then a lot of these files will have already been created for you and you do not
+need to recreate them, only update them if required.
+```
+
 ## Create a `support.secret.values.yaml` file
 
 Only 2i2c staff and our centralized grafana should be able to access the prometheus data on a cluster from outside the cluster.

--- a/docs/hub-deployment-guide/new-cluster/aws.md
+++ b/docs/hub-deployment-guide/new-cluster/aws.md
@@ -337,19 +337,3 @@ automatically deployed by our CI/CD system. Add an entry for the new cluster
 here.
 
 [`upgrade-support-and-staging`]: https://github.com/2i2c-org/infrastructure/blob/18f5a4f8f39ed98c2f5c99091ae9f19a1075c988/.github/workflows/deploy-hubs.yaml#L128-L166
-
-## A note on the support chart for AWS clusters
-
-````{warning}
-When you deploy the support chart on an AWS cluster, you **must** enable the
-`cluster-autoscaler` sub-chart, otherwise the node groups will not automatically
-scale. Include the following in your `support.values.yaml` file:
-
-```yaml
-cluster-autoscaler:
-  enabled: true
-  autoDiscovery:
-    clusterName: <cluster-name>
-  awsRegion: <aws-region>
-```
-````

--- a/docs/hub-deployment-guide/new-cluster/aws.md
+++ b/docs/hub-deployment-guide/new-cluster/aws.md
@@ -105,6 +105,10 @@ for all the possible options. You'd want to make sure to change at least the fol
 Once you have a `.jsonnet` file, you can render it into a config file that eksctl
 can read.
 
+```{tip}
+Make sure to run this command inside the `eksctl` directory.
+```
+
 ```bash
 jsonnet $CLUSTER_NAME.jsonnet > $CLUSTER_NAME.eksctl.yaml
 ```
@@ -119,12 +123,12 @@ against the `*.jsonnet` file and regenerate the YAML file when needed by a
 
 Now you're ready to create the cluster!
 
-```bash
-eksctl create cluster --config-file=$CLUSTER_NAME.eksctl.yaml
+```{tip}
+Make sure to run this command **inside** the `eksctl` directory, otherwise it cannot discover the `ssh-keys` subfolder.
 ```
 
-```{tip}
-Make sure the run this command **inside** the `eksctl` directory, otherwise it cannot discover the `ssh-keys` subfolder.
+```bash
+eksctl create cluster --config-file=$CLUSTER_NAME.eksctl.yaml
 ```
 
 This might take a few minutes.


### PR DESCRIPTION
This PR updates the new AWS cluster and support setup docs with gotchas I noticed during https://github.com/2i2c-org/infrastructure/issues/3827
