### PR TITLE
docs: iteration on aws k8s upgrade docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,8 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+# keep --ignore entries in sync with content in noxfile.py
 live:
-	sphinx-autobuild --ignore "_build/*" --ignore "tmp/*" --ignore "_static/hub-*.json" -b dirhtml -n . _build/dirhtml
+	sphinx-autobuild --ignore "*/_build/*" --ignore "*/tmp/*" --ignore "*/*.json" --ignore "*/*.csv" -b dirhtml -n . _build/dirhtml
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/howto/upgrade-cluster/index.md
+++ b/docs/howto/upgrade-cluster/index.md
@@ -50,6 +50,7 @@ some in shared clusters have been announced ahead of time.
 :maxdepth: 1
 :caption: Upgrading Kubernetes clusters
 upgrade-disruptions.md
+node-upgrade-strategies.md
 k8s-version-skew.md
 aws.md
 ```

--- a/docs/howto/upgrade-cluster/node-upgrade-strategies.md
+++ b/docs/howto/upgrade-cluster/node-upgrade-strategies.md
@@ -1,0 +1,25 @@
+(upgrade-cluster:node-upgrade-strategies)=
+
+# About strategies to upgrade nodes
+
+## About rolling upgrades
+
+To upgrade node group's nodes, we typically do *rolling upgrades*. In a rolling
+upgrade, something new is added to replace something old before its removed.
+
+When doing a rolling upgrade of node groups, we can do a rolling upgrade _fast
+and forcefully_ or _slow and patiently_ - either pods running on a node group's
+nodes get forcefully stopped, or they get to stop on their own.
+
+*Managed* node groups can do fast and forceful rolling upgrades, while
+*unmanaged* node groups need to be re-created to get upgraded k8s software
+(`kubelet` etc).
+
+Core nodes' workloads can be suitable to forcefully relocate, while user nodes'
+workloads should be given time to stop on their own.
+
+## About re-creation upgrades
+
+With unmanaged node groups like on EKS, if disruption isn't a concern or if
+there isn't anything running to disrupt, node groups can be deleted and
+re-created to save time.

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -35,8 +35,13 @@ This guide will assume you have already followed the guidance in [](/topic/infra
 
    Mac users with homebrew can run `brew install eksctl`.
 
-   Verify install and version with `eksctl version`. You typically need a very
-   recent version of this CLI.
+   Verify install and version with `eksctl version`. You should have *the latest
+   version* of this CLI.
+
+   ```{important}
+   Without the latest version, you may install an outdated versions of `aws-node`
+   because [its hardcoded](https://github.com/eksctl-io/eksctl/pull/7756).
+   ```
 
 4. Install [`jsonnet`](https://github.com/google/jsonnet)
 

--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -86,7 +86,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,13 +26,16 @@ def docs(session):
         session.posargs.pop(session.posargs.index("live"))
 
         # Add folders to ignore
+        # keep this in sync with Makefile
         AUTOBUILD_IGNORE_DIRS = [
             "_build",
             "tmp",
         ]
         # Add files to ignore
+        # keep this in sync with Makefile
         AUTOBUILD_IGNORE_FILES = [
-            "_static/*.json",
+            "*.json",
+            "*.csv",
         ]
 
         cmd = ["sphinx-autobuild"]

--- a/terraform/gcp/projects/qcl.tfvars
+++ b/terraform/gcp/projects/qcl.tfvars
@@ -26,7 +26,7 @@ user_buckets = {
 }
 
 notebook_nodes = {
-  # FIXME: tainted, to be deleted when empty, replaced by k8s upgraded variant
+  # FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
   "n2-highmem-4" : {
     min : 0,
     max : 100,


### PR DESCRIPTION
- **No longer assumes empty user nodes**
  Our docs previously assumed there were no users on the user nodes, assuming a re-creation upgrade strategy could be used. This assumption is removed in this iteration.
- **Removed out of scope section**
  I removed the pre-requiesite section "Consider changes to `template.jsonnet`" that I now consider too out of scope to be suggested in docs to be done during a k8s upgrade.
- **Refactoring to centralize misc content**
  Node upgrade strategies, AWS auth, notes on version skew, and maybe something more.
- **Check cluster status and activity**
  Added step to overview what goes on in the cluster before upgrading. This can for example be used to rule out that something broke because of the upgrade (because it was already broken).
- **Facilitate upgrading multiple clusters in parallell**
  Upgrading multiple clusters in parallell is reasonable, and I've now made it so that the guide is easier to scale to run in parallell.

## Related

This was worked in preparation for #4009. If it wasn't done now, it would be harder to handle #4009 even though it wasn't part of scope of #4009 to get this done.

## Review

I think the time efficient approach is to let this be practically reviewed by merging it and then using it - iterating on it further if needed to fix issues with it.