### PR TITLE
basehub: allow shared-volume-reporter to be disabled, and disable it on 2i2c-aws-us and catalystproject-africa

### DIFF
--- a/config/clusters/2i2c-aws-us/basehub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/basehub-common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
   enabled: true
+  volumeReporter:
+    enabled: false
   pv:
     enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
     enabled: true
+    volumeReporter:
+      enabled: false
     pv:
       enabled: true
       # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html

--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -1,5 +1,9 @@
 nfs:
   enabled: true
+  # volumeReporter will report 100% for all hubs as EFS is unbounded, we disable
+  # it to save a limited amount of pods we can allocate per core node
+  volumeReporter:
+    enabled: false
   pv:
     enabled: true
     # from https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html

--- a/helm-charts/basehub/templates/home-space-reporter.yaml
+++ b/helm-charts/basehub/templates/home-space-reporter.yaml
@@ -1,7 +1,15 @@
 {{- if .Values.nfs.enabled }}
+{{- if .Values.nfs.volumeReporter.enabled }}
 # To provide data for the jupyterhub/grafana-dashboards dashboard about free
 # space in the shared volume, which contains users home folders etc, we deploy
 # prometheus node-exporter to collect this data for prometheus server to scrape.
+#
+# This prometheus metrics exporter will when used against a shared EFS storage
+# (AWS NFS service) report an extreme amount of available disk space, making the
+# available space remaining 100%. This makes the jupyterhub/grafana-dashboards
+# graph reporting remaining available disk space in % quite pointless. Due to
+# that, it can make sense to disable this if EFS is used to provide storage as
+# it becomes another pod that eats up the available pods per node.
 #
 # This is based on the Deployment manifest in jupyterhub/grafana-dashboards'
 # readme: https://github.com/jupyterhub/grafana-dashboards#additional-collectors
@@ -64,4 +72,5 @@ spec:
         - name: shared-volume
           persistentVolumeClaim:
             claimName: home-nfs
+{{- end }}
 {{- end }}

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -194,6 +194,14 @@ properties:
         properties:
           enabled:
             type: boolean
+      volumeReporter:
+        type: object
+        additionalProperties: false
+        required:
+          - enabled
+        properties:
+          enabled:
+            type: boolean
       shareCreator:
         type: object
         additionalProperties: false

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -71,6 +71,8 @@ nfs:
   enabled: false
   dirsizeReporter:
     enabled: true
+  volumeReporter:
+    enabled: true
   shareCreator:
     enabled: true
     tolerations: []


### PR DESCRIPTION
Technically why this is acceptable is detailed in #3999.

2i2c-aws-us runs two core nodes, but only requires one for its CPU/memory needs. What makes us have two is the fact that we need room for 66 pods, but each core node only allows for 57 per node.

With this change, we reduce the pods to run on the core nodes with one pod per hub we have deployed --- 7 pods. And that in turn combined with other pod reductions like #3869 will get us below 57 pods to run on the core nodes, allowing us to cut cost for communities on 2i2c-aws-us (I think with almost 200USD total) and help us demonstrate more cost effective cloud operations.

## Related
- #3999 
- Another pod reduction PR: #3869