### PR TITLE
Increase size of pangeo-hubs filestore for homedirs

### DIFF
--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -45,7 +45,7 @@ k8s_versions = {
 enable_network_policy = true
 
 filestores = {
-  "filestore" = { capacity_gb = 4608 }
+  "filestore" = { capacity_gb = 5120 }
 }
 
 user_buckets = {


### PR DESCRIPTION
In response to https://2i2c-org.pagerduty.com/incidents/Q2UO5W8WYZ61RF