### PR TITLE
terraform, aws: bump providers (aws v4 to v5)

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       # ref: https://registry.terraform.io/providers/hashicorp/aws/latest
       source  = "hashicorp/aws"
-      version = "~> 4.52"
+      version = "~> 5.57"
     }
 
     mysql = {
@@ -15,8 +15,9 @@ terraform {
     }
 
     random = {
+      # ref: https://registry.terraform.io/providers/hashicorp/random/latest
       source  = "hashicorp/random"
-      version = "~> 3.5.1"
+      version = "~> 3.6"
     }
   }
   backend "gcs" {


### PR DESCRIPTION
I tested if changes followed doing this, but I saw none when trying a re-apply in 2i2c-aws-us. I checked the changelog a bit via https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023 and didn't see anything obvious. It seems that they are quite careful about introducing a breaking change that hasn't been deprecated, because I saw a few "removing already deprecated changes" things done.

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```