### PR TITLE
hhmi: Enable access to cloudmetadata for binder

### DIFF
--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -1,4 +1,3 @@
-
 userServiceAccount:
   annotations:
     iam.gke.io/gcp-service-account: hhmi-binder@hhmi-398911.iam.gserviceaccount.com

--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -1,3 +1,7 @@
+
+userServiceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: hhmi-binder@hhmi-398911.iam.gserviceaccount.com
 jupyterhub:
   ingress:
     hosts: [hub.binder.hhmi.2i2c.cloud]
@@ -17,6 +21,8 @@ jupyterhub:
       templateVars:
         enabled: false
   singleuser:
+    cloudMetadata:
+      blockWithIptables: false
     cpu:
       limit: 2
     memory:

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -19,9 +19,9 @@ k8s_versions = {
 
 hub_cloud_permissions = {
   "binder" : {
-      allow_access_to_external_requester_pays_buckets : false,
-      bucket_admin_access: [],
-      hub_namespace: "binder"
+    allow_access_to_external_requester_pays_buckets : false,
+    bucket_admin_access : [],
+    hub_namespace : "binder"
   }
 }
 
@@ -29,7 +29,7 @@ hub_cloud_permissions = {
 enable_filestore      = true
 filestore_capacity_gb = 1024
 
-user_buckets          = {}
+user_buckets = {}
 
 # Setup notebook node pools
 notebook_nodes = {

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -17,12 +17,19 @@ k8s_versions = {
 # Tip: uncomment the line below if this cluster will be multi-tenant
 # enable_network_policy  = true
 
+hub_cloud_permissions = {
+  "binder" : {
+      allow_access_to_external_requester_pays_buckets : false,
+      bucket_admin_access: [],
+      hub_namespace: "binder"
+  }
+}
+
 # Setup a filestore for in-cluster NFS
 enable_filestore      = true
 filestore_capacity_gb = 1024
 
 user_buckets          = {}
-hub_cloud_permissions = {}
 
 # Setup notebook node pools
 notebook_nodes = {


### PR DESCRIPTION
We aren't allowing any actual permissions, but without this, any access to GCS will wait for 1min before timing out. And our demo accesses (public) GCS buckets