### PR TITLE
VEDA: removed igarss 2024 hub users

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,7 +60,6 @@ basehub:
             - veda-analytics-access:maap-biomass-team
             - Earth-Information-System:eis-fire
             - Earth-Information-System:swot
-            - nasa-veda-workshops:igarss-eo-workshop-2024
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
updating hub access (removing) for IGARSS workshop users