### PR TITLE
[maintenance] k8s version upgrade

### DIFF
--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -77,9 +77,9 @@ gke:
   meom-ige:
     requesting_daemon_sets: fluentbit-gke,gke-metadata-server,gke-metrics-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 234m
-    memory_requests: 580Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 244m
+    memory_requests: 640Mi
+    k8s_version: v1.29.1-gke.1589018
   pangeo-hubs:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -83,9 +83,9 @@ gke:
   pangeo-hubs:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   qcl:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -47,9 +47,9 @@ gke:
   catalystproject-latam:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 338m
-    memory_requests: 496Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 348m
+    memory_requests: 556Mi
+    k8s_version: v1.29.1-gke.1589018
   cloudbank:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -5,9 +5,9 @@ zone                  = "southamerica-east1-c"
 enable_network_policy = true
 
 k8s_versions = {
-  min_master_version : "1.27.2-gke.1200",
-  core_nodes_version : "1.27.2-gke.1200",
-  notebook_nodes_version : "1.27.2-gke.1200",
+  min_master_version : "1.29.1-gke.1589018",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
 }
 
 enable_filestore      = true

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -6,9 +6,9 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-4"

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -28,10 +28,10 @@ core_node_machine_type = "n2-highmem-4"
 enable_private_cluster = true
 
 k8s_versions = {
-  min_master_version : "1.27.5-gke.200",
-  core_nodes_version : "1.27.5-gke.200",
-  notebook_nodes_version : "1.27.5-gke.200",
-  dask_nodes_version : "1.27.5-gke.200",
+  min_master_version : "1.29.1-gke.1589018",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 # Multi-tenant cluster, network policy is required to enforce separation between hubs


### PR DESCRIPTION
- related https://github.com/2i2c-org/infrastructure/issues/4006

Clusters upgraded:

- meom-ige
- pangeo-hubs
- catalystproject-latam

All change have been tf applied successfully