### PR TITLE
[New Hub] binder.pythia.2i2c.cloud

### DIFF
--- a/config/clusters/projectpythia/cluster.yaml
+++ b/config/clusters/projectpythia/cluster.yaml
@@ -31,3 +31,11 @@ hubs:
       - common.values.yaml
       - prod.values.yaml
       - enc-prod.secret.values.yaml
+  - name: pythia-binder
+    display_name: Binder for use with Project Pythia
+    domain: binder.pythia.2i2c.cloud
+    helm_chart: basehub
+    helm_chart_values_files:
+      - common.values.yaml
+      - pythia-binder.values.yaml
+      - enc-pythia-binder.secret.values.yaml

--- a/config/clusters/projectpythia/enc-pythia-binder.secret.values.yaml
+++ b/config/clusters/projectpythia/enc-pythia-binder.secret.values.yaml
@@ -1,0 +1,23 @@
+jupyterhub:
+    imagePullSecret:
+        create: ENC[AES256_GCM,data:8+0Dcw==,iv:z7hCPBba60WGy0g/76XLVjvOug73eXJFOQMcpr0gDuQ=,tag:wDCvWl/9OGMJ0Oa1kCTP/Q==,type:bool]
+        registry: ENC[AES256_GCM,data:Y7hV6i3YJA==,iv:UfJ4iapX6iauBYCx8uAh2VAknFV5+gFo4xNR48ddsFM=,tag:g4/Q6lXIe0Y56BYYRxD0kQ==,type:str]
+        username: ENC[AES256_GCM,data:FGg2liP/5na27SQROzOtMWoMFrBGfPlIHeF+MYAfxQ8=,iv:AGWQaPaCSW2jCi3Sw1y+Kdh7Zz1KzYjeTjAZ4iDrQhc=,tag:xZTFLGQPpP2rK9Bcak4B3Q==,type:str]
+        password: ENC[AES256_GCM,data:MqNHSUbjF9RRJvmgQXlb63oEQ+R07xDv6WrhQZ43OBZsNJPcTIK2dThNXokn27yt+ap97SgVYct+RHTQ4s3g2w==,iv:W3mEmg10Bzi74f1Qc8YUIvGU5MTP50Uuhnqe7XUAWTs=,tag:JqHvuxusmv5fb20nhOI4uQ==,type:str]
+binderhub-service:
+    buildPodsRegistryCredentials:
+        password: ENC[AES256_GCM,data:82uBfbLF3PnXVZR4DcvML2i6h/wI++RiQnPNkUA2qPMT9dLqoD3xqzwrulhMC2p/M39/U9a9FBRVRjRmSgT+zQ==,iv:YjbGszuuUKsrFyKJSWLHTjrgFmfIJxQ88mt73a5zAvk=,tag:rSf6dxfTADAnW5yGofeLyg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2024-05-27T20:11:52Z"
+          enc: CiUA4OM7eMToeLf5fQgnKvrZXGKFZcOPUlmXBirxzPu2FTmAqdkxEkkAWX/fcVFQzEb04SBjy+ByZyCOayfihNs7RoK/TtYGIs/TDVkYj6/ubVzrkxIHif8Ff0T28PhhhdWWNLzKer3K6nEuOC4M/fjV
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-06-13T12:15:21Z"
+    mac: ENC[AES256_GCM,data:p9puh96HhpONcr2TfwNAKwRITB8qhem9V+q6EWuYvqyEjhXdRtzbMVxtQWCc/ad9jrpBbV91CyCJULk+zQPxWHIGkHjYTDvd9B+K6wYKGkFDHxv4+1huP2XfkyOabdcGXD0XmvVOuECfK14Y+w8ykidJNUxqbGF3JJKTmJ/I7HQ=,iv:WSEns872F4I6ozzrdKBneK8kjeBW19pbcgZGHs/HxPk=,tag:eUY4S53Cr2XaqvI/NaqDSA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -1,6 +1,5 @@
 jupyterhub:
   ingress:
-    enabled: false
     hosts: [hub.binder.pythia.2i2c.cloud]
     tls:
       - hosts: [hub.binder.pythia.2i2c.cloud]
@@ -13,7 +12,6 @@ jupyterhub:
     binderhubUI:
       enabled: true
     homepage:
-      gitRepoBranch: "no-homepage-subsections"
       templateVars:
         org:
           name: ""
@@ -24,7 +22,17 @@ jupyterhub:
       type: none
       extraVolumeMounts: []
     initContainers: []
+    # The profile list in the common values files needs to be emptied
+    # otherwise the launching will fail
+    profileList: []
   hub:
+    config:
+      BinderSpawnerMixin:
+        auth_enabled: false
+      JupyterHub:
+        authenticator_class: "null"
+    # In the common values files this is where fancy profiles gets enabled
+    extraConfig: {}
     redirectToServer: false
     services:
       binder: {}
@@ -34,7 +42,7 @@ jupyterhub:
           - binder
         scopes:
           - servers
-          - read:users # admin:users is required if authentication isn't enabled
+          - admin:users
       user:
         scopes:
           - self
@@ -56,6 +64,8 @@ binderhub-service:
     BinderHub:
       base_url: /
       badge_base_url: https://binder.pythia.2i2c.cloud
+      auth_enabled: false
+      hub_url: https://hub.binder.pythia.2i2c.cloud
       enable_api_only_mode: false
       banner_message: ""
       about_message: Binder for use with Project Pythia
@@ -66,3 +76,5 @@ binderhub-service:
         secretKeyRef:
           name: hub
           key: hub.services.binder.apiToken
+    - name: JUPYTERHUB_API_URL
+      value: "https://hub.binderhub-ui-demo.2i2c.cloud/hub/api"

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -23,6 +23,7 @@ jupyterhub:
     # The profile list in the common values files needs to be emptied
     # otherwise the launching will fail
     profileList: []
+    cmd: jupyter-lab
   hub:
     config:
       BinderSpawnerMixin:
@@ -59,6 +60,7 @@ binderhub-service:
     GitHubRepoProvider:
       allowed_specs:
         - ^ProjectPythia/.*$
+        - binder-examples/requirements
     BinderHub:
       base_url: /
       badge_base_url: https://binder.pythia.2i2c.cloud

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -1,0 +1,68 @@
+jupyterhub:
+  ingress:
+    enabled: false
+    hosts: [hub.binder.pythia.2i2c.cloud]
+    tls:
+      - hosts: [hub.binder.pythia.2i2c.cloud]
+        secretName: https-auto-tls
+  custom:
+    2i2c:
+      add_staff_user_ids_to_admin_users: false
+    jupyterhubConfigurator:
+      enabled: false
+    binderhubUI:
+      enabled: true
+    homepage:
+      gitRepoBranch: "no-homepage-subsections"
+      templateVars:
+        org:
+          name: ""
+    singleuserAdmin:
+      extraVolumeMounts: []
+  singleuser:
+    storage:
+      type: none
+      extraVolumeMounts: []
+    initContainers: []
+  hub:
+    redirectToServer: false
+    services:
+      binder: {}
+    loadRoles:
+      binder:
+        services:
+          - binder
+        scopes:
+          - servers
+          - read:users # admin:users is required if authentication isn't enabled
+      user:
+        scopes:
+          - self
+          # Admin users will by default have access:services, so this is only
+          # observed to be required for non-admin users.
+          - access:services!service=binder
+binderhub-service:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts: [binder.pythia.2i2c.cloud]
+    tls:
+      - hosts: [binder.pythia.2i2c.cloud]
+        secretName: binder-https-auto-tls
+  config:
+    GitHubRepoProvider:
+      allowed_specs:
+        - ^ProjectPythia/.*$
+    BinderHub:
+      base_url: /
+      badge_base_url: https://binder.pythia.2i2c.cloud
+      enable_api_only_mode: false
+      banner_message: ""
+      about_message: Binder for use with Project Pythia
+      image_prefix: quay.io/2i2c-projectpythia/binderhub-ui-
+  extraEnv:
+    - name: JUPYTERHUB_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hub
+          key: hub.services.binder.apiToken

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -7,8 +7,6 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: false
-    jupyterhubConfigurator:
-      enabled: false
     binderhubUI:
       enabled: true
     homepage:
@@ -76,5 +74,11 @@ binderhub-service:
         secretKeyRef:
           name: hub
           key: hub.services.binder.apiToken
+    - name: JUPYTERHUB_CLIENT_ID
+      value: "service-binder"
     - name: JUPYTERHUB_API_URL
-      value: "https://hub.binderhub-ui-demo.2i2c.cloud/hub/api"
+      value: "https://hub.binder.pythia.2i2c.cloud/hub/api"
+    # Without this, the redirect URL to /hub/api/... gets
+    # appended to binderhub's URL instead of the hub's
+    - name: JUPYTERHUB_BASE_URL
+      value: "https://hub.binder.pythia.2i2c.cloud/"

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
     version: 3.3.7
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.240.hdaf17cc
+    version: 0.1.0-0.dev.git.244.h1e88014
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/4134

Couldn't make launching to work yet. Currently getting errors like:

```
[E 240613 18:47:14 launcher:208] Error creating user binder-examples-requirements-nm8uy25q: HTTP 403: Forbidden
    b'{"status": 403, "message": "Missing or invalid credentials."}'
[E 240613 18:47:14 builder:749] Retrying launch of https://github.com/binder-examples/requirements after error (duration=0s, attempt=1): HTTPError()
```

Which might indicate that the api token is not being passed correctly in the user creation request 🤔 