### PR TITLE
terraform, aws: simplify resource tagging by using aws provider's default_tags

### DIFF
--- a/terraform/aws/aws-ce-grafana-backend-iam.tf
+++ b/terraform/aws/aws-ce-grafana-backend-iam.tf
@@ -3,7 +3,6 @@ resource "aws_iam_role" "aws_ce_grafana_backend_iam_role" {
   count = var.enable_aws_ce_grafana_backend_iam ? 1 : 0
 
   name = "aws_ce_grafana_backend_iam_role"
-  tags = var.tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -2,7 +2,7 @@
 resource "aws_s3_bucket" "user_buckets" {
   for_each = var.user_buckets
   bucket   = lower("${var.cluster_name}-${each.key}")
-  tags     = merge(var.tags, each.value.tags)
+  tags     = each.value.tags
 }
 
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration

--- a/terraform/aws/cd.tf
+++ b/terraform/aws/cd.tf
@@ -5,7 +5,6 @@
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user
 resource "aws_iam_user" "continuous_deployer" {
   name = "hub-continuous-deployer"
-  tags = var.tags
 }
 
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key

--- a/terraform/aws/db.tf
+++ b/terraform/aws/db.tf
@@ -20,7 +20,6 @@ resource "aws_security_group" "db" {
   name        = "db"
   description = "Allow traffic into the db"
   vpc_id      = data.aws_eks_cluster.cluster.vpc_config[0]["vpc_id"]
-  tags        = var.tags
 
   ingress {
     to_port          = 3306
@@ -47,8 +46,6 @@ resource "aws_db_subnet_group" "db" {
   count = var.db_enabled ? 1 : 0
 
   subnet_ids = data.aws_subnets.cluster_subnets[0].ids
-
-  tags = var.tags
 }
 
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance
@@ -69,8 +66,6 @@ resource "aws_db_instance" "db" {
   apply_immediately      = true
   availability_zone      = var.cluster_nodes_location
   parameter_group_name   = aws_db_parameter_group.db[0].name
-
-  tags = var.tags
 }
 
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group
@@ -78,7 +73,6 @@ resource "aws_db_parameter_group" "db" {
   count  = var.db_enabled ? 1 : 0
   name   = var.db_instance_identifier
   family = "${var.db_engine}${var.db_engine_version}"
-  tags   = var.tags
 
   dynamic "parameter" {
     for_each = var.db_params

--- a/terraform/aws/efs.tf
+++ b/terraform/aws/efs.tf
@@ -47,7 +47,7 @@ data "aws_security_group" "cluster_nodes_shared_security_group" {
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system
 resource "aws_efs_file_system" "hub_homedirs" {
   for_each = var.filestores
-  tags = merge(var.tags, each.value.tags, {
+  tags = merge(each.value.tags, {
     Name = each.value.name_suffix == null ? "hub-homedirs" : "hub-homedirs-${each.value.name_suffix}"
   })
   encrypted = true

--- a/terraform/aws/grafana-athena-iam.tf
+++ b/terraform/aws/grafana-athena-iam.tf
@@ -3,7 +3,6 @@ resource "aws_iam_role" "grafana_athena_role" {
   count = var.enable_grafana_athena_iam ? 1 : 0
 
   name = "${var.cluster_name}-grafana-athena-iam-role"
-  tags = var.tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/aws/irsa.tf
+++ b/terraform/aws/irsa.tf
@@ -63,7 +63,6 @@ data "aws_iam_policy_document" "irsa_role_assume" {
 resource "aws_iam_role" "irsa_role" {
   for_each = { for index, hr in local.hub_to_role_mapping : hr.iam_role_name => hr }
   name     = "${var.cluster_name}-${each.key}"
-  tags     = var.tags
 
   assume_role_policy = data.aws_iam_policy_document.irsa_role_assume[each.key].json
 }
@@ -72,7 +71,6 @@ resource "aws_iam_role" "irsa_role" {
 resource "aws_iam_policy" "extra_user_policy" {
   for_each = { for index, hr in local.hub_to_role_mapping : hr.iam_role_name => hr if hr.cloud_permissions.extra_iam_policy != "" }
   name     = "${var.cluster_name}-${each.key}-extra-user-policy"
-  tags     = var.tags
 
   description = "Extra permissions granted to users on hub ${each.key} on ${var.cluster_name}"
   policy      = each.value.cloud_permissions.extra_iam_policy

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -36,7 +36,7 @@ provider "aws" {
   # default_tags ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block
   default_tags {
     tags = {
-      for k, v in var.tags : k => replace(v, "{var_cluster_name}", var.cluster_name)
+      for k, v in var.default_tags : k => replace(v, "{var_cluster_name}", var.cluster_name)
     }
   }
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -32,6 +32,13 @@ provider "random" {}
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 provider "aws" {
   region = var.region
+
+  # default_tags ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block
+  default_tags {
+    tags = {
+      for k, v in var.tags : k => replace(v, "{var_cluster_name}", var.cluster_name)
+    }
+  }
 }
 
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "2i2c-aws-us"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "2i2c-aws-us",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/catalystproject-africa.tfvars
+++ b/terraform/aws/projects/catalystproject-africa.tfvars
@@ -2,11 +2,6 @@ region                 = "af-south-1"
 cluster_name           = "catalystproject-africa"
 cluster_nodes_location = "af-south-1a"
 
-tags = {
-  "2i2c.org/cluster-name" : "catalystproject-africa",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -2,7 +2,7 @@ region                 = "us-east-2"
 cluster_name           = "earthscope"
 cluster_nodes_location = "us-east-2a"
 
-tags = {
+default_tags = {
   "2i2c.org/cluster-name" : "{var_cluster_name}",
   "ManagedBy" : "2i2c",
   # Requested by the community in https://2i2c.freshdesk.com/a/tickets/1460

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -3,7 +3,7 @@ cluster_name           = "earthscope"
 cluster_nodes_location = "us-east-2a"
 
 tags = {
-  "2i2c.org/cluster-name" : "earthscope",
+  "2i2c.org/cluster-name" : "{var_cluster_name}",
   "ManagedBy" : "2i2c",
   # Requested by the community in https://2i2c.freshdesk.com/a/tickets/1460
   "earthscope:application:name" : "geolab",

--- a/terraform/aws/projects/gridsst.tfvars
+++ b/terraform/aws/projects/gridsst.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "gridsst"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "gridsst",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/jupyter-health.tfvars
+++ b/terraform/aws/projects/jupyter-health.tfvars
@@ -2,11 +2,6 @@ region                 = "us-east-2"
 cluster_name           = "jupyter-health"
 cluster_nodes_location = "us-east-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "jupyter-health",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/jupyter-meets-the-earth.tfvars
+++ b/terraform/aws/projects/jupyter-meets-the-earth.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "jupyter-meets-the-earth"
 cluster_nodes_location = "us-west-2a"
 
-
-tags = {
-  "2i2c.org/cluster-name" : "jupyter-meets-the-earth",
-  "ManagedBy" : "2i2c",
-}
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/kitware.tfvars
+++ b/terraform/aws/projects/kitware.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "kitware"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "kitware",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "nasa-cryo"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "nasa-cryo",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/nasa-esdis.tfvars
+++ b/terraform/aws/projects/nasa-esdis.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "nasa-esdis"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "nasa-esdis",
-  "ManagedBy" : "2i2c",
-}
-
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "nasa-ghg-hub"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "nasa-ghg-hub",
-  "ManagedBy" : "2i2c",
-}
-
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "nasa-veda"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "nasa-veda",
-  "ManagedBy" : "2i2c",
-}
-
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/openscapes.tfvars
+++ b/terraform/aws/projects/openscapes.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "openscapeshub"
 cluster_nodes_location = "us-west-2b"
 
-tags = {
-  "2i2c.org/cluster-name" : "openscapeshub",
-  "ManagedBy" : "2i2c",
-}
-
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/opensci.tfvars
+++ b/terraform/aws/projects/opensci.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "opensci"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "opensci",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/projectpythia.tfvars
+++ b/terraform/aws/projects/projectpythia.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "projectpythia"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "projectpythia",
-  "ManagedBy" : "2i2c",
-}
-
 default_budget_alert = {
   "enabled" : false,
 }

--- a/terraform/aws/projects/smithsonian.tfvars
+++ b/terraform/aws/projects/smithsonian.tfvars
@@ -2,11 +2,6 @@ region                 = "us-east-2"
 cluster_name           = "smithsonian"
 cluster_nodes_location = "us-east-2b"
 
-tags = {
-  "2i2c.org/cluster-name" : "smithsonian",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/template.tfvars
+++ b/terraform/aws/projects/template.tfvars
@@ -3,15 +3,9 @@
    - location of the nodes of the kubernetes cluster will be <region>a
    - no default scratch buckets support
 */
-
 region                 = "{{ cluster_region }}"
 cluster_name           = "{{ cluster_name }}"
 cluster_nodes_location = "{{ cluster_region }}a"
-
-tags = {
-  "ManagedBy" : "2i2c",
-  "2i2c.org/cluster-name" : "{{ cluster_name }}",
-}
 
 # Tip: uncomment and fill the missing info in the lines below if you want
 #       to setup scratch buckets for the hubs on this cluster.

--- a/terraform/aws/projects/ubc-eoas.tfvars
+++ b/terraform/aws/projects/ubc-eoas.tfvars
@@ -2,11 +2,6 @@ region                 = "ca-central-1"
 cluster_name           = "ubc-eoas"
 cluster_nodes_location = "ca-central-1a"
 
-tags = {
-  "2i2c.org/cluster-name" : "ubc-eoas",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/projects/victor.tfvars
+++ b/terraform/aws/projects/victor.tfvars
@@ -2,11 +2,6 @@ region                 = "us-west-2"
 cluster_name           = "victor"
 cluster_nodes_location = "us-west-2a"
 
-tags = {
-  "2i2c.org/cluster-name" : "victor",
-  "ManagedBy" : "2i2c",
-}
-
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7

--- a/terraform/aws/single-efs-setup.tf
+++ b/terraform/aws/single-efs-setup.tf
@@ -5,7 +5,7 @@
 resource "aws_efs_file_system" "homedirs" {
   count = var.disable_cluster_wide_filestore ? 0 : 1
 
-  tags = merge(var.tags, var.original_single_efs_tags, { Name = "hub-homedirs" })
+  tags = merge(var.original_single_efs_tags, { Name = "hub-homedirs" })
 
   lifecycle_policy {
     transition_to_primary_storage_class = "AFTER_1_ACCESS"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -183,7 +183,7 @@ variable "db_user_password_special_chars" {
   EOT
 }
 
-variable "tags" {
+variable "default_tags" {
   type = map(string)
   default = {
     "2i2c.org/cluster-name" = "{var_cluster_name}"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -184,17 +184,24 @@ variable "db_user_password_special_chars" {
 }
 
 variable "tags" {
-  type        = map(string)
-  default     = { "ManagedBy" : "2i2c" }
+  type = map(string)
+  default = {
+    "2i2c.org/cluster-name" = "{var_cluster_name}"
+    "ManagedBy"             = "2i2c"
+  }
   description = <<-EOT
-  Tags to apply to resources that we manage. The value is an object as we may
-  wish to apply multiple tags. We use CamelCase for tag names to match AWS's
-  tagging style. Current tags are:
+  Default tags to apply to all resources created. The value is an object as we may
+  wish to apply multiple tags.
+
+  Current tags are:
 
   1. ManagedBy: This tag will indicate who manages the deployed resource. By
      default, this will be set to "2i2c". This helps communities who bring their
      own billing account distinguish between resources 2i2c manages, and those
      they deploy and manage themselves.
+  2. 2i2c.org/cluster-name: helps clarify that a resource is associated with the
+     creation of a specific cluster, which can help if a cluster is re-created or
+     multiple clusters would be deployed.
   EOT
 }
 


### PR DESCRIPTION
It turns out that instead of using `var.tags` and setting that explicitly on all resources, we can use `default_tags` on the aws provider thingy in `main.tf` instead. This also enabled referencing `var.tags` and replacing patterns like `{var_cluster_name}`, which made it easy to declare a default value involving a cluster name.

This turned out perfect and is a robust solution to #4711 with regards to non-hub-specific tags at least.

Only one resource (a budget plan) wasn't already tagged explicitly and could be tagged thanks to `default_tags`.