### PR TITLE
Print the names of the EFS servers along with their DNS addresses

### DIFF
--- a/terraform/aws/efs.tf
+++ b/terraform/aws/efs.tf
@@ -109,8 +109,8 @@ resource "aws_efs_mount_target" "hub_homedirs" {
   security_groups = [data.aws_security_group.cluster_nodes_shared_security_group.id]
 }
 
-output "nfs_server_dns_list" {
-  value = values(aws_efs_file_system.hub_homedirs)[*].dns_name
+output "nfs_server_dns_map" {
+  value = { for nfs in values(aws_efs_file_system.hub_homedirs)[*] : nfs.name => nfs.dns_name }
 }
 
 # Enable automatic backups for user homedirectories


### PR DESCRIPTION
Changes an output variable from

```
nfs_server_dns_list           = [
    "fs-0bede1dba0cd22029.efs.us-west-2.amazonaws.com",
    "fs-09a9026ea8f4b4d3b.efs.us-west-2.amazonaws.com",
]
```

to

```
nfs_server_dns_map            = {
    hub-homedirs-staging  = "fs-0bede1dba0cd22029.efs.us-west-2.amazonaws.com"
    hub-homedirs-workshop = "fs-09a9026ea8f4b4d3b.efs.us-west-2.amazonaws.com"
}
```

This means that you don't have to look them up in the AWS console