### PR TITLE
Update OHW images for cert change blocking Github login

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -26,7 +26,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/python:4059588"
+            image: "ghcr.io/oceanhackweek/python:461a00b"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
@@ -35,7 +35,7 @@ basehub:
         - display_name: "R using RStudio"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/r:2b505d5"
+            image: "ghcr.io/oceanhackweek/r:e18dea3"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
We just found out that gh-scoped-creds and gh CLI tools weren't working in our images due to change in Github's TLS certs, so this bumps ca-certificates to try to fix that.