### PR TITLE
terraform, gcp: update k8s minor versions info to include 1.30

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -50,9 +50,8 @@ variable "k8s_version_prefixes" {
   # channel, so we may want to remove or add minor versions here over time.
   #
   default = [
-    "1.27.",
-    "1.28.",
     "1.29.",
+    "1.30.",
     "1.",
   ]
   description = <<-EOT


### PR DESCRIPTION
K8s 1.30 is now part of the regular release channel, we can create new clusters with it.