### PR TITLE
2i2c-aws-us, go-bgc: cleanup remnant scratch buckets from decomissionsed hub

### DIFF
--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -23,9 +23,6 @@ user_buckets = {
   "scratch-ncar-cisl" : {
     "delete_after" : 7
   },
-  "scratch-go-bgc" : {
-    "delete_after" : 7
-  },
   "scratch-itcoocean" : {
     "delete_after" : 7
   },
@@ -54,11 +51,6 @@ hub_cloud_permissions = {
   "ncar-cisl" : {
     "user-sa" : {
       bucket_admin_access : ["scratch-ncar-cisl"],
-    },
-  },
-  "go-bgc" : {
-    "user-sa" : {
-      bucket_admin_access : ["scratch-go-bgc"],
     },
   },
   "itcoocean" : {


### PR DESCRIPTION
- remnant detail from #4120