### PR TITLE
Update docker image tag

### DIFF
--- a/config/clusters/kitware/common.values.yaml
+++ b/config/clusters/kitware/common.values.yaml
@@ -109,7 +109,7 @@ jupyterhub:
       - display_name: Kitware Trame
         default: true
         kubespawner_override:
-          image: kitware/trame:geotrame-cloud
+          image: kitware/trame:pan3d-cloud
           # Not an immutable tag
           image_pull_policy: Always
         profile_options: *profile_options


### PR DESCRIPTION
On the Pan3D project, we have changed the image tag for our cloud docker image. When setting up our 2i2c deployment, we specified "kitware/trame:geotrame-cloud", but now we need to point to "kitware/trame:pan3d-cloud". To resolve this discrepancy, @yuvipanda suggested that I make this PR.