### PR TITLE
[terraform] Create a network in GCP instead of relying on the existence of an existing 'default' network

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -73,10 +73,7 @@ resource "google_container_cluster" "cluster" {
     prevent_destroy = true
   }
 
-  // For private clusters, pass the name of the network and subnetwork created
-  // by the VPC
-  network    = var.enable_private_cluster ? data.google_compute_network.default_network.name : null
-  subnetwork = var.enable_private_cluster ? data.google_compute_subnetwork.default_subnetwork.name : null
+  network    = google_compute_network.network.name
 
   // Dynamically provision the private cluster config when deploying a
   // private cluster

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -73,7 +73,7 @@ resource "google_container_cluster" "cluster" {
     prevent_destroy = true
   }
 
-  network    = google_compute_network.network.name
+  network = google_compute_network.network.name
 
   // Dynamically provision the private cluster config when deploying a
   // private cluster

--- a/terraform/gcp/network.tf
+++ b/terraform/gcp/network.tf
@@ -1,6 +1,6 @@
 resource "google_compute_network" "network" {
-  name    = "${var.prefix}-network"
-  project = var.project_id
+  name                    = "${var.prefix}-network"
+  project                 = var.project_id
   auto_create_subnetworks = true
 }
 

--- a/terraform/gcp/network.tf
+++ b/terraform/gcp/network.tf
@@ -1,27 +1,21 @@
+resource "google_compute_network" "network" {
+  name    = "${var.prefix}-network"
+  project = var.project_id
+  auto_create_subnetworks = true
+}
+
 /**
 * Networking to support private clusters
 *
-* This config is only deployed when the enable_private_cluster variable is set
-* to true
+* Config below here is only deployed when the enable_private_cluster variable is
+* set to true
 */
-
-data "google_compute_network" "default_network" {
-  name    = "default"
-  project = var.project_id
-}
-
-data "google_compute_subnetwork" "default_subnetwork" {
-  name    = "default"
-  project = var.project_id
-  region  = var.region
-}
-
 resource "google_compute_firewall" "iap_ssh_ingress" {
   count = var.enable_private_cluster ? 1 : 0
 
   name    = "allow-ssh"
   project = var.project_id
-  network = data.google_compute_network.default_network.name
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -39,7 +33,7 @@ resource "google_compute_router" "router" {
   name    = "${var.prefix}-router"
   project = var.project_id
   region  = var.region
-  network = data.google_compute_network.default_network.id
+  network = google_compute_network.network.id
 }
 
 resource "google_compute_router_nat" "nat" {

--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -19,7 +19,7 @@ resource "google_filestore_instance" "homedirs" {
   }
 
   networks {
-    network = var.enable_private_cluster ? data.google_compute_network.default_network.name : "default"
+    network = google_compute_network.network.name
     modes   = ["MODE_IPV4"]
   }
 }


### PR DESCRIPTION
Previously when we have deployed to GCP projects using terraform, we have read in a network called `default` that appears in each new project, rather than creating a new one. However, the organisational controls on the [new AWI-CIROH project](https://github.com/2i2c-org/infrastructure/issues/4238) mean there is no `default` network and our deployments were failing. This PR refactors our GCP terraform code to create a network instead of searching for `default`.

- I am not sure if there is a way in terraform to say "if this data source doesn't exist, create something instead", but my brief google search didn't surface much hope
- When we apply this to our existing projects, it may try to recreate filestores and clusters :(
- I am unsure what the implications are, particularly billing, for projects that will have a `default` network and we create another one

I'd appreciate guidance from @yuvipanda on these points