### PR TITLE
automation/deployer: respect PR label `deployer:skip-deploy`

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -99,6 +99,36 @@ jobs:
           pip install --editable .
           pip list
 
+      - name: Get merged/open PR labels
+        uses: actions/github-script@v7
+        id: pr-labels
+        with:
+          script: |
+            let labels = [];
+            if (context.eventName === 'pull_request') {
+              labels = context.payload.pull_request.labels;
+            }
+
+            // Determine if the pushed commit triggering the workflow is
+            // associated with a merged pull request
+            else if (context.eventName === 'push') {
+              // api ref: https://octokit.github.io/rest.js/v20#pulls-list
+              const resp = await github.rest.pulls.list(
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'closed',
+                  sort: 'updated',
+                  direction: 'desc',
+                  per_page: 100,
+                }
+              );
+              const merged_pr = resp.data.find(pr => pr.merge_commit_sha === context.sha);
+              labels = merged_pr?.labels;
+            }
+            labels = (labels || []).map(l => l.name);
+            return labels
+
       - name: Identify files that have been added or modified
         # Action repo: https://github.com/dorny/paths-filter
         uses: dorny/paths-filter@v3
@@ -121,7 +151,7 @@ jobs:
       # by one
       - name: Generate matrix jobs
         run: |
-          deployer generate helm-upgrade-jobs "${{ steps.changed-files.outputs.changed_files }}"
+          deployer generate helm-upgrade-jobs "${{ steps.changed-files.outputs.changed_files }}" '${{ steps.pr-labels.outputs.result }}'
 
       # The comment-deployment-plan-pr.yaml workflow won't have the correct context to
       # know the PR number, so we save it to a file to pass to that workflow

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -103,14 +103,18 @@ jobs:
         uses: actions/github-script@v7
         id: pr-labels
         with:
+          # Both pull_request and push can have triggered this job to run. A
+          # context with PR info (including its labels) is available when this
+          # job is triggered via pull_request, but not when triggered via push -
+          # a push can be triggered by other things than merged PRs. Due to
+          # this, we check if a pushed commit is matching some PRs merge commit,
+          # and if so gets its labels.
           script: |
-            let labels = [];
+            let labels = null;
+
             if (context.eventName === 'pull_request') {
               labels = context.payload.pull_request.labels;
             }
-
-            // Determine if the pushed commit triggering the workflow is
-            // associated with a merged pull request
             else if (context.eventName === 'push') {
               // api ref: https://octokit.github.io/rest.js/v20#pulls-list
               const resp = await github.rest.pulls.list(
@@ -126,8 +130,9 @@ jobs:
               const merged_pr = resp.data.find(pr => pr.merge_commit_sha === context.sha);
               labels = merged_pr?.labels;
             }
-            labels = (labels || []).map(l => l.name);
-            return labels
+
+            label_names = (labels || []).map(l => l.name);
+            return label_names
 
       - name: Identify files that have been added or modified
         # Action repo: https://github.com/dorny/paths-filter

--- a/deployer/commands/generate/helm_upgrade/decision.py
+++ b/deployer/commands/generate/helm_upgrade/decision.py
@@ -68,6 +68,7 @@ def generate_hub_matrix_jobs(
     cluster_config,
     cluster_info,
     added_or_modified_files,
+    pr_labels=None,
     upgrade_all_hubs_on_this_cluster=False,
     upgrade_all_hubs_on_all_clusters=False,
 ):
@@ -88,6 +89,7 @@ def generate_hub_matrix_jobs(
             redeployed.
         added_or_modified_files (set[str]): A set of all added or modified files
             provided in a GitHub Pull Requests
+        pr_labels (list, optional): A list of PR labels
         upgrade_all_hubs_on_this_cluster (bool, optional): If True, generates jobs to
             upgrade all hubs on the given cluster. This is triggered when the
             cluster.yaml file itself has been modified. Defaults to False.
@@ -100,6 +102,9 @@ def generate_hub_matrix_jobs(
             cluster, the cloud provider that cluster runs on, the name of a hub
             deployed to that cluster, and the reason that hub needs to be redeployed.
     """
+    if pr_labels and "deployer:skip-deploy" in pr_labels:
+        return []
+
     # Empty list to store all the matrix job definitions in
     matrix_jobs = []
 
@@ -148,6 +153,7 @@ def generate_support_matrix_jobs(
     cluster_config,
     cluster_info,
     added_or_modified_files,
+    pr_labels=None,
     upgrade_support_on_this_cluster=False,
     upgrade_support_on_all_clusters=False,
 ):
@@ -168,6 +174,7 @@ def generate_support_matrix_jobs(
             cluster to be redeployed.
         added_or_modified_files (set[str]): A set of all added or modified files
             provided in a GitHub Pull Requests
+        pr_labels (list, optional): A list of PR labels
         upgrade_support_on_this_cluster (bool, optional): If True, generates jobs to
             update the support chart on the given cluster. This is triggered when the
             cluster.yaml file itself is modified. Defaults to False.
@@ -192,6 +199,9 @@ def generate_support_matrix_jobs(
                 },
             ]
     """
+    if pr_labels and "deployer:skip-deploy" in pr_labels:
+        return []
+
     # Rename dictionary key
     cluster_info["reason_for_support_redeploy"] = cluster_info.pop(
         "reason_for_redeploy"

--- a/deployer/commands/generate/helm_upgrade/jobs.py
+++ b/deployer/commands/generate/helm_upgrade/jobs.py
@@ -26,13 +26,19 @@ yaml = YAML(typ="safe", pure=True)
 def helm_upgrade_jobs(
     changed_filepaths: str = typer.Argument(
         ..., help="Comma delimited list of files that have changed"
-    )
+    ),
+    pr_labels: str = typer.Argument(
+        "[]",
+        help="JSON formatted list of PR labels, where 'deployer:skip-deploy' is respected.",
+    ),
 ):
     """
-    Analyze added or modified files from a GitHub Pull Request and decide which
-    clusters and/or hubs require helm upgrades to be performed for their *hub helm
-    charts or the support helm chart.
+    Analyze added or modified files and labels from a GitHub Pull Request and
+    decide which clusters and/or hubs require helm upgrades to be performed for
+    their *hub helm charts or the support helm chart.
     """
+    pr_labels = json.loads(pr_labels)
+
     changed_filepaths = changed_filepaths.split(",")
     (
         upgrade_support_on_all_clusters,
@@ -87,6 +93,7 @@ def helm_upgrade_jobs(
                 cluster_config,
                 cluster_info,
                 set(changed_filepaths),
+                pr_labels,
                 upgrade_all_hubs_on_this_cluster=upgrade_all_hubs_on_this_cluster,
                 upgrade_all_hubs_on_all_clusters=upgrade_all_hubs_on_all_clusters,
             )
@@ -99,6 +106,7 @@ def helm_upgrade_jobs(
                 cluster_config,
                 cluster_info,
                 set(changed_filepaths),
+                pr_labels,
                 upgrade_support_on_this_cluster=upgrade_support_on_this_cluster,
                 upgrade_support_on_all_clusters=upgrade_support_on_all_clusters,
             )

--- a/deployer/commands/generate/helm_upgrade/jobs.py
+++ b/deployer/commands/generate/helm_upgrade/jobs.py
@@ -143,10 +143,9 @@ def helm_upgrade_jobs(
     if ci_env:
         # Add these matrix jobs as environment variables for use in another job
         with open(env_file, "a") as f:
-            f.write(f"prod-hub-matrix-jobs={json.dumps(prod_hub_matrix_jobs)}")
-            f.write("\n")
+            f.write(f"prod-hub-matrix-jobs={json.dumps(prod_hub_matrix_jobs)}\n")
             f.write(
-                f"support-and-staging-matrix-jobs={json.dumps(support_and_staging_matrix_jobs)}"
+                f"support-and-staging-matrix-jobs={json.dumps(support_and_staging_matrix_jobs)}\n"
             )
 
         # Don't bother generating a comment if both of the matrices are empty

--- a/tests/test_helm_upgrade_decision.py
+++ b/tests/test_helm_upgrade_decision.py
@@ -171,6 +171,32 @@ def test_generate_hub_matrix_jobs_all_hubs():
         assert isinstance(result_matrix_jobs[0], dict)
 
 
+def test_generate_hub_matrix_jobs_skip_deploy_label():
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_file = {
+        root_path.joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
+    }
+
+    pr_labels = ["unrelated1", "deployer:skip-deploy", "unrelated2"]
+
+    expected_matrix_jobs = []
+
+    result_matrix_jobs = generate_hub_matrix_jobs(
+        cluster_file, cluster_config, cluster_info, modified_file, pr_labels
+    )
+
+    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
+
+
 def test_generate_support_matrix_jobs_one_cluster():
     cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
     with open(cluster_file) as f:
@@ -244,6 +270,32 @@ def test_generate_support_matrix_jobs_all_clusters():
         case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
         assert isinstance(result_matrix_jobs, list)
         assert isinstance(result_matrix_jobs[0], dict)
+
+
+def test_generate_support_matrix_jobs_skip_deploy_label():
+    cluster_file = root_path.joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_file = {
+        root_path.joinpath("tests/test-clusters/cluster1/support.values.yaml"),
+    }
+
+    pr_labels = ["unrelated1", "deployer:skip-deploy", "unrelated2"]
+
+    expected_matrix_jobs = []
+
+    result_matrix_jobs = generate_support_matrix_jobs(
+        cluster_file, cluster_config, cluster_info, modified_file, pr_labels
+    )
+
+    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
 
 
 def test_discover_modified_common_files_hub_helm_charts():


### PR DESCRIPTION
- Fixes #2009

I wanted this a lot in order to:
1. Not need to press merge and then quickly manually cancel the triggered workflow when deciding to not deploy/test
2. Not create noise in `#gha-failures` for manually cancelled workloads, and to not need to comment that it was just a intentionally cancelled workload
3. Be able to visibilize a deploy skip is planned
4. Not incurr delays by queueing many deploys when only a one or few may be relevant

I also wanted this for some additional reasons, like reducing cloud costs for communities and reducing risk of #3214 further, but the main reasons motivating me now to implement this feature was those above.

## Review notes

- **About testing of changes**
  - Acquisition of PR labels in PR and [on merge has been tested in another repo](https://github.com/consideRatio/testing-gh-workflows/actions/runs/9070291918/job/24921758503)
  - `deployer` code changes is partially tested by added tests, where [this PR triggered a run that tested the remaining parts](https://github.com/2i2c-org/infrastructure/actions/runs/9069888846/job/24920451820?pr=4065)
- **About outdated deploy PR comments**
  The PR comment made listing what gets deployed won't get updated once the `deployer:skip-deploy` label gets added. This is also the case if you first push a commit that leads to a deploy, and then reverts the commit. There is no logic to delete an existing comment or update it to declare nothing will get deployed in those situations.