### PR TITLE
GHG Center: Add profile options for workshop

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -113,7 +113,7 @@ basehub:
                     cpu_guarantee: 12
                     cpu_limit: 12
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.4xlarge                                                     
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -96,7 +96,7 @@ basehub:
                     cpu_limit: 12
                     node_selector:
                       node.kubernetes.io/instance-type: r5.4xlarge
-                cpu_12_16:
+                cpu_8_24:
                   display_name: 8 CPU, 24GB RAM
                   kubespawner_override:
                     mem_guarantee: 22.305Gi

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -105,8 +105,7 @@ basehub:
                     cpu_guarantee: 6
                     cpu_limit: 11.8
                     node_selector:
-                      node.kubernetes.io/instance-type: c5.4xlarge
-                                                      
+                      node.kubernetes.io/instance-type: c5.4xlarge                                                     
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -70,6 +70,43 @@ basehub:
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation
               choices:
+                cpu_8_16:
+                  display_name: 8 CPU, 16GB RAM
+                  kubespawner_override:
+                    mem_guarantee: 14.87Gi
+                    mem_limit: 14.87Gi
+                    cpu_guarantee: 4
+                    cpu_limit: 7.8
+                    node_selector:
+                      node.kubernetes.io/instance-type: c5.4xlarge
+                cpu_12_16:
+                  display_name: 12 CPU, 16GB RAM
+                  kubespawner_override:
+                    mem_guarantee: 14.87Gi
+                    mem_limit: 14.87Gi
+                    cpu_guarantee: 6
+                    cpu_limit: 11.8
+                    node_selector:
+                      node.kubernetes.io/instance-type: c5.4xlarge
+                cpu_12_16:
+                  display_name: 8 CPU, 24GB RAM
+                  kubespawner_override:
+                    mem_guarantee: 22.305Gi
+                    mem_limit: 22.305Gi
+                    cpu_guarantee: 4
+                    cpu_limit: 7.8
+                    node_selector:
+                      node.kubernetes.io/instance-type: c5.4xlarge
+                cpu_12_16:
+                  display_name: 12 CPU, 24GB RAM
+                  kubespawner_override:
+                    mem_guarantee: 22.305Gi
+                    mem_limit: 22.305Gi
+                    cpu_guarantee: 6
+                    cpu_limit: 11.8
+                    node_selector:
+                      node.kubernetes.io/instance-type: c5.4xlarge
+                                                      
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -70,42 +70,50 @@ basehub:
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation
               choices:
+                # The `cpu_` options are added by hand, temporarily,
+                # to help evaluate ideal resource options for an upcoming workshop.
+                # See: https://github.com/NASA-IMPACT/veda-jupyterhub/issues/32
+                # Once we settle on the ideal resource allocation for the workshop, we should:
+                #  - Create a new profile for the workshop, with just the resource option needed
+                #  - Pick a more appropriate (compute-optimized) node type and add to eksctl
+                #  - Remove these options from the global resource select options
+                #  - Remove this comment.
                 cpu_8_16:
                   display_name: 8 CPU, 16GB RAM
                   kubespawner_override:
                     mem_guarantee: 14.87Gi
                     mem_limit: 14.87Gi
-                    cpu_guarantee: 4
-                    cpu_limit: 7.8
+                    cpu_guarantee: 8
+                    cpu_limit: 8
                     node_selector:
-                      node.kubernetes.io/instance-type: c5.4xlarge
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 cpu_12_16:
                   display_name: 12 CPU, 16GB RAM
                   kubespawner_override:
                     mem_guarantee: 14.87Gi
                     mem_limit: 14.87Gi
-                    cpu_guarantee: 6
-                    cpu_limit: 11.8
+                    cpu_guarantee: 12
+                    cpu_limit: 12
                     node_selector:
-                      node.kubernetes.io/instance-type: c5.4xlarge
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 cpu_12_16:
                   display_name: 8 CPU, 24GB RAM
                   kubespawner_override:
                     mem_guarantee: 22.305Gi
                     mem_limit: 22.305Gi
-                    cpu_guarantee: 4
-                    cpu_limit: 7.8
+                    cpu_guarantee: 8
+                    cpu_limit: 8
                     node_selector:
-                      node.kubernetes.io/instance-type: c5.4xlarge
-                cpu_12_16:
+                      node.kubernetes.io/instance-type: r5.4xlarge
+                cpu_12_24:
                   display_name: 12 CPU, 24GB RAM
                   kubespawner_override:
                     mem_guarantee: 22.305Gi
                     mem_limit: 22.305Gi
-                    cpu_guarantee: 6
-                    cpu_limit: 11.8
+                    cpu_guarantee: 12
+                    cpu_limit: 12
                     node_selector:
-                      node.kubernetes.io/instance-type: c5.4xlarge                                                     
+                      node.kubernetes.io/instance-type: r5.4xlarge                                                     
                 mem_1_9:
                   display_name: 1.9 GB RAM, upto 3.7 CPUs
                   kubespawner_override:

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -27,8 +27,7 @@ local nodeAz = "us-west-2a";
 local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
-    { instanceType: "r5.16xlarge" },
-    { instanceType: "c5.4xlarge" }
+    { instanceType: "r5.16xlarge" }
 ];
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -28,6 +28,7 @@ local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
     { instanceType: "r5.16xlarge" },
+    { instanceType: "c5.4xlarge" }
 ];
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -27,7 +27,7 @@ local nodeAz = "us-west-2a";
 local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" },
-    { instanceType: "r5.16xlarge" }
+    { instanceType: "r5.16xlarge" },
 ];
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged


### PR DESCRIPTION
Refs https://github.com/NASA-IMPACT/veda-jupyterhub/issues/32

Adding some compute-optimized options for containers.

This:

 - Adds a `c5.4xlarge` instance type to the `eksctl` config to create a nodepool with that instance type (compute optimized)
 - Adds resource options to the profile list for the compute optimized containers

Questions:

 - Should we include the workshop in the `display_name` or so to distinguish these options?
 - @yuvipanda please let me know if the way the resources are specified seems okay - I did some rough conversions between bits and GiB and put in values that seemed appropriate
 - Also, I've set the `cpu_limit` to be what's requested, but the `cpu_guarantee` a bit lower in line with the other resource options, lemme know if that seems okay

@yuvipanda let me know if these seem okay - happy to make any changes :)

cc @sunu @slesaad 