### PR TITLE
deployer: fix to handle 100m of CPU req from GKE's standalone kube-proxy pod

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -78,8 +78,8 @@ jupyterhub:
                 kubespawner_override:
                   mem_guarantee: 3620925866
                   mem_limit: 3620925866
-                  cpu_guarantee: 0.43375
-                  cpu_limit: 3.47
+                  cpu_guarantee: 0.43125
+                  cpu_limit: 3.45
                   node_selector:
                     node.kubernetes.io/instance-type: n2-highmem-4
                 default: true
@@ -88,8 +88,8 @@ jupyterhub:
                 kubespawner_override:
                   mem_guarantee: 7241851732
                   mem_limit: 7241851732
-                  cpu_guarantee: 0.8675
-                  cpu_limit: 3.47
+                  cpu_guarantee: 0.8625
+                  cpu_limit: 3.45
                   node_selector:
                     node.kubernetes.io/instance-type: n2-highmem-4
               mem_13_5:
@@ -97,8 +97,8 @@ jupyterhub:
                 kubespawner_override:
                   mem_guarantee: 14483703464
                   mem_limit: 14483703464
-                  cpu_guarantee: 1.735
-                  cpu_limit: 3.47
+                  cpu_guarantee: 1.725
+                  cpu_limit: 3.45
                   node_selector:
                     node.kubernetes.io/instance-type: n2-highmem-4
               mem_27_0:
@@ -106,8 +106,8 @@ jupyterhub:
                 kubespawner_override:
                   mem_guarantee: 28967406928
                   mem_limit: 28967406928
-                  cpu_guarantee: 3.47
-                  cpu_limit: 3.47
+                  cpu_guarantee: 3.45
+                  cpu_limit: 3.45
                   node_selector:
                     node.kubernetes.io/instance-type: n2-highmem-4
   hub:

--- a/config/clusters/hhmi/common.values.yaml
+++ b/config/clusters/hhmi/common.values.yaml
@@ -98,8 +98,8 @@ basehub:
                   kubespawner_override:
                     mem_guarantee: 3620925866
                     mem_limit: 3620925866
-                    cpu_guarantee: 0.43375
-                    cpu_limit: 3.47
+                    cpu_guarantee: 0.43125
+                    cpu_limit: 3.45
                     node_selector:
                       node.kubernetes.io/instance-type: n2-highmem-4
                   default: true
@@ -108,8 +108,8 @@ basehub:
                   kubespawner_override:
                     mem_guarantee: 7241851732
                     mem_limit: 7241851732
-                    cpu_guarantee: 0.8675
-                    cpu_limit: 3.47
+                    cpu_guarantee: 0.8625
+                    cpu_limit: 3.45
                     node_selector:
                       node.kubernetes.io/instance-type: n2-highmem-4
                 mem_13_5:
@@ -117,8 +117,8 @@ basehub:
                   kubespawner_override:
                     mem_guarantee: 14483703464
                     mem_limit: 14483703464
-                    cpu_guarantee: 1.735
-                    cpu_limit: 3.47
+                    cpu_guarantee: 1.725
+                    cpu_limit: 3.45
                     node_selector:
                       node.kubernetes.io/instance-type: n2-highmem-4
                 mem_27_0:
@@ -126,8 +126,8 @@ basehub:
                   kubespawner_override:
                     mem_guarantee: 28967406928
                     mem_limit: 28967406928
-                    cpu_guarantee: 3.47
-                    cpu_limit: 3.47
+                    cpu_guarantee: 3.45
+                    cpu_limit: 3.45
                     node_selector:
                       node.kubernetes.io/instance-type: n2-highmem-4
             image:

--- a/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
+++ b/deployer/commands/generate/resource_allocation/daemonset_requests.yaml
@@ -14,6 +14,11 @@
 # - We may deploy or change a DaemonSet's requests over time (support-cryptnono,
 #   support-prometheus-node-exporter)
 #
+# Besides requests from DaemonSet resources, GKE apparently has a controller
+# creating a standalone kube-proxy pod per node, currently requesting 100m CPU
+# (no memory requests). These needs to be accounted for as well in the end, but
+# isn't tracked by in this file.
+#
 # This file isn't updated by automation, but can easily be updated by manually
 # running a command once for each cluster:
 #

--- a/deployer/commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/commands/generate/resource_allocation/node-capacity-info.json
@@ -63,11 +63,11 @@
             "memory": 29779155746
         },
         "measured_overhead": {
-            "cpu": 0.45,
+            "cpu": 0.47,
             "memory": 811748818
         },
         "available": {
-            "cpu": 3.47,
+            "cpu": 3.45,
             "memory": 28967406928
         }
     }


### PR DESCRIPTION
Followup to #4050 that didn't resolve by #4069 as the GKE's kube-proxy pod wasn't from a DaemonSet but a standalone pod created by a non-standard controller (but seems to behave like a pod controlled by a deployment -> replicaset controller).