### PR TITLE
Tweak New Hub Turnup Phase 1 issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_new-hub_phase-1.yaml
+++ b/.github/ISSUE_TEMPLATE/02_new-hub_phase-1.yaml
@@ -34,7 +34,7 @@ body:
         | Name of cloud account | | |
         | Community Representative(s) (GitHub handles or email) | | |
         | Have the Technical Contacts been added to the [AirTable](https://airtable.com/appbjBTRIbgRiElkr/pagD3XyZjqBunYMnC)? | `Yes/No` | |
-        
+
         Available runbooks:
         - https://infrastructure.2i2c.org/hub-deployment-guide/runbooks/phase1/#available-runbooks
       required: true

--- a/.github/ISSUE_TEMPLATE/02_new-hub_phase-1.yaml
+++ b/.github/ISSUE_TEMPLATE/02_new-hub_phase-1.yaml
@@ -20,12 +20,13 @@ body:
       label: >-
         Required information for setting up a cloud account for a new community
         on a dedicated cluster.
-      description: >-
+
+      value: |-
         This phase is applicable for cases where a community is being setup on a
         dedicated cluster. The following table lists the information that must
-        be provided before this phase can start. Use the Notes column to provide
-        any other contextual information.
-      value: |-
+        be provided before this phase can be marked as READY and begin.
+        Use the Notes column to provide any other contextual information.
+
         | Question | Answer | Notes |
         | :--- | :--- | :--- |
         | Cloud Provider | `AWS/GCP` | |
@@ -33,8 +34,7 @@ body:
         | Name of cloud account | | |
         | Community Representative(s) (GitHub handles or email) | | |
         | Have the Technical Contacts been added to the [AirTable](https://airtable.com/appbjBTRIbgRiElkr/pagD3XyZjqBunYMnC)? | `Yes/No` | |
-    validations:
+        
+        Available runbooks:
+        - https://infrastructure.2i2c.org/hub-deployment-guide/runbooks/phase1/#available-runbooks
       required: true
-  - type: markdown
-    attributes:
-      value: "Available runbooks: https://infrastructure.2i2c.org/hub-deployment-guide/runbooks/phase1/#available-runbooks"


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/3908#issuecomment-2139217109, I discovered that some markdown information in the issue form was being lost when the issue was submitted, and I didn't want to be. This PR is a bit of a hack that retains the desired text when the issue is submitted. The downside is that this text is within the `textarea` element's `value` definition which means it will be editable by the person completing the form.