### PR TITLE
Small fixes in 4 hubs - bucket name references and explicit config for consistency

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -81,8 +81,7 @@ jupyterhub:
             mountPath: /home/jovyan/shared-public
             subPath: _shared-public
     extraEnv:
-      SCRATCH_BUCKET: s3://scratch-itcoocean/$(JUPYTERHUB_USER)
-      PANGEO_SCRATCH: s3://scratch-itcoocean/$(JUPYTERHUB_USER)
+      SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-itcoocean/$(JUPYTERHUB_USER)
     profileList:
       # NOTE: About node sharing
       #

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -50,8 +50,7 @@ basehub:
           enable_auth_state: true
     singleuser:
       extraEnv:
-        SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: s3://2i2c-aws-us-scratch-researchdelight/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-showcase/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: s3://2i2c-aws-us-persistent-showcase/$(JUPYTERHUB_USER)
         GH_SCOPED_CREDS_CLIENT_ID: Iv1.f9261c4c78b4dfdd
         GH_SCOPED_CREDS_APP_URL: https://github.com/apps/2i2c-community-showcase-hub

--- a/config/clusters/jupyter-meets-the-earth/staging.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/staging.values.yaml
@@ -12,9 +12,6 @@ basehub:
       tls:
         - hosts: [staging.jmte.2i2c.cloud]
           secretName: https-auto-tls
-
     singleuser:
       extraEnv:
-        # This bucket is created via terraform.
-        SCRATCH_BUCKET: s3://jupyter-meets-the-earth-staging-scratch/$(JUPYTERHUB_USER)
-        PANGEO_SCRATCH: s3://jupyter-meets-the-earth-staging-scratch/$(JUPYTERHUB_USER)
+        SCRATCH_BUCKET: s3://jupyter-meets-the-earth-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -5,3 +5,7 @@ basehub:
       tls:
         - hosts: [smithsonian.2i2c.cloud]
           secretName: https-auto-tls
+    hub:
+      config:
+        GitHubOAuthenticator:
+          oauth_callback_url: https://smithsonian.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -5,3 +5,7 @@ basehub:
       tls:
         - hosts: [staging.smithsonian.2i2c.cloud]
           secretName: https-auto-tls
+    hub:
+      config:
+        GitHubOAuthenticator:
+          oauth_callback_url: https://staging.smithsonian.2i2c.cloud/hub/oauth_callback

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -14,7 +14,7 @@ user_buckets = {
   "scratch-dask-staging" : {
     "delete_after" : 7
   },
-  "scratch-researchdelight" : {
+  "scratch-showcase" : {
     "delete_after" : 7
   },
   "persistent-showcase" : {
@@ -46,7 +46,7 @@ hub_cloud_permissions = {
   "showcase" : {
     "user-sa" : {
       bucket_admin_access : [
-        "scratch-researchdelight",
+        "scratch-showcase",
         "persistent-showcase",
       ],
     },

--- a/terraform/aws/projects/jupyter-meets-the-earth.tfvars
+++ b/terraform/aws/projects/jupyter-meets-the-earth.tfvars
@@ -11,6 +11,9 @@ user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7
   },
+  // IMPORTANT: This bucket isn't used, they are instead using s3://jmte-scratch
+  //            that doesn't have a delete_after policy setup etc, but maybe
+  //            they want to have.
   "scratch" : {
     "delete_after" : 7
   },


### PR DESCRIPTION
- **2i2c-aws-us, showcase: rename empty scratchbucket to showcase from researchdelight**
- **2i2c-aws-us, itcoocean: fix SCRATCH_BUCKET env var value**
- **jmte, staging: fix SCRATCH_BUCKET env var value**
- **smithsonian: add github auth callback url explicitly**