### PR TITLE
terraform, gcp: declare regional_cluster explicitly only when false

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -1,9 +1,8 @@
 prefix     = "two-eye-two-see-uk"
 project_id = "two-eye-two-see-uk"
 
-zone             = "europe-west2-b"
-region           = "europe-west2"
-regional_cluster = true
+zone   = "europe-west2-b"
+region = "europe-west2"
 
 k8s_versions = {
   min_master_version : "1.27.4-gke.900",

--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -2,7 +2,6 @@ prefix                = "latam"
 project_id            = "catalystproject-392106"
 region                = "southamerica-east1"
 zone                  = "southamerica-east1-c"
-regional_cluster      = true
 enable_network_policy = true
 
 k8s_versions = {

--- a/terraform/gcp/projects/cluster.tfvars.template
+++ b/terraform/gcp/projects/cluster.tfvars.template
@@ -11,9 +11,6 @@ project_id = "{{ project_id }}"
 zone   = "{{ cluster_region }}"
 region = "{{ cluster_region }}"
 
-# Default to a HA cluster for reliability
-regional_cluster = true
-
 # TODO: Before applying this, identify a k8s version to specify. Pick the latest
 #       k8s version from GKE's regular release channel. Look at the output
 #       called `regular_channel_latest_k8s_versions` as seen when using

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -4,9 +4,6 @@ project_id = "hhmi-398911"
 zone   = "us-west2-b"
 region = "us-west2"
 
-# Default to a HA cluster for reliability
-regional_cluster = true
-
 core_node_machine_type = "n2-highmem-4"
 
 k8s_versions = {

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -12,9 +12,8 @@ k8s_versions = {
 }
 
 # GPUs not available in us-central1-b
-zone             = "us-central1-c"
-region           = "us-central1"
-regional_cluster = true
+zone   = "us-central1-c"
+region = "us-central1"
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy = true

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -1,9 +1,8 @@
 prefix     = "linked-earth"
 project_id = "linked-earth-hubs"
 
-zone             = "us-central1-c"
-region           = "us-central1"
-regional_cluster = true
+zone   = "us-central1-c"
+region = "us-central1"
 
 k8s_versions = {
   min_master_version : "1.27.4-gke.900",

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -23,6 +23,7 @@ project_id             = "pangeo-integration-te-3eea"
 billing_project_id     = "pangeo-integration-te-3eea"
 zone                   = "us-central1-b"
 region                 = "us-central1"
+regional_cluster       = false
 core_node_machine_type = "n2-highmem-4"
 enable_private_cluster = true
 
@@ -39,8 +40,6 @@ enable_network_policy = true
 # Setup a filestore for NFS
 enable_filestore      = true
 filestore_capacity_gb = 4608
-
-regional_cluster = false
 
 
 user_buckets = {

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -1,9 +1,8 @@
 prefix     = "qcl"
 project_id = "qcl-hub"
 
-zone             = "europe-west1-d"
-region           = "europe-west1"
-regional_cluster = true
+zone   = "europe-west1-d"
+region = "europe-west1"
 
 k8s_versions = {
   min_master_version : "1.27.4-gke.900",


### PR DESCRIPTION
Previously we declared regional_cluster explicitly to true sometimes, and othertimes it was omitted and the default value (true) of the variable was used. With this PR we simply lean on the default variable value consistently instead.

For example `awi-ciroh.tfvars` didn't include regional_cluster=true, but `leap.tfvars` did.

(PR Extracted from #3464)