### PR TITLE
readthedocs: update build environment from old mambaforge to latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     # ref: https://github.com/readthedocs/readthedocs.org/issues/8595
     # ref: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
     #
-    python: "mambaforge-4.10"
+    python: mambaforge-latest
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
mambaforge 4.10 gave us Python 3.9, and mambaforge 22.9 would give python 3.10, and I think the latest gives us Python 3.10 still - even if the latest would become mambaforge 24.x or if its 22.9.

I don't think there is a need to worry that we get too modern Python versions.

## References
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
- https://github.com/conda-forge/miniforge/blob/HEAD/Miniforge3/construct.yaml#L31