### PR TITLE
binderhub: Bump repo2docker image version

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -43,7 +43,7 @@ binderhub-service:
       use_registry: true
     KubernetesBuildExecutor:
       # Get ourselves a newer repo2docker!
-      build_image: quay.io/jupyterhub/repo2docker:2023.06.0-8.gd414e99
+      build_image: quay.io/jupyterhub/repo2docker:2024.03.0-21.g09f3d53
       node_selector:
         # Schedule builder pods to run on user nodes only
         hub.jupyter.org/node-purpose: user


### PR DESCRIPTION
Brings us up to what mybinder.org is using right now, so we can say 'if it works on mybinder.org, it will work here'.

https://github.com/jupyterhub/mybinder.org-deploy/blob/9a332761fe3ccce06e9d89a692c26970206120ec/mybinder/values.yaml#L193 is how I found the current used version