### PR TITLE
nasa-veda: Change some hub-side permissions for the binder

### DIFF
--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -168,7 +168,7 @@ hub_cloud_permissions = {
                 "s3:GetObject",
                 "s3:ListBucketVersions",
                 "s3:ListBucket",
-                "s3:GetBucketLocation",
+                "s3:GetBucketLocation"
               ],
               "Resource": [
                 "arn:aws:s3:::veda-data-store",

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -165,16 +165,10 @@ hub_cloud_permissions = {
             {
               "Effect": "Allow",
               "Action": [
-                "s3:PutObject",
                 "s3:GetObject",
-                "s3:ListBucketMultipartUploads",
-                "s3:AbortMultipartUpload",
                 "s3:ListBucketVersions",
-                "s3:CreateBucket",
                 "s3:ListBucket",
-                "s3:DeleteObject",
                 "s3:GetBucketLocation",
-                "s3:ListMultipartUploadParts"
               ],
               "Resource": [
                 "arn:aws:s3:::veda-data-store",


### PR DESCRIPTION
These were not in effect (as the S3 bucket side has not been opened), and we're toning these down now for an additional level of security.