### PR TITLE
docs: how to opt-out of aws budget alerts

### DIFF
--- a/docs/howto/budget-alerts.md
+++ b/docs/howto/budget-alerts.md
@@ -1,9 +1,27 @@
-(howto:enable-budget-alerts)=
-# Enable Budget Alerts
+(howto:setting-up-budget-alerts)=
+# Setting up Budget Alerts
 
-This document describes how to enable budget alerts for a cluster.
+As of July 2024, we look to setup budget alerts for all cloud projects where we
+pay the bill from the cloud provider, independently if we pass through these
+costs or not to the community. We currently don't look to setup budget alerts
+for communities paying their cloud provider bill directly.
+
+This document describes how to enable (or opt-out of) budget alerts for a
+cluster via the cluster's associated terraform variables file (`.tfvars`).
 
 `````{tab-set}
+````{tab-item} AWS
+:sync: aws-key
+
+AWS budget alerts are setup by default. To opt-out, declare:
+
+```
+default_budget_alert = {
+  "enabled" : false,
+}
+```
+````
+
 ````{tab-item} GCP
 :sync: gcp-key
 

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -404,10 +404,11 @@ Workspaces are defined **per backend**.
 If you can't find the workspace you're looking for, double check you've enabled the correct backend.
 ```
 
-## Enable Budget Alerting
+## Setting up Budget Alerts
 
-If 2i2c is passing cloud costs through to the community, we enable budget alerting to be forewarned of runaway bills.
-You will need to update the `.tfvars` file before the next step by following instructions in [](howto:enable-budget-alerts).
+Follow the instructions in [](howto:setting-up-budget-alerts) to determine if and
+how you should setup budget alerts.
+
 You can learn more about our budget alerts in [](topic:billing:budget-alerts).
 
 ## Plan and Apply Changes

--- a/docs/topic/billing/budget-alerts.md
+++ b/docs/topic/billing/budget-alerts.md
@@ -6,7 +6,13 @@ bankruptcy is second only to "The US healthcare system sucks, your honor" in the
 US court system. "How much is my cloud going to cost?" is a big anxiety for a lot
 of our users, and hence us. We set up billing alerts to help deal with this anxiety.
 
-See [](howto:enable-budget-alerts) for instructions on enabling this feature.
+To setup budget alerts, refer to [](howto:setting-up-budget-alerts). To learn
+more about them from the cloud provider's documentation, visit it at either
+[AWS], [GCP], or [Azure].
+
+[aws]: https://aws.amazon.com/aws-cost-management/aws-budgets/
+[azure]: https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/cost-mgt-alerts-monitor-usage-spending
+[gcp]: https://cloud.google.com/billing/docs/how-to/budgets
 
 ## When are the alerts triggered?
 

--- a/docs/topic/billing/tools.md
+++ b/docs/topic/billing/tools.md
@@ -49,9 +49,6 @@ All cloud providers allow us to set up alerts that fire whenever a particular
 project is about to cost more than a specific amount, or is forecast to go over a specific amount by the end of the month if current trends continue.
 This can be *extremely helpful* in assuaging communities of cost overruns
 but requires we have a prediction for *what numbers* to set these budgets at,
-as well as what to do when the alerts fire. Usually, these alerts can be
-set up manually in the UI or (preferably) via Terraform. We currently only
-utilise these on GCP, and more details can be found in [](topic:billing:budget-alerts).
+as well as what to do when the alerts fire.
 
-More information: [GCP](https://cloud.google.com/billing/docs/how-to/budgets), [AWS](https://aws.amazon.com/aws-cost-management/aws-budgets/)
-and [Azure](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/cost-mgt-alerts-monitor-usage-spending).
+More details can be found in [](topic:billing:budget-alerts).


### PR DESCRIPTION
- added how to opt-out of aws budget alerts
- some refactoring to avoid describing if we should setup budget alerts or not in multiple places
- some refactoring to handle that budget alerts for AWS is made opt-out, while its opt-in for GCP and Azure

---

![image](https://github.com/user-attachments/assets/680f3317-67ac-47ac-96c0-8b2d1f285350)

- fixes #4481