### PR TITLE
Revert "openscapes/workshop: Put more users on r5.16xlarge nodes"

### DIFF
--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -43,7 +43,7 @@ basehub:
                     cpu_guarantee: 0.2328125
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.16xlarge
+                      node.kubernetes.io/instance-type: r5.xlarge
                   default: true
                 mem_3_7:
                   display_name: 3.7 GB RAM, upto 3.7 CPUs
@@ -53,7 +53,7 @@ basehub:
                     cpu_guarantee: 0.465625
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.16xlarge
+                      node.kubernetes.io/instance-type: r5.xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -62,7 +62,7 @@ basehub:
                     cpu_guarantee: 0.93125
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.16xlarge
+                      node.kubernetes.io/instance-type: r5.xlarge
                 mem_14_8:
                   display_name: 14.8 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -71,7 +71,7 @@ basehub:
                     cpu_guarantee: 1.8625
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.16xlarge
+                      node.kubernetes.io/instance-type: r5.xlarge
                 mem_29_7:
                   display_name: 29.7 GB RAM, upto 3.7 CPUs
                   kubespawner_override:
@@ -80,7 +80,7 @@ basehub:
                     cpu_guarantee: 3.725
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.16xlarge
+                      node.kubernetes.io/instance-type: r5.xlarge
                 mem_60_6:
                   display_name: 60.6 GB RAM, upto 15.6 CPUs
                   kubespawner_override:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#4145

Ref https://github.com/2i2c-org/infrastructure/issues/4144

Event is over