### PR TITLE
deployer: add aws cluster.yaml file generation for parity with gcp

### DIFF
--- a/config/clusters/templates/aws/cluster.yaml
+++ b/config/clusters/templates/aws/cluster.yaml
@@ -1,0 +1,26 @@
+name: {{ cluster_name }}
+provider: aws # {{ sign_in_url }}
+aws:
+  key: enc-deployer-credentials.secret.json
+  clusterType: eks
+  clusterName: {{ cluster_name }}
+  region: {{ cluster_region }}
+  billing:
+    paid_by_us: {{ paid_by_us }}
+support:
+  helm_chart_values_files:
+    - support.values.yaml
+    - enc-support.secret.values.yaml
+hubs: []
+  # Uncomment the lines below once the support infrastructure was deployed and
+  # you are ready to add the first cluster
+
+  # - name: {{ hub_name }}
+  #   # Tip: consider changing this to something more human friendly
+  #   display_name: "{{ cluster_name }} - {{ hub_name }}"
+  #   domain: {{ hub_name }}.{{ cluster_name }}.2i2c.cloud
+  #   helm_chart: {{ hub_type }}
+  #   helm_chart_values_files:
+  #     - common.values.yaml
+  #     - {{ hub_name }}.values.yaml
+  #     - enc-{{ hub_name }}.secret.values.yaml

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -107,6 +107,7 @@ We automatically generate the files required to setup a new cluster:
 - A ssh public key used by `eksctl` to grant access to the private key.
 - A `.tfvars` terraform variables file that will setup most of the non EKS infrastructure.
 - The cluster config directory in `./config/cluster/<new-cluster>`
+- The `cluster.yaml` config file
 - The support values file `support.values.yaml`
 - The the support credentials encrypted file `enc-support.values.yaml` 
 ````
@@ -135,12 +136,13 @@ You can generate these with:
 :sync: aws-key
 
 ```bash
-export CLUSTER_NAME=<cluster-name>;
+export CLUSTER_NAME=<cluster-name>
 export CLUSTER_REGION=<cluster-region-like ca-central-1>
+export ACCOUNT_ID=<declare 2i2c for clusters under 2i2c SSO, otherwise an account id or alias>
 ```
 
 ```bash
-deployer generate dedicated-cluster aws --cluster-name=$CLUSTER_NAME --cluster-region=$CLUSTER_REGION
+deployer generate dedicated-cluster aws --cluster-name=$CLUSTER_NAME --cluster-region=$CLUSTER_REGION --account-id=$ACCOUNT_ID
 ```
 
 After running this command, you will be asked to provide the type of hub that will be deployed in the cluster, i.e. `basehub` or `daskhub`.
@@ -547,29 +549,8 @@ Create a `cluster.yaml` file under the `config/cluster/$CLUSTER_NAME>` folder an
 
 ````{tab-item} AWS
 :sync: aws-key
-```yaml
-name: <your-cluster-name>
-provider: aws # <copy paste link to sign in url here>
-aws:
-  key: enc-deployer-credentials.secret.json
-  clusterType: eks
-  clusterName: $CLUSTER_NAME
-  region: $CLUSTER_REGION
-  billing:
-    # For an AWS account explicitly configured to have the cloud bill
-    # paid directly by the community and not through 2i2c, declare
-    # paid_by_us to false
-    paid_by_us: true
-support:
-  helm_chart_values_files:
-    - support.values.yaml
-    - enc-support.secret.values.yaml
-hubs: []
-```
 
-```{note}
-The `aws.key` file is defined _relative_ to the location of the `cluster.yaml` file.
-```
+A `cluster.yaml` file should already have been generated as part of [](new-cluster:generate-cluster-files).
 ````
 
 ````{tab-item} Google Cloud


### PR DESCRIPTION
I didn't get a cluster.yaml file while generating things for https://github.com/2i2c-org/infrastructure/issues/4696 so I made our deployer command do it for us going onwards.