### PR TITLE
AWI-CIROH: Fix missing auth_state config

### DIFF
--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -35,12 +35,14 @@ basehub:
         JupyterHub:
           authenticator_class: github
         GitHubOAuthenticator:
+          populate_teams_in_auth_state: true
           allowed_organizations:
             - alabamawaterinstitute
             - NOAA-OWP
           scope:
             - read:org
         Authenticator:
+          enable_auth_state: True
           admin_users:
             - jameshalgren
             - arpita0911patel


### PR DESCRIPTION
Without this, allowed_groups was not being effective in restricting GPU users

Ref: #3957 