### PR TITLE
update nasa-esdis, nasa-ghg and nasa-veda to use latest singleuser image

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -59,7 +59,7 @@ jupyterhub:
         description: Pangeo based notebook with a Python environment
         default: true
         kubespawner_override:
-          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
+          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
           init_containers:
             # Need to explicitly fix ownership here, as otherwise these directories will be owned
             # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -65,7 +65,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
           profile_options: &profile_options
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -67,7 +67,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-03-20
+            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
This is mostly to bring in the new version of `jupyterlab-myst` (v2.3.2) to fix https://github.com/NASA-IMPACT/veda-jupyterhub/issues/14

This uses `pangeo-notebook` version `2024.04.05`

It would be really great if more folks could test this. How to test:

 - Open the staging VEDA hub (or any other hub you want to test on)
 - Choose Bring your Own Image and in the Image field enter: `public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09`
 - Open up and try the example notebooks, other things to test that things work as expected

cc @jsignell @wildintellect @abarciauskas-bgse

Once we have things tested and approved by at least 1 of the folks above, I'll take this PR out of draft and tag 2i2c folks to coordinate deploy.