### PR TITLE
Allow debug flag to be passed to helm upgrade command for support deployment

### DIFF
--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -74,7 +74,11 @@ def deploy_support(
     cert_manager_version: str = typer.Option(
         "v1.12.1", help="Version of cert-manager to install"
     ),
-    debug: bool = typer.Option(False, "--debug", help="When present, the `--debug` flag will be passed to the `helm upgrade` command."),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="When present, the `--debug` flag will be passed to the `helm upgrade` command.",
+    ),
 ):
     """
     Deploy support components to a cluster
@@ -88,7 +92,9 @@ def deploy_support(
 
     if cluster.support:
         with cluster.auth():
-            cluster.deploy_support(cert_manager_version=cert_manager_version, debug=debug)
+            cluster.deploy_support(
+                cert_manager_version=cert_manager_version, debug=debug
+            )
 
 
 @app.command()

--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -74,6 +74,7 @@ def deploy_support(
     cert_manager_version: str = typer.Option(
         "v1.12.1", help="Version of cert-manager to install"
     ),
+    debug: bool = typer.Option(False, "--debug", help="When present, the `--debug` flag will be passed to the `helm upgrade` command."),
 ):
     """
     Deploy support components to a cluster
@@ -87,7 +88,7 @@ def deploy_support(
 
     if cluster.support:
         with cluster.auth():
-            cluster.deploy_support(cert_manager_version=cert_manager_version)
+            cluster.deploy_support(cert_manager_version=cert_manager_version, debug=debug)
 
 
 @app.command()

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -38,7 +38,7 @@ class Cluster:
         else:
             raise ValueError(f'Provider {self.spec["provider"]} not supported')
 
-    def deploy_support(self, cert_manager_version):
+    def deploy_support(self, cert_manager_version, debug):
         cert_manager_url = "https://charts.jetstack.io"
 
         print_colour("Provisioning cert-manager...")
@@ -93,6 +93,9 @@ class Cluster:
 
             for values_file in values_files:
                 cmd.append(f"--values={values_file}")
+
+            if debug:
+                cmd.append("--debug")
 
             print_colour(f"Running {' '.join([str(c) for c in cmd])}")
             subprocess.check_call(cmd)


### PR DESCRIPTION
I just had to write this up and thought it would be useful to keep, especially as we already have it for hubs