### PR TITLE
automation: disable bumping of binderhub chart versions

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -26,11 +26,6 @@ jobs:
         include:
           # For each new helm chart to bump the subchart versions of, add a new item in
           # this matrix.
-          - name: "binderhub"
-            chart_path: "helm-charts/binderhub/Chart.yaml"
-            # To bump multiple subchart versions, provide the chart name and a URL to
-            # a published list of versions in this dictionary.
-            chart_urls: '{"binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml"}'
           - name: "support"
             chart_path: "helm-charts/support/Chart.yaml"
             chart_urls: '{"cryptnono": "https://cryptnono.github.io/cryptnono/index.yaml", "cluster-autoscaler": "https://kubernetes.github.io/autoscaler/index.yaml", "ingress-nginx": "https://kubernetes.github.io/ingress-nginx/index.yaml", "grafana": "https://grafana.github.io/helm-charts/index.yaml", "prometheus": "https://prometheus-community.github.io/helm-charts/index.yaml"}'


### PR DESCRIPTION
- closes #3885

@yuvipanda in https://github.com/2i2c-org/infrastructure/pull/3885#issuecomment-2035368251
> Given that we've decided to not use this helm chart, I'd suggest we turn off auto-update for this one.