### PR TITLE
Misc updates on testing hub server spawing of binderhubs and documentation

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -43,7 +43,7 @@ hubs:
       - enc-imagebuilding-demo.secret.values.yaml
   - name: binderhub-ui-demo
     display_name: "2i2c Binderhub UI demo"
-    domain: hub.binderhub-ui-demo-demo.2i2c.cloud
+    domain: hub.binderhub-ui-demo.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
       - basehub-common.values.yaml

--- a/config/clusters/projectpythia/cluster.yaml
+++ b/config/clusters/projectpythia/cluster.yaml
@@ -33,7 +33,7 @@ hubs:
       - enc-prod.secret.values.yaml
   - name: pythia-binder
     display_name: Binder for use with Project Pythia
-    domain: binder.pythia.2i2c.cloud
+    domain: hub.binder.pythia.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
       - common.values.yaml

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -23,7 +23,33 @@ jupyterhub:
     # The profile list in the common values files needs to be emptied
     # otherwise the launching will fail
     profileList: []
-    cmd: jupyter-lab
+    cmd:
+      - python3
+      - "-c"
+      - |
+        import os
+        import sys
+
+        try:
+            import jupyterlab
+            import jupyterlab.labapp
+            major = int(jupyterlab.__version__.split(".", 1)[0])
+        except Exception as e:
+            print("Failed to import jupyterlab: {e}", file=sys.stderr)
+            have_lab = False
+        else:
+            have_lab = major >= 3
+
+        if have_lab:
+            # technically, we could accept another jupyter-server-based frontend
+            print("Launching jupyter-lab", file=sys.stderr)
+            exe = "jupyter-lab"
+        else:
+            print("jupyter-lab not found, launching jupyter-notebook", file=sys.stderr)
+            exe = "jupyter-notebook"
+
+        # launch the notebook server
+        os.execvp(exe, sys.argv)
   hub:
     config:
       BinderSpawnerMixin:

--- a/config/clusters/templates/common/binderhub-ui-hub.values.yaml
+++ b/config/clusters/templates/common/binderhub-ui-hub.values.yaml
@@ -41,7 +41,33 @@ jupyterhub:
     initContainers: []
     profileList: []
 {% if authenticator == "none" %}
-    cmd: jupyter-lab
+    cmd:
+      - python3
+      - "-c"
+      - |
+        import os
+        import sys
+
+        try:
+            import jupyterlab
+            import jupyterlab.labapp
+            major = int(jupyterlab.__version__.split(".", 1)[0])
+        except Exception as e:
+            print("Failed to import jupyterlab: {e}", file=sys.stderr)
+            have_lab = False
+        else:
+            have_lab = major >= 3
+
+        if have_lab:
+            # technically, we could accept another jupyter-server-based frontend
+            print("Launching jupyter-lab", file=sys.stderr)
+            exe = "jupyter-lab"
+        else:
+            print("jupyter-lab not found, launching jupyter-notebook", file=sys.stderr)
+            exe = "jupyter-notebook"
+
+        # launch the notebook server
+        os.execvp(exe, sys.argv)
 {% endif %}
   hub:
 {% if authenticator == "none" %}

--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -165,6 +165,35 @@ def run_hub_health_check(
         print_colour("ERROR: No hubs with this name found!")
         sys.exit(1)
 
+    # Skip the regular hub health check for hubs with binderhub ui that are not authenticated
+    for values_file_name in hub.spec["helm_chart_values_files"]:
+        if not any(
+            substr in os.path.basename(values_file_name)
+            for substr in ["secret", "common"]
+        ):
+            values_file = config_file_path.parent.joinpath(values_file_name)
+            config = yaml.load(values_file)
+            binderhub_ui = (
+                config.get("jupyterhub", {})
+                .get("custom", {})
+                .get("binderhubUI", {})
+                .get("enabled")
+            )
+            authentication = (
+                config.get("jupyterhub", {})
+                .get("hub", {})
+                .get("config", {})
+                .get("JupyterHub", {})
+                .get("authenticator_class", "")
+            )
+
+    if binderhub_ui and authentication == "null":
+        print_colour(
+            f"Testing {hub.spec['name']} is not yet supported. Skipping ...",
+            "yellow",
+        )
+        return
+
     print_colour(f"Running hub health check for {hub.spec['name']}...")
 
     # Check if this hub has a domain override file. If yes, apply override.

--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -165,28 +165,6 @@ def run_hub_health_check(
         print_colour("ERROR: No hubs with this name found!")
         sys.exit(1)
 
-    # Skip the regular hub health check for hubs with binderhub ui that are also launching user servers
-    for values_file_name in hub.spec["helm_chart_values_files"]:
-        if not any(
-            substr in os.path.basename(values_file_name)
-            for substr in ["secret", "common"]
-        ):
-            values_file = config_file_path.parent.joinpath(values_file_name)
-            config = yaml.load(values_file)
-            binderhub_ui = (
-                config.get("jupyterhub", {})
-                .get("custom", {})
-                .get("binderhubUI", {})
-                .get("enabled")
-            )
-
-    if binderhub_ui:
-        print_colour(
-            f"Skipping hub health check for {hub.spec['name']} because it's a binderhub...",
-            "yellow",
-        )
-        return
-
     print_colour(f"Running hub health check for {hub.spec['name']}...")
 
     # Check if this hub has a domain override file. If yes, apply override.

--- a/deployer/health_check_tests/test_hub_health.py
+++ b/deployer/health_check_tests/test_hub_health.py
@@ -46,10 +46,6 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             hub_url,
             test_notebook_path,
             username=username,
-            user_options={
-                "token": service_api_token,
-                "image": "quay.io/2i2c-projectpythia/binderhub-ui-binder-2dexamples-2drequirements-55ab5c:50533eb470ee6c24e872043d30b2fee463d6943f",
-            },
             server_creation_timeout=360,
             kernel_execution_timeout=360,  # This doesn't do anything yet
             create_user=True,

--- a/deployer/health_check_tests/test_hub_health.py
+++ b/deployer/health_check_tests/test_hub_health.py
@@ -46,6 +46,10 @@ async def check_hub_health(hub_url, test_notebook_path, service_api_token):
             hub_url,
             test_notebook_path,
             username=username,
+            user_options={
+                "token": service_api_token,
+                "image": "quay.io/2i2c-projectpythia/binderhub-ui-binder-2dexamples-2drequirements-55ab5c:50533eb470ee6c24e872043d30b2fee463d6943f",
+            },
             server_creation_timeout=360,
             kernel_execution_timeout=360,  # This doesn't do anything yet
             create_user=True,

--- a/docs/hub-deployment-guide/runbooks/phase3/initial-hub-setup.md
+++ b/docs/hub-deployment-guide/runbooks/phase3/initial-hub-setup.md
@@ -168,6 +168,10 @@ All of the following steps must be followed in order to consider phase 3.1 compl
    Please pay attention to all the fields that have been auto-generated for you by this command and change every one that doesn't match the community's requirements or was not rendered correctly before copying-pasting it into the relevant files.
    ```
 
+   ```{important}
+   If you are deploying a binderhub ui style hub, then make sure that in the `cluster.yaml` file **the hub's domain** is entered instead of the binderhub's, for testing purposes.
+   ```
+
 1. **Add the new cluster to CI/CD**
 
    ```{important}


### PR DESCRIPTION
This is currently failing for unauthenticated binderhubs because of some issue with the token being passed to `/user/api/kernelspecs` or dropped. Seeing this in the notebook logs:


```bash
[I 2024-06-20 14:22:15.949 ServerApp] 302 GET /user/deployment-service-check/ (@192.168.15.175) 0.51ms
[W 2024-06-20 14:22:21.607 ServerApp] wrote error: 'Forbidden'
    Traceback (most recent call last):
      File "/srv/conda/envs/notebook/lib/python3.10/site-packages/tornado/web.py", line 1788, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/srv/conda/envs/notebook/lib/python3.10/site-packages/tornado/web.py", line 3289, in wrapper
        url = self.get_login_url()
      File "/srv/conda/envs/notebook/lib/python3.10/site-packages/jupyter_server/base/handlers.py", line 782, in get_login_url
        raise web.HTTPError(403)
    tornado.web.HTTPError: HTTP 403: Forbidden
[W 2024-06-20 14:22:21.608 ServerApp] 403 GET /user/deployment-service-check/api/kernelspecs (@192.168.14.203) 1.89ms referer=None
```

But in that get request, the token should be passed because it's done under the same session here

https://github.com/Quansight/jhub-client/blob/860dff7365bdccc5208724390529b00b8198ccef/jhub_client/api.py#L226

Which gets called by https://github.com/Quansight/jhub-client/blob/860dff7365bdccc5208724390529b00b8198ccef/jhub_client/execute.py#L87
so not sure what's that about.


Can it be because of https://github.com/aio-libs/aiohttp/issues/5783? I do see a 302 in the logs