### PR TITLE
Enable alerting on full disk for Azure clusters

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -78,6 +78,9 @@ resource "azurerm_kubernetes_cluster" "jupyterhub" {
   resource_group_name               = azurerm_resource_group.jupyterhub.name
   kubernetes_version                = var.kubernetes_version
   dns_prefix                        = "k8s"
+  # role_based_access_control_enabled was added as the default changed from false
+  # to true when migrating from v2 to v3 of the provider. Setting back to false
+  # prevented forced recreation of the cluster.
   role_based_access_control_enabled = false
 
   lifecycle {
@@ -142,6 +145,9 @@ resource "azurerm_kubernetes_cluster" "jupyterhub" {
       "hub.jupyter.org/node-purpose" = "core",
       "k8s.dask.org/node-purpose"    = "core"
     }, var.node_pools["core"][0].labels)
+    # node_taints field will be removed in v4.0 of the Azure Provider since the AKS API
+    # doesn't allow arbitrary node taints on the default node pool. A warning that
+    # this field will be deprecated is produced.
     node_taints = concat([], var.node_pools["core"][0].taints)
 
     orchestrator_version = coalesce(var.node_pools["core"][0].kubernetes_version, var.kubernetes_version)

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -27,6 +27,12 @@ terraform {
       version = "~> 2.25"
     }
 
+    # Used to decrypt sops encrypted secrets containing PagerDuty keys
+    sops = {
+      # ref: https://registry.terraform.io/providers/carlpett/sops/latest
+      source  = "carlpett/sops"
+      version = "~> 0.7.2"
+    }
   }
   backend "gcs" {
     bucket = "two-eye-two-see-org-terraform-state"

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -73,11 +73,11 @@ provider "kubernetes" {
 
 
 resource "azurerm_kubernetes_cluster" "jupyterhub" {
-  name                              = "hub-cluster"
-  location                          = azurerm_resource_group.jupyterhub.location
-  resource_group_name               = azurerm_resource_group.jupyterhub.name
-  kubernetes_version                = var.kubernetes_version
-  dns_prefix                        = "k8s"
+  name                = "hub-cluster"
+  location            = azurerm_resource_group.jupyterhub.location
+  resource_group_name = azurerm_resource_group.jupyterhub.name
+  kubernetes_version  = var.kubernetes_version
+  dns_prefix          = "k8s"
   # role_based_access_control_enabled was added as the default changed from false
   # to true when migrating from v2 to v3 of the provider. Setting back to false
   # prevented forced recreation of the cluster.

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -225,8 +225,8 @@ locals {
       "registry" : "https://${azurerm_container_registry.container_registry.login_server}"
     }
   }
+  storage_threshold = "${var.storage_size * var.fileshare_alert_available_fraction}"
 }
-
 
 output "kubeconfig" {
   value     = azurerm_kubernetes_cluster.jupyterhub.kube_config_raw

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -4,6 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       # ref: https://registry.terraform.io/providers/hashicorp/azurerm/latest
+      #
+      # FIXME: In v4 of this module, we will lose the ability to taint the default
+      #        node pool. See comment in azurerm_kubernetes_cluster block and
+      #        deprecation warning in output
+      #
       source  = "hashicorp/azurerm"
       version = "~> 3.107"
     }

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -19,13 +19,6 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.25"
     }
-
-    # Used to decrypt sops encrypted secrets containing PagerDuty keys
-    sops = {
-      # ref: https://registry.terraform.io/providers/carlpett/sops/latest
-      source  = "carlpett/sops"
-      version = "~> 0.7.2"
-    }
   }
   backend "gcs" {
     bucket = "two-eye-two-see-org-terraform-state"

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -12,7 +12,7 @@ terraform {
       #        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#migrating-to-new--renamed-resources.
       #
       source  = "hashicorp/azurerm"
-      version = "~> 2.99"
+      version = "~> 3.107.0"
     }
 
     azuread = {
@@ -80,11 +80,12 @@ provider "kubernetes" {
 
 
 resource "azurerm_kubernetes_cluster" "jupyterhub" {
-  name                = "hub-cluster"
-  location            = azurerm_resource_group.jupyterhub.location
-  resource_group_name = azurerm_resource_group.jupyterhub.name
-  kubernetes_version  = var.kubernetes_version
-  dns_prefix          = "k8s"
+  name                              = "hub-cluster"
+  location                          = azurerm_resource_group.jupyterhub.location
+  resource_group_name               = azurerm_resource_group.jupyterhub.name
+  kubernetes_version                = var.kubernetes_version
+  dns_prefix                        = "k8s"
+  role_based_access_control_enabled = false
 
   lifecycle {
     # An additional safeguard against accidentally deleting the cluster.

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -4,15 +4,8 @@ terraform {
   required_providers {
     azurerm = {
       # ref: https://registry.terraform.io/providers/hashicorp/azurerm/latest
-      #
-      # FIXME: v3 has been released and we are still at v2, see release notes:
-      #        https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.0.0
-      #
-      #        We may need to remove old state and then then import it according to
-      #        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#migrating-to-new--renamed-resources.
-      #
       source  = "hashicorp/azurerm"
-      version = "~> 3.107.0"
+      version = "~> 3.107"
     }
 
     azuread = {

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -225,7 +225,7 @@ locals {
       "registry" : "https://${azurerm_container_registry.container_registry.login_server}"
     }
   }
-  storage_threshold = "${var.storage_size * var.fileshare_alert_available_fraction}"
+  storage_threshold = var.storage_size * var.fileshare_alert_available_fraction
 }
 
 output "kubeconfig" {

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -7,7 +7,9 @@ terraform {
       #
       # FIXME: In v4 of this module, we will lose the ability to taint the default
       #        node pool. See comment in azurerm_kubernetes_cluster block and
-      #        deprecation warning in output
+      #        deprecation warning in output.
+      #
+      #        Tracked in: https://github.com/2i2c-org/infrastructure/issues/4233
       #
       source  = "hashicorp/azurerm"
       version = "~> 3.107"

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -24,6 +24,13 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.25"
     }
+
+    # Used to decrypt sops encrypted secrets containing PagerDuty keys
+    sops = {
+      # ref: https://registry.terraform.io/providers/carlpett/sops/latest
+      source  = "carlpett/sops"
+      version = "~> 0.7.2"
+    }
   }
   backend "gcs" {
     bucket = "two-eye-two-see-org-terraform-state"

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -8,11 +8,6 @@
 *   https://2i2c-org.pagerduty.com/service-directory/?direction=asc&query=&team_ids=all
 *
 */
-data "sops_file" "pagerduty_service_integration_keys" {
-  # Read sops encrypted file containing integration key for pagerduty
-  source_file = "secret/enc-pagerduty-service-integration-keys.secret.yaml"
-}
-
 resource "azurerm_monitor_action_group" "alerts" {
   name                = "AlertsActionGroup" # Changing this forces a recreation
   resource_group_name = var.resourcegroup_name

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -20,7 +20,8 @@ resource "azurerm_monitor_action_group" "alerts" {
 }
 
 resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
-  name                = "Used disk space greater than ${local.storage_threshold} GB on ${var.subscription_id}"
+  # Changing the name forces a recreation every time we apply
+  name                = "Used disk space approaching capacity on Azure Subscription ${var.subscription_id}"
   resource_group_name = var.resourcegroup_name
   scopes              = [azurerm_storage_account.homes.id]
   description         = "Action will be triggered when used disk space is greater than ${local.storage_threshold} GB."

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -30,7 +30,7 @@ resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
   scopes              = [azurerm_storage_account.homes.id]
   description         = "Action will be triggered when used disk space is greater than ${local.storage_threshold} GB."
 
-  window_size = "PT1H"  # Window to aggregate over: 1 Hour
+  window_size = "PT1H" # Window to aggregate over: 1 Hour
 
   criteria {
     metric_namespace = "Microsoft.Storage/storageAccounts"

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -25,17 +25,17 @@ resource "azurerm_monitor_action_group" "alerts" {
 }
 
 resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
-  name                = "Used disk space > ${locals.storage_threshold} GB on ${var.subscription_id}"
+  name                = "Used disk space > ${local.storage_threshold} GB on ${var.subscription_id}"
   resource_group_name = var.resourcegroup_name
   scopes              = [azurerm_storage_account.homes.id]
-  description         = "Action will be triggered when used disk space is > ${locals.storage_threshold} GB."
+  description         = "Action will be triggered when used disk space is > ${local.storage_threshold} GB."
 
   criteria {
     metric_namespace = "Microsoft.Storage/storageAccounts"
     metric_name      = "UsedCapacity"
     aggregation      = "Average"
     operator         = "GreaterThan"
-    threshold        = locals.storage_threshold * 1000000000 # Convert GB to Bytes
+    threshold        = local.storage_threshold * 1000000000 # Convert GB to Bytes
   }
 
   action {

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -25,10 +25,10 @@ resource "azurerm_monitor_action_group" "alerts" {
 }
 
 resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
-  name                = "Used disk space > ${local.storage_threshold} GB on ${var.subscription_id}"
+  name                = "Used disk space greater than ${local.storage_threshold} GB on ${var.subscription_id}"
   resource_group_name = var.resourcegroup_name
   scopes              = [azurerm_storage_account.homes.id]
-  description         = "Action will be triggered when used disk space is > ${local.storage_threshold} GB."
+  description         = "Action will be triggered when used disk space is greater than ${local.storage_threshold} GB."
 
   criteria {
     metric_namespace = "Microsoft.Storage/storageAccounts"

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -25,7 +25,7 @@ resource "azurerm_monitor_action_group" "alerts" {
 }
 
 resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
-  name                = "Used disk space > ${locals.storage_threshold} GB on ${var.project_id}"
+  name                = "Used disk space > ${locals.storage_threshold} GB on ${var.subscription_id}"
   resource_group_name = var.resourcegroup_name
   scopes              = [azurerm_storage_account.homes.id]
   description         = "Action will be triggered when used disk space is > ${locals.storage_threshold} GB."

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -14,7 +14,7 @@ data "sops_file" "pagerduty_service_integration_keys" {
 }
 
 resource "azurerm_monitor_action_group" "alerts" {
-  name                = "AlertsActionGroup"  # Changing this forces a recreation
+  name                = "AlertsActionGroup" # Changing this forces a recreation
   resource_group_name = var.resourcegroup_name
   short_name          = "alertaction"
 
@@ -35,7 +35,7 @@ resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
     metric_name      = "UsedCapacity"
     aggregation      = "Average"
     operator         = "GreaterThan"
-    threshold        = "${locals.storage_threshold * 1000000000}"  # Convert GB to Bytes
+    threshold        = locals.storage_threshold * 1000000000 # Convert GB to Bytes
   }
 
   action {

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -1,0 +1,15 @@
+/**
+* This file defines alerts and notification channels for sending information to
+* PagerDuty in order to trigger incidents. This relies on pre-registered
+* PagerDuty services with "Microsoft Azure" integrations in 2i2c's PagerDuty
+* account.
+*
+* - PagerDuty services in 2i2c's PagerDuty account:
+*   https://2i2c-org.pagerduty.com/service-directory/?direction=asc&query=&team_ids=all
+*
+*/
+data "sops_file" "pagerduty_service_integration_keys" {
+  # Read sops encrypted file containing integration key for pagerduty
+  source_file = "secret/enc-pagerduty-service-integration-keys.secret.yaml"
+}
+

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -8,6 +8,11 @@
 *   https://2i2c-org.pagerduty.com/service-directory/?direction=asc&query=&team_ids=all
 *
 */
+data "sops_file" "pagerduty_service_integration_keys" {
+  # Read sops encrypted file containing integration key for pagerduty
+  source_file = "secret/enc-pagerduty-service-integration-keys.secret.yaml"
+}
+
 resource "azurerm_monitor_action_group" "alerts" {
   name                = "AlertsActionGroup" # Changing this forces a recreation
   resource_group_name = var.resourcegroup_name
@@ -15,7 +20,7 @@ resource "azurerm_monitor_action_group" "alerts" {
 
   webhook_receiver {
     name        = "callpagerdutyapi"
-    service_uri = "https://events.pagerduty.com/integration/5ebdc22d2399400cd0560e450b579333/enqueue"
+    service_uri = data.sops_file.pagerduty_service_integration_keys.data["disk_space_service_uri"]
   }
 }
 

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -13,3 +13,14 @@ data "sops_file" "pagerduty_service_integration_keys" {
   source_file = "secret/enc-pagerduty-service-integration-keys.secret.yaml"
 }
 
+resource "azurerm_monitor_action_group" "alerts" {
+  name                = "AlertsActionGroup"  # Changing this forces a recreation
+  resource_group_name = var.resourcegroup_name
+  short_name          = "alertaction"
+
+  webhook_receiver {
+    name        = "callpagerdutyapi"
+    service_uri = "https://events.pagerduty.com/integration/5ebdc22d2399400cd0560e450b579333/enqueue"
+  }
+}
+

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -30,6 +30,8 @@ resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
   scopes              = [azurerm_storage_account.homes.id]
   description         = "Action will be triggered when used disk space is greater than ${local.storage_threshold} GB."
 
+  window_size = "PT1H"  # Window to aggregate over: 1 Hour
+
   criteria {
     metric_namespace = "Microsoft.Storage/storageAccounts"
     metric_name      = "UsedCapacity"

--- a/terraform/azure/pagerduty.tf
+++ b/terraform/azure/pagerduty.tf
@@ -24,3 +24,21 @@ resource "azurerm_monitor_action_group" "alerts" {
   }
 }
 
+resource "azurerm_monitor_metric_alert" "disk_space_full_alert" {
+  name                = "Used disk space > ${locals.storage_threshold} GB on ${var.project_id}"
+  resource_group_name = var.resourcegroup_name
+  scopes              = [azurerm_storage_account.homes.id]
+  description         = "Action will be triggered when used disk space is > ${locals.storage_threshold} GB."
+
+  criteria {
+    metric_namespace = "Microsoft.Storage/storageAccounts"
+    metric_name      = "UsedCapacity"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = "${locals.storage_threshold * 1000000000}"  # Convert GB to Bytes
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts.id
+  }
+}

--- a/terraform/azure/secret/enc-pagerduty-service-integration-keys.secret.yaml
+++ b/terraform/azure/secret/enc-pagerduty-service-integration-keys.secret.yaml
@@ -1,0 +1,19 @@
+#ENC[AES256_GCM,data:oRVabPf6eEIgydOu7ZHQjJ6aK8nPGIFM4ZJwyRl5WKFj8Jw6UInVlibw3JIfnhj9Um0sX9Lor30DALqEZguLB3Q1YQeqaS839vgHVblztoOz,iv:083nqW+UDPozSBepDwTE2vxQHNQhGvWKv1VRHik1XpE=,tag:UdTpXqwS8nNP3TU7p/qj5A==,type:comment]
+#ENC[AES256_GCM,data:a9sqeIo+AMfubLy6U7OPrpMt+WUH+1BPPh/x/AfnvTcRMAxcoaarKFbiWzTmXIp9lSoTjj7eEqDDtX0eSB9XchymLCl34XoRkxf4IBM7eMrP,iv:hGyCmyac5VgkEGlMp4nrhYk67LrYXpYOGTCGr3lDLUY=,tag:aUXIlylpS8mgpbzCEYvRlg==,type:comment]
+#ENC[AES256_GCM,data:IqbZocr8Y3XDWuNOef/GuYh2Mx+cqXYn/kzisb/AhDdZ9vx6OPXFYpfwmLWN/1ZQ30VtP3ZAWr6rM7+CWgqAI1I9DJsYVZ1YsojyTgnNedMp,iv:wW+6nm/gOf6Hz0Y+KnZbXOk3yapUcsMyewvevzYz3YI=,tag:8zPL4vb755ex0VbHJUK2mg==,type:comment]
+#ENC[AES256_GCM,data:u0kd2qGcUb+0NLEc4RxEAea1BEluXHA03ABEpbP2An9FCup9K+XTT0QJrXQbGpIXZxYTqrAPlwkbmyER8QovQW38e4b+uLgUCPkaR0Bi953H3BaJfQ==,iv:crNfxSoK2JbCvRPIHKhIXpji2u69T1hb4u8EY3K7N5o=,tag:6/fUx9AJb56bTsq+opB47Q==,type:comment]
+disk_space: ENC[AES256_GCM,data:s1akWbhcsfOxT46gt30PGA1wnin3YVZ0oa2j6REWvJw=,iv:h0Y3S7r1IjpCMvSxcbRUD+0LYlfGAlIMDYcz0tZZxqo=,tag:uw8dvoo5SXSNZhRxtWcDEQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-05-31T13:38:11Z"
+          enc: CiUA4OM7eFfDybSy3uqugaXB9jaz0r7487fzs4ucW+tEWrjUYeAQEkkAWX/fcRKdraIr0fMn2SznjdRopmrxTYLZHG2fXvEfKjHQX59sw1ubPRjKa/iqfSGUf6Y60vf7gpNDJruvp9pRaO+NlYX6vF7R
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-05-31T13:38:11Z"
+    mac: ENC[AES256_GCM,data:yce2AfrcdL1FlTGjtjhK9le3r1iCp7nvqx7W7O4zVx6MpdAa7a+jExdZkI7TymgxfrJ+8zTh6jQHHkfgE8BJ7kLI3/Qbsg26WtCx8DXN75rxJaowo0Xdqj/T/3uVRCNl6l1SGe/miQq//x775CjyjtfTpVif4sq+fHsr7BIhv0s=,iv:q39Fc/m5m/90uJ9IcAhh4Y+4tYVbwAKufe3K9NB20WA=,tag:vbl0S5nbGIAHElx09hfCag==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/terraform/azure/secret/enc-pagerduty-service-integration-keys.secret.yaml
+++ b/terraform/azure/secret/enc-pagerduty-service-integration-keys.secret.yaml
@@ -1,19 +1,15 @@
-#ENC[AES256_GCM,data:oRVabPf6eEIgydOu7ZHQjJ6aK8nPGIFM4ZJwyRl5WKFj8Jw6UInVlibw3JIfnhj9Um0sX9Lor30DALqEZguLB3Q1YQeqaS839vgHVblztoOz,iv:083nqW+UDPozSBepDwTE2vxQHNQhGvWKv1VRHik1XpE=,tag:UdTpXqwS8nNP3TU7p/qj5A==,type:comment]
-#ENC[AES256_GCM,data:a9sqeIo+AMfubLy6U7OPrpMt+WUH+1BPPh/x/AfnvTcRMAxcoaarKFbiWzTmXIp9lSoTjj7eEqDDtX0eSB9XchymLCl34XoRkxf4IBM7eMrP,iv:hGyCmyac5VgkEGlMp4nrhYk67LrYXpYOGTCGr3lDLUY=,tag:aUXIlylpS8mgpbzCEYvRlg==,type:comment]
-#ENC[AES256_GCM,data:IqbZocr8Y3XDWuNOef/GuYh2Mx+cqXYn/kzisb/AhDdZ9vx6OPXFYpfwmLWN/1ZQ30VtP3ZAWr6rM7+CWgqAI1I9DJsYVZ1YsojyTgnNedMp,iv:wW+6nm/gOf6Hz0Y+KnZbXOk3yapUcsMyewvevzYz3YI=,tag:8zPL4vb755ex0VbHJUK2mg==,type:comment]
-#ENC[AES256_GCM,data:u0kd2qGcUb+0NLEc4RxEAea1BEluXHA03ABEpbP2An9FCup9K+XTT0QJrXQbGpIXZxYTqrAPlwkbmyER8QovQW38e4b+uLgUCPkaR0Bi953H3BaJfQ==,iv:crNfxSoK2JbCvRPIHKhIXpji2u69T1hb4u8EY3K7N5o=,tag:6/fUx9AJb56bTsq+opB47Q==,type:comment]
-disk_space: ENC[AES256_GCM,data:s1akWbhcsfOxT46gt30PGA1wnin3YVZ0oa2j6REWvJw=,iv:h0Y3S7r1IjpCMvSxcbRUD+0LYlfGAlIMDYcz0tZZxqo=,tag:uw8dvoo5SXSNZhRxtWcDEQ==,type:str]
+disk_space_service_uri: ENC[AES256_GCM,data:WusTnIvMcE9zaGfF1AD5QbiFwg+/JUti4zYU6SeD8mYRa1ZZVL1qT14GO2YfPs5LYE+9pOZ2zIfoaFJOXmArkDIWtPc3qvdRt8Bm7fOWvqv0,iv:PJQw8CwiAKCy4y+Opy4FeOofpEwc3IvG/XbezSsYLzc=,tag:oJymeH+2EkAAIS2+meSooQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2024-05-31T13:38:11Z"
-          enc: CiUA4OM7eFfDybSy3uqugaXB9jaz0r7487fzs4ucW+tEWrjUYeAQEkkAWX/fcRKdraIr0fMn2SznjdRopmrxTYLZHG2fXvEfKjHQX59sw1ubPRjKa/iqfSGUf6Y60vf7gpNDJruvp9pRaO+NlYX6vF7R
+          created_at: "2024-06-14T12:26:08Z"
+          enc: CiUA4OM7eGet11mVomgzV59cip2vdaMAp4ixSXaE7ZCPnPFS1J4jEkkAWX/fcVOKu7vC4PheH7d/AkhqJYqvRKBtfhjjWAHsCfLr+3dSy7iY3FesRESw6wRXbhAJ9w9l3XSCDUrQY6sr+368q6zMfWZ6
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-05-31T13:38:11Z"
-    mac: ENC[AES256_GCM,data:yce2AfrcdL1FlTGjtjhK9le3r1iCp7nvqx7W7O4zVx6MpdAa7a+jExdZkI7TymgxfrJ+8zTh6jQHHkfgE8BJ7kLI3/Qbsg26WtCx8DXN75rxJaowo0Xdqj/T/3uVRCNl6l1SGe/miQq//x775CjyjtfTpVif4sq+fHsr7BIhv0s=,iv:q39Fc/m5m/90uJ9IcAhh4Y+4tYVbwAKufe3K9NB20WA=,tag:vbl0S5nbGIAHElx09hfCag==,type:str]
+    lastmodified: "2024-06-14T12:26:09Z"
+    mac: ENC[AES256_GCM,data:kTg7+8cedY2mSFkZDkmVLE9ewuR6cCzvEY7v5hy3Aau4L/I/ObTh3RqKsedTdfn7UV07PfJfguevlLCzSr8cxTGPksDo756IW7pHiyK9lzaq2Db24OuWsLT3/rQpi0izmgi+4dkug5LgSJoNHVrXkTLqpaLN1NhHSKgy/LMSwac=,iv:bQmgoYSe+ArbktD5Ju+06RnHR9yijTF9F+7OVZengxE=,tag:MZ+5NJeE8LdGKDEpHNYWTg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -140,6 +140,6 @@ variable "fileshare_alert_available_fraction" {
   type        = number
   default     = 0.9
   description = <<-EOT
-  Decimal fraction (between 0 and 1) of free space in fileshare available over which to fire an alert to pagerduty.
+  Decimal fraction (between 0 and 1) of total space available in fileshare. If used space is over this, we fire an alert to pagerduty.
   EOT
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -135,3 +135,11 @@ variable "storage_size" {
   Size (in GB) of the storage to provision
   EOT
 }
+
+variable "fileshare_alert_available_fraction" {
+  type        = number
+  default     = 0.9
+  description = <<-EOT
+  Decimal fraction (between 0 and 1) of free space in fileshare available over which to fire an alert to pagerduty.
+  EOT
+}


### PR DESCRIPTION
- fixes https://github.com/2i2c-org/infrastructure/issues/3320

Unlike in GCP, we only have access to a `UsedCapacity` metric (as opposed to a percentage of free disk space). Therefore, I have tried to define a fraction of the total storage size _above which_ we trigger an alert.