### PR TITLE
k8s maintenance, meom-ige: update dask node pool's version

### DIFF
--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -12,6 +12,7 @@ k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",
   core_nodes_version : "1.29.1-gke.1589018",
   notebook_nodes_version : "1.29.1-gke.1589018",
+  dask_nodes_version : "1.29.1-gke.1589018",
 }
 
 core_node_machine_type = "n2-highmem-4"


### PR DESCRIPTION
This was left unspecified and got stuck behind