### PR TITLE
[openscapes-Athena] Have one bucket to write to and one for reading purposes

### DIFF
--- a/terraform/aws/grafana-athena-iam.tf
+++ b/terraform/aws/grafana-athena-iam.tf
@@ -62,7 +62,7 @@ resource "aws_iam_role" "grafana_athena_role" {
           Resource = ["*"]
         },
         {
-          Sid    = "AthenaS3Access"
+          Sid    = "AthenaS3WriteAccess"
           Effect = "Allow"
           Action = [
             "s3:GetBucketLocation",
@@ -73,7 +73,16 @@ resource "aws_iam_role" "grafana_athena_role" {
             "s3:AbortMultipartUpload",
             "s3:PutObject"
           ]
-          Resource = ["arn:aws:s3:::${var.athena_storage_bucket}*"]
+          Resource = ["arn:aws:s3:::${var.athena_write_storage_bucket}*"]
+        },
+        {
+          Sid    = "AthenaS3ReadAccess"
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject",
+            "s3:ListBucket"
+          ]
+          Resource = ["arn:aws:s3:::${var.athena_read_storage_bucket}*"]
       }]
     })
   }

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -8,8 +8,10 @@ default_budget_alert = {
   "enabled" : false,
 }
 
-enable_grafana_athena_iam = true
-athena_storage_bucket     = "openscapes-cost-usage-report"
+enable_grafana_athena_iam   = true
+athena_write_storage_bucket = "openscapes-cost-usage-report"
+athena_read_storage_bucket  = "openscapes-2i2c-cur"
+
 
 # Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
 tags = {}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -46,9 +46,15 @@ variable "user_buckets" {
 }
 
 
-variable "athena_storage_bucket" {
+variable "athena_write_storage_bucket" {
   type        = string
-  description = "The name of the S3 bucket where Athena related data will be stored"
+  description = "The name of the S3 bucket where Grafana query results from Athena will be stored"
+  default     = ""
+}
+
+variable "athena_read_storage_bucket" {
+  type        = string
+  description = "The name of the S3 bucket where Athena tables and data is stored"
   default     = ""
 }
 


### PR DESCRIPTION
For https://github.com/2i2c-org/infrastructure/issues/4550

In order to execute the query in the linked issue, we need read access to the bucket where data is stored.