### PR TITLE
catalystproject-latam, labi: add two initial admin users

### DIFF
--- a/config/clusters/catalystproject-latam/labi.values.yaml
+++ b/config/clusters/catalystproject-latam/labi.values.yaml
@@ -20,7 +20,9 @@ jupyterhub:
         scope:
           - read:org
       Authenticator:
-        admin_users: []
+        admin_users:
+          - paul-hernandez-herrera # Paúl Hernandez
+          - aolivera-labi # Andrés Olivera
 
   singleuser:
     profileList:


### PR DESCRIPTION
Adds users as described in https://github.com/2i2c-org/infrastructure/issues/4258#issuecomment-2195535041