### PR TITLE
nasa hubs: update singleuser image to new image based on pangeo-notebook:2024.06.02

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -59,7 +59,7 @@ jupyterhub:
         description: Pangeo based notebook with a Python environment
         default: true
         kubespawner_override:
-          image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
+          image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5
           init_containers:
             # Need to explicitly fix ownership here, as otherwise these directories will be owned
             # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -85,7 +85,7 @@ basehub:
             - US-GHG-Center:ghg-trial-access
             - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
+            image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -115,7 +115,7 @@ basehub:
           description: Pangeo based notebook with a Python environment
           default: true
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
+            image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
Fixes https://github.com/NASA-IMPACT/veda-jupyterhub/issues/40

Updates the `singleuser` image used on the nasa-ghg, nasa-veda and nasa-esdis to use images built via https://github.com/nasa-IMPACT/pangeo-notebook-veda-image/ .

This updates the Pangeo base image to `pangeo-notebook:2024.06.02`. I see `pangeo` has published new versions in the past few days and we may want to do another upgrade soon, but we had not updated in a couple months and I think moving to `2024.06.02` for now is probably good.

We have run some notebook tests as part of CI and this image seems to generally work. I also did a quick check and things seemed okay to me, but it would be great to have at least another set of eyes on it.

How to test:

 - Login to any of the hubs, choose the Bring Your Own Image option and put in `public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5`. Verify that test notebooks, etc. work as expected.

We should wait for approval and sign-off from either @wildintellect or @jsignell before we merge this.
