### PR TITLE
dandi: fix out of sync grafana service account token

### DIFF
--- a/config/clusters/dandi/enc-grafana-token.secret.yaml
+++ b/config/clusters/dandi/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:lIAqF3jj8MkwegfcSWQXYHgoCEEdaN8R5/UFSkBPdCBmwSb0wK0jtOQaNol1Xg==,iv:ephtL8S+djDG4vnRMZpjOo4uncEynzqCxUtic9MGA8A=,tag:HFA/Dvm7rLPuf7Fpt3dTgQ==,type:str]
+grafana_token: ENC[AES256_GCM,data:mJ61/YiO0YkX2e6UlxO+fSibJZDJCi4QnoYHxQZgibafOYVb/lW/x0YSpCA3Pw==,iv:mCJ5EtZCO1tIi3NFdD2ALTZg2qbFwejl5uymDnfVaIA=,tag:Me9yD+wK+A5caJDPJmYZZQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2024-03-28T11:08:02Z"
-          enc: CiUA4OM7eAt8g6jUz4eBmZDJnmBNBb46ry/gg48r3NGKbusMuMMJEkkAXoW3JrCEy5GKfXt3TKEDyUgUn7Ki48h7umK/oH7YH0p8sapZ6a9BjzcVTKEs+Qy2PUXb7cZ3gI4bycCRJGHEHUA03oOai4fA
+          created_at: "2024-04-03T21:25:34Z"
+          enc: CiUA4OM7eHdRa2/KOSKDQVH0TUcylL0XoNseNJopjeKj0C/I02znEkkAXoW3JsW1SQeP/rNnyeimBAh+JJVVBAE9RYcQeGNeE2jjaQcNCIOHU4kQ23IKHtFWQlnzLX4cX0q7BVv0RvL/v2tBHjwBuV8b
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-03-28T11:08:03Z"
-    mac: ENC[AES256_GCM,data:0iv4bIKDkKN7eVaNrPvf9BrJ43daWZXrcy51i2GET3r8EUaPDAVfszAWvWF6FjZTfSMrVKKzfx78yJNY6R54cKrNW4vQRkAlVteiumO5kPAP1Z87t+NviDQkRTyjlslNzJaKuXeQCmp6HMZ7knmM9Hg4j2IQaSIip9tt6Rov7Ag=,iv:fU5xMf9z9NyMyJUefxymNFD88f92XovIizmZqud1nqM=,tag:o/gre7sph7io6QM2oWzKHA==,type:str]
+    lastmodified: "2024-04-03T21:25:34Z"
+    mac: ENC[AES256_GCM,data:N2F5+jecPHS97PSfeBsldHYvaDwm1g9LwgoH11CR4qVJKPiveBxoFPifeFeQ3YpPEvb2DdP6uUR6IGBZTBLK1pObvGwB3VcwObw+e0ve+Svd+PqsRrXq0U7RB5Qsd6IInuYFPrv6rTRf9OtpfCz+Ae3hKZ/6r8ck/L8/Vg2fmmo=,iv:DmVp2Rzl1+qJGQRifEOEU/EO6u5TZt67L0PWGKAmzVU=,tag:vBeOVoGayDGHTNvoSPpDSQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1


### PR DESCRIPTION
Should fix this issue in the deploy grafana dashboards workflow, gettinf 401 unauthorized when accessing grafana with a token stashed encrypted in this git repo.

I re-ran `deployer grafana new-token dandi` and verified I could deploy the dashboards with this new token.

![image](https://github.com/2i2c-org/infrastructure/assets/3837114/caa76a26-0203-4b57-a697-3fcc786b42c2)
