### PR TITLE
opensci, sciencecore: setup admin-sa and a persistent bucket

### DIFF
--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -1,3 +1,12 @@
+userServiceAccount:
+  enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::211125293633:role/opensci-sciencecore
+adminServiceAccount:
+  enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::211125293633:role/opensci-sciencecore-admin-sa
+
 jupyterhub:
   ingress:
     hosts:
@@ -27,7 +36,12 @@ jupyterhub:
         funded_by:
           name: ""
           url: ""
+    singleuserAdmin:
+      serviceAccountName: admin-sa
   singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://opensci-scratch-sciencecore/$(JUPYTERHUB_USER)
+      PERSISTENT_BUCKET: s3://opensci-persistent-sciencecore/$(JUPYTERHUB_USER)
     profileList:
       - display_name: "Only Profile Available, this info is not shown in the UI"
         slug: only-choice

--- a/terraform/aws/projects/opensci.tfvars
+++ b/terraform/aws/projects/opensci.tfvars
@@ -8,21 +8,28 @@ user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7
   },
-  "scratch" : {
+  "scratch-sciencecore" : {
     "delete_after" : 7
+  },
+  "persistent-sciencecore" : {
+    "delete_after" : null
   },
 }
 
 
 hub_cloud_permissions = {
   "staging" : {
-    requestor_pays : true,
-    bucket_admin_access : ["scratch-staging"],
-    extra_iam_policy : ""
+    "user-sa" : {
+      bucket_admin_access : ["scratch-staging"],
+    },
   },
-  "prod" : {
-    requestor_pays : true,
-    bucket_admin_access : ["scratch"],
-    extra_iam_policy : ""
+  "sciencecore" : {
+    "user-sa" : {
+      bucket_admin_access : ["scratch-sciencecore"],
+      bucket_readonly_access : ["persistent-sciencecore"],
+    },
+    "admin-sa" : {
+      bucket_admin_access : ["scratch-sciencecore", "persistent-sciencecore"],
+    },
   },
 }


### PR DESCRIPTION
There is terraform config in this PR that requires logic from #3932 already deployed and applied. By having this merged, we avoid having the sciencecore hub loose its admin/non-admin configured s3 bucket access pending review of #3932 though.