### PR TITLE
Update node groups for AWS clusters

### DIFF
--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -67,7 +67,7 @@ local daskNodes = [];
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -96,7 +96,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/opensci.jsonnet
+++ b/eksctl/opensci.jsonnet
@@ -67,7 +67,7 @@ local daskNodes = [];
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/smithsonian.jsonnet
+++ b/eksctl/smithsonian.jsonnet
@@ -85,7 +85,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {


### PR DESCRIPTION
- related to #4009 

Clusters upgraded:

- catalystproject-africa
- gridsst
- opensci
- smithsonian