### PR TITLE
openscapes: add cost allocation tag alpha.eksctl.io/cluster-name

### DIFF
--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -98,6 +98,7 @@ hub_cloud_permissions = {
 active_cost_allocation_tags = [
   "2i2c:hub-name",
   "2i2c:node-purpose",
+  "alpha.eksctl.io/cluster-name",
   "aws:eks:cluster-name",
   "kubernetes.io/cluster/{var_cluster_name}",
   "kubernetes.io/created-for/pvc/name",


### PR DESCRIPTION
Part of work in https://github.com/2i2c-org/infrastructure/issues/4713, where the tag is recognized to be a tag name of relevance to complement `2i2c:hub-name` and `kubernetes.io/cluster/{var_cluster_name}`.