### PR TITLE
[docs] binderhub and daskhub: scheduler/worker pods to have permission to pull built images

### DIFF
--- a/docs/howto/features/binderhub-ui.md
+++ b/docs/howto/features/binderhub-ui.md
@@ -409,6 +409,7 @@ binderhub-service:
     password: <password>
 ```
 
+(features:binderhub-service:private-registry)=
 ### 4. If pushing to quay.io registry, also setup the credentials for image pulling
 
 When pushing to the quay registry, the images are pushed as `private` by default (even if the plan doesn't allow it).
@@ -422,4 +423,15 @@ jupyterhub:
       registry: quay.io
       username: <robot_account_name>
       password: <password>
+```
+
+If dask-gateway is enabled, the scheduler and worker pods needs to be configured
+to reference the k8s Secret created by the JupyterHub chart through the config
+above. This is done like below:
+
+```yaml
+dask-gateway:
+  gateway:
+    backend:
+      imagePullSecrets: [{name: image-pull-secret}]
 ```

--- a/docs/howto/features/dask.md
+++ b/docs/howto/features/dask.md
@@ -23,7 +23,7 @@ To enable dask-gateway support on a hub, the following configuration changes nee
           enabled: true
     ```
 
-1. set `jupyterhub.singleuser.cloudMetadata.blockWithIptables` to false
+1. set `jupyterhub.singleuser.cloudMetadata.blockWithIptables` to false:
 
     This is to don't block access to the cloud provider's metadata server!
     If we do the coupling between the cloud providers IAM permissions and
@@ -38,6 +38,12 @@ To enable dask-gateway support on a hub, the following configuration changes nee
         cloudMetadata:
           blockWithIptables: false
     ```
+
+1. if binderhub is enabled to work against a private container registry:
+
+    Then dask-gateway's scheduler and worker pods need to pull from that
+    registry, so follow steps in [](features:binderhub-service:private-registry)
+    to set up permissions for that.
 
 (howto:features:daskhub)=
 ## To an existing cluster


### PR DESCRIPTION
- Part of https://github.com/2i2c-org/infrastructure/issues/4301