### PR TITLE
[catalystproject-africa] Enable 2i2c admin access for MUST hub

### DIFF
--- a/config/clusters/catalystproject-africa/must.values.yaml
+++ b/config/clusters/catalystproject-africa/must.values.yaml
@@ -5,6 +5,9 @@ jupyterhub:
       - hosts: [must.af.catalystproject.2i2c.cloud]
         secretName: https-auto-tls
   custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_of_type: "google"
     homepage:
       templateVars:
         org:

--- a/config/clusters/catalystproject-africa/must.values.yaml
+++ b/config/clusters/catalystproject-africa/must.values.yaml
@@ -13,7 +13,7 @@ jupyterhub:
         org:
           name: "MUST"
           url: https://www.must.ac.mw/
-          logo_url: https://www.must.ac.mw/wp-content/themes/mustwebsite/images/must-logo.png
+          logo_url: https://www.must.ac.mw/imgs/logo/must%20log%20black.png
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
I noticed that access for 2i2c staff was not enabled for the catalystproject-africa, MUST hub, which is using CILogon.

This PR quickly fixes that.