### PR TITLE
awi-ciroh: Fix typo in group restriction

### DIFF
--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -118,7 +118,7 @@ basehub:
               node.kubernetes.io/instance-type: n2-highmem-16
         - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
           description: "Start a container on a dedicated node with a GPU"
-          allowed_teams:
+          allowed_groups:
             - 2i2c-org:hub-access-for-2i2c-staff
             - AlabamaWaterInstitute:2i2c_portal_users_gpu
           profile_options:

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -95,7 +95,7 @@ basehub:
               node.kubernetes.io/instance-type: n2-highmem-16
         - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
           description: "Start a container on a dedicated node with a GPU"
-          allowed_teams:
+          allowed_groups:
             - 2i2c-org:hub-access-for-2i2c-staff
             - AlabamaWaterInstitute:2i2c_portal_users_gpu
           profile_options:

--- a/docs/howto/features/gpu.md
+++ b/docs/howto/features/gpu.md
@@ -161,7 +161,7 @@ jupyterhub:
       profileList:
         - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
           description: "Start a container on a dedicated node with a GPU"
-          allowed_teams:
+          allowed_groups:
             - 2i2c-org:hub-access-for-2i2c-staff
             - <github-org>:<team-name>
           profile_options:


### PR DESCRIPTION
This was deployed at the time allowed_teams switched to allowed_groups, and this was missed.

Ref https://2i2c.freshdesk.com/a/tickets/1616
Ref https://github.com/2i2c-org/infrastructure/issues/3957