### PR TITLE
docs: make myst-parser install work with recently released v4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-myst-parser[sphinx,linkify]
+myst-parser[linkify]
 pandas
 pyyaml
 python-hcl2


### PR DESCRIPTION
Our RTD builds failed without this.