### PR TITLE
include new QGIS image, with improved outer UI and clipboard handling

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -143,5 +143,5 @@ jupyterhub:
           # Launch people directly into the Linux desktop when they start
           default_url: /desktop
           # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-          image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
+          image: quay.io/2i2c/nasa-qgis-image:0d0765090250
         profile_options: *profile_options

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -152,7 +152,7 @@ basehub:
           kubespawner_override:
             default_url: /desktop
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
+            image: quay.io/2i2c/nasa-qgis-image:0d0765090250
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -190,7 +190,7 @@ basehub:
             # Launch people directly into the Linux desktop when they start
             default_url: /desktop
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: quay.io/2i2c/nasa-qgis-image:babb0fa15dfa
+            image: quay.io/2i2c/nasa-qgis-image:0d0765090250
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)


### PR DESCRIPTION
Includes a much improved UI for the shell around the QGIS desktop in Jupyter. Thanks much to @yuvipanda for the work in https://github.com/jupyterhub/jupyter-remote-desktop-proxy that added this.

This is what the UI now looks like:

<img width="1437" alt="Screenshot 2024-03-29 at 1 50 48 PM" src="https://github.com/2i2c-org/infrastructure/assets/72280/524805c1-b0e7-435c-931a-bb71de41615a">

 - Improves how Copy - Paste works
 - Gives access in the UI to go back to JupyterHub launcher + Server manager
 - Greatly improves the look of the shell UI, to make this look and behave well integrated into the JupyterHub setup.

I tested this image on staging and it seems to work well.

cc @yuvipanda 