### PR TITLE
2i2c-aws-us/itcoocean and pangeo-hubs: enable auth state and populate github teams

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -34,12 +34,14 @@ jupyterhub:
         authenticator_class: github
       GitHubOAuthenticator:
         oauth_callback_url: https://itcoocean.2i2c.cloud/hub/oauth_callback
+        populate_teams_in_auth_state: true
         allowed_organizations:
           - Hackweek-ITCOocean:itcoocean-hackweek-2023
           - nmfs-opensci:2i2c-demo
         scope:
           - read:org
       Authenticator:
+        enable_auth_state: true
         admin_users:
           - eeholmes # Eli Holmes, Community representative
   singleuser:

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -191,7 +191,6 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
-          enable_auth_state: true
           populate_teams_in_auth_state: true
           allowed_organizations:
             - 2i2c-org:hub-access-for-2i2c-staff
@@ -207,6 +206,7 @@ basehub:
           scope:
             - read:org
         Authenticator:
+          enable_auth_state: true
           admin_users:
             - amfriesz
             - jules32

--- a/config/clusters/pangeo-hubs/common.values.yaml
+++ b/config/clusters/pangeo-hubs/common.values.yaml
@@ -36,11 +36,13 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
+          populate_teams_in_auth_state: true
           allowed_organizations:
             - pangeo-data:us-central1-b-gcp
           scope:
             - read:org
         Authenticator:
+          enable_auth_state: true
           admin_users:
             - rabernat
             - jhamman


### PR DESCRIPTION
Related to #4043.

I see that we have this error:

```
User scottyhq does not have any auth_state set, profile_list filtering not available
User scottyhq is part of groups 
[W 2024-05-08 16:54:56.672 JupyterHub web:1873] 403 GET /hub/spawn (10.128.0.52): 
    Your JupyterHub group membership is insufficient to launch any server profiles.
    
    JupyterHub groups you are a member of are .
    
    If you are part of additional groups, log out of this JupyterHub and log back in to refresh that information.
```

And I saw no config in pangeo-hubs about enabling auth state stuff - have they recently introduced allowed_teams or similar in profile lists?

---

- [FIXED] 2i2c-aws-us, itcoocean
- [OK] 2i2c-aws-us, showcase
- [OK] leap
- [OK] meom-ige
- [OK] nasa-cryo
- [OK] openscapes
- [FIXED] pangeo-hubs
- [OK] smithsonian
