### PR TITLE
[binderhub-ui-demo] Use a branch for the homepage repo that removes subsections after login

### DIFF
--- a/config/clusters/2i2c/binderhub-ui-demo.values.yaml
+++ b/config/clusters/2i2c/binderhub-ui-demo.values.yaml
@@ -15,6 +15,7 @@ jupyterhub:
     binderhubUI:
       enabled: true
     homepage:
+      gitRepoBranch: "no-homepage-subsections"
       templateVars:
         org:
           name: Demo binderhub UI with binderhub-service


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/4197

This is how it looks like now:

<img width="869" alt="Screenshot 2024-06-11 at 11 11 48" src="https://github.com/2i2c-org/infrastructure/assets/7579677/599b06b4-7a22-4cd1-9f7b-b4b9d6a82cca">
