### PR TITLE
Disable auto assign @engineering to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# This team will be the default owner for everything in
-# the repo. Unless a later match takes precedence,
-# @2i2c-org/engineering will be requested for
-# review when someone opens a pull request.
-# Documentation about how to edit this file is available at
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @2i2c-org/engineering


### PR DESCRIPTION
In the planning for April 4th, 2024, we agreed to disable the automatic assignment of the team @engineering as a code reviewer. This can be achieved by modifying the CODEOWNERS file in the .github/ directory.

If I understand correctly, it is safe to delete the file since we do not utilize this option in this repository:

![image](https://github.com/2i2c-org/infrastructure/assets/12158718/0dcc19a8-bdd0-450a-98d4-fd36c6f2ae5f)

Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners