### PR TITLE
aws hubs: consistent setup of cloud permissions and bucket envs

### DIFF
--- a/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
+++ b/config/clusters/2i2c-aws-us/ncar-cisl.values.yaml
@@ -52,6 +52,8 @@ basehub:
         # pangeo/pangeo-notebook is maintained at: https://github.com/pangeo-data/pangeo-docker-images
         name: pangeo/pangeo-notebook
         tag: "2023.05.18"
+      extraEnv:
+        SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-ncar-cisl/$(JUPYTERHUB_USER)
       profileList:
         # NOTE: About node sharing
         #

--- a/config/clusters/gridsst/prod.values.yaml
+++ b/config/clusters/gridsst/prod.values.yaml
@@ -12,3 +12,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://gridsst.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://gridsst-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/gridsst/staging.values.yaml
+++ b/config/clusters/gridsst/staging.values.yaml
@@ -12,3 +12,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.gridsst.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://gridsst-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/jupyter-health/prod.values.yaml
+++ b/config/clusters/jupyter-health/prod.values.yaml
@@ -11,3 +11,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://jupyter-health.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://jupyter-health-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/jupyter-health/staging.values.yaml
+++ b/config/clusters/jupyter-health/staging.values.yaml
@@ -11,3 +11,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.jupyter-health.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://jupyter-health-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/kitware/prod.values.yaml
+++ b/config/clusters/kitware/prod.values.yaml
@@ -12,3 +12,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://kitware.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://kitware-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/kitware/staging.values.yaml
+++ b/config/clusters/kitware/staging.values.yaml
@@ -12,3 +12,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.kitware.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://kitware-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/nasa-ghg/prod.values.yaml
+++ b/config/clusters/nasa-ghg/prod.values.yaml
@@ -16,3 +16,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://hub.ghg.center/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://nasa-ghg-hub-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -16,3 +16,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.ghg.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://nasa-ghg-hub-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -15,6 +15,8 @@ basehub:
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod
+      extraEnv:
+        SCRATCH_BUCKET: s3://nasa-veda-scratch/$(JUPYTERHUB_USER)
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -6,6 +6,8 @@ basehub:
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging
+      extraEnv:
+        SCRATCH_BUCKET: s3://nasa-veda-scratch-staging/$(JUPYTERHUB_USER)
       initContainers:
         - &volume_ownership_fix_initcontainer
           name: volume-mount-ownership-fix

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -1,3 +1,8 @@
+userServiceAccount:
+  enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::211125293633:role/opensci-staging
+
 jupyterhub:
   ingress:
     hosts:
@@ -28,6 +33,8 @@ jupyterhub:
           name: ""
           url: ""
   singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://opensci-scratch-staging/$(JUPYTERHUB_USER)
     profileList:
       - display_name: "Only Profile Available, this info is not shown in the UI"
         slug: only-choice

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -1,4 +1,9 @@
 basehub:
+  userServiceAccount:
+    enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::969396938818:role/smithsonian-prod
+
   jupyterhub:
     ingress:
       hosts: [smithsonian.2i2c.cloud]
@@ -9,3 +14,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://smithsonian.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://smithsonian-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -1,4 +1,9 @@
 basehub:
+  userServiceAccount:
+    enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::969396938818:role/smithsonian-staging
+
   jupyterhub:
     ingress:
       hosts: [staging.smithsonian.2i2c.cloud]
@@ -9,3 +14,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.smithsonian.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://smithsonian-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/ubc-eoas/prod.values.yaml
+++ b/config/clusters/ubc-eoas/prod.values.yaml
@@ -1,3 +1,8 @@
+userServiceAccount:
+  enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::259060176665:role/ubc-eoas-prod
+
 jupyterhub:
   ingress:
     hosts: [ubc-eoas.2i2c.cloud]
@@ -8,3 +13,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://ubc-eoas.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://ubc-eoas-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/ubc-eoas/staging.values.yaml
+++ b/config/clusters/ubc-eoas/staging.values.yaml
@@ -1,3 +1,8 @@
+userServiceAccount:
+  enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::259060176665:role/ubc-eoas-staging
+
 jupyterhub:
   ingress:
     hosts: [staging.ubc-eoas.2i2c.cloud]
@@ -8,3 +13,6 @@ jupyterhub:
     config:
       CILogonOAuthenticator:
         oauth_callback_url: https://staging.ubc-eoas.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://ubc-eoas-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/victor/prod.values.yaml
+++ b/config/clusters/victor/prod.values.yaml
@@ -13,3 +13,6 @@ basehub:
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://victor.2i2c.cloud/hub/oauth_callback
+    singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://victor-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/victor/staging.values.yaml
+++ b/config/clusters/victor/staging.values.yaml
@@ -14,6 +14,8 @@ basehub:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.victor.2i2c.cloud/hub/oauth_callback
     singleuser:
+      extraEnv:
+        SCRATCH_BUCKET: s3://victor-scratch-staging/$(JUPYTERHUB_USER)
       profileList:
         # Create a small instance that can launch a custom image
         - display_name: "Bring your own image - Small: m5.large"


### PR DESCRIPTION
I saw that we had several hubs where buckets were setup in terraform, but not made available to hubs. This PR setups access to the buckets.

Does parts of whats needed for #3864 - looked at all AWS clusters' hubs.

- This PR hasn't verified access works, and for several hubs I think it won't work due to `singleuser.cloudMetadata.blockWithIptables` defaulting to false, for example for opensci's staging hub.
- This PR has used terraform as the source of truth if hubs should have access to buckets - so if a scratch bucket was defined for staging, then staging should have access to if for example. So, we could opt to instead delete the buckets from terraform as an alternative to setting up access to it.