### PR TITLE
Update budget alert config for Azure terraform for a clean apply

### DIFF
--- a/terraform/azure/budget-alerts.tf
+++ b/terraform/azure/budget-alerts.tf
@@ -1,5 +1,7 @@
 data "azurerm_subscription" "current" {}
 resource "azurerm_consumption_budget_subscription" "budget" {
+  count = var.budget_alert_enabled ? 1 : 0
+
   name            = "BudgetSubscription-${var.resourcegroup_name}"
   subscription_id = data.azurerm_subscription.current.id
 
@@ -12,7 +14,7 @@ resource "azurerm_consumption_budget_subscription" "budget" {
   }
 
   notification {
-    enabled        = var.budget_alert_enabled ? true : false
+    enabled        = true
     threshold      = 120
     operator       = "GreaterThanOrEqualTo"
     threshold_type = "Forecasted"

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -12,9 +12,9 @@ resourcegroup_name             = "2i2c-utoronto-cluster"
 global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 location                       = "canadacentral"
-budget_alert_amount = null
-storage_size = 10240
-ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
+budget_alert_amount            = null
+storage_size                   = 10240
+ssh_pub_key                    = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
 
 # List available versions via: az aks get-versions --location westus2 -o table
 kubernetes_version = "1.28.3"

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -12,13 +12,12 @@ resourcegroup_name             = "2i2c-utoronto-cluster"
 global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 location                       = "canadacentral"
-
+budget_alert_amount = null
 storage_size = 10240
 ssh_pub_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQJ4h39UYNi1wybxAH+jCFkNK2aqRcuhDkQSMx0Hak5xkbt3KnT3cOwAgUP1Vt/SjhltSTuxpOHxiAKCRnjwRk60SxKhUNzPHih2nkfYTmBBjmLfdepDPSke/E0VWvTDIEXz/L8vW8aI0QGPXnXyqzEDO9+U1buheBlxB0diFAD3vEp2SqBOw+z7UgrGxXPdP+2b3AV+X6sOtd6uSzpV8Qvdh+QAkd4r7h9JrkFvkrUzNFAGMjlTb0Lz7qAlo4ynjEwzVN2I1i7cVDKgsGz9ZG/8yZfXXx+INr9jYtYogNZ63ajKR/dfjNPovydhuz5zQvQyxpokJNsTqt1CiWEUNj georgiana@georgiana"
 
 # List available versions via: az aks get-versions --location westus2 -o table
 kubernetes_version = "1.28.3"
-
 
 # Ref https://github.com/2i2c-org/meta/issues/539
 kubernetes_rbac_enabled = false


### PR DESCRIPTION
- Only create a budget_consumption_subscription resource if budget_alert_enabled variable is true
- Set a null budget_alert_amount for UToronto so we are not asked for this variable on the cmd line

I ran into these issues while working on #4487 