### PR TITLE
2i2c, climatematch: update authorized github users

### DIFF
--- a/config/clusters/2i2c/climatematch.values.yaml
+++ b/config/clusters/2i2c/climatematch.values.yaml
@@ -87,10 +87,10 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://climatematch.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - ClimateMatchAcademy:2023students
+          - ClimateMatchAcademy:2024students
         scope:
           - read:org
       Authenticator:
         admin_users:
-          - WesleyTheGeolien
+          - iamzoltan
           - abodner


### PR DESCRIPTION
Changes for the 2024 Climate Course at Neuromatch.

Is it possible for these changes to take effect May 1?