### PR TITLE
Update UToronto terraform config to match UI

### DIFF
--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -13,7 +13,7 @@ global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 location                       = "canadacentral"
 
-storage_size = 8192
+storage_size = 10240
 ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
 
 # List available versions via: az aks get-versions --location westus2 -o table


### PR DESCRIPTION
This PR updates our terraform config for disk storage to match what's in the Azure UI for the Toronto cluster. I used the workaround [here](https://github.com/2i2c-org/infrastructure/issues/890#issuecomment-1879072422) to deploy this. It also explains a discrepancy in the numbers I was seeing when deploying the fileshare alerting in #3320 