### PR TITLE
Update spyglass image

### DIFF
--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -67,7 +67,7 @@ jupyterhub:
     defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2FLorenFrankLab%2Fspyglass-demo&urlpath=lab%2Ftree%2Fspyglass-demo%2Fnotebooks%2F00_HubQuickStart.ipynb&branch=main
     image:
       name: quay.io/lorenlab/hhmi-spyglass-image
-      tag: "62b90867ea22"
+      tag: "82450331e8f1"
     memory:
       limit: 3.4G
       guarantee: 3.4G


### PR DESCRIPTION
This updates the image tag for spyglass since we've just pushed an addition of jupyterlab-myst

I'm assuming this is the right tag based on [the GitHub action logs here](https://github.com/LorenFrankLab/hhmi-spyglass-image/actions/runs/8900298360/job/24441556790):

<img width="836" alt="image" src="https://github.com/2i2c-org/infrastructure/assets/1839645/f0e12c47-2ebf-4e33-bfca-6de7a4bfc4fd">

And the quay.io page here:

![CleanShot 2024-04-30 at 12 24 26@2x](https://github.com/2i2c-org/infrastructure/assets/1839645/8f71f791-7a25-47f2-bde8-1331a64a2d2a)
