### PR TITLE
nasa-veda: update pangeo singleuser image

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -139,7 +139,7 @@ basehub:
                   display_name: Modified Pangeo Notebook
                   description: Pangeo based notebook with a Python environment
                   kubespawner_override:
-                    image: public.ecr.aws/nasa-veda/nasa-veda-singleuser:2024-04-09
+                    image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:6fcf6cfa3192
                     init_containers:
                       # Need to explicitly fix ownership here, as otherwise these directories will be owned
                       # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
Updates the `pangeo` single user image to the latest image from https://github.com/nasa-IMPACT/pangeo-notebook-veda-image/

Keeps the pangeo base image version to `pangeo/pangeo-notebook:2024.06.0`, but adds the following:

 - The `bxplorer` Jupyterlab extension to browse s3 buckets 
 - `code-server` to have VSCode as IDE in Jupyterlab 
 - `jupyterhub-sshd-proxy` to facilitate connecting to the hub backend from local VSCode

cc @sunu @wildintellect @jsignell @sgibson91 