### PR TITLE
[DO NOT MERGE: BROKEN] Attempting to fix Azure backups in terraform

### DIFF
--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -50,6 +50,12 @@ resource "azurerm_recovery_services_vault" "homedir_recovery_vault" {
   sku                 = "Standard"
 }
 
+resource "azurerm_backup_container_storage_account" "protection_container" {
+  resource_group_name = azurerm_resource_group.jupyterhub.name
+  recovery_vault_name = azurerm_recovery_services_vault.homedir_recovery_vault.name
+  storage_account_id  = azurerm_storage_account.homes.id
+}
+
 resource "azurerm_backup_policy_file_share" "backup_policy" {
   name                = "homedir-recovery-vault-policy"
   resource_group_name = azurerm_resource_group.jupyterhub.name

--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -72,3 +72,12 @@ resource "azurerm_backup_policy_file_share" "backup_policy" {
     count = 5
   }
 }
+
+resource "azurerm_backup_protected_file_share" "homes" {
+  resource_group_name       = azurerm_resource_group.jupyterhub.name
+  recovery_vault_name       = azurerm_recovery_services_vault.homedir_recovery_vault.name
+  source_storage_account_id = azurerm_backup_container_storage_account.protection_container.storage_account_id
+  source_file_share_name    = azurerm_storage_share.homes.name
+  backup_policy_id          = azurerm_backup_policy_file_share.backup_policy.id
+  depends_on                = [azurerm_backup_container_storage_account.protection_container]
+}


### PR DESCRIPTION
This PR documents what I tried as part of:
- https://github.com/2i2c-org/infrastructure/issues/4487

The terraform plan is clean, however during apply, I get the following error:

```
│ Error: [ERROR] fileshare 'homes' not found in protectable or protected fileshares, make sure Storage Account "2i2cutorontohubstorage" is registered with Recovery Service Vault "homedir-recovery-vault" (Resource Group "2i2c-utoronto-cluster")
│ 
│   with azurerm_backup_protected_file_share.homes,
│   on storage.tf line 76, in resource "azurerm_backup_protected_file_share" "homes":
│   76: resource "azurerm_backup_protected_file_share" "homes" {
```

Googling the error, this was apparently fixed upstream in v2.86.0, and we are using v3.111, so I'm not sure why we are still seeing this.
- https://github.com/hashicorp/terraform-provider-azurerm/issues/14056