### PR TITLE
Remove use of cloud-user-sa from openscapes hub

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -35,7 +35,6 @@ basehub:
             name: NASA Openscapes
             url: https://nasa-openscapes.github.io/
     singleuser:
-      serviceAccountName: cloud-user-sa
       defaultUrl: /lab
       extraEnv:
         GH_SCOPED_CREDS_CLIENT_ID: "Iv1.6981e043b45f042f"

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -20,11 +20,6 @@ local clusterRegion = "us-west-2";
 local masterAzs = ["us-west-2a", "us-west-2b", "us-west-2c"];
 local nodeAz = "us-west-2b";
 
-// List of namespaces where we have hubs deployed
-// Each will get a ServiceAccount that will get credentials to talk
-// to AWS services, via https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
-local namespaces = ['staging', 'prod'];
-
 // Node definitions for notebook nodes. Config here is merged
 // with our notebook node definition.
 // A `node.kubernetes.io/instance-type label is added, so pods
@@ -60,16 +55,6 @@ local daskNodes = [
     availabilityZones: masterAzs,
     iam: {
         withOIDC: true,
-
-        serviceAccounts: [{
-            metadata: {
-                name: "cloud-user-sa",
-                namespace: namespace
-            },
-            attachPolicyARNs:[
-                "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-            ],
-        } for namespace in namespaces],
     },
     // If you add an addon to this config, run the create addon command.
     //


### PR DESCRIPTION
Without this, https://github.com/2i2c-org/infrastructure/issues/3694 does not quite take, as the `user-sa` service account is not attached to the user pod.

This unifies all our infrastructure so nobody is using service accounts created by `eksctl`. Since openscapes is *just about* to start using S3, this is a good time to make sure it's set up in a standard way.

Fixes https://github.com/2i2c-org/infrastructure/issues/3273