### PR TITLE
terraform, aws: add last-3-months-mean budget with alerts on forcasted use above 120% for accounts we pay the cloud bill

### DIFF
--- a/config/clusters/projectpythia/cluster.yaml
+++ b/config/clusters/projectpythia/cluster.yaml
@@ -6,10 +6,7 @@ aws:
   clusterName: projectpythia
   region: us-west-2
   billing:
-    # For an AWS account explicitly configured to have the cloud bill
-    # paid directly by the community and not through 2i2c, declare
-    # paid_by_us to false
-    paid_by_us: true
+    paid_by_us: false
 support:
   helm_chart_values_files:
     - support.values.yaml

--- a/terraform/aws/budget-alerts.tf
+++ b/terraform/aws/budget-alerts.tf
@@ -1,0 +1,27 @@
+resource "aws_budgets_budget" "budgets" {
+  count = var.default_budget_alert.enabled ? 1 : 0
+
+  name        = "Auto-adjusting budget for ${var.cluster_name}"
+  budget_type = "COST"
+  limit_unit  = "USD"
+  time_unit   = "MONTHLY"
+
+  auto_adjust_data {
+    auto_adjust_type = "HISTORICAL"
+
+    historical_options {
+      budget_adjustment_period = 3
+    }
+  }
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold           = 120
+    threshold_type      = "PERCENTAGE"
+    notification_type   = "FORECASTED"
+    subscriber_email_addresses = [
+      for email in var.default_budget_alert.subscriber_email_addresses :
+      replace(email, "{var_cluster_name}", var.cluster_name)
+    ]
+  }
+}

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -4,6 +4,10 @@ cluster_name = "earthscope"
 
 cluster_nodes_location = "us-east-2a"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 tags = {
   "ManagedBy" : "2i2c",
   # Requested by the community in https://2i2c.freshdesk.com/a/tickets/1460

--- a/terraform/aws/projects/jupyter-meets-the-earth.tfvars
+++ b/terraform/aws/projects/jupyter-meets-the-earth.tfvars
@@ -4,6 +4,10 @@ cluster_name = "jupyter-meets-the-earth"
 
 cluster_nodes_location = "us-west-2a"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}
 

--- a/terraform/aws/projects/nasa-esdis.tfvars
+++ b/terraform/aws/projects/nasa-esdis.tfvars
@@ -4,6 +4,10 @@ cluster_name = "nasa-esdis"
 
 cluster_nodes_location = "us-west-2a"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}
 

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -4,6 +4,10 @@ cluster_name = "nasa-ghg-hub"
 
 cluster_nodes_location = "us-west-2a"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}
 

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -4,6 +4,10 @@ cluster_name = "nasa-veda"
 
 cluster_nodes_location = "us-west-2a"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}
 

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -4,6 +4,10 @@ cluster_name = "openscapeshub"
 
 cluster_nodes_location = "us-west-2b"
 
+default_budget_alert = {
+  "enabled" : false,
+}
+
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}
 

--- a/terraform/aws/projects/projectpythia.tfvars
+++ b/terraform/aws/projects/projectpythia.tfvars
@@ -1,14 +1,12 @@
-/*
- Some of the assumptions this template makes about the cluster:
-   - location of the nodes of the kubernetes cluster will be <region>a
-   - no default scratch buckets support
-*/
-
 region = "us-west-2"
 
 cluster_name = "projectpythia"
 
 cluster_nodes_location = "us-west-2a"
+
+default_budget_alert = {
+  "enabled" : false,
+}
 
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}

--- a/terraform/aws/projects/template.tfvars
+++ b/terraform/aws/projects/template.tfvars
@@ -1,5 +1,5 @@
 /*
- Some of the assumptions this template makes about the cluster:
+ Some of the assumptions this jinja2 template makes about the cluster:
    - location of the nodes of the kubernetes cluster will be <region>a
    - no default scratch buckets support
 */

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -182,3 +182,17 @@ variable "tags" {
      they deploy and manage themselves.
   EOT
 }
+
+variable "default_budget_alert" {
+  type = object({
+    enabled : optional(bool, true)
+    subscriber_email_addresses : optional(
+      list(string),
+      ["support+{var_cluster_name}@2i2c.org"]
+    )
+  })
+  default     = {}
+  description = <<-EOT
+  A boilerplate budget alert initially setup for AWS accounts we pay the bill for.
+  EOT
+}


### PR DESCRIPTION
- fixes https://github.com/2i2c-org/meta/issues/1256 which also includes screenshots etc on how it can look when we receive emails related to alerting

When enabling this, I've seen "budget updated" emails from the ones below. Worried that I've failed to set it up for an account I  manually checked the ones I didn't receive an email from.

Email received about budget update:
- [ ] 2i2c-aws-us (manually checked, budget updated, alert setup)
- [x] catalystproject-africa
- [x] gridsst
- [ ] jupyter-health (manually checked, budget updated, alert setup)
- [x] kitware
- [x] nasa-cryo
- [x] opensci
- [ ] smithsonian (manually checked, budget updated, alert setup)
- [x] ubc-eoas
- [ ] victor (manually checked, budget updated, alert setup)