### PR TITLE
2i2c-uk and linked-earth: k8s upgraded from 1.27 to 1.29

### DIFF
--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -29,9 +29,9 @@ gke:
   2i2c-uk:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   awi-ciroh:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -71,9 +71,9 @@ gke:
   linked-earth:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   meom-ige:
     requesting_daemon_sets: fluentbit-gke,gke-metadata-server,gke-metrics-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/deployer/commands/generate/resource_allocation/instance_capacities.yaml
+++ b/deployer/commands/generate/resource_allocation/instance_capacities.yaml
@@ -30,9 +30,9 @@ n2-highmem-4:
   cpu_capacity_high: 4.0
   cpu_allocatable_low: 3.92
   cpu_allocatable_high: 3.92
-  mem_capacity_low: 31.357Gi
+  mem_capacity_low: 31.354Gi
   mem_capacity_high: 31.357Gi
-  mem_allocatable_low: 27.738Gi
+  mem_allocatable_low: 27.734Gi
   mem_allocatable_high: 27.738Gi
 n2-highmem-8:
   cpu_capacity_low: 8.0
@@ -48,9 +48,9 @@ n2-highmem-16:
   cpu_capacity_high: 16.0
   cpu_allocatable_low: 15.89
   cpu_allocatable_high: 15.89
-  mem_capacity_low: 125.807Gi
+  mem_capacity_low: 125.804Gi
   mem_capacity_high: 125.81Gi
-  mem_allocatable_low: 116.549Gi
+  mem_allocatable_low: 116.545Gi
   mem_allocatable_high: 116.551Gi
 n2-highmem-32:
   cpu_capacity_low: 32.0
@@ -66,28 +66,46 @@ n1-standard-2:
   cpu_capacity_high: 2.0
   cpu_allocatable_low: 1.93
   cpu_allocatable_high: 1.93
-  mem_capacity_low: 7.276Gi
+  mem_capacity_low: 7.272Gi
   mem_capacity_high: 7.276Gi
-  mem_allocatable_low: 5.483Gi
+  mem_allocatable_low: 5.479Gi
   mem_allocatable_high: 5.483Gi
 n1-standard-8:
   cpu_capacity_low: 8.0
   cpu_capacity_high: 8.0
   cpu_allocatable_low: 7.91
   cpu_allocatable_high: 7.91
-  mem_capacity_low: 29.387Gi
+  mem_capacity_low: 29.384Gi
   mem_capacity_high: 29.387Gi
-  mem_allocatable_low: 25.888Gi
+  mem_allocatable_low: 25.885Gi
   mem_allocatable_high: 25.888Gi
 n1-standard-16:
   cpu_capacity_low: 16.0
   cpu_capacity_high: 16.0
   cpu_allocatable_low: 15.89
   cpu_allocatable_high: 15.89
-  mem_capacity_low: 58.87Gi
+  mem_capacity_low: 58.866Gi
   mem_capacity_high: 58.87Gi
-  mem_allocatable_low: 53.571Gi
+  mem_allocatable_low: 53.567Gi
   mem_allocatable_high: 53.571Gi
+n1-standard-32:
+  cpu_capacity_low: 32.0
+  cpu_capacity_high: 32.0
+  cpu_allocatable_low: 31.85
+  cpu_allocatable_high: 31.85
+  mem_capacity_low: 117.925Gi
+  mem_capacity_high: 117.925Gi
+  mem_allocatable_low: 109.027Gi
+  mem_allocatable_high: 109.027Gi
+n1-standard-64:
+  cpu_capacity_low: 64.0
+  cpu_capacity_high: 64.0
+  cpu_allocatable_low: 63.77
+  cpu_allocatable_high: 63.77
+  mem_capacity_low: 235.947Gi
+  mem_capacity_high: 235.947Gi
+  mem_allocatable_low: 224.448Gi
+  mem_allocatable_high: 224.448Gi
 
 # EKS instance types
 r5.xlarge:

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -5,9 +5,9 @@ zone   = "europe-west2-b"
 region = "europe-west2"
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-4"
@@ -18,7 +18,15 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
+  # FIXME: This was held back during an upgrade, once its empty we should delete
+  #        it and rely on the -b node pool.
   "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+    node_version : "1.27.4-gke.900",
+  },
+  "n2-highmem-4-b" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
@@ -32,7 +40,7 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-  }
+  },
 }
 
 user_buckets = {}

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -18,14 +18,6 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
-  # FIXME: This was held back during an upgrade, once its empty we should delete
-  #        it and rely on the -b node pool.
-  "n2-highmem-4" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-4",
-    node_version : "1.27.4-gke.900",
-  },
   "n2-highmem-4-b" : {
     min : 0,
     max : 100,

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -5,10 +5,10 @@ zone   = "us-central1-c"
 region = "us-central1"
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
-  dask_nodes_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-4"


### PR DESCRIPTION
- Two GKE clusters upgraded for #4006