### PR TITLE
Update Earthscope common.values.yaml to include geolab img

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -155,6 +155,12 @@ basehub:
                   image: "{value}"
               choices:
                 jupyter-scipy:
+                  display_name: GeoLab
+                  slug: geolab-general
+                  kubespawner_override:
+                    # FIXME: use quay.io/ for tags after 2023-10-20
+                    image: public.ecr.aws/earthscope-dev/geolab:td-dev-dd5851e6
+                jupyter-scipy:
                   display_name: Jupyter
                   slug: jupyter-scipy
                   kubespawner_override:

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -154,7 +154,7 @@ basehub:
                 kubespawner_override:
                   image: "{value}"
               choices:
-                jupyter-scipy:
+                geolab-general:
                   display_name: GeoLab
                   slug: geolab-general
                   kubespawner_override:

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -158,7 +158,6 @@ basehub:
                   display_name: GeoLab
                   slug: geolab-general
                   kubespawner_override:
-                    # FIXME: use quay.io/ for tags after 2023-10-20
                     image: public.ecr.aws/earthscope-dev/geolab:td-dev-dd5851e6
                 jupyter-scipy:
                   display_name: Jupyter


### PR DESCRIPTION
Adding an EarthScope public ECR image choice to hub dropdown menu.

EarthScope is still developing on its public repo->public image repo chain, but wanting to add this dev image to test the hub.
Thank you 2i2c! @yuvipanda 