### PR TITLE
leap: fix YAML syntax issues (and our RTD build by doing it)

### DIFF
--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -299,7 +299,6 @@ basehub:
         - display_name: "CPU only"
           description: *profile_list_description
           slug: medium-base
-          default: true
           allowed_groups:
             - leap-stc:leap-pangeo-base-access
           profile_options:

--- a/config/clusters/leap/common.values.yaml
+++ b/config/clusters/leap/common.values.yaml
@@ -129,8 +129,7 @@ basehub:
         #          wasted energy.
         #
         - display_name: "Devs Only"
-          description: &profile_list_description "Start a container limited to a chosen share of capacity on a node of this type"
-          default: true
+          description: "Start a container limited to a chosen share of capacity on a node of this type"
           allowed_groups:
             - 2i2c-org:hub-access-for-2i2c-staff
             - leap-stc:leap-pangeo-dev-access
@@ -177,7 +176,12 @@ basehub:
                   slug: "pytorch"
                   kubespawner_override:
                     image: "pangeo/pytorch-notebook:2024.04.08"
-          kubespawner_override: &medium_kubespawner_override
+                leap-pangeo-edu:
+                  display_name: LEAP Education Notebook (Testing Prototype)
+                  slug: "leap_edu"
+                  kubespawner_override:
+                    image: "quay.io/jbusecke/leap-edu-image:fa442ab4851c"
+          kubespawner_override:
             cpu_limit: null
             mem_limit: null
             node_selector:
@@ -251,9 +255,9 @@ basehub:
                     cpu_guarantee: 1.6
                     mem_limit: 128G
                     cpu_limit: 16
-            image: &profile_list_profile_options_image
+            image:
               display_name: Image
-              unlisted_choice: &profile_list_unlisted_choice
+              unlisted_choice:
                 enabled: True
                 display_name: "Custom image"
                 validation_regex: "^.+:.+$"


### PR DESCRIPTION
@jbusecke there were YAML syntax issues in a recent change by the use of `&profile_list_profile_options_image` and `*profile_list_profile_options_image` etc.

When `&` is used, its an "anchor", so other fields can reference it with `*` to re-use that value. The issue was duplicatin of anchors.

I've fixed it by de-duplicating content - but in doing so also added the image choice `leap-pangeo-edu` to the dev profile - I think this may be acceptable though as its just something you can opt to ignore.