### PR TITLE
nasa-veda: update qgis image

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -178,7 +178,7 @@ basehub:
                     # Launch people directly into the Linux desktop when they start
                     default_url: /desktop
                     # Built from https://github.com/2i2c-org/nasa-qgis-image
-                    image: quay.io/2i2c/nasa-qgis-image:0d0765090250
+                    image: quay.io/2i2c/nasa-qgis-image:d76118ea0c15
             resource_allocation:
               display_name: Resource Allocation
               choices:


### PR DESCRIPTION
Updates STAC endpoints URLs for VEDA and GHG Center in the QGIS STAC Plugin.

Refs https://github.com/NASA-IMPACT/veda-docs/issues/153

cc @slesaad @sgibson91 

No rush on merging this, can wait until Monday :-)