### PR TITLE
terraform, aws: support specifying bucket specific tags

### DIFF
--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "user_buckets" {
   for_each = var.user_buckets
   bucket   = lower("${var.cluster_name}-${each.key}")
-  tags     = var.tags
+  tags     = merge(var.tags, each.value.tags)
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "user_bucket_expiry" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -23,7 +23,8 @@ variable "user_buckets" {
   type = map(
     object({
       delete_after : optional(number, null),
-      archival_storageclass_after : optional(number, null)
+      archival_storageclass_after : optional(number, null),
+      tags : optional(map(string), {}),
     })
   )
   default     = {}
@@ -40,6 +41,7 @@ variable "user_buckets" {
   2. `archival_storageclass_after` - number of days after *creation* an
      object in this bucket will be automatically transitioned to a cheaper,
      slower storageclass for cost savings. Set to null to not transition.
+  3. `tags` - bucket specific tags to be merged into the general tags variable.
   EOT
 }
 


### PR DESCRIPTION
The intent is to allow 2i2c:hub-name to be specified. I saw no option
to easily and robustly add the 2i2c:hub-name tag automatically by using
other config or variables. The `hub_cloud_permissions` variable included
details about hub name, but I don't think we could be certain all
buckets would be tied to a hub name through that, so it seemed
problematic to try to use that information. With that in mind, I settled
for explicitly configuring any tags.
