### PR TITLE
2i2c cluster: update k8s 1.27 to 1.29

### DIFF
--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -23,9 +23,9 @@ gke:
   2i2c:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: binder-staging-dind,binder-staging-image-cleaner,imagebuilding-demo-binderhub-service-docker-api
-    cpu_requests: 344m
-    memory_requests: 596Mi
-    k8s_version: v1.27.10-gke.1055000
+    cpu_requests: 354m
+    memory_requests: 656Mi
+    k8s_version: v1.29.1-gke.1589020
   2i2c-uk:
     requesting_daemon_sets: calico-node,fluentbit-gke,gke-metadata-server,gke-metrics-agent,ip-masq-agent,netd,pdcsi-node,support-cryptnono,support-prometheus-node-exporter
     other_daemon_sets: ""

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -9,10 +9,10 @@ k8s_versions = {
   # NOTE: This isn't a regional cluster / highly available cluster, when
   #       upgrading the control plane, there will be ~5 minutes of k8s not being
   #       available making new server launches error etc.
-  min_master_version : "1.27.4-gke.900",
-  core_nodes_version : "1.27.4-gke.900",
-  notebook_nodes_version : "1.27.4-gke.900",
-  dask_nodes_version : "1.27.4-gke.900",
+  min_master_version : "1.29.1-gke.1589020",
+  core_nodes_version : "1.29.1-gke.1589020",
+  notebook_nodes_version : "1.29.1-gke.1589020",
+  dask_nodes_version : "1.29.1-gke.1589020",
 }
 
 core_node_machine_type = "n2-highmem-4"
@@ -22,7 +22,7 @@ enable_filestore      = true
 filestore_capacity_gb = 5120
 
 notebook_nodes = {
-  "n2-highmem-4-b" : {
+  "n2-highmem-4" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",


### PR DESCRIPTION
- For #4006

Done during sunday to reduce risk of issues causing disruptions for this cluster that is shared with many users spread across timezones.