### PR TITLE
Update deployer creds for catalystproject-africa cluster

### DIFF
--- a/config/clusters/catalystproject-africa/enc-deployer-credentials.secret.json
+++ b/config/clusters/catalystproject-africa/enc-deployer-credentials.secret.json
@@ -1,25 +1,25 @@
 {
 	"AccessKey": {
-		"AccessKeyId": "ENC[AES256_GCM,data:bfCE3ZpL41S3Wyr/V10jSBkW82Y=,iv:GugLeAOPcDUhIC+3K8Phu1ffEgklOYOVjLFl0+cxjx0=,tag:hvJw1++oLHxGwi8oij6osA==,type:str]",
-		"SecretAccessKey": "ENC[AES256_GCM,data:XhXGhTzsFltDWaqtwuGH83qtgmwGDzNhTYcCz+B0ij9dDAtihvuJHw==,iv:3UKbS+LkJ/aYzYNqTekyzn3eu4762VBSiB7Wwnw2SM4=,tag:YhmpjJM2O/vF2l2JESv+Aw==,type:str]",
-		"UserName": "ENC[AES256_GCM,data:euhwQ17ckzGAIc6xBoBV86q3xLehPVc=,iv:CABEE1Xm9r1gLHcyBk+OubZmAI82mcWmmg8BoZfdF9g=,tag:4LJDpycqrRfDXb/L3meraQ==,type:str]"
+		"AccessKeyId": "ENC[AES256_GCM,data:VZcSZWroKPUAn7fVjPCxXbGT1k4=,iv:pE8IcPmu5zSE/XGIN1zBuKggL+CMxBp6pQ2doZez2aw=,tag:SbKmbeJtJtehlsWdushZiQ==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:MJzhBxiFMjcqLXHWTnNyEACo05b96DMdqFgsUOifyVATbzsvRNIE7A==,iv:HlEsLl3gqe5obSYK4jy4sJxd1+ZcX6Wp2mGBuTL7gRU=,tag:lIRp4LkYRV3nes5+rC09bg==,type:str]",
+		"UserName": "ENC[AES256_GCM,data:J7O/t3fTzAu5U+u404Dic80ap4Tzu9w=,iv:6YKnouEMxM17p3tBlSqby9HgZ01KfllnrFIy0kJxZFA=,tag:NJwmqErd50WhvEp3ey2KhQ==,type:str]"
 	},
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2023-07-13T13:28:13Z",
-				"enc": "CiUA4OM7eGp3IZKuPCqLiEoBZn65f7wQY47PiQakb3WhBpnJ3gj1EkkAyiwFHFdx6/wa539yy2NQHlnMaaE2An6XBUCt6p+8G4wMzc0mDKPgze/n2NIdTEOCeAaBI20037Ei0U9krn+U2nsxbi5v25rF"
+				"created_at": "2024-06-13T14:22:10Z",
+				"enc": "CiUA4OM7eBZfp4t2oHj7u+RKvR5EqysTVhCnjuuD6o1ETWgzMSh6EkkAWX/fceugZtVF+SDG+gwOnvx71HO2Qf4oVGHCrAidbrlsbHUNgNAtTi9tXSLeHgw4/dADpTVJpCSrch0ktQ077e2Ip/INIIxT"
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-07-13T13:28:13Z",
-		"mac": "ENC[AES256_GCM,data:miAlgaz9yZPvqxesOr4HcQL0NL+niNVudefR9JorqF9MDop+GSUBvu6s496oI2CKxowaGcwrNE41ogG6KMX9Xn6aFhnvFm0fGusccGQ10gujqhdY2UPkg3s53vS5EVowvboFxqiZyMBA1bQqNJT1TwWA7qUrE2fSiFtufuRypXg=,iv:y7H8/4OxOVrZW2VwRPgIACP5Ay9mw/QGQSWptGhcIhQ=,tag:jieJkKSMqbvbqCN28k0s5A==,type:str]",
+		"lastmodified": "2024-06-13T14:22:11Z",
+		"mac": "ENC[AES256_GCM,data:gO4cO8PsteNg9llCG943TrpGuARA+cpddfLsgrdY77bvUswG5bQH8iNz0eQ3adq+1xz8bsJ1jS0+indMQAftVeZlZY5pYeeYxR64nQRiQmgxUvcYGoRXuX2L17Ug7kE4K8q1zcdRssGftQ6KJwAYMWjrmpCq67fqVuqYHZ2Pg1w=,iv:1eVQVABGOaHztxBJRF6IgQGB4q/VTEtjoto8A72+T4k=,tag:i05eq4H/GFHjUUDXq8BIBQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.7.3"
+		"version": "3.8.1"
 	}
 }


### PR DESCRIPTION
whilst working on #4216, the terraform plan indicated that the continuous deployer credentials would be updated in place, so I am committing any changes to the repo to be safe

Result of applying the below plan

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_iam_access_key.continuous_deployer will be updated in-place
  ~ resource "aws_iam_access_key" "continuous_deployer" {
        id                   = "AKIAXG55LPZNHKIRKEFW"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```