### PR TITLE
GCP filestore restore procedure to also update terraform config

### DIFF
--- a/docs/howto/filesystem-backups/restore-filesystem.md
+++ b/docs/howto/filesystem-backups/restore-filesystem.md
@@ -17,16 +17,32 @@ Due to the length of the steps listed in that document, we will not repeat them 
 ## GCP
 
 ```{note}
-We follow GCP's guidance for [restoring fileshares from a backup](https://cloud.google.com/filestore/docs/backup-restore#restore)
+We follow GCP's guidance for [restoring fileshares from a backup](https://cloud.google.com/filestore/docs/backup-restore#restore).
 ```
 
-To restore a share on a Filestore instance on GCP, we follow the documentation
-linked above. In short, this involves:
+To restore a share on a Filestore instance on GCP, we start by following the
+documentation linked above. In short, this involves:
 
 1. [Go to the Filestore instances page](https://console.cloud.google.com/filestore/instances) in the GCP console
-1. Click the instance ID of the Filestore you want to restore and click the "Backups" tab
-1. Locate the backup you want to restore from (most likely the most recently created), and click (...) "More actions"
-1. Click "Restore backup" and then select "Source instance"
-1. Click "Restore" and complete the dialog box that appears
+2. Click the instance ID of the Filestore you want to restore and click the "Backups" tab
+3. Locate the backup you want to restore from (most likely the most recently created), and click (...) "More actions"
+4. Click "Restore backup" and then select "Source instance"
+5. Click "Restore" and complete the dialog box that appears
 
-This should successfully restore the Filestore instance to its last backed-up state
+This should successfully restore the Filestore instance to its last backed-up state.
+
+Once this is done, you should also set the terraform variable `source_backup` to
+reference this web console change. Practically, you should configure something
+like below in the `terraform/gcp/projects/$CLUSTER_NAME.tfvars` file:
+
+```
+filestores = {
+  "filestore" : {
+    # ...
+    source_backup : "projects/<gcp project name>/locations/<filestore region>/backups/<backup name>",
+  },
+}
+```
+
+You can determine the value of `source_backup` by trying a `terraform plan`
+which should present the value in an associated error.

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -21,7 +21,10 @@ core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 filestores = {
-  "filestore" : { capacity_gb : 5120 }
+  "filestore" : {
+    capacity_gb : 5120,
+    source_backup : "projects/two-eye-two-see/locations/us-central1/backups/test",
+  },
 }
 enable_filestore_backups = true
 

--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -13,8 +13,9 @@ resource "google_filestore_instance" "homedirs" {
   }
 
   file_shares {
-    capacity_gb = each.value.capacity_gb
-    name        = "homes"
+    capacity_gb   = each.value.capacity_gb
+    name          = "homes"
+    source_backup = each.value.source_backup
   }
 
   networks {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -322,6 +322,7 @@ variable "filestores" {
     name_suffix : optional(string, null),
     capacity_gb : optional(number, 1024),
     tier : optional(string, "BASIC_HDD"),
+    source_backup : optional(string, null),
   }))
   default = {
     "filestore" : {}
@@ -341,6 +342,10 @@ variable "filestores" {
   - tier: Google FileStore service tier to use. Most likely BASIC_HDD
       (for slower home directories, min $204 / month) or BASIC_SSD (for
       faster home directories, min $768 / month). Default: BASIC_HDD.
+  - source_backup: To restore from a backup, this can be set. If a
+      backup has been done from the web console, this must be updated
+      to match retroactively as terraform apply will otherwise lead to
+      a blocked re-creation attempt.
   EOT
 }
 


### PR DESCRIPTION
- Fixes #4655

The issue was that after restore via a web console, terraform will end up trying to recreate the filestore instance because it is trying to force `source_backup` to be null when it is after the web console restore referencing the backup it was restored from.

The fix in this PR is to update the docs to update the terraform config as well after having made a change in the web console. We could reasonably also do a filestore restore using terraform by setting `source_backup` directly, but that felt like adding complexity to a very sensitive operation. Due to that, I've instead just patched to set `source_backup` retroactively in terraform.