### PR TITLE
[opensci, big-binder] Rename GH team

### DIFF
--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -73,7 +73,7 @@ jupyterhub:
       GitHubOAuthenticator:
         oauth_callback_url: https://hub.big.binder.opensci.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
-          - 2i2c-nasa-binder-access:big-binder-team
+          - 2i2c-ephemeral-hubs:access
     redirectToServer: false
     services:
       binder:


### PR DESCRIPTION
Rename GH org and team from

"2i2c-nasa-binder-access:big-binder-team" 

to 

"2i2c-ephemeral-hubs:access"