### PR TITLE
nasa-veda: update QGIS image using jupyter-qgis-remote-proxy

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -214,10 +214,10 @@ basehub:
           slug: qgis
           description: Linux desktop in the browser, with qgis installed
           kubespawner_override:
-            # Launch people directly into the Linux desktop when they start
-            default_url: /desktop
+            # Launch people directly into QGIS when they start
+            default_url: /qgis
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: quay.io/2i2c/nasa-qgis-image:0d0765090250
+            image: quay.io/2i2c/nasa-qgis-image:ce0b7c7f33ea
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)


### PR DESCRIPTION
Refs https://github.com/NASA-IMPACT/veda-jupyterhub/issues/2

Uses https://github.com/sunu/jupyter-remote-qgis-proxy to create a custom /qgis endpoint that accepts query parameters to open datasets in QGIS.

I have tested this using the Bring Your Own Image feature and it seemed to work well. I think it should be fine to deploy, and it hopefully can make for a nice demo.

cc @sunu @yuvipanda 