### PR TITLE
[deployer] Explicitly enable the cluster-autoscaler when generating the support chart for aws clusters

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -23,6 +23,8 @@ on:
       - .github/actions/setup-deploy/**
       - helm-charts/**
       - config/clusters/**
+      # Exclude the template configuration files
+      - "!config/clusters/templates"
   pull_request:
     branches:
       - main
@@ -38,6 +40,8 @@ on:
       - .github/actions/setup-deploy/**
       - helm-charts/**
       - config/clusters/**
+      # Exclude the template configuration files
+      - "!config/clusters/templates"
 
 # When multiple PRs triggering this workflow are merged, queue them instead
 # of running them in parallel

--- a/config/clusters/templates/common/support.values.yaml
+++ b/config/clusters/templates/common/support.values.yaml
@@ -26,3 +26,10 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.{{ cluster_name }}.2i2c.cloud
+{% if provider == "aws" %}
+cluster-autoscaler:
+  enabled: true
+  autoDiscovery:
+    clusterName: {{ cluster_name }}
+  awsRegion: {{ cluster_region }}
+{% endif %}

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -126,6 +126,9 @@ def aws(
     # and support files
 
     vars = {
+        # Also store the provider, as it's useful for some jinja templates
+        # to differentiate between them when rendering the configuration
+        "provider": "aws",
         "cluster_name": cluster_name,
         "hub_type": hub_type,
         "cluster_region": cluster_region,

--- a/deployer/commands/generate/dedicated_cluster/gcp.py
+++ b/deployer/commands/generate/dedicated_cluster/gcp.py
@@ -83,6 +83,9 @@ def gcp(
     # These are the variables needed by the templates used to generate the cluster config file
     # and support files
     vars = {
+        # Also store the provider, as it's useful for some jinja templates
+        # to differentiate between them when rendering the configuration
+        "provider": "gcp",
         "cluster_name": cluster_name,
         "hub_type": hub_type,
         "cluster_region": cluster_region,


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/3881