### PR TITLE
Move gh-scoped-creds ENV variables to common for VEDA Hub

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -83,6 +83,9 @@ basehub:
       cloudMetadata:
         blockWithIptables: false
       defaultUrl: /lab
+      extraEnv:
+        GH_SCOPED_CREDS_CLIENT_ID: "Iv23liG9LZ45xmB20syA"
+        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/veda-hub-github-scoped-creds
       initContainers:
         - &volume_ownership_fix_initcontainer
           name: volume-mount-ownership-fix

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -4,9 +4,6 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging
   jupyterhub:
     singleuser:
-      extraEnv:
-        GH_SCOPED_CREDS_CLIENT_ID: "Iv23liG9LZ45xmB20syA"
-        GH_SCOPED_CREDS_APP_URL: https://github.com/apps/veda-hub-github-scoped-creds
       initContainers:
         - &volume_ownership_fix_initcontainer
           name: volume-mount-ownership-fix


### PR DESCRIPTION
Follow up to #4582, moving the configuration to apply to both prod and staging. I tested that it worked first by starting a instance on the staging up, using `gh-scoped-creds` as Jupyter magic, and pushing to a repository that had been added to the app.