### PR TITLE
deployer: add --skip-refresh flag to deploy command

### DIFF
--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -117,9 +117,9 @@ def deploy(
         "--dry-run",
         help="""When present, the `--dry-run` flag will be passed to the `helm upgrade` command.""",
     ),
-    skip_update: bool = typer.Option(
+    skip_refresh: bool = typer.Option(
         False,
-        "--skip-update",
+        "--skip-refresh",
         help="""When present, the helm charts and schemas will not be updated.""",
     ),
 ):
@@ -127,7 +127,7 @@ def deploy(
     Deploy one or more hubs in a given cluster
     """
     validate_cluster_config(cluster_name)
-    validate_hub_config(cluster_name, hub_name, skip_update)
+    validate_hub_config(cluster_name, hub_name, skip_refresh)
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
     with open(config_file_path) as f:

--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -117,12 +117,17 @@ def deploy(
         "--dry-run",
         help="""When present, the `--dry-run` flag will be passed to the `helm upgrade` command.""",
     ),
+    skip_update: bool = typer.Option(
+        False,
+        "--skip-update",
+        help="""When present, the helm charts and schemas will not be updated.""",
+    ),
 ):
     """
     Deploy one or more hubs in a given cluster
     """
     validate_cluster_config(cluster_name)
-    validate_hub_config(cluster_name, hub_name)
+    validate_hub_config(cluster_name, hub_name, skip_update)
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
     with open(config_file_path) as f:

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -58,11 +58,11 @@ def _prepare_helm_charts_dependencies_and_schemas():
 
     daskhub_dir = HELM_CHARTS_DIR.joinpath("daskhub")
     # Not generating schema for daskhub, as it is dead
-    subprocess.check_call(["helm", "dep", "up", daskhub_dir])
+    subprocess.check_call(["helm", "dep", "up", daskhub_dir, "--skip-refresh"])
 
     support_dir = HELM_CHARTS_DIR.joinpath("support")
     _generate_values_schema_json(support_dir)
-    subprocess.check_call(["helm", "dep", "up", support_dir])
+    subprocess.check_call(["helm", "dep", "up", support_dir, "--skip-refresh"])
 
 
 def get_list_of_hubs_to_operate_on(cluster_name, hub_name):
@@ -98,13 +98,13 @@ def cluster_config(
 def hub_config(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(None, help="Name of hub to operate on"),
-    skip_update: bool = typer.Argument(False, help="Skip the helm dep update"),
+    skip_refresh: bool = typer.Argument(False, help="Skip the helm dep update"),
 ):
     """
     Validates the provided non-encrypted helm chart values files for each hub of
     a specific cluster.
     """
-    if not skip_update:
+    if not skip_refresh:
         _prepare_helm_charts_dependencies_and_schemas()
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -98,12 +98,14 @@ def cluster_config(
 def hub_config(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(None, help="Name of hub to operate on"),
+    skip_update: bool = typer.Argument(False, help="Skip the helm dep update"),
 ):
     """
     Validates the provided non-encrypted helm chart values files for each hub of
     a specific cluster.
     """
-    _prepare_helm_charts_dependencies_and_schemas()
+    if not skip_update:
+        _prepare_helm_charts_dependencies_and_schemas()
 
     config_file_path = find_absolute_path_to_cluster_file(cluster_name)
 

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -58,11 +58,11 @@ def _prepare_helm_charts_dependencies_and_schemas():
 
     daskhub_dir = HELM_CHARTS_DIR.joinpath("daskhub")
     # Not generating schema for daskhub, as it is dead
-    subprocess.check_call(["helm", "dep", "up", daskhub_dir, "--skip-refresh"])
+    subprocess.check_call(["helm", "dep", "up", daskhub_dir])
 
     support_dir = HELM_CHARTS_DIR.joinpath("support")
     _generate_values_schema_json(support_dir)
-    subprocess.check_call(["helm", "dep", "up", support_dir, "--skip-refresh"])
+    subprocess.check_call(["helm", "dep", "up", support_dir])
 
 
 def get_list_of_hubs_to_operate_on(cluster_name, hub_name):


### PR DESCRIPTION
This is something I wrote some time ago and now I will open a PR to discuss.

The `deployer deploy` command runs `helm dep up` several times to ensure that the Helm charts and their dependencies are up-to-date.

I think this is okay, but if I need several deployments in the same day, it's not worth running the update each time.

So this PR adds a flag `--skip-update` to skip that phase and run the validation directly.

Example:

```
$ time deployer deploy projectpythia staging
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://2i2c.org/binderhub-service/" chart repository
...Successfully got an update from the "https://jupyterhub.github.io/helm-chart/" chart repository
Saving 2 charts
Downloading jupyterhub from repo https://jupyterhub.github.io/helm-chart/
Downloading binderhub-service from repo https://2i2c.org/binderhub-service/
Deleting outdated charts
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://helm.dask.org/" chart repository
Saving 2 charts
Downloading dask-gateway from repo https://helm.dask.org/
Deleting outdated charts
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://cryptnono.github.io/cryptnono/" chart repository
...Successfully got an update from the "https://kubernetes.github.io/ingress-nginx" chart repository
...Successfully got an update from the "https://kubernetes.github.io/autoscaler" chart repository
...Successfully got an update from the "https://grafana.github.io/helm-charts" chart repository
...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
Saving 5 charts
Downloading prometheus from repo https://prometheus-community.github.io/helm-charts
Downloading grafana from repo https://grafana.github.io/helm-charts
Downloading ingress-nginx from repo https://kubernetes.github.io/ingress-nginx
Downloading cluster-autoscaler from repo https://kubernetes.github.io/autoscaler
Downloading cryptnono from repo https://cryptnono.github.io/cryptnono/
Deleting outdated charts
1 / 1: Validating non-encrypted hub values files for staging...
Added new context arn:aws:eks:us-west-2:590183926898:cluster/projectpythia to /tmp/tmprdzpqsaa
Deploying hub staging...
Running helm upgrade --install --create-namespace --wait --namespace=staging staging /mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/helm-charts/basehub --values=/mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/config/clusters/projectpythia/common.values.yaml --values=/mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/config/clusters/projectpythia/staging.values.yaml --values=/tmp/tmp1dwrt2me
Release "staging" has been upgraded. Happy Helming!
NAME: staging
LAST DEPLOYED: Mon May 27 18:09:55 2024
NAMESPACE: staging
STATUS: deployed
REVISION: 5
TEST SUITE: None

________________________________________________________
Executed in  143,53 secs    fish           external
   usr time   18,31 secs  887,00 micros   18,31 secs
   sys time    2,51 secs  272,00 micros    2,50 secs
```
```
$ time deployer deploy projectpythia staging --skip-update 
1 / 1: Validating non-encrypted hub values files for staging...
Added new context arn:aws:eks:us-west-2:590183926898:cluster/projectpythia to /tmp/tmplxtcjxxv
Deploying hub staging...
Running helm upgrade --install --create-namespace --wait --namespace=staging staging /mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/helm-charts/basehub --values=/mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/config/clusters/projectpythia/common.values.yaml --values=/mnt/stuff/Documentos/CCAD/2i2c/2i2c-infrastructure/config/clusters/projectpythia/staging.values.yaml --values=/tmp/tmpv0eh856_
Release "staging" has been upgraded. Happy Helming!
NAME: staging
LAST DEPLOYED: Mon May 27 18:11:09 2024
NAMESPACE: staging
STATUS: deployed
REVISION: 6
TEST SUITE: None

________________________________________________________
Executed in   69,92 secs    fish           external
   usr time   10,53 secs  581,00 micros   10,53 secs
   sys time    1,41 secs  175,00 micros    1,41 secs
```
