### PR TITLE
Migrate catalyst-latam prod hubs to new filestore server (except unitefa-conicet)

### DIFF
--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -6,7 +6,7 @@ nfs:
       - soft
       - noatime
     # Google FileStore IP
-    serverIP: 172.21.82.226
+    serverIP: 172.16.137.210
     # Name of Google Filestore share
     baseShareName: /homes/
 jupyterhub:

--- a/config/clusters/catalystproject-latam/staging.values.yaml
+++ b/config/clusters/catalystproject-latam/staging.values.yaml
@@ -1,14 +1,3 @@
-nfs:
-  enabled: true
-  pv:
-    enabled: true
-    mountOptions:
-      - soft
-      - noatime
-    # Google FileStore IP
-    serverIP: 172.16.137.210
-    # Name of Google Filestore share
-    baseShareName: /homes/
 jupyterhub:
   ingress:
     hosts: [staging.latam.catalystproject.2i2c.cloud]

--- a/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
+++ b/config/clusters/catalystproject-latam/unitefa-conicet.values.yaml
@@ -1,3 +1,8 @@
+nfs:
+  pv:
+    # FIXME: This is the old server IP. Needs to be migrated across to
+    #        the new server IP when there are no users
+    serverIP: 172.21.82.226
 jupyterhub:
   ingress:
     hosts: [unitefa-conicet.latam.catalystproject.2i2c.cloud]


### PR DESCRIPTION
- related to #4368 

Waiting for there to be no users on unitefa-conicet hub before this process is repeated for them.