### PR TITLE
leap: change cluster.yaml's `gcp.billing.paid_by_us` to false

### DIFF
--- a/config/clusters/leap/cluster.yaml
+++ b/config/clusters/leap/cluster.yaml
@@ -6,7 +6,7 @@ gcp:
   cluster: leap-cluster
   zone: us-central1
   billing:
-    paid_by_us: true
+    paid_by_us: false
     bigquery:
       project: leap-pangeo
       dataset: cloud_costs


### PR DESCRIPTION
- part of #3711

It seems that LEAP isn't paid by us, but via credits + a credit card I didn't recognize the last digits of to be CH's.