### PR TITLE
2i2c-aws-us, staging and dask-staging: declare scratch bucket env

### DIFF
--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -31,6 +31,8 @@ basehub:
       image:
         name: pangeo/pangeo-notebook
         tag: "latest"
+      extraEnv:
+        SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-dask-staging/$(JUPYTERHUB_USER)
     hub:
       config:
         JupyterHub:

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -32,3 +32,6 @@ jupyterhub:
         authenticator_class: "github"
       GitHubOAuthenticator:
         oauth_callback_url: "https://staging.aws.2i2c.cloud/hub/oauth_callback"
+  singleuser:
+    extraEnv:
+      SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-staging/$(JUPYTERHUB_USER)


### PR DESCRIPTION
This is extracted from b2fbbf88, part of https://github.com/2i2c-org/infrastructure/pull/3977. I'm using the staging hubs to test things sometimes, and want to not get confused by not having `SCRATCH_BUCKET` set when testing access to a scratch bucket (this can be relevant to verify function of buckets with network policy enforcement for example).