### PR TITLE
4/6 gke clusters still on 1.27: update to 1.29

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -21,5 +21,5 @@ jupyterhub:
       name: quay.io/2i2c/cloudbank-data8-image
       tag: d2746e55a4ee
     nodeSelector:
-      # Put everything on the most appropriate nodepool for these users
-      cloud.google.com/gke-nodepool: nb-n2-highmem-4
+      # Put everything on the most appropriate instance type for these users
+      node.kubernetes.io/instance-type: n2-highmem-4

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -284,7 +284,8 @@ basehub:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility
             node_selector:
-              cloud.google.com/gke-nodepool: nb-gpu-t4
+              node.kubernetes.io/instance-type: n1-standard-8
+              cloud.google.com/gke-accelerator: nvidia-tesla-t4
             mem_limit: 30G
             mem_guarantee: 24G
             extra_resource_limits:

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -35,9 +35,9 @@ gke:
   awi-ciroh:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   callysto:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -53,9 +53,9 @@ gke:
   cloudbank:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   hhmi:
     requesting_daemon_sets: fluentbit-gke,gke-metadata-server,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -64,10 +64,10 @@ gke:
     k8s_version: v1.27.10-gke.1055000
   leap:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
-    other_daemon_sets: ""
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    other_daemon_sets: maintenance-handler
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589018
   linked-earth:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
@@ -89,9 +89,9 @@ gke:
   qcl:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""
-    cpu_requests: 338m
-    memory_requests: 496Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 348m
+    memory_requests: 556Mi
+    k8s_version: v1.29.1-gke.1589018
 eks:
   2i2c-aws-us:
     requesting_daemon_sets: aws-node,ebs-csi-node,kube-proxy,support-cryptnono,support-prometheus-node-exporter

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -5,10 +5,10 @@ region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 enable_filestore       = true
-filestore_capacity_gb  = 1536
+filestore_capacity_gb  = 2048
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.27.4-gke.900",
   notebook_nodes_version : "1.27.4-gke.900",
   dask_nodes_version : "1.27.4-gke.900",

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -9,9 +9,9 @@ filestore_capacity_gb  = 2048
 
 k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
-  dask_nodes_version : "1.27.4-gke.900",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 user_buckets = {
@@ -31,7 +31,7 @@ user_buckets = {
 
 # Setup notebook node pools
 notebook_nodes = {
-  "n2-highmem-4" : {
+  "n2-highmem-4-b" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -10,9 +10,9 @@ k8s_versions = {
   #       upgrading the control plane, there will be ~5 minutes of k8s not being
   #       available making new server launches error etc.
   min_master_version : "1.29.1-gke.1589018",
-  core_nodes_version : "1.27.5-gke.200",
-  notebook_nodes_version : "1.27.5-gke.200",
-  dask_nodes_version : "1.27.5-gke.200",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-2"
@@ -22,7 +22,14 @@ enable_filestore      = true
 filestore_capacity_gb = 1024
 
 notebook_nodes = {
+  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
   "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+    node_version : "1.27.5-gke.200",
+  },
+  "n2-highmem-4-b" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
@@ -36,7 +43,7 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-  }
+  },
 }
 
 # Setup a single node pool for dask workers.

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -6,7 +6,10 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
-  min_master_version : "1.27.5-gke.200",
+  # NOTE: This isn't a regional cluster / highly available cluster, when
+  #       upgrading the control plane, there will be ~5 minutes of k8s not being
+  #       available making new server launches error etc.
+  min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.27.5-gke.200",
   notebook_nodes_version : "1.27.5-gke.200",
   dask_nodes_version : "1.27.5-gke.200",

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -5,7 +5,7 @@ project_id = "leap-pangeo"
 core_node_machine_type = "n2-highmem-4"
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.27.4-gke.900",
   notebook_nodes_version : "1.27.4-gke.900",
   dask_nodes_version : "1.27.4-gke.900",

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -6,9 +6,9 @@ core_node_machine_type = "n2-highmem-4"
 
 k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
-  dask_nodes_version : "1.27.4-gke.900",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 # GPUs not available in us-central1-b
@@ -79,19 +79,49 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
+  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
   "n2-highmem-16" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.
     min : 1,
     max : 100,
     machine_type : "n2-highmem-16",
+    node_version : "1.27.4-gke.900",
+  },
+  "n2-highmem-16-b" : {
+    # A minimum of one is configured for LEAP to ensure quick startups at all
+    # time. Cost is not a greater concern than optimizing startup times.
+    min : 1,
+    max : 100,
+    machine_type : "n2-highmem-16",
+    node_version : "1.27.4-gke.900",
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64"
   }
+  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
   "gpu-t4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    node_version : "1.27.4-gke.900",
+    gpu : {
+      enabled : true,
+      type : "nvidia-tesla-t4",
+      count : 1
+    },
+    zones : [
+      # Get GPUs wherever they are available, as sometimes a single
+      # zone might be out of GPUs.
+      "us-central1-a",
+      "us-central1-b",
+      "us-central1-c",
+      "us-central1-f"
+    ]
+  },
+  "gpu-t4-b" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -6,6 +6,9 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
+  # NOTE: This isn't a regional cluster / highly available cluster, when
+  #       upgrading the control plane, there will be ~5 minutes of k8s not being
+  #       available making new server launches error etc.
   min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.29.1-gke.1589018",
   notebook_nodes_version : "1.29.1-gke.1589018",

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -28,6 +28,9 @@ core_node_machine_type = "n2-highmem-4"
 enable_private_cluster = true
 
 k8s_versions = {
+  # NOTE: This isn't a regional cluster / highly available cluster, when
+  #       upgrading the control plane, there will be ~5 minutes of k8s not being
+  #       available making new server launches error etc.
   min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.29.1-gke.1589018",
   notebook_nodes_version : "1.29.1-gke.1589018",

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -6,6 +6,9 @@ region           = "us-central1"
 regional_cluster = false
 
 k8s_versions = {
+  # NOTE: This isn't a regional cluster / highly available cluster, when
+  #       upgrading the control plane, there will be ~5 minutes of k8s not being
+  #       available making new server launches error etc.
   min_master_version : "1.27.4-gke.900",
   core_nodes_version : "1.27.4-gke.900",
   notebook_nodes_version : "1.27.4-gke.900",

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -5,7 +5,7 @@ zone   = "europe-west1-d"
 region = "europe-west1"
 
 k8s_versions = {
-  min_master_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.27.4-gke.900",
   notebook_nodes_version : "1.27.4-gke.900",
 }
@@ -14,7 +14,7 @@ core_node_machine_type = "n2-highmem-2"
 enable_network_policy  = true
 
 enable_filestore      = true
-filestore_capacity_gb = 35840
+filestore_capacity_gb = 3584
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -6,8 +6,8 @@ region = "europe-west1"
 
 k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
+  core_nodes_version : "1.29.1-gke.1589018",
+  notebook_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-2"
@@ -26,7 +26,14 @@ user_buckets = {
 }
 
 notebook_nodes = {
+  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
   "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+    node_version : "1.27.4-gke.900",
+  },
+  "n2-highmem-4-b" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
@@ -56,11 +63,18 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highcpu-32",
   },
+  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
   "n2-highcpu-96" : {
     min : 0,
     max : 100,
     machine_type : "n2-highcpu-96",
-  }
+    node_version : "1.27.4-gke.900",
+  },
+  "n2-highcpu-96-b" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highcpu-96",
+  },
 }
 
 hub_cloud_permissions = {


### PR DESCRIPTION
- **4/6 gke clusters still on 1.27: update k8s to 1.29**
- **deployer: update daemonset_requests.yaml**
- **4/6 gke clusters still on 1.27: update core/user nodes to 1.29**
