### PR TITLE
[openscapes] Make grafana pod get credentials to assume the new athena IAM Role via annotations

### DIFF
--- a/config/clusters/openscapes/support.values.yaml
+++ b/config/clusters/openscapes/support.values.yaml
@@ -31,6 +31,9 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - grafana.openscapes.2i2c.cloud
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::783616723547:role/openscapeshub-grafana-athena-iam-role
   grafana.ini:
     server:
       root_url: https://grafana.openscapes.2i2c.cloud/


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/4548

Screenshots relevant for the definition of done:

<img width="1433" alt="Screenshot 2024-08-05 at 16 47 21" src="https://github.com/user-attachments/assets/4cc22bec-87bf-4978-869d-426c89f40d7b">
<img width="1440" alt="Screenshot 2024-08-05 at 16 26 58" src="https://github.com/user-attachments/assets/5301b182-c781-447c-8002-e96846502630">
