### PR TITLE
automation: also deploy grafana's global dashboard for 2i2c cluster, and deploy all dashboards daily

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -70,4 +70,4 @@ jobs:
 
       - name: Deploy grafana dashboards for ${{ matrix.cluster_name }}
         run: |
-          deployer grafana deploy-dashboards ${{ matrix.cluster_name }} ${{ matrix.deploy_flags }}
+          deployer grafana deploy-dashboards ${{ matrix.deploy_flags }} ${{ matrix.cluster_name }}

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -1,6 +1,10 @@
 name: Deploy grafana dashboards
 
-on: workflow_dispatch
+on:
+  schedule:
+    # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
+    - cron: "0 5 * * *"
+  workflow_dispatch:
 
 jobs:
   deploy_grafana_dashboards:

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -4,13 +4,17 @@ on: workflow_dispatch
 
 jobs:
   deploy_grafana_dashboards:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
         include:
-          # The grafana for 2i2c cluster holds also info about all other clusters
+          # The grafana for 2i2c cluster holds also info about all other
+          # clusters and gets an additional dashboard deployed for that
+          - cluster_name: 2i2c
+            deploy_flags: --dashboards-dir=global-dashboards
+
           - cluster_name: 2i2c
           - cluster_name: 2i2c-aws-us
           - cluster_name: 2i2c-uk
@@ -41,12 +45,11 @@ jobs:
           - cluster_name: jupyter-health
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install deployer
         run: |
@@ -63,4 +66,4 @@ jobs:
 
       - name: Deploy grafana dashboards for ${{ matrix.cluster_name }}
         run: |
-          deployer grafana deploy-dashboards ${{ matrix.cluster_name }}
+          deployer grafana deploy-dashboards ${{ matrix.cluster_name }} ${{ matrix.deploy_flags }}

--- a/deployer/commands/grafana/deploy_dashboards.py
+++ b/deployer/commands/grafana/deploy_dashboards.py
@@ -12,7 +12,12 @@ from .utils import get_grafana_token, get_grafana_url
 
 @grafana_app.command()
 def deploy_dashboards(
-    cluster_name: str = typer.Argument(..., help="Name of cluster to operate on")
+    cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
+    dashboards_dir: str = typer.Option(
+        "dashboards",
+        help="""(Optional) ./deploy.py script accepts --dashboards-dir flag, and
+             this is the value we provide to that flag.""",
+    ),
 ):
     """
     Deploy the latest official JupyterHub dashboards to a cluster's grafana
@@ -42,7 +47,7 @@ def deploy_dashboards(
     try:
         print_colour(f"Deploying grafana dashboards to {cluster_name}...")
         subprocess.check_call(
-            ["./deploy.py", grafana_url],
+            ["./deploy.py", grafana_url, f"--dashboards-dir={dashboards_dir}"],
             env=deploy_script_env,
             cwd="grafana-dashboards",
         )


### PR DESCRIPTION
The global dashboard wasn't getting updated over time through our automation. I think this is the long-term fix for #3911, where I previously just manually patched it after finding it outdated and malfunctioning due to it.