### PR TITLE
Add missing inline comments

### DIFF
--- a/config/clusters/2i2c-aws-us/basehub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/basehub-common.values.yaml
@@ -1,5 +1,7 @@
 nfs:
   enabled: true
+  # volumeReporter will report 100% for all hubs as EFS is unbounded, we disable
+  # it to save a limited amount of pods we can allocate per core node
   volumeReporter:
     enabled: false
   pv:

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -1,6 +1,8 @@
 basehub:
   nfs:
     enabled: true
+    # volumeReporter will report 100% for all hubs as EFS is unbounded, we disable
+    # it to save a limited amount of pods we can allocate per core node
     volumeReporter:
       enabled: false
     pv:


### PR DESCRIPTION
I disabled volumeReporter in #4000 for 2i2c-aws-us and catalystproject-africa in order to try get them to use just one core node  instead of two, but I forgot to commit an inline comment describing this in the config for 2i2c-aws-us.