### PR TITLE
[openscapes] Give access to athena datasource to relevant s3 buckets

### DIFF
--- a/terraform/aws/grafana-athena-iam.tf
+++ b/terraform/aws/grafana-athena-iam.tf
@@ -73,16 +73,7 @@ resource "aws_iam_role" "grafana_athena_role" {
             "s3:AbortMultipartUpload",
             "s3:PutObject"
           ]
-          Resource = ["arn:aws:s3:::aws-athena-query-results-*"]
-        },
-        {
-          Sid    = "AthenaExamplesS3Access"
-          Effect = "Allow"
-          Action = [
-            "s3:GetObject",
-            "s3:ListBucket"
-          ]
-          Resource = ["arn:aws:s3:::athena-examples*"]
+          Resource = ["arn:aws:s3:::${var.athena_storage_bucket}*"]
       }]
     })
   }

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -9,6 +9,7 @@ default_budget_alert = {
 }
 
 enable_grafana_athena_iam = true
+athena_storage_bucket     = "openscapes-cost-usage-report"
 
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -45,6 +45,13 @@ variable "user_buckets" {
   EOT
 }
 
+
+variable "athena_storage_bucket" {
+  type        = string
+  description = "The name of the S3 bucket where Athena related data will be stored"
+  default     = ""
+}
+
 variable "hub_cloud_permissions" {
   type = map(
     map(


### PR DESCRIPTION
For https://github.com/2i2c-org/infrastructure/issues/4549

Prior to this, we copy-pasted the permissions from the Grafana docs, including the name of the bucket, which clearly doesn't exist for us.

This PR adds a new variable that will hold the name of bucket that we wish to use to store the query results to. For openscapes, the specific bucket was implied from Erik's message in https://github.com/2i2c-org/infrastructure/issues/4550.