### PR TITLE
opensci, sciencecore: startup jupyterlab instead of classic UI by default

### DIFF
--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -39,6 +39,7 @@ jupyterhub:
     singleuserAdmin:
       serviceAccountName: admin-sa
   singleuser:
+    defaultUrl: /lab
     extraEnv:
       SCRATCH_BUCKET: s3://opensci-scratch-sciencecore/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://opensci-persistent-sciencecore/$(JUPYTERHUB_USER)


### PR DESCRIPTION
Is JupyterLab preferred over the classic UI view for the "Pangeo notebook image" and "Jupyter SciPy Notebook" image choices? This PR makes it so if approved.

Ping @kyttmacmanus and @jmunroe 