### PR TITLE
Default access to external buckets to false systematically

### DIFF
--- a/terraform/gcp/projects/cluster.tfvars.template
+++ b/terraform/gcp/projects/cluster.tfvars.template
@@ -58,7 +58,7 @@ filestore_capacity_gb = 1024
 #
 #hub_cloud_permissions = {
 #  "{{ hub_name }}" : {
-#    allow_access_to_external_requester_pays_buckets : true,
+#    allow_access_to_external_requester_pays_buckets : false,
 #    bucket_admin_access : ["scratch-{{ hub_name }}"],
 #    hub_namespace : "{{ hub_name }}"
 #  },


### PR DESCRIPTION
We have a variable under `allow_access_to_external_requester_pays_buckets` being `false` by default if left unspecified, but its explicitly specified true in a comment for new hubs. This just toggles that comment to false. We could also remove it, but I'm neutral on the pro/con of specifying this explicitly so I'll leave it specified explicitly as its done for many hubs.

- fixes #3775

This is a change in a comment, so should be very safe to merge without requesting review and doesn't really require knowledge sharing either.