### PR TITLE
Bumping k8s node groups version on AWS clusters

### DIFF
--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -79,7 +79,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -110,7 +110,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/nasa-esdis.jsonnet
+++ b/eksctl/nasa-esdis.jsonnet
@@ -67,7 +67,7 @@ local daskNodes = [];
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -80,7 +80,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -79,7 +79,7 @@ local daskNodes = [
     nodeGroups: [n + {clusterName:: $.metadata.name} for n in [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -69,7 +69,7 @@ local daskNodes = [];
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -84,7 +84,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {


### PR DESCRIPTION
- related to https://github.com/2i2c-org/infrastructure/issues/4009

Clusters upgraded in this PR

- earthscope
- jmte
- nasa-esdis
- nasa-veda
- openscapes
- ubc-eoas
- victor