### PR TITLE
Update deploy-hubs workflow to explicitly avoid cancelling in-progress or pending workflows when merged to main

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -57,7 +57,9 @@ on:
 #
 # ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 #
-concurrency: ${{ github.workflow }}-${{ github.head_ref || 'not-a-pr' }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || 'not-a-pr' }}
+  cancel-in-progress: false
 
 # This environment variable triggers the deployer to colourise print statements in the
 # GitHug Actions logs for easy reading


### PR DESCRIPTION
Merging https://github.com/2i2c-org/infrastructure/pull/4456 cancelled the pending workflow of https://github.com/2i2c-org/infrastructure/pull/4455 which was undesired behaviour and resulted in me making local deploys