### PR TITLE
pchub: fix broken grafana dashboard deployments

### DIFF
--- a/config/clusters/pchub/enc-grafana-token.secret.yaml
+++ b/config/clusters/pchub/enc-grafana-token.secret.yaml
@@ -1,15 +1,15 @@
-grafana_token: ENC[AES256_GCM,data:QZahZIvf+EKQPolv9RFSEJy+OWqghBM+ejOWAFKdQVjLyklEukuwXJnDDoUWPw==,iv:PU+dsYOO6qEJE6zoCTjkpvY+fR5pQ9MJ1Nnhn318zAc=,tag:ffjtznQJNmDSHURcKwGjow==,type:str]
+grafana_token: ENC[AES256_GCM,data:wTAK0ghkzrMHgzwmg/7dn2SKgccADBD/GMWiQbC0rR3iF74OpjrTzO9G/kEXiQ==,iv:Yaw/iF9z99eZKbWq1Fwf7By72DU52lHZbvfUVq2br64=,tag:SrCewcHezJTIC9rCcawxoQ==,type:str]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2023-02-17T04:03:31Z"
-          enc: CiUA4OM7eLRUO7RuJad23ABqIeYgpsMJtvxdNz3E8T20IV2u8i3qEkgA+0T9hZhp8XKyUPxjUIXkEMhS5dbymfY+7HrCO9qh9HG/F5QIyL/QefFilBENh9liQt3b58DreDJH47C5Qsu5Un+gdt5vN9w=
+          created_at: "2024-06-25T06:30:27Z"
+          enc: CiUA4OM7eBG20vFsSUH1WZGvDV8rqbHbrCuQVICO6aaml5QdDsObEkkAWX/fcX8UORD37bP+HcneFUG4bk7LlOEI0S+oHVMX7WNLGSiHLnhCUp0lD02lTrjUrvopdmUPI2XH3jF/qfxt89csAvG/IjL2
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-17T04:03:31Z"
-    mac: ENC[AES256_GCM,data:uIgLocKhcKWS9/jaWXQdJ5yp1PFwf87OnJZBnEQqO6TbBSmjQmo3PizX+My1csRJ6iSACJNq6218/7i689Vxt4YjvQSZ9VNfMl+6pUgwjV+Z+guYdcvFhIYvRvZV1vaSnFD2o8yVgtiRc8+l+HS/0vnXAcbZure2zgzWXALXG74=,iv:g47wnZK5R93XuJW9f7YD9WvvU/m6ICQ6dOvRM+xG6go=,tag:Edh9xXZLyFTyoqhRXyj8iA==,type:str]
+    lastmodified: "2024-06-25T06:30:28Z"
+    mac: ENC[AES256_GCM,data:g7RrYsC5eXWNvoR+v63y/DOoe2vLUTXNDP9BB4ExM1IIvJxntJUnIsCp/IZqOT2PO50vjHGeYx+Mi3IVLIh9EKaQ+e4xCF+lmZ8Cw++YakmB4gJ2AoQgJtBS+RYZS/Cp66QTbaieb5VwHDhHvIABUJ5JstVdhslFHcEGIVEOCnQ=,iv:+ghpdoIK+bMhIJi7MEQ41DAdb1mLFkSjvPjrERR9VjE=,tag:PbWs1b7JT0rs8ybk7hBqpA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.2
+    version: 3.8.1


### PR DESCRIPTION
I'm not sure why the grafana deploy workflow failed, but re-creating a token against the grafana servers + re-regestering the clusters prometheus server against the central grafana dashboard seems to have done the trick.