### PR TITLE
2i2c, binderhub-ui-demo: remove fixme workaround with no effect

### DIFF
--- a/config/clusters/2i2c/binderhub-ui-demo.values.yaml
+++ b/config/clusters/2i2c/binderhub-ui-demo.values.yaml
@@ -87,14 +87,6 @@ binderhub-service:
       image_prefix: us-central1-docker.pkg.dev/two-eye-two-see/binderhub-ui-demo-registry/binderhub-service-
       banner_message: "Testing binderhub used by 2i2c"
       about_message: "Testing binderhub used by 2i2c"
-  extraConfig:
-    # FIXME: set KubernetesBuildExecutor.push_secret again
-    #        without this for some reason the build pods
-    #        search after the wrong secret name (i.e. the default name)
-    #        set by binderhub in KubernetesBuildExecutor.push_secret
-    01-binderhub-service-set-push-secret: |
-      import os
-      c.KubernetesBuildExecutor.push_secret = os.environ["PUSH_SECRET_NAME"]
   extraEnv:
     - name: JUPYTERHUB_API_TOKEN
       valueFrom:


### PR DESCRIPTION
I think the reasons for this ending up could have been that a restart
led to a already running build pod was detected, and that it then
reported the same error because it had not been re-created with the
relevant credentials setup after the binderhub pod was restarted.

I really don't know, but removing this config and starting a fresh build
pod works.
