### PR TITLE
[NeuroHackademy] Change the default image to the 2024 image and new tag.

### DIFF
--- a/config/clusters/2i2c-aws-us/neurohackademy.values.yaml
+++ b/config/clusters/2i2c-aws-us/neurohackademy.values.yaml
@@ -33,10 +33,10 @@ jupyterhub:
           [credential "https://github.com"]
           helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 356717
           useHttpPath = true
-    # User image: https://quay.io/repository/arokem/nh2023?tab=tags
+    # User image: https://quay.io/repository/arokem/nh2024?tab=tags
     image:
-      name: quay.io/arokem/nh2023
-      tag: "894883dfb3bd"
+      name: quay.io/arokem/nh2024
+      tag: "b97329d773de"
     defaultUrl: "/lab"
     extraTolerations:
       - key: "2i2c.org/community"


### PR DESCRIPTION
While we are still working out some issues with our automated builds in https://github.com/NeuroHackademy2024/jhub-image, we'd like to adjust the default image to use to this version that has some new software installed and should be good enough for now. 

Let me know if there is another better way to request such changes (e.g., support email).