### PR TITLE
terraform, gcp: bump providers (google still at v4, v5 out now)

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -5,24 +5,29 @@ terraform {
   required_providers {
     google = {
       # ref: https://registry.terraform.io/providers/hashicorp/google/latest
+      #
+      # FIXME: v5 is out but we've not managed to migrate the config yet, we run
+      #        into something about taints. See the upgrade guide at:
+      #        https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_5_upgrade.
+      #
       source  = "google"
-      version = "~> 4.55"
+      version = "~> 4.85"
     }
     google-beta = {
       # ref: https://registry.terraform.io/providers/hashicorp/google-beta/latest
       source  = "google-beta"
-      version = "~> 4.55"
+      version = "~> 4.85"
     }
     kubernetes = {
       # ref: https://registry.terraform.io/providers/hashicorp/kubernetes/latest
       source  = "hashicorp/kubernetes"
-      version = "~> 2.18"
+      version = "~> 2.31"
     }
     # Used to decrypt sops encrypted secrets containing PagerDuty keys
     sops = {
       # ref: https://registry.terraform.io/providers/carlpett/sops/latest
       source  = "carlpett/sops"
-      version = "~> 0.7.2"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/gcp/registry.tf
+++ b/terraform/gcp/registry.tf
@@ -4,8 +4,6 @@
 * Hosting it in the same project makes node startup time faster.
 */
 resource "google_artifact_registry_repository" "registry" {
-  provider = google-beta
-
   for_each = toset(var.container_repos)
 
   location      = var.region


### PR DESCRIPTION
- **terraform, gcp: bump providers (google still at v4, v5 out now)**
- **terraform, gcp: stop using google-beta where no longer needed**
