### PR TITLE
2i2c, ohw: scratch bucket access for community managed google group

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -65,6 +65,11 @@ user_buckets = {
   },
   "scratch-ohw" : {
     "delete_after" : 7,
+    "extra_admin_members" : [
+      # Requested via https://2i2c.freshdesk.com/a/tickets/2051, Erik and James
+      # were added as group owners besides Alex who requested it.
+      "group:pilot-hubs-scratch-ohw-writers@googlegroups.com",
+    ],
   },
 }
 


### PR DESCRIPTION
Applying this is blocked by #4655.

EDIT: No longer blocked, apply was successfull - going for it!