### PR TITLE
Remove feature for restricting profile options based on github org membership

### DIFF
--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -66,30 +66,9 @@ You can remove yourself from the org once you have confirmed that login is worki
      ...
    ```
 
-4. **Edit the non-secret config under `config/clusters/<cluster_name>/<hub_name>.values.yaml`.**
-   You should make sure the matching hub config takes one of the following forms.
-
-   To authenticate against a GitHub organisation (Note the `read:user` scope. See comment box below.):
-
-    ```yaml
-    jupyterhub:
-      custom:
-        2i2c:
-          add_staff_user_ids_to_admin_users: true
-          add_staff_user_ids_of_type: github
-      hub:
-        config:
-          JupyterHub:
-            authenticator_class: github
-          GitHubOAuthenticator:
-            oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
-            allowed_organizations:
-              - ORG_NAME
-            scope:
-              - read:user
-    ```
-
-   To authenticate against a GitHub Team (Note the `read:org` scope. See the comment box below.):
+4. **Edit the non-secret config under `config/clusters/<cluster_name>/<hub_name>.values.yaml`,**
+   making sure we ask for enough permissions (`read:org`) so we know what organizations (or
+   teams) users are a part of
 
     ```yaml
     jupyterhub:
@@ -105,17 +84,9 @@ You can remove yourself from the org once you have confirmed that login is worki
             oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
             allowed_organizations:
               - ORG_NAME:TEAM_NAME
+              - ORG_NAME
             scope:
               - read:org
-    ```
-
-    ```{admonition} A note on scopes
-    When authenticating against a whole organisation, we used the `read:user` scope in the example above.
-    This means that the GitHub OAuth App will read the _user's_ profile to determine whether the currently authenticating user is a member of the listed organisation. **It also requires the user to have their membership of the organisation publicly listed otherwise authentication will fail, even if they are valid members.**
-
-    To avoid this requirement, you may choose to use the `read:org` scope instead. This grants the GitHub OAuth App permission to read the profile of the _whole organisation_, however, and may be more powerful than the organisation owners wish to grant. So use your best judgment here.
-
-    When authenticating against a GitHub Team, we are required to use the `read:org` scope as the GitHub OAuth App needs to know which teams belong to the organisation as well as the members of the specified team.
     ```
 
     ````{note}

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -173,8 +173,7 @@ This only works if the hub is already set to allow people only from certain GitH
 to log in.
 
 The key `allowed_teams` can be set for any profile definition, with a list of GitHub
-teams (formatted as `<github-org>:<team-name>`) or GitHub organizations (formatted
-just as `<github-org>`) that will get access to that profile. Users
+teams (formatted as `<github-org>:<team-name>`) that will get access to that profile. Users
 need to be a member of any one of the listed teams for access. The list of teams a user
 is part of is fetched at login time - so if the user is added to a GitHub team, they need
 to log out and log back in to the JupyterHub (not necessarily to GitHub!) to see the new
@@ -200,7 +199,7 @@ To enable this access,
 
    If `populate_teams_in_auth_state` is not set, this entire feature is disabled.
 
-2. Specify which teams or orgs should have access to which profiles with an
+2. Specify which teams should have access to which profiles with an
    `allowed_teams` key under `profileList`:
 
     ```yaml
@@ -230,6 +229,12 @@ To enable this access,
     that profile. Add `2i2c-org:hub-access-for-2i2c-staff` to all
     `allowed_teams` so 2i2c engineers can log in to debug issues. If
     `allowed_teams` is not set, that profile is not available to anyone.
+
+    ```{note}
+    We used to allow restricting which profiles users can see based on what
+    org they were a part of, rather than just the *teams* they were a part of.
+    We no longer support this.
+    ```
 
 ### Enabling team based access on hub with pre-existing users
 

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1043,11 +1043,8 @@ jupyterhub:
                     allowed_profiles.append(profile)
                     continue
 
-                # allowed_teams can be "org" or "org:team", and we check
-                # membership just in time for orgs if needed
-                # casefold them so we can do case insensitive comparisons, as github itself is case insensitive (but preserving)
+                # casefold teams so we can do case insensitive comparisons, as github itself is case insensitive (but preserving)
                 # for orgs and teams
-                allowed_orgs = set([o.casefold() for o in allowed_teams if ':' not in o])
                 allowed_teams = set([t.casefold() for t in allowed_teams if ':' in t])
 
                 if allowed_teams & teams:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1055,24 +1055,6 @@ jupyterhub:
                     allowed_profiles.append(profile)
                     continue
 
-                if "token_response" in auth_state:
-                    access_token = auth_state["token_response"]["access_token"]
-                    token_type = auth_state["token_response"]["token_type"]
-                else:
-                    # token_response was introduced to auth_state in
-                    # oauthenticator 16, so this is adjusting to an auth_state
-                    # set by oauthenticator 15
-                    access_token = auth_state["access_token"]
-                    token_type = "token"
-                for allowed_org in allowed_orgs:
-                    user_in_allowed_org = await spawner.authenticator._check_membership_allowed_organizations(
-                        allowed_org, spawner.user.name, access_token, token_type
-                    )
-                    if user_in_allowed_org:
-                        print(f"Allowing profile {profile['display_name']} for user {spawner.user.name} based on org membership")
-                        allowed_profiles.append(profile)
-                        break
-
             if len(allowed_profiles) == 0:
                 # If no profiles are allowed, user should not be able to spawn anything!
                 # If we don't explicitly stop this, user will be logged into the 'default' settings


### PR DESCRIPTION
This gets rid of restricting profile options based on github *org* membership, rather than *teams* membership. This is a complete no-op for any of our communities, as it turns out nobody is using this feature! Getting rid of this makes sure that new communities will not use this feature, as it relies on internal implementation details of the GitHub authenticator and may be hard to upstream when the time comes. See https://github.com/2i2c-org/infrastructure/issues/4021 for upstreaming plan.

Ref https://github.com/2i2c-org/infrastructure/issues/3900
https://github.com/2i2c-org/infrastructure/pull/3883 is based on this.