### PR TITLE
Upgrade nasa-cryo core node group to newer k8s version

### DIFF
--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -90,7 +90,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {


### PR DESCRIPTION
- related to #4009 

I forgot about the core node group while sorting the user server node groups