### PR TITLE
tf, gcp: make it less verbose to define filestores by making attributes optional

### DIFF
--- a/terraform/gcp/projects/awi-ciroh-2.tfvars
+++ b/terraform/gcp/projects/awi-ciroh-2.tfvars
@@ -7,11 +7,7 @@ enable_network_policy  = true
 enable_logging         = false
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 4915,
-    tier        = "BASIC_HDD"
-  }
+  "filestore" = { capacity_gb = 5939 }
 }
 
 # This project does not have cloud costs passed through by 2i2c

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -10,11 +10,7 @@ core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 9216,
-    tier        = "BASIC_HDD"
-  }
+  "filestore" = { capacity_gb = 9216 }
 }
 
 k8s_versions = {

--- a/terraform/gcp/projects/catalystproject-latam.tfvars
+++ b/terraform/gcp/projects/catalystproject-latam.tfvars
@@ -15,15 +15,10 @@ k8s_versions = {
 }
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 6144,
-    tier        = "BASIC_HDD"
-  },
-  filestore_b = {
+  "filestore" = { capacity_gb = 6144 },
+  "filestore_b" = {
     name_suffix = "b",
-    capacity_gb = 2048,
-    tier        = "BASIC_HDD"
+    capacity_gb = 2048
   }
 }
 

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -24,11 +24,7 @@ region = "us-central1"
 enable_network_policy = true
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 3072,
-    tier        = "BASIC_HDD"
-  }
+  "filestore" = { capacity_gb = 3072 }
 }
 
 user_buckets = {

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -46,11 +46,7 @@ k8s_versions = {
 enable_network_policy = true
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 4608,
-    tier        = "BASIC_HDD"
-  }
+  "filestore" = { capacity_gb = 4608 }
 }
 
 user_buckets = {

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,11 +23,7 @@ core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 filestores = {
-  filestore = {
-    name_suffix = null,
-    capacity_gb = 5120,
-    tier        = "BASIC_HDD"
-  }
+  "filestore" : { capacity_gb : 5120 }
 }
 
 notebook_nodes = {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -325,13 +325,13 @@ variable "enable_private_cluster" {
 }
 
 variable "filestores" {
-  type = map(map(any))
+  type = map(object({
+    name_suffix : optional(string, null),
+    capacity_gb : optional(number, 1024),
+    tier : optional(string, "BASIC_HDD"),
+  }))
   default = {
-    "filestore" = {
-      "name_suffix" = null,
-      "capacity_gb" = 1024,
-      "tier"        = "BASIC_HDD"
-    }
+    "filestore" : {}
   }
   description = <<-EOT
   Deploy one or more FileStores for home directories.


### PR DESCRIPTION
this is a noop for our existing gcp clusters