### PR TITLE
Update version of cryptnono image

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -432,6 +432,10 @@ cryptnono:
         cpu: 5m
         memory: 100Mi
 
+  image:
+    # Brings in https://github.com/cryptnono/cryptnono/pull/33
+    tag: 0.3.1-0.dev.git.138.ha4b11b8
+
   detectors:
     # Disable the execwhacker detector for now, as it matures by being deployed on mybinder.org
     execwhacker:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -434,6 +434,7 @@ cryptnono:
 
   image:
     # Brings in https://github.com/cryptnono/cryptnono/pull/33
+    # FIXME: Unset this once that gets merged and we update to the newest cryptnono version
     tag: 0.3.1-0.dev.git.138.ha4b11b8
 
   detectors:


### PR DESCRIPTION
Brings in https://github.com/cryptnono/cryptnono/pull/33 temporarily, until it gets reviewed and merged.