### PR TITLE
[catalystproject-latam] Update tf filestore_capacity_gb variable to match what's in state

### DIFF
--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -11,7 +11,7 @@ k8s_versions = {
 }
 
 enable_filestore      = true
-filestore_capacity_gb = 1024
+filestore_capacity_gb = 6144
 
 core_node_machine_type = "n2-highmem-2"
 


### PR DESCRIPTION
I was doing some work towards #4214 and noticed that the size of the filestore was going to be decreased. I assume it has been bumped in the UI and not updated here. This PR brings our tf code inline with the current tf state.

Here is the plan that made me realise I needed to make this change (it is **not** the result of applying this PR):

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_filestore_instance.homedirs[0] will be updated in-place
  ~ resource "google_filestore_instance" "homedirs" {
        id          = "projects/catalystproject-392106/locations/southamerica-east1-c/instances/latam-homedirs"
        name        = "latam-homedirs"
        # (5 unchanged attributes hidden)

      ~ file_shares {
          ~ capacity_gb = 6144 -> 1024
            name        = "homes"
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```