### PR TITLE
pre-commit: bring prettier back to v3 to avoid issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 repos:
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0 # Don't upgrade, v4 causes "No files matching [...]" issues
     hooks:
       - id: prettier
 


### PR DESCRIPTION
When working with files ignored by prettierconfig and trying to commit changes, we'd see the following when using v4.

![image](https://github.com/user-attachments/assets/c2a87d4a-0256-4324-bb30-c80164af09b4)
