### PR TITLE
Move service account specification to basehub

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -52,7 +52,6 @@ jupyterhub:
     # We want to access IAM roles here, even though this is not set up to use dask
     cloudMetadata:
       blockWithIptables: false
-    serviceAccountName: user-sa
     defaultUrl: /lab
     profileList:
       - display_name: "Modified Pangeo Notebook"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -244,8 +244,10 @@ jupyterhub:
         limits:
           memory: 1Gi
   singleuser:
-    # Default to mounting the user service account we create, so we can give users
-    # appropriate cloud permissions when needed.
+    # basehub creates a k8s ServiceAccount for the hubs users that isn't granted
+    # permissions to the k8s api-server or other resources by default. Cloud
+    # infra permissions can be granted to all users by declaring annotations on
+    # this k8s ServiceAccount via basehub config userServiceAccount.annotations.
     serviceAccountName: user-sa
     # Need to explicitly fix ownership here, as otherwise these directories will be owned
     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -244,6 +244,9 @@ jupyterhub:
         limits:
           memory: 1Gi
   singleuser:
+    # Default to mounting the user service account we create, so we can give users
+    # appropriate cloud permissions when needed.
+    serviceAccountName: user-sa
     # Need to explicitly fix ownership here, as otherwise these directories will be owned
     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
     #

--- a/helm-charts/daskhub/values.yaml
+++ b/helm-charts/daskhub/values.yaml
@@ -15,7 +15,6 @@ basehub:
         # storage buckets.
         #
         blockWithIptables: false
-      serviceAccountName: user-sa
       extraEnv:
         # About DASK_ prefixed variables we set:
         #


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/3826 to prevent that from happening again in other hubs. The service account is *created* in basehub, so it should just be set there too.