### PR TITLE
Refactor passthrough chart config - no nesting of class names under `binderhub-service.config`

### DIFF
--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -99,9 +99,9 @@ binderhub-service:
       enable_api_only_mode: false
       banner_message: ""
       about_message: ""
-      DockerRegistry:
-        url: &url https://quay.io
-        username: &username hhmi-binder+image_builder
+    DockerRegistry:
+      url: &url https://quay.io
+      username: &username hhmi-binder+image_builder
     GitHubRepoProvider:
       allowed_specs:
         - "^binder-examples/.*"

--- a/config/clusters/hhmi/enc-binder.secret.values.yaml
+++ b/config/clusters/hhmi/enc-binder.secret.values.yaml
@@ -8,9 +8,8 @@ binderhub-service:
     buildPodsRegistryCredentials:
         password: ENC[AES256_GCM,data:DKWXNUzMn+PoJHLozWpB69PdL/u8SKv4foY/VaUORbsf0rW4sT/Gy/2YYRblXeIKUVtfWRZKwZlLbkFi9hBmCg==,iv:P2PL0d4bHosNm4mL4W9j1Nu0BxWpW5wdtpHRLidskH0=,tag:puAcIi+94w5sjQOQA8WzJw==,type:str]
     config:
-        BinderHub:
-            DockerRegistry:
-                password: ENC[AES256_GCM,data:MDzC0i/BMW0nFBKenLLYpusb3ZtbI5mmzSeltyyK/oamDELibBo6GShNpT6wQ8fftEcogcXkNr4Euo2KDMZdHA==,iv:6/yPU6zwPixPUGs6z5wWHPvQt0FYVr7GJyrJ8maiJUY=,tag:Bf/xSqrkDhGBujAQxAlpXQ==,type:str]
+        DockerRegistry:
+            password: ENC[AES256_GCM,data:R3duzBCn35R7O5HRlH0KhPo7r8XEJ2Kh24DSsJRTyrMUrPh5WKc2cmhukh9JwqgdfdlOhGO8LQ7DEr8I3OAUHQ==,iv:bEDNf/YI0W8GkjBbWQWq+9/7L1bArCmstYLWirPPIWw=,tag:LgRsAQIg404Cnz0WGMv1Ew==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -20,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-03T16:49:36Z"
-    mac: ENC[AES256_GCM,data:Y6ld5UeMd2nicBFcNSKVK6ub36BUKe7dMgO7h3JKbMruA/YYNefVvJ05OIlZTm83FE1AE01t1t4lNnLBE+F1TV2C4ovKHJZSbvQTyCiM61t2ZElfphhJ3QJIj0gl/dWa8DoErlNhVtCQyyL4mIPjsuBZmUZih4UdGyPXpuUzlrc=,iv:oaPzwVfYrw18eDlieLZqfTVawbCsakbPqKuIURIyrV0=,tag:WaSXvw/dKwqm2GSHpz0+kA==,type:str]
+    lastmodified: "2024-07-04T07:11:50Z"
+    mac: ENC[AES256_GCM,data:8L5DhZ5RLbG5ocolojLYIGNXmXzk2rNwSffRaJ+uV1zM1bXJIlEVaiSXQlqGKHyH+JmrqZ21KgNgO8ohTfiL5ffRudxNF4Xc79SxfJ+yyYuHVA5UipZW5osZvfvy8K+f6J6C74Bg+sLTQe28Ki6ufF0I/boQznnNO6zv5QIPivU=,iv:oHtVWvaZKlNElntK9Pje1LycpkSn0xbvayAJQpcDkLk=,tag:QSgHWKMY4isnsy6mkd8MLg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -96,9 +96,9 @@ binderhub-service:
       enable_api_only_mode: false
       banner_message: ""
       about_message: ""
-      DockerRegistry:
-        url: &url https://quay.io
-        username: &username opensci-big-binder+image_builder
+    DockerRegistry:
+      url: &url https://quay.io
+      username: &username opensci-big-binder+image_builder
   extraEnv:
     - name: JUPYTERHUB_API_TOKEN
       valueFrom:

--- a/config/clusters/opensci/enc-big-binder.secret.values.yaml
+++ b/config/clusters/opensci/enc-big-binder.secret.values.yaml
@@ -2,9 +2,8 @@ binderhub-service:
     buildPodsRegistryCredentials:
         password: ENC[AES256_GCM,data:jlyeDAdAdaiaFn4fpA/xo2xIe+XDrvK56L5Lbv4jS1M4HuSVtY8Rj+sb04GFMGkECXhLQuW9xTX56K71ExyscA==,iv:pBwWNRhhVMpRTBIm+5xbQduAxfA4OU3rnqBa3UMtGAw=,tag:IpgKcgJn1ziq1bFDXmt8WA==,type:str]
     config:
-        BinderHub:
-            DockerRegistry:
-                password: ENC[AES256_GCM,data:xS5DWaaFpnNNsf3ukTcay2iZRKxl6hFmarTaF/dp1UeG+3xGuo3iJ5VsFK2GXO7Drp1GW3QYvnU1A7LrvenWCA==,iv:9IhrvPKMaK/KejN2Hl/gr5GknAIsaBW3hwyPAECj7JA=,tag:gL9NK97L+rMTuZ6U0xbhmQ==,type:str]
+        DockerRegistry:
+            password: ENC[AES256_GCM,data:kesnuZZvi6D//kh6jZ7FX0bl5xUHBsAR7SoCnXYuNFqgEEpEby+ye5ccoGeT3+V2B/wksWMCbxn6PVhpD3wRlQ==,iv:s2Is1LeMHXio8w7ugS0KeqQG3HEdIubr5Vz/yOc/kZ4=,tag:ljEzwoAj3UCqLV+aLuUgpg==,type:str]
 jupyterhub:
     hub:
         config:
@@ -25,8 +24,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-03T16:42:56Z"
-    mac: ENC[AES256_GCM,data:LQfy/V9yU/LVJi3uYQ6jUI97sUPFoHXcAAgUE3+imD5tHFlJN1MV8aEVoZ2jbncQD1SgwecrVUiGlkDWxUGb1lbnTxX5YdIdsZh7w664O1smVdcx0wOJAzDl4klf0/YJ92vzPcK+zm/dSvoySIQY+8qMJEu+iF4UYAGML4LELtE=,iv:1NonFH+PWaZiaHL7xAJ9HoYZTijKnTnBrGIZf3Sy/jk=,tag:xUkfbZ7PrVw2qlbBdjWh/Q==,type:str]
+    lastmodified: "2024-07-04T07:10:40Z"
+    mac: ENC[AES256_GCM,data:7CIqUD8/mHIxTWx4OmU9rmGkN4PKOWjUN3JbdTO1/dFMn/JHNH8ws4ojVjSn4N04q+k9DwUtls8NzjJqvNbngAX4CiZCNJcbnMegXzrFev4Y6UT/HV6to++ebPQgt931fjRLX/63SwCdTiVbzA0qlncFSs0aUuMjmQiGmuOwz0w=,iv:xeCQRp37sPKvJOc9zQ9m5dHP8pFaR6WcUFXGe1e+Ahc=,tag:IDUaq95Tk7zfwE9kflw0hA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/config/clusters/opensci/enc-small-binder.secret.values.yaml
+++ b/config/clusters/opensci/enc-small-binder.secret.values.yaml
@@ -6,9 +6,8 @@ jupyterhub:
         password: ENC[AES256_GCM,data:u9eYni6XSwFXk2u/N7pHJiCTX43sc6na3DqujkXDJ31qA2pigwxWd35yNjiTS78aTlM0nM2P6h2K9AmhKZk0kg==,iv:K+Ow+Rx1HWktxNZxcf1jrk9j4wAjvfYF4KAxJmuh4+c=,tag:OG1QvIFmBONsVeb2LsT+VA==,type:str]
 binderhub-service:
     config:
-        BinderHub:
-            DockerRegistry:
-                password: ENC[AES256_GCM,data:C9CoHntRSVitEO+spxcHjZTzylwFG/CUz99uJcTLf15LZ+fDAxbt8QPDiH6QOx6coCxwsMIQnbEN9MwBHb/YdA==,iv:fOzdExlgKBxGnCvOUxGsgAoIveKEO16ACkU1maTf3aQ=,tag:f/cKaPIJ4/cDGZAV2ankKw==,type:str]
+        DockerRegistry:
+            password: ENC[AES256_GCM,data:jqdq+slGBaQV3Kym1w1zqKv/oZLua1T8ZtSgnBxtbaJgQwJof66eaLDF82S7NpTvfNOA5jn7n/vKoAo+dt7eUw==,iv:I+p7NSoAk7eF6vl2NGX9kgf/gDYordVwN1L0kB6lx6Y=,tag:aVTfKdr2pQsYBjOxKyfpXw==,type:str]
     buildPodsRegistryCredentials:
         password: ENC[AES256_GCM,data:q3PD3kqWvOchBVcFHT/j3bN3Y2JUroqPkknaN2CDIFWteZz3bU+hk7aTpgyZbVgQXusIl00JrweVuJ53F9ISqg==,iv:AJIM5e7RNimP/PoAlbPtFPjaCOekBMb6xoTqHM3qfKs=,tag:OP4TN2UGsXxC1cGtujXQdg==,type:str]
 sops:
@@ -20,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-07-03T16:47:50Z"
-    mac: ENC[AES256_GCM,data:KpgW0VzSTSKxXbZFdc/U7SpXNyTn5uYqQrvosT35XK1SL4E495WGFcON9u5sIVfp5vVW+fzEPgJmNzEM3PIcVDSLcQgY4BKs0RMQ9OhKNcqHRMp049wZCXfvX/tDdsBiyAQ9lJYHKT5QOLFeAyNuX2MxxMqay6ohOe7bUbCZQgk=,iv:8zz8Y1WXIUIgAw4CcPcrCO2GiHlS4P2IDSB1fQdht0g=,tag:EqKAfD4bngOpM1oxly+85Q==,type:str]
+    lastmodified: "2024-07-04T07:06:35Z"
+    mac: ENC[AES256_GCM,data:rIIx2vO+LGk0IK9cKkcxw/91gBy8/6UXKkQtSACcBiY2vzpffh3MI5yrxlL+xV9KNO2bIby9vpLERxOG9qPL01LvVCJ9jIQSTlspQ8E48qzqwnJzNhR/4TcCEF4II+xt9IfC7xiZyr7tR6BXzI8CDbHLAyaPsAVoXRygtrV4AUs=,iv:gTPy3mwoS9BZiI53s39wcsUlO8ww8RdX/e9qAVjfOis=,tag:/ovFZyPyrBNhHtmzqP15Ug==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -95,9 +95,9 @@ binderhub-service:
       banner_message: "Please email support@2i2c.org to request repositories to be added to the allow list"
       # Update the about message as more repos are added to GitHubRepoProvider.allowed_specs
       about_message: "Launchable repositories are: github.com/binder-examples/requirements and github.com/2i2c-org/*"
-      DockerRegistry:
-        url: &url https://quay.io
-        username: &username opensci-small-binder+image_builder
+    DockerRegistry:
+      url: &url https://quay.io
+      username: &username opensci-small-binder+image_builder
     GitHubRepoProvider:
       allowed_specs:
         - "^2i2c-org/.*$"


### PR DESCRIPTION
This is a followup refactor of a detail in #4344

---

Chart configuration for binderhub-service and jupyterhub under `config`
and `hub.config` respectively are mapping to configuring traitlets such
as `c.BinderHub.log_level`, where you just have a single class name and
a single traitlets based configuration name.

Apparently it could work still by nesting class names in the chart
config, but it was very unexpected for me it did as I think writing
`c.ClassA.ClassB.traitlet_name = 5` would fail traitlets validation
checks.

Anyhow, since both things works, this is a pure refactor to avoid
confusion about this.