### PR TITLE
cryo: Enable larger /dev/shm for GPU users

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -79,6 +79,9 @@ basehub:
       defaultUrl: /lab
       storage:
         extraVolumes:
+          - name: dev-shm
+            emptyDir:
+              medium: Memory
         extraVolumeMounts:
           # A shared folder readable & writeable by everyone
           # https://github.com/CryoInTheCloud/hub-image/issues/43#issuecomment-1466392517
@@ -90,6 +93,8 @@ basehub:
             mountPath: /home/jovyan/shared
             subPath: _shared
             readOnly: true
+          - name: dev-shm
+            mountPath: /dev/shm
       initContainers:
         - name: volume-mount-ownership-fix
           image: busybox:1.36.1


### PR DESCRIPTION
Easier to enable for *everyone*, and I don't think there's any negative in enabling higher shm for users in general.

Ref https://github.com/2i2c-org/infrastructure/issues/4563