### PR TITLE
nasa-ghg: remove custom profiles and config for ghg-ssim 2024 workshop

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -56,7 +56,6 @@ basehub:
             - US-GHG-Center:ghg-external-collaborators
             - US-GHG-Center:ghg-workshop-access
             - US-GHG-Center:ghg-trial-access
-            - US-GHG-Center:ssim-ghg-2024
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org
@@ -254,45 +253,6 @@ basehub:
                   image: "{value}"
               choices: {}
             resource_allocation: *profile_options_resource_allocation
-
-        # Following profile list items are added for the SSIM-GHG-Workshop 2024.
-        # They specify custom resource allocations and custom images for the workshop
-        # They are the only profile options users in the US-GHG-Center:ssim-ghg-2024
-        # team should have access to. These profile items as well as this comment should
-        # be cleaned up once the workshop is over.
-        - display_name: "SSIM-GHG 2024 Workshop: Python"
-          description: Python notebook for SSIM-GHG 2024 Workshop
-          allowed_groups:
-            - US-GHG-Center:ssim-ghg-2024
-            - 2i2c-org:hub-access-for-2i2c-staff
-          slug: ssim-ghg-2024-python
-          kubespawner_override:
-            # Custom image for workshop: https://github.com/NASA-IMPACT/ssim-ghg-workshop-2024-python-image
-            image: public.ecr.aws/nasa-veda/ssim-ghg-workshop-2024-python-image:1e641d14629a
-            # Adjusted to try to land only one user on each node
-            mem_guarantee: 27G
-            mem_limit: 27G
-            cpu_guarantee: 14
-            cpu_limit: 16
-            node_selector:
-              node.kubernetes.io/instance-type: c5.4xlarge
-        - display_name: "SSIM-GHG 2024 Workshop: R"
-          description: R notebook for SSIM-GHG 2024 Workshop
-          allowed_groups:
-            - US-GHG-Center:ssim-ghg-2024
-            - 2i2c-org:hub-access-for-2i2c-staff
-          slug: ssim-ghg-2024-r
-          kubespawner_override:
-            # Custom image for workshop: https://github.com/NASA-IMPACT/ssim-ghg-workshop-2024-r-image
-            image: public.ecr.aws/nasa-veda/ssim-ghg-workshop-2024-r-image:c7936af92743
-            # Adjusted to try to land only one user on each node
-            mem_guarantee: 27G
-            mem_limit: 27G
-            cpu_guarantee: 14
-            cpu_limit: 16
-            node_selector:
-              node.kubernetes.io/instance-type: c5.4xlarge
-
     scheduling:
       userScheduler:
         enabled: true

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -28,7 +28,6 @@ local notebookNodes = [
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.4xlarge" , nameSuffix : "b" },
     { instanceType: "r5.16xlarge" },
-    { instanceType: "c5.4xlarge"},
 ];
 local daskNodes = [
     // Node definitions for dask worker nodes. Config here is merged


### PR DESCRIPTION
Remove customizations done for the SSIM-GHG workshop as per https://github.com/NASA-IMPACT/veda-jupyterhub/issues/29#issuecomment-2199886011 : 

 - Removes access for the `US-GHG-Center:ssim-ghg-2024` group
 - Removes the two custom profile options created for the workshop for Python and R
 - Removes the `c5.4xlarge` instance type from the `eksctl` config

cc @yuvipanda @sgibson91 @slesaad 