### PR TITLE
Add veda prod bucket to production Hub

### DIFF
--- a/terraform/aws/projects/nasa-esdis.tfvars
+++ b/terraform/aws/projects/nasa-esdis.tfvars
@@ -49,6 +49,8 @@ hub_cloud_permissions = {
                 "s3:ListMultipartUploadParts"
               ],
               "Resource": [
+                "arn:aws:s3:::veda-data-store",
+                "arn:aws:s3:::veda-data-store/*",
                 "arn:aws:s3:::veda-data-store-staging",
                 "arn:aws:s3:::veda-data-store-staging/*",
                 "arn:aws:s3:::veda-nex-gddp-cmip6-public",

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -51,6 +51,8 @@ hub_cloud_permissions = {
                 "arn:aws:s3:::ghgc-data-store/*",
                 "arn:aws:s3:::ghgc-data-store-staging",
                 "arn:aws:s3:::ghgc-data-store-staging/*",
+                "arn:aws:s3:::veda-data-store",
+                "arn:aws:s3:::veda-data-store/*",
                 "arn:aws:s3:::veda-data-store-staging",
                 "arn:aws:s3:::veda-data-store-staging/*",
                 "arn:aws:s3:::lp-prod-protected",

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -108,6 +108,8 @@ hub_cloud_permissions = {
                 "arn:aws:s3:::ghgc-data-store/*",
                 "arn:aws:s3:::ghgc-data-store-staging",
                 "arn:aws:s3:::ghgc-data-store-staging/*",
+                "arn:aws:s3:::veda-data-store",
+                "arn:aws:s3:::veda-data-store/*",
                 "arn:aws:s3:::veda-data-store-staging",
                 "arn:aws:s3:::veda-data-store-staging/*",
                 "arn:aws:s3:::lp-prod-protected",

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -113,6 +113,8 @@ hub_cloud_permissions = {
                 "s3:ListMultipartUploadParts"
               ],
               "Resource": [
+                "arn:aws:s3:::veda-data-store",
+                "arn:aws:s3:::veda-data-store/*",
                 "arn:aws:s3:::veda-data-store-staging",
                 "arn:aws:s3:::veda-data-store-staging/*",
                 "arn:aws:s3:::veda-nex-gddp-cmip6-public",


### PR DESCRIPTION
This PR adds the VEDA production s3 bucket to the Hub production and staging instances for the following projects:

- nasa-veda
- nasa-ghg
- nasa-esdis

Ref https://github.com/2i2c-org/infrastructure/issues/4535