### PR TITLE
eksctl: default to not creating a unused NAT gateway to pay for

### DIFF
--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -78,6 +78,14 @@ local daskNodes = [];
     iam: {
         withOIDC: true,
     },
+    vpc: {
+        nat: {
+            // Use of a NAT gateway isn't required for our cluster with k8s
+            // nodes having public instanceTypes, so its disabled to reduce
+            // cost.
+            gateway: "Disable",
+        }
+    }
     // If you add an addon to this config, run the create addon command.
     //
     //    eksctl create addon --config-file=<< cluster_name >>.eksctl.yaml


### PR DESCRIPTION
Enable/Disable NAT gateway can only be done during cluster creation by eksctl currently, let's default to not having it setup given @yuvipanda's comment https://github.com/2i2c-org/infrastructure/issues/2313#issuecomment-2030742704.

- I think this sufficiently fixes #2313