### PR TITLE
smithsonian: Put some profile options on larger nodes

### DIFF
--- a/config/clusters/smithsonian/common.values.yaml
+++ b/config/clusters/smithsonian/common.values.yaml
@@ -114,7 +114,8 @@ basehub:
                     cpu_guarantee: 0.465625
                     cpu_limit: 3.725
                     node_selector:
-                      node.kubernetes.io/instance-type: r5.xlarge
+                      # Bump to a larger node for https://2i2c.freshdesk.com/a/tickets/1929
+                      node.kubernetes.io/instance-type: r5.4xlarge
                 mem_7_4:
                   display_name: 7.4 GB RAM, upto 3.7 CPUs
                   kubespawner_override:


### PR DESCRIPTION
Improves startup time, per https://2i2c.freshdesk.com/a/tickets/1929