### PR TITLE
Create cloud service accounts with permissions needed for gcp-filestore-backups to run

### DIFF
--- a/terraform/gcp/filestore-backup-workload-identity.tf
+++ b/terraform/gcp/filestore-backup-workload-identity.tf
@@ -25,10 +25,10 @@ resource "google_project_iam_custom_role" "filestore_backups" {
 }
 
 resource "google_project_iam_member" "filestore_backups_binding" {
-  count    = var.enable_filestore_backups ? 1 : 0
-  project  = var.project_id
-  role     = google_project_iam_custom_role.filestore_backups[0].name
-  member   = "serviceAccount:${google_service_account.filestore_backup_sa[0].email}"
+  count   = var.enable_filestore_backups ? 1 : 0
+  project = var.project_id
+  role    = google_project_iam_custom_role.filestore_backups[0].name
+  member  = "serviceAccount:${google_service_account.filestore_backup_sa[0].email}"
 }
 
 # Bind the Kubernetes Service Accounts to their appropriate Google Cloud Service Accounts

--- a/terraform/gcp/filestore-backup-workload-identity.tf
+++ b/terraform/gcp/filestore-backup-workload-identity.tf
@@ -1,0 +1,53 @@
+# Set up a Workload Identity and Google Service Account (with appropriate
+# permissions) with a binding to a Kubernetes Service Account to perform backups
+# of the Filestore.
+
+# Create the service account if we are enabling filestore backups
+resource "google_service_account" "filestore_backup_sa" {
+  count = var.enable_filestore_backups ? 1 : 0
+  # Service account IDs are limited to 30 chars
+  account_id   = "${var.prefix}-filestore-backup"
+  display_name = "Service account for gcp-filestore-backups pods in ${var.prefix}"
+  project      = var.project_id
+}
+
+# To manage backups of the GCP Filestore, the calling code needs to have
+# file.backups.* permission. We create a role granting just this to provide the
+# filestore backup SA, so pods can use it.
+resource "google_project_iam_custom_role" "filestore_backups" {
+  count = var.enable_filestore_backups ? 1 : 0
+  // Role names can't contain -, so we swap them out. BOO
+  role_id     = replace("${var.prefix}_filestore_backups", "-", "_")
+  project     = var.project_id
+  title       = "Identify as project role for pods in ${var.prefix}"
+  description = "Minimal role for gcp-filestore-backups pods on ${var.prefix} to identify as current project"
+  permissions = ["file.backups.*"]
+}
+
+resource "google_project_iam_member" "filestore_backups_binding" {
+  count    = var.enable_filestore_backups ? 1 : 0
+  project  = var.project_id
+  role     = google_project_iam_custom_role.filestore_backups[0].name
+  member   = "serviceAccount:${google_service_account.filestore_backup_sa[0].email}"
+}
+
+# Bind the Kubernetes Service Accounts to their appropriate Google Cloud Service Accounts
+resource "google_service_account_iam_binding" "filestore_backups_binding" {
+  count              = var.enable_filestore_backups ? 1 : 0
+  service_account_id = google_service_account.filestore_backup_sa[0].id
+  role               = "roles/iam.workloadIdentityUser"
+  # This will be deployed into the support namespace
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[support/gcp-filestore-backups-sa]"
+  ]
+}
+
+output "gcp_filestore_backups_k8s_sa_annotations" {
+  value       = var.enable_filestore_backups ? "iam.gke.io/gcp-service-account: ${google_service_account.filestore_backup_sa[0].email}" : ""
+  description = <<-EOT
+  Annotations to apply to gcpFilestoreBackups in the support chart to enable cloud permissions for its pods.
+
+  This should be specified under gcpFilestoreBackups.annotations in a support
+  values file created for the cluster.
+  EOT
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -353,8 +353,8 @@ variable "filestore_alert_available_percent" {
 }
 
 variable "enable_filestore_backups" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = <<-EOT
   Provide a Workload Identity and appropriate permissions to perform backups of
   the Filestore.

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -352,6 +352,20 @@ variable "filestore_alert_available_percent" {
   EOT
 }
 
+variable "enable_filestore_backups" {
+  type = bool
+  default = false
+  description = <<-EOT
+  Provide a Workload Identity and appropriate permissions to perform backups of
+  the Filestore.
+
+  When enabled, this will create a GCP Service Account with permissions to manage
+  Filestore backups and bind it to a K8s Service Account for use in the support
+  chart. An output of the appropriate annotations to apply in the support chart
+  will also be provided.
+  EOT
+}
+
 
 variable "enable_node_autoprovisioning" {
   type        = bool


### PR DESCRIPTION
- fixes #4396