### PR TITLE
terraform, aws: make configuring cost allocation tags possible

### DIFF
--- a/terraform/aws/cost-allocation.tf
+++ b/terraform/aws/cost-allocation.tf
@@ -1,0 +1,7 @@
+# ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_cost_allocation_tag
+resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
+  for_each = toset(var.active_cost_allocation_tags)
+
+  tag_key = replace(each.key, "{var_cluster_name}", var.cluster_name)
+  status  = "Active"
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -236,3 +236,11 @@ variable "filestores" {
         By default, this will be set to "hub-homedirs-{name_suffix}".
   EOT
 }
+
+variable "active_cost_allocation_tags" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  Tags to be treated as active cost allocation tags.
+  EOT
+}


### PR DESCRIPTION
First step for #4473.