### PR TITLE
AWI-CIORH: Bump Filestore capacity

### DIFF
--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -5,7 +5,7 @@ region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 enable_filestore       = true
-filestore_capacity_gb  = 2048
+filestore_capacity_gb  = 2560
 
 k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",


### PR DESCRIPTION
To make sure we don't run out during the ongoing event.

Ref https://github.com/2i2c-org/infrastructure/issues/3957