### PR TITLE
[New hub] Openscapes workshop hub

### DIFF
--- a/config/clusters/openscapes/cluster.yaml
+++ b/config/clusters/openscapes/cluster.yaml
@@ -35,3 +35,11 @@ hubs:
       - common.values.yaml
       - prod.values.yaml
       - enc-prod.secret.values.yaml
+  - name: workshop
+    display_name: "Openscapes Workshop"
+    domain: workshop.openscapes.2i2c.cloud
+    helm_chart: daskhub
+    helm_chart_values_files:
+      - common.values.yaml
+      - workshop.values.yaml
+      - enc-workshop.secret.values.yaml

--- a/config/clusters/openscapes/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapes/enc-workshop.secret.values.yaml
@@ -1,0 +1,20 @@
+basehub:
+    jupyterhub:
+        hub:
+            config:
+                DummyAuthenticator:
+                    password: ENC[AES256_GCM,data:HV9zz4JNMIXi5w==,iv:D1aqnuwuf48r2/dmVV6ncAA73WHw+PKRKkTZWTNuh8U=,tag:Hi0AM6poDHb1NRUjU+te5w==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-05-08T09:31:47Z"
+          enc: CiUA4OM7eBdovFANc0d+XmOQJYFQ47/KHwvMIxOQ9TK3a1vDK8ZoEkkAXoW3Jg7seRGkPDVLnDil4GXRdZgXQa7bjK0Qt8yUGHZkbM0Qqd0k5gjq0Ry0Rr0EXnPGu0Fi0BUo91BnhGwCFWScJ/JxL5nh
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-05-08T09:36:05Z"
+    mac: ENC[AES256_GCM,data:Ra15LKnmI9+Ju/fXHe57LoNADJL0xUxD5tK7V11HegrA+2lnH6frqTtYxS7qX5Uu1AvAjFmgxnnzfJMYpBgtYzrxV1q3jhxuE5FNVDFJi+jiF0gnS686L3xRvy/jonLcWSocsT8IWlY8OnZrghlQIzDk4i7B8Kxfzosd8zE7Gbk=,iv:oExubMShHKeI9L8Po7g7rGPwnZYQOEHldVdYA/D4wNc=,tag:BJUICO51XeaKr5iUR3HB6A==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -6,6 +6,7 @@ basehub:
       jupyterhubConfigurator:
         enabled: false
       homepage:
+        gitRepoBranch: "no-homepage-customizations"
         templateVars:
           org:
             name: ""
@@ -30,3 +31,113 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: dummy
+        Authenticator:
+          enable_auth_state: false
+          admin_users: []
+    singleuser:
+      defaultUrl: /lab
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.6981e043b45f042f"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/openscapes-github-push-access
+      profileList:
+        - display_name: Python
+          description: Python datascience environment
+          default: true
+          kubespawner_override:
+            image: openscapes/python:39dffde
+          profile_options: &profile_options
+            requests: &profile_options_resource_allocation
+              display_name: Resource Allocation
+              choices:
+                mem_1_9:
+                  display_name: 1.9 GB RAM, upto 3.7 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 1991244775
+                    mem_limit: 1991244775
+                    cpu_guarantee: 0.2328125
+                    cpu_limit: 3.725
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.xlarge
+                  default: true
+                mem_3_7:
+                  display_name: 3.7 GB RAM, upto 3.7 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 3982489550
+                    mem_limit: 3982489550
+                    cpu_guarantee: 0.465625
+                    cpu_limit: 3.725
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.xlarge
+                mem_7_4:
+                  display_name: 7.4 GB RAM, upto 3.7 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 7964979101
+                    mem_limit: 7964979101
+                    cpu_guarantee: 0.93125
+                    cpu_limit: 3.725
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.xlarge
+                mem_14_8:
+                  display_name: 14.8 GB RAM, upto 3.7 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 15929958203
+                    mem_limit: 15929958203
+                    cpu_guarantee: 1.8625
+                    cpu_limit: 3.725
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.xlarge
+                mem_29_7:
+                  display_name: 29.7 GB RAM, upto 3.7 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 31859916406
+                    mem_limit: 31859916406
+                    cpu_guarantee: 3.725
+                    cpu_limit: 3.725
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.xlarge
+                mem_60_6:
+                  display_name: 60.6 GB RAM, upto 15.6 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 65094448840
+                    mem_limit: 65094448840
+                    cpu_guarantee: 7.8475
+                    cpu_limit: 15.695
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.4xlarge
+                mem_121_2:
+                  display_name: 121.2 GB RAM, upto 15.6 CPUs
+                  kubespawner_override:
+                    mem_guarantee: 130188897681
+                    mem_limit: 130188897681
+                    cpu_guarantee: 15.695
+                    cpu_limit: 15.695
+                    node_selector:
+                      node.kubernetes.io/instance-type: r5.4xlarge
+        - display_name: R
+          description: R (with RStudio) + Python environment
+          kubespawner_override:
+            image: openscapes/rocker:a7596b5
+            # Ensures container working dir is homedir
+            # https://github.com/2i2c-org/infrastructure/issues/2559
+            working_dir: /home/rstudio
+          profile_options: *profile_options
+        - display_name: Matlab
+          description: Matlab environment
+          kubespawner_override:
+            image: openscapes/matlab:2023-11-28
+          profile_options: *profile_options
+        - display_name: "Bring your own image"
+          description: Specify your own docker image (must have python and jupyterhub installed in it)
+          slug: custom
+          profile_options:
+            image:
+              display_name: Image
+              unlisted_choice:
+                enabled: True
+                display_name: "Custom image"
+                validation_regex: "^.+:.+$"
+                validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+                kubespawner_override:
+                  image: "{value}"
+              choices: {}
+            resource_allocation: *profile_options_resource_allocation

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -1,0 +1,32 @@
+basehub:
+  jupyterhub:
+    custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: false
+      jupyterhubConfigurator:
+        enabled: false
+      homepage:
+        templateVars:
+          org:
+            name: ""
+            logo_url: ""
+            url: ""
+          designed_by:
+            name: ""
+            url: ""
+          operated_by:
+            name: ""
+            url: ""
+          funded_by:
+            name: ""
+            url: ""
+    ingress:
+      hosts: [workshop.openscapes.2i2c.cloud]
+      tls:
+        - hosts: [workshop.openscapes.2i2c.cloud]
+          secretName: https-auto-tls
+    hub:
+      allowNamedServers: true
+      config:
+        JupyterHub:
+          authenticator_class: dummy

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -37,8 +37,8 @@ basehub:
     singleuser:
       defaultUrl: /lab
       extraEnv:
-        GH_SCOPED_CREDS_CLIENT_ID: "Iv1.6981e043b45f042f"
-        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/openscapes-github-push-access
+        SCRATCH_BUCKET: s3://openscapeshub-scratch-workshop/$(JUPYTERHUB_USER)
+        PERSISTENT_BUCKET: s3://openscapeshub-persistent-workshop/$(JUPYTERHUB_USER)
       profileList:
         - display_name: Python
           description: Python datascience environment

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -11,6 +11,9 @@ user_buckets = {
   "scratch" : {
     "delete_after" : 7
   },
+  "scratch-workshop" : {
+    "delete_after" : 7
+  },
   "prod-homedirs-archive" : {
     "archival_storageclass_after" : 3
   },
@@ -18,6 +21,9 @@ user_buckets = {
     "delete_after" : null
   },
   "persistent" : {
+    "delete_after" : null
+  },
+  "persistent-workshop" : {
     "delete_after" : null
   }
 }
@@ -37,6 +43,14 @@ hub_cloud_permissions = {
       bucket_admin_access : [
         "scratch",
         "persistent",
+      ],
+    }
+  },
+  "workshop" : {
+    "user-sa" : {
+      bucket_admin_access : [
+        "scratch-workshop",
+        "persistent-workshop",
       ],
     }
   },


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/3984

Deployed and running at https://workshop.openscapes.2i2c.cloud/hub/login


### How is this different from the other hubs

- it uses a specific branch of the homepage repository https://github.com/2i2c-org/default-hub-homepage/tree/no-homepage-customizations that disables all customizations done to the login page (the most important one is the login button specific to OAuth based authentication). This is to allow us to have a username and password prompt. Ideally, we would still be able to have custom info on that this page, but that will be tackled and prioritized separately
- it uses the dummy authenticator with a global password
- disables the configurator

### Team feedback needed

From @yuvipanda:
- should we provide all the original profile options to all users now that we cannot filter based on GitHub team membership or should the profile list be adjusted?
- I believe we need to protect extra this hub and enable https://infrastructure.2i2c.org/howto/features/cryptnono/? Do you agree?

From @sgibson91:
- does the terraform plan look good to you?