### PR TITLE
automation: reduce risk of deployments getting cancelled

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -45,10 +45,19 @@ on:
       # Exclude the template configuration files
       - "!config/clusters/templates"
 
-# When multiple PRs triggering this workflow are merged, queue them instead
-# of running them in parallel
-# https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
-concurrency: deploy
+# Queue triggered executions of this workflow stemming from pushes to avoid
+# deployment conflicts.
+#
+# By using a different concurrency groups for pull requests and pushes, we
+# reduce the risk of cancelling a queued but not started workflow as discussed
+# in https://github.com/2i2c-org/infrastructure/issues/3214.
+#
+# github.head_ref is used to create PR unique concurrency groups, and for
+# workflow executions not triggered by a PR we get a dedicated group.
+#
+# ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+#
+concurrency: ${{ github.workflow }}-${{ github.head_ref || 'not-a-pr' }}
 
 # This environment variable triggers the deployer to colourise print statements in the
 # GitHug Actions logs for easy reading

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -14,10 +14,9 @@ on:
       # The way terraform is deployed might have changed!
       - .github/workflows/ensure-uptime-checks.yaml
 
-# When multiple PRs triggering this workflow are merged, queue them instead
-# of running them in parallel
-# https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
-concurrency: uptime-checks
+# Queue executions of this workflow to avoid conflicts
+# ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency: ${{ github.workflow }}
 
 # This environment variable triggers the deployer to colourise print statements in the
 # GitHub Actions logs for easy reading


### PR DESCRIPTION
This isn't a fix for https://github.com/2i2c-org/infrastructure/issues/3214, but it reduces the risk of it happening.

The problem:
- We want to deploy with the "deploy and test hubs" workflow in sequence, so we enable the "concurrency" functionality
- The concurrency functionality cancels workflows not having started and still being queued, and there is no workaround to my knowledge (see #3214)

The improvement in this PR:
- We specify a concurrency group that differ between PRs and merges to main - making the queue we really care about (merges to main) smaller, and due to that less likely to have its deployment cancelled.