### PR TITLE
support chart: update grafana chart 6.61.2 to 7.3.7 (grafana 10.1.5 to 10.4.0)

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 6.61.2
+    version: 7.3.7
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -271,6 +271,10 @@ prometheus:
 # values ref: https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 #
 grafana:
+  # We decrypt and pass `grafana.adminPassword` just in time as part of
+  # deploying grafana, and find it acceptable - so we disable this strict check.
+  assertNoLeakedSecrets: false
+
   persistence:
     # A PVC is used to enable Grafana to store auth details and dashboard
     # definitions.


### PR DESCRIPTION
This is not a breaking change for us now, grafana itself still supports our dashboard definitions from jupyterhub/grafana-dashboards, and the chart major version bump relates to a [for us unused chart configuration](https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#to-700).

There were upgrade errors stemming from grafana introducing (without a major version bump, but should have been!) a [strict check for secrets being passed introduced in chart version 7.1.0](https://github.com/grafana/helm-charts/pull/2867) - this PR handles that by disabling the (too) strict check - see Yuvi's comment for example in https://github.com/2i2c-org/infrastructure/pull/3482#issuecomment-1894722474, which I also align with.

- Fixes #3619