### PR TITLE
awi-ciroh: Always pull images in staging environment

### DIFF
--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -128,5 +128,9 @@ basehub:
         PERSISTENT_BUCKET: gs://awi-ciroh-persistent-staging/$(JUPYTERHUB_USER)
     hub:
       config:
+        KubeSpawner:
+          # Requested as part of https://2i2c.freshdesk.com/a/tickets/1607, to
+          # make it easier to test custom images
+          image_pull_policy: Always
         GitHubOAuthenticator:
           oauth_callback_url: "https://staging.ciroh.awi.2i2c.cloud/hub/oauth_callback"


### PR DESCRIPTION
Helpful for testing their custom built images.

Asked for in https://2i2c.freshdesk.com/a/tickets/1607

Ref: https://github.com/2i2c-org/infrastructure/issues/3957