### PR TITLE
Upgrade nasa-ghg node groups to newer k8s version

### DIFF
--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -26,7 +26,8 @@ local nodeAz = "us-west-2a";
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
     { instanceType: "r5.xlarge" },
-    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.4xlarge" },  // FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
+    { instanceType: "r5.4xlarge" , nameSuffix : "b" },
     { instanceType: "r5.16xlarge" },
 ];
 local daskNodes = [
@@ -79,7 +80,7 @@ local daskNodes = [
     nodeGroups: [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {


### PR DESCRIPTION
- related to #4009 

Added a new user server node group since there are some active servers atm. The old node group should be deleted once it has drained.