### PR TITLE
Deploy gcp-filestore-backups for GCP shared cluster

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -67,3 +67,11 @@ grafana:
           - grafana.pilot.2i2c.cloud
   plugins:
     - grafana-bigquery-datasource
+
+gcpFilestoreBackups:
+  enabled: true
+  filestoreName: pilot-hubs-homedirs
+  project: two-eye-two-see
+  zone: us-central1-b
+  annotations:
+    iam.gke.io/gcp-service-account: pilot-hubs-filestore-backup@two-eye-two-see.iam.gserviceaccount.com

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -26,3 +26,4 @@ charts:
     images:
       gcp-filestore-backups:
         imageName: quay.io/2i2c/gcp-filestore-backups
+        valuesPath: gcpFilestoreBackups.image

--- a/helm-charts/images/gcp-filestore-backups/Dockerfile
+++ b/helm-charts/images/gcp-filestore-backups/Dockerfile
@@ -12,8 +12,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
-RUN mkdir -p /app
+RUN mkdir -p /app/.config/gcloud
+RUN chown 1000:1000 /app/.config/gcloud
+
 COPY gcp-filestore-backups.py /app/
 WORKDIR /app
 
-ENV CLOUDSDK_CONFIG=/app
+ENV CLOUDSDK_CONFIG=/app/.config/gcloud

--- a/helm-charts/images/gcp-filestore-backups/Dockerfile
+++ b/helm-charts/images/gcp-filestore-backups/Dockerfile
@@ -15,3 +15,5 @@ RUN pip install -r /tmp/requirements.txt
 RUN mkdir -p /app
 COPY gcp-filestore-backups.py /app/
 WORKDIR /app
+
+ENV CLOUDSDK_CONFIG=/app

--- a/helm-charts/images/gcp-filestore-backups/Dockerfile
+++ b/helm-charts/images/gcp-filestore-backups/Dockerfile
@@ -12,4 +12,6 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
 
-COPY gcp-filestore-backups.py /
+RUN mkdir -p /app
+COPY gcp-filestore-backups.py /app/
+WORKDIR /app

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -30,5 +30,5 @@ spec:
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: False
-            readOnlyRootFilesystem: True
+            readOnlyRootFilesystem: False
 {{- end -}}

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: gcp-filestore-backups
     spec:
       strategy:
-        type: Recreate
+        type: "Recreate"
       serviceAccountName: gcp-filestore-backups-sa
       automountServiceAccountToken: false
       containers:

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gcp-filestore-backups
 spec:
   replicas: 1
+  strategy:
+    type: "Recreate"
   selector:
     matchLabels:
       app: gcp-filestore-backups
@@ -13,8 +15,6 @@ spec:
       labels:
         app: gcp-filestore-backups
     spec:
-      strategy:
-        type: "Recreate"
       serviceAccountName: gcp-filestore-backups-sa
       automountServiceAccountToken: false
       containers:

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: gcp-filestore-backups
-          image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9876.heb46be97"
+          image: '{{ .Values.gcpFilestoreBackups.image }}'
           command:
             - python
             - gcp-filestore-backups.py

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: gcp-filestore-backups
-          image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9800.hbcab1958"
+          image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9876.heb46be97"
           command:
             - python
             - gcp-filestore-backups.py

--- a/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
+++ b/helm-charts/support/templates/gcp-filestore-backups/deployment.yaml
@@ -30,5 +30,9 @@ spec:
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: False
+            # The image used for gcp-filestore-backups uses gcloud, which wants to
+            # write a log file. Without setting readOnlyRootFilesystem = False,
+            # gcloud will not have permissions to write it's log file and will
+            # fail and crash the pod.
             readOnlyRootFilesystem: False
 {{- end -}}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -171,6 +171,7 @@ properties:
     additionalProperties: false
     required:
       - enabled
+      - image
     # Require options to be set *only* if gcpFilestoreBackups is enabled
     if:
       properties:
@@ -187,6 +188,11 @@ properties:
         type: boolean
         description: |
           Enable automatic daily backups of GCP Filestores
+      image:
+        type: string
+        description: |
+          The image name and tag to use for the gcp-filestore-backups pod.
+          Will be set by chartpress.
       filestoreName:
         type: string
         description: |

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -504,6 +504,7 @@ prometheusStorageClass:
 # Setup a deployment that will periodically backup the Filestore contents
 gcpFilestoreBackups:
   enabled: false
+  image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9876.heb46be97"
 
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -504,7 +504,7 @@ prometheusStorageClass:
 # Setup a deployment that will periodically backup the Filestore contents
 gcpFilestoreBackups:
   enabled: false
-  image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9879.h1861bf08"
+  image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9882.h6f05b0fa"
 
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -504,7 +504,7 @@ prometheusStorageClass:
 # Setup a deployment that will periodically backup the Filestore contents
 gcpFilestoreBackups:
   enabled: false
-  image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9876.heb46be97"
+  image: "quay.io/2i2c/gcp-filestore-backups:0.0.1-0.dev.git.9879.h1861bf08"
 
 # A placeholder as global values that can be referenced from the same location
 # of any chart should be possible to provide, but aren't necessarily provided or

--- a/terraform/gcp/filestore-backup-workload-identity.tf
+++ b/terraform/gcp/filestore-backup-workload-identity.tf
@@ -21,7 +21,13 @@ resource "google_project_iam_custom_role" "filestore_backups" {
   project     = var.project_id
   title       = "Identify as project role for pods in ${var.prefix}"
   description = "Minimal role for gcp-filestore-backups pods on ${var.prefix} to identify as current project"
-  permissions = ["file.backups.*"]
+  permissions = [
+    "file.backups.create",
+    "file.backups.update",
+    "file.backups.delete",
+    "file.backups.get",
+    "file.backups.list"
+  ]
 }
 
 resource "google_project_iam_member" "filestore_backups_binding" {

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -23,6 +23,7 @@ enable_network_policy  = true
 filestores = {
   "filestore" : { capacity_gb : 5120 }
 }
+enable_filestore_backups = true
 
 notebook_nodes = {
   "n2-highmem-4" : {


### PR DESCRIPTION
- fixes #4397 

---

- enables relevant resources in terraform
- enables gcp-filestore-backups in support chart for 2i2c cluster
- makes chartpress able to write the image name and tag into the support chart values
- applies any fixes required to allow code to function