### PR TITLE
automation: update kubectl (to 1.28), helm (to 3.14), and python (to 3.11)

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -84,10 +84,10 @@ runs:
 
     # Manually update a pinning of kubectl to a minor version based on:
     #
-    # - the current range of k8s version in our k8s clusters, as of 2023-05-24,
-    #   this is k8s 1.22 - 1.25
-    # - the expected change in this range, as of 2023-05-24, is to expand to
-    #   1.22 - 1.26
+    # - the current range of k8s version in our k8s clusters, as of 2024-04-17,
+    #   this is k8s 1.27 - 1.29
+    # - the next expected change in this range, as of 2024-04-17, is to expand
+    #   to include 1.30
     # - the kubectl <-> k8s api-server skew policy of +/- one minor version
     # - the policy of attempting to update our kubectl version here to be +/-
     #   one minor versions of future k8s clusters additions or upgrades, so that
@@ -105,7 +105,7 @@ runs:
     #
     - uses: azure/setup-kubectl@v4
       with:
-        version: "v1.25.10"
+        version: "v1.28.8"
 
     # This action use the github official cache mechanism internally
     - name: Install sops

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -80,7 +80,7 @@ runs:
         #
         # - helm versions: https://github.com/helm/helm/releases
         #
-        version: v3.12.0
+        version: v3.14.4
 
     # Manually update a pinning of kubectl to a minor version based on:
     #

--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -48,7 +48,7 @@ runs:
   steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.11"
 
     # There will always be a cache hit on the cache key when this composite
     # action is run, as its only done after the "generate-jobs" job has been run

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -73,13 +73,11 @@ jobs:
       prod-hub-matrix-jobs: ${{ env.prod-hub-matrix-jobs }}
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install Python 3.9
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       # There will almost never be a cache hit on the cache key when this job is
       # run, as it is the first of all jobs in this workflow. An exception is if
@@ -225,8 +223,7 @@ jobs:
         jobs: ${{ fromJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup deploy for ${{ matrix.jobs.cluster_name }}
         uses: ./.github/actions/setup-deploy
@@ -398,8 +395,7 @@ jobs:
         jobs: ${{ fromJson(needs.filter-generate-jobs.outputs.filtered-prod-hub-matrix-jobs) }}
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
         uses: ./.github/actions/setup-deploy

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -29,8 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       # Uptime checks are set up and managed via terraform
       - uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/test-deployer-code.yaml
+++ b/.github/workflows/test-deployer-code.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -U pip

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Check for file changes
         # Don't run this step when we manually trigger the workflow
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install deployer module dependencies
         run: |


### PR DESCRIPTION
Kubernetes 1.30 is released today, and we were still using kubectl 1.25 against our clsuters versioned between 1.27 - 1.29, so I figured this bump made sense.