### PR TITLE
Add ENV variables for gh-scoped-creds app to VEDA staging Hub

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -4,6 +4,9 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging
   jupyterhub:
     singleuser:
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv23liG9LZ45xmB20syA"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/veda-hub-github-scoped-creds
       initContainers:
         - &volume_ownership_fix_initcontainer
           name: volume-mount-ownership-fix


### PR DESCRIPTION
This PR adds the environment variables to support [pushing to GitHub via gh-scoped-creds](https://infrastructure.2i2c.org/howto/features/github/). I created the [veda-hub-github-scoped-creds app](https://github.com/apps/veda-hub-github-scoped-creds) following [these instructions](https://github.com/jupyterhub/gh-scoped-creds#github-app-configuration). I subsequently requested the app be transferred to the 2i2c-org on GitHub so that users don't get confused by the app's ownership.

After confirming this works, I could open a separate PR to move the env variables to common.

cc @yuvipanda @batpad @wildintellect 