### PR TITLE
DANDI & BICAN: Default interface to lab & enable named servers

### DIFF
--- a/config/clusters/bican/common.values.yaml
+++ b/config/clusters/bican/common.values.yaml
@@ -48,6 +48,7 @@ jupyterhub:
           - satra
           - djarecka
   singleuser:
+    defaultUrl: /lab
     profileList:
       - display_name: "DANDI (CPU)"
         description: "Default DANDI image with JupyterLab"
@@ -55,7 +56,6 @@ jupyterhub:
         kubespawner_override:
           image: dandiarchive/dandihub:latest
           image_pull_policy: Always
-          default_url: /lab
         profile_options: &profile_options_cpu
           requests:
             display_name: Resource Allocation

--- a/config/clusters/dandi/common.values.yaml
+++ b/config/clusters/dandi/common.values.yaml
@@ -50,6 +50,7 @@ jupyterhub:
     userScheduler:
       enabled: true
   singleuser:
+    defaultUrl: /lab
     profileList:
       - display_name: "DANDI (CPU)"
         description: "Default DANDI image with JupyterLab"
@@ -57,7 +58,6 @@ jupyterhub:
         kubespawner_override:
           image: dandiarchive/dandihub:latest
           image_pull_policy: Always
-          default_url: /lab
         profile_options: &profile_options_cpu
           requests:
             display_name: Resource Allocation

--- a/config/clusters/dandi/common.values.yaml
+++ b/config/clusters/dandi/common.values.yaml
@@ -14,6 +14,7 @@ nfs:
     baseShareName: /
 jupyterhub:
   hub:
+    allowNamedServers: true
     config:
       JupyterHub:
         authenticator_class: github


### PR DESCRIPTION
Earlier was just defaulting the first profile item to lab. I'll add this to the spec on the issue.

Ref https://github.com/2i2c-org/infrastructure/issues/3827
Ref https://github.com/2i2c-org/infrastructure/issues/3824