### PR TITLE
binderhub-service deploy: hide irrelevant services dropdown entry

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -116,6 +116,7 @@ jupyterhub:
         # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
         # for something more readable and requiring less copy-pasting
         url: http://imagebuilding-demo-binderhub-service:8090
+        display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
       tag: "0.0.1-0.dev.git.7567.ha4162031"

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -116,6 +116,7 @@ jupyterhub:
         # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
         # for something more readable and requiring less copy-pasting
         url: http://sciencecore-binderhub-service:8090
+        display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
       tag: "0.0.1-0.dev.git.7567.ha4162031"


### PR DESCRIPTION
This is an artifact of how we configure things, and we don't want it to show up like this:
![image](https://github.com/2i2c-org/infrastructure/assets/3837114/aeb1bb8a-59d5-490d-845c-f2436110792d)

By using `display: false`, we avoid it. See https://jupyterhub.readthedocs.io/en/stable/reference/services.html#properties-of-a-service