### PR TITLE
nasa-ghg and nasa-veda: Use an init container to populate example notebooks

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -66,6 +66,42 @@ basehub:
           default: true
           kubespawner_override:
             image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
+            init_containers:
+              # Need to explicitly fix ownership here, as otherwise these directories will be owned
+              # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid
+              - name: volume-mount-ownership-fix
+                image: busybox:1.36.1
+                command:
+                  - sh
+                  - -c
+                  - id && chown 1000:1000 /home/jovyan /home/jovyan/shared && ls -lhd /home/jovyan
+                securityContext:
+                  runAsUser: 0
+                volumeMounts:
+                  - name: home
+                    mountPath: /home/jovyan
+                    subPath: "{username}"
+                  # mounted without readonly attribute here,
+                  # so we can chown it appropriately
+                  - name: home
+                    mountPath: /home/jovyan/shared
+                    subPath: _shared
+              # this container uses nbgitpuller to mount https://github.com/US-GHG-Center/ghgc-docs/ for user pods
+              # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init
+              - name: jupyterhub-gitpuller-init
+                image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
+                env:
+                  - name: TARGET_PATH
+                    value: ghgc-docs
+                  - name: SOURCE_REPO
+                    value: "https://github.com/US-GHG-Center/ghgc-docs"
+                volumeMounts:
+                  - name: home
+                    mountPath: /home/jovyan
+                    subPath: "{username}"
+                securityContext:
+                  runAsUser: 1000
+                  runAsGroup: 1000
           profile_options: &profile_options
             resource_allocation: &profile_options_resource_allocation
               display_name: Resource Allocation

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -90,13 +90,14 @@ basehub:
                     mountPath: /home/jovyan/shared
                     subPath: _shared
               # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
-              # image source: https://github.com/NASA-IMPACT/veda-jh-environments/tree/main/docker-images/base/nasa-veda-singleuser-init
-              - name: nasa-veda-singleuser-init
-                image: public.ecr.aws/nasa-veda/nasa-veda-singleuser-init:38e8998f9be64b0a59ac6c4d6d152d3403121dfc4be6d49bdf52ddc92827af8a
-                command:
-                  - "python3"
-                  - "/opt/k8s-init-container-nb-docs.py"
-                  - "/home/jovyan"
+              # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init
+              - name: jupyterhub-gitpuller-init
+                image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
+                env:
+                  - name: TARGET_PATH
+                    value: veda-docs
+                  - name: SOURCE_REPO
+                    value: "https://github.com/NASA-IMPACT/veda-docs"
                 volumeMounts:
                   - name: home
                     mountPath: /home/jovyan


### PR DESCRIPTION
We use [jupyterhub-gitpuller-init](https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init) to clone the example notebooks into the user's workspace for nasa-veda and nasa-ghg hubs.

Addresses https://github.com/NASA-IMPACT/veda-jupyterhub/issues/28 and https://github.com/NASA-IMPACT/veda-jupyterhub/issues/18

cc @batpad 