### PR TITLE
catalystproject-latam: set notebook node disk sizes back to 100 gb

### DIFF
--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -34,29 +34,21 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
-    # Per https://github.com/2i2c-org/infrastructure/issues/4213
-    disk_size_gb : 400,
   },
   "n2-highmem-16" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",
-    # Per https://github.com/2i2c-org/infrastructure/issues/4213
-    disk_size_gb : 400,
   },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
-    # Per https://github.com/2i2c-org/infrastructure/issues/4213
-    disk_size_gb : 400,
   },
   "gpu-t4-highmem-4" : {
     min : 0,
     max : 20,
     machine_type : "n1-highmem-4",
-    # Per https://github.com/2i2c-org/infrastructure/issues/4213
-    disk_size_gb : 400,
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",
@@ -67,8 +59,6 @@ notebook_nodes = {
     min : 0,
     max : 20,
     machine_type : "n1-highmem-16",
-    # Per https://github.com/2i2c-org/infrastructure/issues/4213
-    disk_size_gb : 400,
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",


### PR DESCRIPTION
- fixes #4374 