### PR TITLE
ci: stop using fork of dorny/paths-filter, its no longer needed

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -97,9 +97,7 @@ jobs:
 
       - name: Identify files that have been added or modified
         # Action repo: https://github.com/dorny/paths-filter
-        # Fork of the repo above that we use: https://github.com/frouioui/paths-filter/tree/main
-        # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
-        uses: frouioui/paths-filter@main
+        uses: dorny/paths-filter@v3
         id: changed-files
         with:
           token: ""

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -28,7 +28,7 @@ on:
       - "config/clusters/**"
       # Exclude changes the templates directory from
       # triggering this workflow
-      - "!config/clusters/templates"
+      - "!config/clusters/templates/**"
       - "helm-charts/**"
       - "deployer/**"
       - "requirements.txt"
@@ -102,6 +102,11 @@ jobs:
               - added|modified: .github/workflows/validate-clusters.yaml
             cluster_specific:
               - added|modified: config/clusters/**
+              # We want to ignore config/clusters/templates/**, but it seems its
+              # not be possible for us to do so with a single call to this
+              # action. Let's try to ignore jobs failing triggered by stuff in
+              # templates/.
+              # - added|modified: !config/clusters/templates/**
 
       # Only run this step if there *ARE* changes under the common filter, *OR*
       # we have manually triggered the workflow

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -85,9 +85,7 @@ jobs:
         # Don't run this step when we manually trigger the workflow
         if: github.event_name != 'workflow_dispatch'
         # Action repo: https://github.com/dorny/paths-filter
-        # Fork of the repo above that we use: https://github.com/frouioui/paths-filter/tree/main
-        # In order to take advantage of https://github.com/dorny/paths-filter/pull/133
-        uses: frouioui/paths-filter@main
+        uses: dorny/paths-filter@v3
         id: file_changes
         with:
           token: ""


### PR DESCRIPTION
Thanks to clear comments by @sgibson91 (EDIT: by @GeorgianaElena), its clear to me we can stop using a temporary workaround using a fork of `dorny/paths-filter` with a fix.