### PR TITLE
basehub: trim away redundant egress network policy addition

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -819,20 +819,11 @@ jupyterhub:
       #    this guarantee doesn't actually change our scheduling.
       guarantee: 0.05
     networkPolicy:
-      # Allow unrestricted access to the internet but not local cluster network
       enabled: true
+      # Egress to internet is allowed by default via z2jh's egressAllowRules,
+      # but we need to add a few custom rules for the cluster internal
+      # networking.
       egress:
-        - to:
-            - ipBlock:
-                cidr: 0.0.0.0/0
-                except:
-                  # Don't allow network access to private IP ranges
-                  # Listed in https://datatracker.ietf.org/doc/html/rfc1918
-                  - 10.0.0.0/8
-                  - 172.16.0.0/12
-                  - 192.168.0.0/16
-                  # Don't allow network access to the metadata IP
-                  - 169.254.169.254/32
         # Allow code in hubs to talk to ingress provider, so they can talk to
         # the hub via its public URL
         - to:


### PR DESCRIPTION
The `singleuser` NetworkPolicy resource already includes this part thanks to [`singleuser.networkPolicy.egressAllowRules.nonPrivateIPs`](https://z2jh.jupyter.org/en/stable/resources/reference.html#hub-networkpolicy-egressallowrules-nonprivateips) which defaults to true.

With this change, we end up with user pods not having this duplicated, where the value of the change is just the reduced complexity and avoiding confusion.

```
  - to:
    - ipBlock:
        cidr: 0.0.0.0/0
        except:
        - 10.0.0.0/8
        - 172.16.0.0/12
        - 192.168.0.0/16
        - 169.254.169.254/32
```