### PR TITLE
k8s maintenance: upgrade all eks control planes to 1.29

### DIFF
--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -57,7 +57,7 @@ local daskNodes = [
     metadata+: {
         name: "2i2c-aws-us",
         region: clusterRegion,
-        version: '1.27',
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -38,7 +38,7 @@ local daskNodes = [];
     metadata+: {
         name: "catalystproject-africa",
         region: clusterRegion,
-        version: '1.27'
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [
     metadata+: {
         name: "earthscope",
         region: clusterRegion,
-        version: "1.28",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -67,7 +67,7 @@ local daskNodes = [
     metadata+: {
         name: "gridsst",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -81,7 +81,7 @@ local daskNodes = [
     metadata+: {
         name: "jupyter-meets-the-earth",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -60,7 +60,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-cryo",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-esdis.jsonnet
+++ b/eksctl/nasa-esdis.jsonnet
@@ -38,7 +38,7 @@ local daskNodes = [];
     metadata+: {
         name: "nasa-esdis",
         region: clusterRegion,
-        version: '1.27',
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {
@@ -58,6 +58,7 @@ local daskNodes = [];
             // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
             //
             name: 'aws-ebs-csi-driver',
+            version: "latest",
             wellKnownPolicies: {
                 ebsCSIController: true,
             },

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-ghg-hub",
         region: clusterRegion,
-        version: '1.27',
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -51,7 +51,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-veda",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [
     metadata+: {
         name: "openscapeshub",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/opensci.jsonnet
+++ b/eksctl/opensci.jsonnet
@@ -38,7 +38,7 @@ local daskNodes = [];
     metadata+: {
         name: "opensci",
         region: clusterRegion,
-        version: "1.28",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -56,7 +56,7 @@ local daskNodes = [
     metadata+: {
         name: "smithsonian",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -40,7 +40,7 @@ local daskNodes = [];
     metadata+: {
         name: "ubc-eoas",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -55,7 +55,7 @@ local daskNodes = [
     metadata+: {
         name: "victor",
         region: clusterRegion,
-        version: "1.27",
+        version: "1.29",
     },
     availabilityZones: masterAzs,
     iam: {


### PR DESCRIPTION
- Fixes #4007

No node pools has been upgraded as part of this yet.