### PR TITLE
terraform, openscapes: declare a few cost allocation tags

### DIFF
--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -75,3 +75,12 @@ hub_cloud_permissions = {
     }
   },
 }
+
+active_cost_allocation_tags = [
+  "2i2c:hub-name",
+  "2i2c:node-purpose",
+  "aws:eks:cluster-name",
+  "kubernetes.io/cluster/{var_cluster_name}",
+  "kubernetes.io/created-for/pvc/name",
+  "kubernetes.io/created-for/pvc/namespace",
+]


### PR DESCRIPTION
- Fixes #4473

Based on #4528 to make a few cloud tags be treated as cost allocation tags.