### PR TITLE
[Neurohackademy] Modify R profile to use kubespawner_override options matching Python profile

### DIFF
--- a/config/clusters/2i2c-aws-us/neurohackademy.values.yaml
+++ b/config/clusters/2i2c-aws-us/neurohackademy.values.yaml
@@ -110,9 +110,16 @@ jupyterhub:
       - display_name: R machine
         slug: R
         description: "Start a container with R available"
-        image:
-          name: quay.io/arokem/nh2024-r
-          tag: "40c35e7ea05e"
+        kubespawner_override:
+          image: "quay.io/arokem/nh2024-r:40c35e7ea05e"
+          cpu_guarantee: 0.5
+          cpu_limit: 14
+          mem_guarantee: 4G
+          mem_limit: 16G
+          node_selector:
+            node.kubernetes.io/instance-type: r5.xlarge
+            2i2c.org/community: neurohackademy
+          init_containers: *init_containers
       - display_name: "Bring your own image"
         description: Specify your own docker image (must have python and jupyterhub installed in it)
         slug: custom


### PR DESCRIPTION
@arokem we needed a `kubespawner_override` block to mimic the other profiles. The "Choose your own image" profile with a `profile_options` block is a special case. I've deployed this locally and it works now. I've also set the other overrides to match the Python profile - let me know if that shouldn't be the case.