### PR TITLE
basehub: support creation of admin-sa k8s ServiceAccount via `adminServiceAccount`

### DIFF
--- a/helm-charts/basehub/templates/serviceaccount-admin.yaml
+++ b/helm-charts/basehub/templates/serviceaccount-admin.yaml
@@ -1,0 +1,7 @@
+{{ if .Values.adminServiceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-sa
+  annotations: {{ .Values.adminServiceAccount.annotations | toJson }}
+{{- end }}

--- a/helm-charts/basehub/templates/serviceaccount-user.yaml
+++ b/helm-charts/basehub/templates/serviceaccount-user.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations: {{ .Values.userServiceAccount.annotations | toJson}}
   name: user-sa
+  annotations: {{ .Values.userServiceAccount.annotations | toJson }}
 {{- end }}

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -450,6 +450,8 @@ properties:
                   additionalProperties: true
               extraEnv:
                 type: object
+              serviceAccountName:
+                type: string
           2i2c:
             type: object
             additionalProperties: false

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -16,6 +16,7 @@ required:
   - global
   - jupyterhub
   - userServiceAccount
+  - adminServiceAccount
   - dex
   - staticWebsite
   - ingressBasicAuth
@@ -143,6 +144,27 @@ properties:
 
           Config must still be set for notebook and dask pods to actually use
           this service account, which is named user-sa.
+      annotations:
+        type: object
+        additionalProperties: true
+        description: |
+          Dictionary of annotations that can be applied to the service account.
+
+          When used with GKE and Workload Identity, you need to set
+          the annotation with key "iam.gke.io/gcp-service-account" to the
+          email address of the Google Service Account whose credentials it
+          should have.
+  adminServiceAccount:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enables creation of a Service Account named admin-sa for opt-in use
+          via jupyterhub.custom.singleuserAdmin.serviceAccountName.
       annotations:
         type: object
         additionalProperties: true

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -5,6 +5,10 @@ userServiceAccount:
   enabled: true
   annotations: {}
 
+adminServiceAccount:
+  enabled: false
+  annotations: {}
+
 binderhub-service:
   enabled: false
   nodeSelector:


### PR DESCRIPTION
- **basehub: add custom.singleuserAdmin.serviceAccountName to schema**
- **basehub: support creation of admin-sa k8s ServiceAccount**
