### PR TITLE
Migrate to new binderhub-service naming and unpin (update) repo2docker

### DIFF
--- a/config/clusters/2i2c/binderhub-ui-demo.values.yaml
+++ b/config/clusters/2i2c/binderhub-ui-demo.values.yaml
@@ -41,7 +41,6 @@ jupyterhub:
     redirectToServer: false
     services:
       binder:
-        oauth_no_confirm: true
         oauth_redirect_uri: https://binderhub-ui-demo.2i2c.cloud/oauth_callback
     loadRoles:
       binder:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -113,12 +113,6 @@ jupyterhub:
   hub:
     # Allows for multiple concurrent demos
     allowNamedServers: true
-    services:
-      binder:
-        # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
-        # for something more readable and requiring less copy-pasting
-        url: http://imagebuilding-demo-binderhub-service:8090
-        display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
       tag: "0.0.1-0.dev.git.8663.h049aa2c2"

--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -66,8 +66,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: "null"
     redirectToServer: false
-    services:
-      binder: {}
     loadRoles:
       binder:
         services:

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -73,7 +73,6 @@ jupyterhub:
     redirectToServer: false
     services:
       binder:
-        oauth_no_confirm: true
         oauth_redirect_uri: https://big.binder.opensci.2i2c.cloud/oauth_callback
     loadRoles:
       binder:

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -140,12 +140,6 @@ jupyterhub:
 
   hub:
     allowNamedServers: true
-    services:
-      binder:
-        # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
-        # for something more readable and requiring less copy-pasting
-        url: http://sciencecore-binderhub-service:8090
-        display: false
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
       tag: "0.0.1-0.dev.git.8663.h049aa2c2"

--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -61,8 +61,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: "null"
     redirectToServer: false
-    services:
-      binder: {}
     loadRoles:
       binder:
         services:

--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -17,9 +17,3 @@ jupyterhub:
           - ProjectPythia
         scope:
           - read:org
-    services:
-      binder:
-        # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
-        # for something more readable and requiring less copy-pasting
-        url: http://prod-binderhub-service:8090
-        display: false

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -59,8 +59,6 @@ jupyterhub:
     # In the common values files this is where fancy profiles gets enabled
     extraConfig: {}
     redirectToServer: false
-    services:
-      binder: {}
     loadRoles:
       binder:
         services:

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -17,9 +17,3 @@ jupyterhub:
           - ProjectPythia
         scope:
           - read:org
-    services:
-      binder:
-        # FIXME: ref https://github.com/2i2c-org/binderhub-service/issues/57
-        # for something more readable and requiring less copy-pasting
-        url: http://staging-binderhub-service:8090
-        display: false

--- a/config/clusters/projectpythia/testing.values.yaml
+++ b/config/clusters/projectpythia/testing.values.yaml
@@ -21,8 +21,6 @@ jupyterhub:
     profileList: []
   hub:
     redirectToServer: false
-    services:
-      binder: {}
     loadRoles:
       binder:
         services:

--- a/config/clusters/templates/common/binderhub-ui-hub.values.yaml
+++ b/config/clusters/templates/common/binderhub-ui-hub.values.yaml
@@ -95,13 +95,11 @@ jupyterhub:
   {% endif %}
 {% endif %}
     redirectToServer: false
+    {% if authenticator != "none" %}
     services:
       binder:
-      {% if authenticator != "none" %}
-        oauth_no_confirm: true
         oauth_redirect_uri: https://{{ binderhub_domain }}/oauth_callback
-      {% else %} {}
-      {% endif %}
+    {% endif %}
     loadRoles:
       binder:
         services:

--- a/docs/howto/features/binderhub-ui.md
+++ b/docs/howto/features/binderhub-ui.md
@@ -187,9 +187,6 @@ jupyterhub:
   hub:
     services:
       binder:
-        # skip the OAuth confirmation page
-        oauth_no_confirm: true
-        # the service will have a public url instead of being contacted via /services/:name
         oauth_redirect_uri: https://<binderhub-public-url>/oauth_callback
 ```
 
@@ -272,18 +269,7 @@ jupyterhub:
       add_staff_user_ids_to_admin_users: false
 ```
 
-#### 3. Check the binder hub service
-
-Setup `binder` as a jupyterhub externally managed service.
-
-```yaml
-jupyterhub:
-  hub:
-    services:
-      binder: {}
-```
-
-#### 4. Check the roles
+#### 3. Check the roles
 Setup a `binder` and a `user` role and make sure the correct permissions are being assigned to this new service but also to the users so that they can access the service.
 
 ```yaml

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     version: 3.3.7
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.244.h1e88014
+    version: 0.1.0-0.dev.git.255.h7580133
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled
     # If bumping the version of dask-gateway, please also bump the default version set

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1009,10 +1009,17 @@ jupyterhub:
         #
         admin: true
       dask-gateway:
-        # We provide an entry here for dask-gateway unconditionally, so
-        # our helm chart will correctly autogenerate a secret with appropriate
-        # keys. It's not used if dask-gateway is not enabled.
+        # We provide an entry here for dask-gateway unconditionally, so the
+        # jupyterhub chart will autogenerate a secret with appropriate keys.
+        # It's not used if dask-gateway is not enabled.
         display: false
+      binder:
+        # We provide an entry here for binderhub-service unconditionally, so the
+        # jupyterhub chart will autogenerate a secret with appropriate keys.
+        # It's not used if binderhub-service is not enabled.
+        display: false
+        url: http://binderhub:8090
+        oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
       tag: "0.0.1-0.dev.git.8663.h049aa2c2"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -42,8 +42,6 @@ binderhub-service:
       base_url: /services/binder
       use_registry: true
     KubernetesBuildExecutor:
-      # Get ourselves a newer repo2docker!
-      build_image: quay.io/jupyterhub/repo2docker:2024.03.0-21.g09f3d53
       node_selector:
         # Schedule builder pods to run on user nodes only
         hub.jupyter.org/node-purpose: user


### PR DESCRIPTION
- Fixes https://github.com/2i2c-org/infrastructure/issues/4370

I've manually deployed this and tested on our binderhub-service enabled hubs, with fancy profiles and binderhub-ui. For this to deploy, I had to delete a few ingress resources manually ahead of time to avoid conflicts.