### PR TITLE
Configure GCP terraform to create multiple filestores without overwriting existing filestores

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -17,10 +17,6 @@ k8s_versions = {
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
-# Setup a filestore for in-cluster NFS
-enable_filestore      = true
-filestore_capacity_gb = 1024
-
 notebook_nodes = {
   "n2-highmem-4-b" : {
     min : 0,

--- a/terraform/gcp/projects/awi-ciroh-2.tfvars
+++ b/terraform/gcp/projects/awi-ciroh-2.tfvars
@@ -4,9 +4,15 @@ zone                   = "us-central1-b"
 region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
-enable_filestore       = true
-filestore_capacity_gb  = 4915
 enable_logging         = false
+
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 4915,
+    tier        = "BASIC_HDD"
+  }
+]
 
 # This is the average of total costs for Apr -> Jun 2024 +20% in USD
 # This value is calculated from the OLD cluster we used to manage

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -1,5 +1,6 @@
-billing_account_id  = "0157F7-E3EA8C-25AC3C"
-budget_alert_amount = "800"
+budget_alert_enabled = false
+billing_account_id   = "0157F7-E3EA8C-25AC3C"
+budget_alert_amount  = "800"
 
 prefix                 = "awi-ciroh"
 project_id             = "awi-ciroh"
@@ -7,8 +8,14 @@ zone                   = "us-central1-b"
 region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
-enable_filestore       = true
-filestore_capacity_gb  = 2560
+
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 9216,
+    tier        = "BASIC_HDD"
+  }
+]
 
 k8s_versions = {
   min_master_version : "1.29.1-gke.1589018",

--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -14,8 +14,13 @@ k8s_versions = {
   notebook_nodes_version : "1.29.1-gke.1589018",
 }
 
-enable_filestore      = true
-filestore_capacity_gb = 6144
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 6144,
+    tier        = "BASIC_HDD"
+  }
+]
 
 core_node_machine_type = "n2-highmem-2"
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -23,9 +23,6 @@ k8s_versions = {
 core_node_machine_type = "n2-highmem-2"
 enable_network_policy  = true
 
-enable_filestore      = true
-filestore_capacity_gb = 1024
-
 notebook_nodes = {
   "n2-highmem-4-b" : {
     min : 0,

--- a/terraform/gcp/projects/cluster.tfvars.template
+++ b/terraform/gcp/projects/cluster.tfvars.template
@@ -39,10 +39,6 @@ core_node_machine_type = "n2-highmem-2"
 #
 enable_network_policy  = true
 
-# Setup a filestore for in-cluster NFS
-enable_filestore      = true
-filestore_capacity_gb = 1024
-
 # Tip: uncomment and fill the missing info in the lines below if you want
 #       to setup scratch buckets for the hubs on this cluster.
 #

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -29,10 +29,6 @@ hub_cloud_permissions = {
   }
 }
 
-# Setup a filestore for in-cluster NFS
-enable_filestore      = true
-filestore_capacity_gb = 1024
-
 user_buckets = {}
 
 # Setup notebook node pools

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -24,9 +24,13 @@ region = "us-central1"
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy = true
 
-# Setup a filestore for in-cluster NFS
-enable_filestore      = true
-filestore_capacity_gb = 3072
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 3072,
+    tier        = "BASIC_HDD"
+  }
+]
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/gcp/projects/linked-earth.tfvars
+++ b/terraform/gcp/projects/linked-earth.tfvars
@@ -18,9 +18,6 @@ k8s_versions = {
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
-enable_filestore      = true
-filestore_capacity_gb = 1024
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -45,10 +45,13 @@ k8s_versions = {
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
 enable_network_policy = true
 
-# Setup a filestore for NFS
-enable_filestore      = true
-filestore_capacity_gb = 4608
-
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 4608,
+    tier        = "BASIC_HDD"
+  }
+]
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -22,8 +22,13 @@ k8s_versions = {
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
-enable_filestore      = true
-filestore_capacity_gb = 5120
+filestores = [
+  {
+    name_suffix = null,
+    capacity_gb = 5120,
+    tier        = "BASIC_HDD"
+  }
+]
 
 notebook_nodes = {
   "n2-highmem-4" : {

--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -1,11 +1,11 @@
 resource "google_filestore_instance" "homedirs" {
 
-  name     = "${var.prefix}-homedirs"
+  name     = var.filestores[count.index].name_suffix == null ? "${var.prefix}-homedirs" : "${var.prefix}-homedirs-${var.filestores[count.index].name_suffix}"
   location = var.zone
-  tier     = var.filestore_tier
+  tier     = var.filestores[count.index].tier
   project  = var.project_id
 
-  count = var.enable_filestore ? 1 : 0
+  count = length(var.filestores)
 
   lifecycle {
     # Additional safeguard against deleting the filestore
@@ -14,7 +14,7 @@ resource "google_filestore_instance" "homedirs" {
   }
 
   file_shares {
-    capacity_gb = var.filestore_capacity_gb
+    capacity_gb = var.filestores[count.index].capacity_gb
     name        = "homes"
   }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -324,36 +324,28 @@ variable "enable_private_cluster" {
   EOT
 }
 
-variable "enable_filestore" {
-  type        = bool
-  default     = false
+variable "filestores" {
+  type = list(map(any))
+  default = [{
+    "name_suffix" = null,
+    "capacity_gb" = 1024,
+    "tier"        = "BASIC_HDD"
+  }]
   description = <<-EOT
-  Deploy a Google FileStore for home directories
+  Deploy one or more FileStores for home directories.
 
   This provisions a managed NFS solution that can be mounted as
   home directories for users. If this is not enabled, a manual or
-  in-cluster NFS solution must be set up
-  EOT
-}
+  in-cluster NFS solution must be set up.
 
-variable "filestore_capacity_gb" {
-  type        = number
-  default     = 1024
-  description = <<-EOT
-  Minimum size (in GB) of Google FileStore.
-
-  Minimum is 1024 for BASIC_HDD tier, and 2560 for BASIC_SSD tier.
-  EOT
-}
-
-variable "filestore_tier" {
-  type        = string
-  default     = "BASIC_HDD"
-  description = <<-EOT
-  Google FileStore service tier to use.
-
-  Most likely BASIC_HDD (for slower home directories, min $204 / month) or
-  BASIC_SSD (for faster home directories, min $768 / month)
+  - name-suffix: Suffix to append to the name of the FileStore. This
+      prevents name-clashing. Default: null.
+  - capacity_gb: Minimum size (in GB) of Google FileStore. Minimum
+      is 1024 for BASIC_HDD tier, and 2560 for BASIC_SSD tier.
+      Default: 1024.
+  - tier: Google FileStore service tier to use. Most likely BASIC_HDD
+      (for slower home directories, min $204 / month) or BASIC_SSD (for
+      faster home directories, min $768 / month). Default: BASIC_HDD.
   EOT
 }
 


### PR DESCRIPTION
- fixes #4334 

All existing clusters have been checked to ensure that this is a noop change