### PR TITLE
aws hubs: provide marging in resource requests for user pods to fit on nodes in EKS k8s 1.28+

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -269,65 +269,65 @@ jupyterhub:
               mem_1_9:
                 display_name: 1.9 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 1992701952
-                  mem_limit: 1992701952
-                  cpu_guarantee: 0.234375
-                  cpu_limit: 3.75
+                  mem_guarantee: 1991244775
+                  mem_limit: 1991244775
+                  cpu_guarantee: 0.2328125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3985403904
-                  mem_limit: 3985403904
-                  cpu_guarantee: 0.46875
-                  cpu_limit: 3.75
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
+                  cpu_guarantee: 0.465625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7970807808
-                  mem_limit: 7970807808
-                  cpu_guarantee: 0.9375
-                  cpu_limit: 3.75
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
+                  cpu_guarantee: 0.93125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 15941615616
-                  mem_limit: 15941615616
-                  cpu_guarantee: 1.875
-                  cpu_limit: 3.75
+                  mem_guarantee: 15929958203
+                  mem_limit: 15929958203
+                  cpu_guarantee: 1.8625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_29_7:
                 display_name: 29.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 31883231232
-                  mem_limit: 31883231232
-                  cpu_guarantee: 3.75
-                  cpu_limit: 3.75
+                  mem_guarantee: 31859916406
+                  mem_limit: 31859916406
+                  cpu_guarantee: 3.725
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_60_6:
-                display_name: 60.6 GB RAM, upto 15.7 CPUs
+                display_name: 60.6 GB RAM, upto 15.6 CPUs
                 kubespawner_override:
-                  mem_guarantee: 65094813696
-                  mem_limit: 65094813696
-                  cpu_guarantee: 7.86
-                  cpu_limit: 15.72
+                  mem_guarantee: 65094448840
+                  mem_limit: 65094448840
+                  cpu_guarantee: 7.8475
+                  cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
               mem_121_2:
-                display_name: 121.2 GB RAM, upto 15.7 CPUs
+                display_name: 121.2 GB RAM, upto 15.6 CPUs
                 kubespawner_override:
-                  mem_guarantee: 130189627392
-                  mem_limit: 130189627392
-                  cpu_guarantee: 15.72
-                  cpu_limit: 15.72
+                  mem_guarantee: 130188897681
+                  mem_limit: 130188897681
+                  cpu_guarantee: 15.695
+                  cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
         kubespawner_override:

--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -67,38 +67,38 @@ jupyterhub:
               mem_1_9:
                 display_name: 1.9 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 1991341312
-                  mem_limit: 1991341312
-                  cpu_guarantee: 0.234375
-                  cpu_limit: 3.75
+                  mem_guarantee: 1991244775
+                  mem_limit: 1991244775
+                  cpu_guarantee: 0.2328125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3982682624
-                  mem_limit: 3982682624
-                  cpu_guarantee: 0.46875
-                  cpu_limit: 3.75
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
+                  cpu_guarantee: 0.465625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7965365248
-                  mem_limit: 7965365248
-                  cpu_guarantee: 0.9375
-                  cpu_limit: 3.75
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
+                  cpu_guarantee: 0.93125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 15930730496
-                  mem_limit: 15930730496
-                  cpu_guarantee: 1.875
-                  cpu_limit: 3.75
+                  mem_guarantee: 15929958203
+                  mem_limit: 15929958203
+                  cpu_guarantee: 1.8625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
       - display_name: "Bring your own image"

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -102,29 +102,29 @@ jupyterhub:
               mem_1_9:
                 display_name: 1.9 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 1992701952
-                  mem_limit: 1992701952
-                  cpu_guarantee: 0.234375
-                  cpu_limit: 3.75
+                  mem_guarantee: 1991244775
+                  mem_limit: 1991244775
+                  cpu_guarantee: 0.2328125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3985403904
-                  mem_limit: 3985403904
-                  cpu_guarantee: 0.46875
-                  cpu_limit: 3.75
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
+                  cpu_guarantee: 0.465625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7970807808
-                  mem_limit: 7970807808
-                  cpu_guarantee: 0.9375
-                  cpu_limit: 3.75
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
+                  cpu_guarantee: 0.93125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
       - display_name: R

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -73,65 +73,65 @@ basehub:
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 1991341312
-                    mem_limit: 1991341312
-                    cpu_guarantee: 0.234375
-                    cpu_limit: 3.75
+                    mem_guarantee: 1991244775
+                    mem_limit: 1991244775
+                    cpu_guarantee: 0.2328125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 3982682624
-                    mem_limit: 3982682624
-                    cpu_guarantee: 0.46875
-                    cpu_limit: 3.75
+                    mem_guarantee: 3982489550
+                    mem_limit: 3982489550
+                    cpu_guarantee: 0.465625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 7965365248
-                    mem_limit: 7965365248
-                    cpu_guarantee: 0.9375
-                    cpu_limit: 3.75
+                    mem_guarantee: 7964979101
+                    mem_limit: 7964979101
+                    cpu_guarantee: 0.93125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 15930730496
-                    mem_limit: 15930730496
-                    cpu_guarantee: 1.875
-                    cpu_limit: 3.75
+                    mem_guarantee: 15929958203
+                    mem_limit: 15929958203
+                    cpu_guarantee: 1.8625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 31861460992
-                    mem_limit: 31861460992
-                    cpu_guarantee: 3.75
-                    cpu_limit: 3.75
+                    mem_guarantee: 31859916406
+                    mem_limit: 31859916406
+                    cpu_guarantee: 3.725
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.7 CPUs
+                  display_name: 60.6 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65094813696
-                    mem_limit: 65094813696
-                    cpu_guarantee: 7.86
-                    cpu_limit: 15.72
+                    mem_guarantee: 65094448840
+                    mem_limit: 65094448840
+                    cpu_guarantee: 7.8475
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.7 CPUs
+                  display_name: 121.2 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130189627392
-                    mem_limit: 130189627392
-                    cpu_guarantee: 15.72
-                    cpu_limit: 15.72
+                    mem_guarantee: 130188897681
+                    mem_limit: 130188897681
+                    cpu_guarantee: 15.695
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
         - display_name: "Rocker Geospatial with RStudio"

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -110,65 +110,65 @@ basehub:
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 1991341312
-                    mem_limit: 1991341312
-                    cpu_guarantee: 0.234375
-                    cpu_limit: 3.75
+                    mem_guarantee: 1991244775
+                    mem_limit: 1991244775
+                    cpu_guarantee: 0.2328125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 3982682624
-                    mem_limit: 3982682624
-                    cpu_guarantee: 0.46875
-                    cpu_limit: 3.75
+                    mem_guarantee: 3982489550
+                    mem_limit: 3982489550
+                    cpu_guarantee: 0.465625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 7965365248
-                    mem_limit: 7965365248
-                    cpu_guarantee: 0.9375
-                    cpu_limit: 3.75
+                    mem_guarantee: 7964979101
+                    mem_limit: 7964979101
+                    cpu_guarantee: 0.93125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 15930730496
-                    mem_limit: 15930730496
-                    cpu_guarantee: 1.875
-                    cpu_limit: 3.75
+                    mem_guarantee: 15929958203
+                    mem_limit: 15929958203
+                    cpu_guarantee: 1.8625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 31861460992
-                    mem_limit: 31861460992
-                    cpu_guarantee: 3.75
-                    cpu_limit: 3.75
+                    mem_guarantee: 31859916406
+                    mem_limit: 31859916406
+                    cpu_guarantee: 3.725
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.7 CPUs
+                  display_name: 60.6 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65094813696
-                    mem_limit: 65094813696
-                    cpu_guarantee: 7.86
-                    cpu_limit: 15.72
+                    mem_guarantee: 65094448840
+                    mem_limit: 65094448840
+                    cpu_guarantee: 7.8475
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.7 CPUs
+                  display_name: 121.2 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130189627392
-                    mem_limit: 130189627392
-                    cpu_guarantee: 15.72
-                    cpu_limit: 15.72
+                    mem_guarantee: 130188897681
+                    mem_limit: 130188897681
+                    cpu_guarantee: 15.695
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
         - display_name: "Rocker Geospatial with RStudio"

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -65,65 +65,65 @@ basehub:
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 1991341312
-                    mem_limit: 1991341312
-                    cpu_guarantee: 0.234375
-                    cpu_limit: 3.75
+                    mem_guarantee: 1991244775
+                    mem_limit: 1991244775
+                    cpu_guarantee: 0.2328125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 3982682624
-                    mem_limit: 3982682624
-                    cpu_guarantee: 0.46875
-                    cpu_limit: 3.75
+                    mem_guarantee: 3982489550
+                    mem_limit: 3982489550
+                    cpu_guarantee: 0.465625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 7965365248
-                    mem_limit: 7965365248
-                    cpu_guarantee: 0.9375
-                    cpu_limit: 3.75
+                    mem_guarantee: 7964979101
+                    mem_limit: 7964979101
+                    cpu_guarantee: 0.93125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 15930730496
-                    mem_limit: 15930730496
-                    cpu_guarantee: 1.875
-                    cpu_limit: 3.75
+                    mem_guarantee: 15929958203
+                    mem_limit: 15929958203
+                    cpu_guarantee: 1.8625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 31861460992
-                    mem_limit: 31861460992
-                    cpu_guarantee: 3.75
-                    cpu_limit: 3.75
+                    mem_guarantee: 31859916406
+                    mem_limit: 31859916406
+                    cpu_guarantee: 3.725
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.7 CPUs
+                  display_name: 60.6 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65094813696
-                    mem_limit: 65094813696
-                    cpu_guarantee: 7.86
-                    cpu_limit: 15.72
+                    mem_guarantee: 65094448840
+                    mem_limit: 65094448840
+                    cpu_guarantee: 7.8475
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.7 CPUs
+                  display_name: 121.2 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130189627392
-                    mem_limit: 130189627392
-                    cpu_guarantee: 15.72
-                    cpu_limit: 15.72
+                    mem_guarantee: 130188897681
+                    mem_limit: 130188897681
+                    cpu_guarantee: 15.695
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
         - display_name: R

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -96,38 +96,38 @@ jupyterhub:
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3982682624
-                  mem_limit: 3982682624
-                  cpu_guarantee: 0.46875
-                  cpu_limit: 3.75
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
+                  cpu_guarantee: 0.465625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7965365248
-                  mem_limit: 7965365248
-                  cpu_guarantee: 0.9375
-                  cpu_limit: 3.75
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
+                  cpu_guarantee: 0.93125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 15930730496
-                  mem_limit: 15930730496
-                  cpu_guarantee: 1.875
-                  cpu_limit: 3.75
+                  mem_guarantee: 15929958203
+                  mem_limit: 15929958203
+                  cpu_guarantee: 1.8625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_29_7:
                 display_name: 29.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 31861460992
-                  mem_limit: 31861460992
-                  cpu_guarantee: 3.75
-                  cpu_limit: 3.75
+                  mem_guarantee: 31859916406
+                  mem_limit: 31859916406
+                  cpu_guarantee: 3.725
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
 

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -74,38 +74,38 @@ jupyterhub:
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3982682624
-                  mem_limit: 3982682624
-                  cpu_guarantee: 0.46875
-                  cpu_limit: 3.75
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
+                  cpu_guarantee: 0.465625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7965365248
-                  mem_limit: 7965365248
-                  cpu_guarantee: 0.9375
-                  cpu_limit: 3.75
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
+                  cpu_guarantee: 0.93125
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 15930730496
-                  mem_limit: 15930730496
-                  cpu_guarantee: 1.875
-                  cpu_limit: 3.75
+                  mem_guarantee: 15929958203
+                  mem_limit: 15929958203
+                  cpu_guarantee: 1.8625
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_29_7:
                 display_name: 29.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 31861460992
-                  mem_limit: 31861460992
-                  cpu_guarantee: 3.75
-                  cpu_limit: 3.75
+                  mem_guarantee: 31859916406
+                  mem_limit: 31859916406
+                  cpu_guarantee: 3.725
+                  cpu_limit: 3.725
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
 

--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -92,65 +92,65 @@ basehub:
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 1991341312
-                    mem_limit: 1991341312
-                    cpu_guarantee: 0.234375
-                    cpu_limit: 3.75
+                    mem_guarantee: 1991244775
+                    mem_limit: 1991244775
+                    cpu_guarantee: 0.2328125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 3982682624
-                    mem_limit: 3982682624
-                    cpu_guarantee: 0.46875
-                    cpu_limit: 3.75
+                    mem_guarantee: 3982489550
+                    mem_limit: 3982489550
+                    cpu_guarantee: 0.465625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 7965365248
-                    mem_limit: 7965365248
-                    cpu_guarantee: 0.9375
-                    cpu_limit: 3.75
+                    mem_guarantee: 7964979101
+                    mem_limit: 7964979101
+                    cpu_guarantee: 0.93125
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 15930730496
-                    mem_limit: 15930730496
-                    cpu_guarantee: 1.875
-                    cpu_limit: 3.75
+                    mem_guarantee: 15929958203
+                    mem_limit: 15929958203
+                    cpu_guarantee: 1.8625
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
-                    mem_guarantee: 31861460992
-                    mem_limit: 31861460992
-                    cpu_guarantee: 3.75
-                    cpu_limit: 3.75
+                    mem_guarantee: 31859916406
+                    mem_limit: 31859916406
+                    cpu_guarantee: 3.725
+                    cpu_limit: 3.725
                     node_selector:
                       node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
-                  display_name: 60.6 GB RAM, upto 15.7 CPUs
+                  display_name: 60.6 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 65094813696
-                    mem_limit: 65094813696
-                    cpu_guarantee: 7.86
-                    cpu_limit: 15.72
+                    mem_guarantee: 65094448840
+                    mem_limit: 65094448840
+                    cpu_guarantee: 7.8475
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
                 mem_121_2:
-                  display_name: 121.2 GB RAM, upto 15.7 CPUs
+                  display_name: 121.2 GB RAM, upto 15.6 CPUs
                   kubespawner_override:
-                    mem_guarantee: 130189627392
-                    mem_limit: 130189627392
-                    cpu_guarantee: 15.72
-                    cpu_limit: 15.72
+                    mem_guarantee: 130188897681
+                    mem_limit: 130188897681
+                    cpu_guarantee: 15.695
+                    cpu_limit: 15.695
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
         - display_name: "Rocker Geospatial with RStudio"


### PR DESCRIPTION
EKS k8s 1.28+ eat up a bit more allocatable cpu compared to k8s 1.27 and lower. With no margin for error added, we need to update resource allocation requests.

More details in #3902 --- fixes #3902.

Not having done this is a blocker for doing EKS k8s upgrades, and we should upgrade to k8s 1.28 or 1.29 now according to #3955. I'd like to have this resolved as soon as possible to allow me to do opportunistic k8s upgrades.