### PR TITLE
automation: grafana dashboard deployment requires go-jsonnet

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -58,7 +58,12 @@ jobs:
       - name: Install deployer
         run: |
           python3 -m pip install --editable .
-          sudo apt install jsonnet
+
+      - name: Install jsonnet (go-jsonnet)
+        run: |
+          JSONNET_VERSION=0.20.0
+          wget -qO- https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz \
+              | tar -xvz --one-top-level=$HOME/.local/bin
 
       - name: Install sops
         uses: mdgreenwald/mozilla-sops-action@v1.6.0


### PR DESCRIPTION
`jsonnet` is available in a c++ version and a golang version, and only the golang version works with the library grafonnet versions 10.2.0+ (maybe it was 10.3.0+ or so, but around here) which is used by jupyterhub/grafana-dashboards.

So this change installs the golang based jsonnet instead so that our automation to re-deploy grafana dashboards starts working again.

I've hardcoded the version to 0.20.0, but releases are infrequent and I figure we don't need to automate bumping that.