### PR TITLE
Set resource limits/guarantees on opensci/small-binder

### DIFF
--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -29,6 +29,11 @@ jupyterhub:
           name: ""
           url: ""
   singleuser:
+    cpu:
+      limit: 2
+    memory:
+      limit: 4G
+      guarantee: 2G
     storage:
       type: none
       extraVolumeMounts: []


### PR DESCRIPTION
- follow-up to #4246 where I forgot to set these