### PR TITLE
[opensci, small-binder] Remove repo allowlist

### DIFF
--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -121,6 +121,7 @@ binderhub-service:
         - "^2i2c-org/.*$"
         - "^sciencecore/.*$"
         - binder-examples/requirements
+        - "^2i2c-nasa-binder-access/.*$"
 
   extraEnv:
     - name: JUPYTERHUB_API_TOKEN

--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -107,22 +107,10 @@ binderhub-service:
       auth_enabled: false
       enable_api_only_mode: false
       banner_message: >-
-        Want to launch a NASA related repository you care about from this Binder
-        instance? Please email
-        <a href="mailto:binder-requests@2i2c.org">binder-requests@2i2c.org</a>
-        with information and we will get back to you!
-      # Update the about message as more repos are added to GitHubRepoProvider.allowed_specs
-      about_message: "Launchable repositories are: github.com/binder-examples/requirements and github.com/2i2c-org/* and github.com/sciencecore/*"
+        For documentation on how to use this service, please visit https://2i2c-nasa-binder-access.github.io/docs/. Funded by NASA NSPIRES F.15 High Priority Open-Source Science Award NNH22ZDA001N-HPOSS.
     DockerRegistry:
       url: &url https://quay.io
       username: &username opensci-small-binder+image_builder
-    GitHubRepoProvider:
-      allowed_specs:
-        - "^2i2c-org/.*$"
-        - "^sciencecore/.*$"
-        - binder-examples/requirements
-        - "^2i2c-nasa-binder-access/.*$"
-
   extraEnv:
     - name: JUPYTERHUB_API_TOKEN
       valueFrom:


### PR DESCRIPTION
~~I am trying to build documentation at https://2i2c-nasa-binder-access.github.io/docs/ and would like to connect to a the open science small binder service to it.~~

Closes https://github.com/2i2c-org/meta/issues/1299