### PR TITLE
latam/plnc: Fix domain specification in cluster.yaml

### DIFF
--- a/config/clusters/catalystproject-latam/cluster.yaml
+++ b/config/clusters/catalystproject-latam/cluster.yaml
@@ -59,7 +59,7 @@ hubs:
       - enc-iner.secret.values.yaml
   - name: plnc
     display_name: "Catalyst Project, LatAm - PLNC"
-    domain: plnc.latam.catalystproject.2i2c.cloud
+    domain: hub.pln.villena.cl
     helm_chart: basehub
     helm_chart_values_files:
       - common.values.yaml


### PR DESCRIPTION
Causes healthcheck to fail.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/4173

Fixes https://github.com/2i2c-org/infrastructure/issues/4163