### PR TITLE
Allow setting uniform bucket level access

### DIFF
--- a/terraform/gcp/buckets.tf
+++ b/terraform/gcp/buckets.tf
@@ -11,6 +11,8 @@ resource "google_storage_bucket" "user_buckets" {
   // Set these values explicitly so they don't "change outside terraform"
   labels = {}
 
+  uniform_bucket_level_access = each.value.uniform_bucket_level_access_only
+
   dynamic "logging" {
     for_each = each.value.usage_logs ? [1] : []
 

--- a/terraform/gcp/projects/awi-ciroh-2.tfvars
+++ b/terraform/gcp/projects/awi-ciroh-2.tfvars
@@ -25,16 +25,20 @@ k8s_versions = {
 #        on the project
 # user_buckets = {
 #   "scratch-staging" : {
-#     "delete_after" : 7
+#     "delete_after" : 7,
+#     "uniform_bucket_level_access_only": true
 #   },
 #   "scratch" : {
-#     "delete_after" : 7
+#     "delete_after" : 7,
+#     "uniform_bucket_level_access_only": true
 #   },
 #   "persistent-staging" : {
-#     "delete_after" : null
+#     "delete_after" : null,
+#     "uniform_bucket_level_access_only": true
 #   },
 #   "persistent" : {
-#     "delete_after" : null
+#     "delete_after" : null,
+#     "uniform_bucket_level_access_only": true
 #   }
 # }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -259,7 +259,8 @@ variable "user_buckets" {
     delete_after : number,
     extra_admin_members : optional(list(string), []),
     public_access : optional(bool, false),
-    usage_logs : optional(bool, false)
+    usage_logs : optional(bool, false),
+    uniform_bucket_level_access_only : optional(bool, false)
   }))
   default     = {}
   description = <<-EOT
@@ -289,6 +290,14 @@ variable "user_buckets" {
   access to objects in this GCS bucket. https://cloud.google.com/storage/docs/access-logs
   has more details. The bucket these will be written to can be determined by
   the `usage_logs_bucket` terraform output variable.
+
+  'uniform_bucket_level_access_only', if set to true, will enforce *only*
+  Uniform Bucket Level access (https://cloud.google.com/storage/docs/uniform-bucket-level-access)
+  for this bucket. When enabled, all cloud bucket ACLs are disabled - only IAM
+  permission policies are applied. Even though we only use IAM permission policies,
+  this defaults to false to give us flexibility, as it can be *enabled* at any time
+  but *can not* be disabled 90 days after enabling! Set this to true if operating
+  under security restrictions that require it to be enabled.
   EOT
 }
 


### PR DESCRIPTION
No-op on other clusters, and required for setting up buckets on the new AWI-CIROH cluster. Doesn't change any of our effective policies, since we do not use ACLs

Ref https://github.com/2i2c-org/infrastructure/issues/4238