### PR TITLE
nasa-esdis: Provide access to grss india workshop team

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -40,7 +40,7 @@ jupyterhub:
         authenticator_class: github
       GitHubOAuthenticator:
         allowed_organizations:
-          - nasa-veda-workshops:ieee-grss-webinar-mar-2024
+          - nasa-veda-workshops:grss-workshop-india-apr-2024
         scope:
           - read:org
       Authenticator:


### PR DESCRIPTION
# Changes
- Removes access from the ieee grss webinar team
- Adds access to the grss india workshop team at SRM university