### PR TITLE
AWI-CIROH: Disable configurator

### DIFF
--- a/config/clusters/awi-ciroh-2/common.values.yaml
+++ b/config/clusters/awi-ciroh-2/common.values.yaml
@@ -15,6 +15,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         templateVars:
           org:


### PR DESCRIPTION
Not in use anymore as we use profile lists here.

Ref https://github.com/2i2c-org/infrastructure/issues/4238