### PR TITLE
update default image for jupyter-health

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -54,12 +54,12 @@ jupyterhub:
   singleuser:
     defaultUrl: /lab
     profileList:
-      - display_name: "Pangeo Notebook"
+      - display_name: "Default image"
         slug: pangeo
-        description: Pangeo based notebook with a Python environment
+        description: Jupyter Health default image
         default: true
         kubespawner_override:
-          image: quay.io/pangeo/pangeo-notebook:2024.03.22
+          image: quay.io/jupyterhealth/singleuser-premvp:latest
         profile_options: &profile_options
           resource_allocation: &profile_options_resource_allocation
             display_name: Resource Allocation
@@ -101,45 +101,6 @@ jupyterhub:
                   cpu_limit: 3.75
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-              mem_29_7:
-                display_name: 29.7 GB RAM, upto 3.7 CPUs
-                kubespawner_override:
-                  mem_guarantee: 31861460992
-                  mem_limit: 31861460992
-                  cpu_guarantee: 3.75
-                  cpu_limit: 3.75
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
-              mem_60_6:
-                display_name: 60.6 GB RAM, upto 15.7 CPUs
-                kubespawner_override:
-                  mem_guarantee: 65094813696
-                  mem_limit: 65094813696
-                  cpu_guarantee: 7.86
-                  cpu_limit: 15.72
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.4xlarge
-              mem_121_2:
-                display_name: 121.2 GB RAM, upto 15.7 CPUs
-                kubespawner_override:
-                  mem_guarantee: 130189627392
-                  mem_limit: 130189627392
-                  cpu_guarantee: 15.72
-                  cpu_limit: 15.72
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.4xlarge
-      - display_name: "Rocker Geospatial with RStudio"
-        slug: rocker
-        description: R environment with many geospatial libraries pre-installed
-        kubespawner_override:
-          image: rocker/binder:4.3
-          image_pull_policy: Always
-          # Launch RStudio after the user logs in
-          default_url: /rstudio
-          # Ensures container working dir is homedir
-          # https://github.com/2i2c-org/infrastructure/issues/2559
-          working_dir: /home/rstudio
-        profile_options: *profile_options
       - display_name: "Bring your own image"
         description: Specify your own docker image (must have python and jupyterhub installed in it)
         slug: custom


### PR DESCRIPTION
we now have an [image-building repo](https://github.com/jupyterhealth/singleuser-image), so use that

- set default image to https://quay.io/repository/jupyterhealth/singleuser-premvp:latest
- remove large node size choices (we aren't doing anything big yet)
- remove geospatial image choice