### PR TITLE
eksctl: update new cluster template to use k8s 1.30

### DIFF
--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -69,7 +69,7 @@ local daskNodes = [];
             version should be the latest support version by the eksctl CLI, see
             https://eksctl.io/getting-started/ for a list of supported versions.
         -#}
-        version: "1.29",
+        version: "1.30",
         tags+: {
             "ManagedBy": "2i2c"
         },


### PR DESCRIPTION
We should use 1.30 going onwards as its now sufficiently mature according to policy definition.