### PR TITLE
openscapes: Add 2024 cohort, remove defunct workshop team from 2i2c access

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -47,14 +47,14 @@ basehub:
           default: true
           allowed_teams:
             - 2i2c-org:hub-access-for-2i2c-staff
-            - NASA-Openscapes:workshopaccess-2i2c
+            - NASA-Openscapes:workshopaccess-2i2c # legacy but no plans to delete immediately until fledged
             - NASA-Openscapes:longtermaccess-2i2c
-            - NASA-Openscapes:championsaccess-2i2c
+            - NASA-Openscapes:championsaccess-2i2c # legacy but no plans to delete immediately until fledged
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
             - nasa-openscapes-workshops:AdminTeam
-            - nasa-openscapes-workshops:ChampionsAccess-2i2c
-            - nasa-openscapes-workshops:LongtermAccess-2i2c
-            - nasa-openscapes-workshops:WorkshopAccess-2i2c
+            - nasa-openscapes-workshops:champions-access-2i2c-2024
+            - nasa-openscapes-workshops:ChampionsAccess-2i2c # legacy, will delete - has only one user from 2023 cohort
+            - nasa-openscapes-workshops:WorkshopAccess-2i2c # From SWOT workshop 2024-02-13
             - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
             image: openscapes/python:4f340eb
@@ -135,8 +135,8 @@ basehub:
             - NASA-Openscapes:championsaccess-2i2c
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
             - nasa-openscapes-workshops:AdminTeam
+            - nasa-openscapes-workshops:champions-access-2i2c-2024
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
-            - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
             - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
@@ -154,8 +154,8 @@ basehub:
             - NASA-Openscapes:championsaccess-2i2c
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
             - nasa-openscapes-workshops:AdminTeam
+            - nasa-openscapes-workshops:champions-access-2i2c-2024
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
-            - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
             - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           kubespawner_override:
@@ -169,7 +169,7 @@ basehub:
             - 2i2c-org:hub-access-for-2i2c-staff
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
             - nasa-openscapes-workshops:AdminTeam
-            - nasa-openscapes-workshops:LongtermAccess-2i2c
+            - nasa-openscapes-workshops:champions-access-2i2c-2024
           profile_options:
             image:
               display_name: Image
@@ -200,8 +200,8 @@ basehub:
             - NASA-Openscapes:championsaccess-2i2c
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
             - nasa-openscapes-workshops:AdminTeam
+            - nasa-openscapes-workshops:champions-access-2i2c-2024
             - nasa-openscapes-workshops:ChampionsAccess-2i2c
-            - nasa-openscapes-workshops:LongtermAccess-2i2c
             - nasa-openscapes-workshops:WorkshopAccess-2i2c
             - nasa-openscapes-workshops:emit-methane-plume-2024-03-14
           scope:
@@ -212,3 +212,4 @@ basehub:
             - jules32
             - erinmr
             - betolink
+            - ateucher


### PR DESCRIPTION
[Not yet ready to merge!] 

This adds the new 2024 champions cohort and does a bit of cleanup by removing a defunct team from nasa-openscapes-workshops.

We would like to rename nasa-openscapes-workshops:WorkshopAccess-2i2c but not yet sure if that will break access - if so, need to coordinate timing of renaming the team and deploying these changes.

This also adds @ateucher as admin