### PR TITLE
Allow self-merging new hub PRs

### DIFF
--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -56,6 +56,8 @@ any approval.
 7. *Cleanly* reverting a change that failed CI
 8. Updating soon to be expired credentials
 9. Spelling and grammar error fixes in documentation or code comments
+10. Setting up a new hub following our new hub turn up process, without any extra feature development
+    or customization.
 
 ## Self-merging as a community partner
 


### PR DESCRIPTION
As part of https://github.com/2i2c-org/meta/issues/897, we are working heavily on *standardizing* what constitutes a new hub. The new hub is first turned up with some standard options, and any non-standard customizations are done after the fact.

Engineers can still request and wait for review if they want to, but I think this will increase our velocity without undue danger. We can always revert this if needed - I feel this is a safe, small thing to try.

Ref https://github.com/2i2c-org/meta/issues/897