### PR TITLE
scripts: Support pagination in rsync-active-users

### DIFF
--- a/extra-scripts/rsync-active-users.py
+++ b/extra-scripts/rsync-active-users.py
@@ -94,19 +94,22 @@ def get_all_users(hub_url, token):
 
     while True:
         url = f"{hub_url}/hub/api/users?offset={offset}&limit={limit}"
-        resp = requests.get(url, headers={
-            "Authorization": f"token {token}",
-            "Accept": "application/jupyterhub-pagination+json"
-        })
+        resp = requests.get(
+            url,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/jupyterhub-pagination+json",
+            },
+        )
 
         paginated_resp = resp.json()
-        users = paginated_resp['items']
-        pagination = paginated_resp.get('_pagination', {}).get('next', None)
+        users = paginated_resp["items"]
+        pagination = paginated_resp.get("_pagination", {}).get("next", None)
         if pagination is None:
             break
         else:
-            offset = pagination['offset']
-            limit = pagination['limit']
+            offset = pagination["offset"]
+            limit = pagination["limit"]
         for user in users:
             if user["last_activity"]:
                 user["last_activity"] = parse(user.get("last_activity"))


### PR DESCRIPTION
JupyterHub will otherwise silently only return the first 200 users, which is not very good.

Ref https://github.com/2i2c-org/infrastructure/issues/4238