### PR TITLE
terraform, aws: ManagedBy and 2i2c.org/cluster-name tags for all clusters

### DIFF
--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "2i2c-aws-us"
-
+region                 = "us-west-2"
+cluster_name           = "2i2c-aws-us"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "2i2c-aws-us",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/catalystproject-africa.tfvars
+++ b/terraform/aws/projects/catalystproject-africa.tfvars
@@ -1,11 +1,11 @@
-region = "af-south-1"
-
-cluster_name = "catalystproject-africa"
-
+region                 = "af-south-1"
+cluster_name           = "catalystproject-africa"
 cluster_nodes_location = "af-south-1a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "catalystproject-africa",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -1,18 +1,17 @@
-region = "us-east-2"
-
-cluster_name = "earthscope"
-
+region                 = "us-east-2"
+cluster_name           = "earthscope"
 cluster_nodes_location = "us-east-2a"
 
-default_budget_alert = {
-  "enabled" : false,
-}
-
 tags = {
+  "2i2c.org/cluster-name" : "earthscope",
   "ManagedBy" : "2i2c",
   # Requested by the community in https://2i2c.freshdesk.com/a/tickets/1460
   "earthscope:application:name" : "geolab",
-  "earthscope:application:owner" : "research-onramp-to-the-cloud"
+  "earthscope:application:owner" : "research-onramp-to-the-cloud",
+}
+
+default_budget_alert = {
+  "enabled" : false,
 }
 
 user_buckets = {

--- a/terraform/aws/projects/gridsst.tfvars
+++ b/terraform/aws/projects/gridsst.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "gridsst"
-
+region                 = "us-west-2"
+cluster_name           = "gridsst"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "gridsst",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/jupyter-health.tfvars
+++ b/terraform/aws/projects/jupyter-health.tfvars
@@ -1,11 +1,11 @@
-region = "us-east-2"
-
-cluster_name = "jupyter-health"
-
+region                 = "us-east-2"
+cluster_name           = "jupyter-health"
 cluster_nodes_location = "us-east-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "jupyter-health",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/jupyter-meets-the-earth.tfvars
+++ b/terraform/aws/projects/jupyter-meets-the-earth.tfvars
@@ -1,15 +1,15 @@
-region = "us-west-2"
-
-cluster_name = "jupyter-meets-the-earth"
-
+region                 = "us-west-2"
+cluster_name           = "jupyter-meets-the-earth"
 cluster_nodes_location = "us-west-2a"
 
+
+tags = {
+  "2i2c.org/cluster-name" : "jupyter-meets-the-earth",
+  "ManagedBy" : "2i2c",
+}
 default_budget_alert = {
   "enabled" : false,
 }
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/kitware.tfvars
+++ b/terraform/aws/projects/kitware.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "kitware"
-
+region                 = "us-west-2"
+cluster_name           = "kitware"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "kitware",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "nasa-cryo"
-
+region                 = "us-west-2"
+cluster_name           = "nasa-cryo"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "nasa-cryo",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/nasa-esdis.tfvars
+++ b/terraform/aws/projects/nasa-esdis.tfvars
@@ -1,15 +1,15 @@
-region = "us-west-2"
-
-cluster_name = "nasa-esdis"
-
+region                 = "us-west-2"
+cluster_name           = "nasa-esdis"
 cluster_nodes_location = "us-west-2a"
+
+tags = {
+  "2i2c.org/cluster-name" : "nasa-esdis",
+  "ManagedBy" : "2i2c",
+}
 
 default_budget_alert = {
   "enabled" : false,
 }
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -1,15 +1,15 @@
-region = "us-west-2"
-
-cluster_name = "nasa-ghg-hub"
-
+region                 = "us-west-2"
+cluster_name           = "nasa-ghg-hub"
 cluster_nodes_location = "us-west-2a"
+
+tags = {
+  "2i2c.org/cluster-name" : "nasa-ghg-hub",
+  "ManagedBy" : "2i2c",
+}
 
 default_budget_alert = {
   "enabled" : false,
 }
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -1,15 +1,15 @@
-region = "us-west-2"
-
-cluster_name = "nasa-veda"
-
+region                 = "us-west-2"
+cluster_name           = "nasa-veda"
 cluster_nodes_location = "us-west-2a"
+
+tags = {
+  "2i2c.org/cluster-name" : "nasa-veda",
+  "ManagedBy" : "2i2c",
+}
 
 default_budget_alert = {
   "enabled" : false,
 }
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -1,8 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "openscapeshub"
-
+region                 = "us-west-2"
+cluster_name           = "openscapeshub"
 cluster_nodes_location = "us-west-2b"
+
+tags = {
+  "2i2c.org/cluster-name" : "openscapeshub",
+  "ManagedBy" : "2i2c",
+}
 
 default_budget_alert = {
   "enabled" : false,
@@ -12,10 +15,6 @@ enable_grafana_athena_iam         = true
 enable_aws_ce_grafana_backend_iam = true
 athena_write_storage_bucket       = "openscapes-cost-usage-report"
 athena_read_storage_bucket        = "openscapes-2i2c-cur"
-
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 # The initial EFS is now used by the prod hub only
 # So we tag it appropriately for costs purposes
@@ -98,8 +97,8 @@ hub_cloud_permissions = {
 active_cost_allocation_tags = [
   "2i2c:hub-name",
   "2i2c:node-purpose",
+  "2i2c.org/cluster-name",
   "alpha.eksctl.io/cluster-name",
-  "aws:eks:cluster-name",
   "kubernetes.io/cluster/{var_cluster_name}",
   "kubernetes.io/created-for/pvc/name",
   "kubernetes.io/created-for/pvc/namespace",

--- a/terraform/aws/projects/opensci.tfvars
+++ b/terraform/aws/projects/opensci.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "opensci"
-
+region                 = "us-west-2"
+cluster_name           = "opensci"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "opensci",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/projectpythia.tfvars
+++ b/terraform/aws/projects/projectpythia.tfvars
@@ -1,15 +1,15 @@
-region = "us-west-2"
-
-cluster_name = "projectpythia"
-
+region                 = "us-west-2"
+cluster_name           = "projectpythia"
 cluster_nodes_location = "us-west-2a"
+
+tags = {
+  "2i2c.org/cluster-name" : "projectpythia",
+  "ManagedBy" : "2i2c",
+}
 
 default_budget_alert = {
   "enabled" : false,
 }
-
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
 
 # Tip: uncomment and fill the missing info in the lines below if you want
 #       to setup scratch buckets for the hubs on this cluster.

--- a/terraform/aws/projects/smithsonian.tfvars
+++ b/terraform/aws/projects/smithsonian.tfvars
@@ -2,8 +2,10 @@ region                 = "us-east-2"
 cluster_name           = "smithsonian"
 cluster_nodes_location = "us-east-2b"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "smithsonian",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/template.tfvars
+++ b/terraform/aws/projects/template.tfvars
@@ -8,6 +8,11 @@ region                 = "{{ cluster_region }}"
 cluster_name           = "{{ cluster_name }}"
 cluster_nodes_location = "{{ cluster_region }}a"
 
+tags = {
+  "ManagedBy" : "2i2c",
+  "2i2c.org/cluster-name" : "{{ cluster_name }}",
+}
+
 # Tip: uncomment and fill the missing info in the lines below if you want
 #       to setup scratch buckets for the hubs on this cluster.
 #

--- a/terraform/aws/projects/ubc-eoas.tfvars
+++ b/terraform/aws/projects/ubc-eoas.tfvars
@@ -1,11 +1,11 @@
-region = "ca-central-1"
-
-cluster_name = "ubc-eoas"
-
+region                 = "ca-central-1"
+cluster_name           = "ubc-eoas"
 cluster_nodes_location = "ca-central-1a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "ubc-eoas",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/projects/victor.tfvars
+++ b/terraform/aws/projects/victor.tfvars
@@ -1,11 +1,11 @@
-region = "us-west-2"
-
-cluster_name = "victor"
-
+region                 = "us-west-2"
+cluster_name           = "victor"
 cluster_nodes_location = "us-west-2a"
 
-# Remove this variable to tag all our resources with {"ManagedBy": "2i2c"}
-tags = {}
+tags = {
+  "2i2c.org/cluster-name" : "victor",
+  "ManagedBy" : "2i2c",
+}
 
 user_buckets = {
   "scratch-staging" : {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -259,10 +259,34 @@ variable "filestores" {
 }
 
 variable "active_cost_allocation_tags" {
-  type        = list(string)
-  default     = []
+  type    = list(string)
+  default = []
+
   description = <<-EOT
   Tags to be treated as active cost allocation tags.
+
+  Without permissions on the billing account, we get the following
+  error if we try to use this:
+
+      Failed to update Cost Allocation Tag:
+      Linked account doesn't have access to cost allocation tags.
+
+  Due to that, we don't provide a default value here, but if we could,
+  we would want to activate at least the following that are relevant
+  to cost attribution currently as piloted by the openscapes cluster:
+
+  - 2i2c:hub-name
+  - 2i2c.org/cluster-name
+  - alpha.eksctl.io/cluster-name
+  - kubernetes.io/cluster/{var_cluster_name}
+
+  Cost allocation tags can only be activated after sufficient amount of
+  time has passed since resources was tagged, so expect a few hours or
+  up to 24 hours in order you can activate them without running into
+  this error:
+
+      Failed to update Cost Allocation Tag:
+      Tag keys not found: 2i2c.org/cluster-name
   EOT
 }
 


### PR DESCRIPTION
AWS tags managed via terraform could be applied to all clusters by updates, and no re-creation was needed etc.

In `eksctl` they are only applied on re-creation though, so there its trouble to adjust tags.

All changes are applied fully except in openscapes that needs to be applied again soonish.