### PR TITLE
Update OHW Python image

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -26,7 +26,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/python:341190e"
+            image: "ghcr.io/oceanhackweek/python:82a498f"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
The pixi environment management experiment continues. 

I missed testing if pixi-kernel could find the base environment after changing the install directory, but JupyterLab worked and installing a new environment in a subdirectory worked as well.

https://github.com/oceanhackweek/jupyter-image/pull/79

xref #4469