### PR TITLE
docs: remove outdated note about specifying daskhub

### DIFF
--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -145,13 +145,6 @@ export ACCOUNT_ID=<declare 2i2c for clusters under 2i2c SSO, otherwise an accoun
 deployer generate dedicated-cluster aws --cluster-name=$CLUSTER_NAME --cluster-region=$CLUSTER_REGION --account-id=$ACCOUNT_ID
 ```
 
-After running this command, you will be asked to provide the type of hub that will be deployed in the cluster, i.e. `basehub` or `daskhub`.
-
-- If you already know that the there will be daskhubs running in this cluster, then type in `daskhub` and hit ENTER.
-
-  This will generate a specific node pool for dask workers to run on, in the appropriate `.jsonnet` file that will be used with `eksctl`.
-- Otherwise, just hit ENTER and it will default to a basehub infrastructure that you can later amend if daskhubs will be needed by following the guide on [how to add support for daskhubs in an existing cluster](howto:features:daskhub).
-
 This will generate the following files:
 
 1. `eksctl/$CLUSTER_NAME.jsonnet` with a default cluster configuration, deployed to `us-west-2`
@@ -244,13 +237,6 @@ export PROJECT_ID=<gcp-project-id>
 ```bash
 deployer generate dedicated-cluster gcp --cluster-name=$CLUSTER_NAME --project-id=$PROJECT_ID --cluster-region=$CLUSTER_REGION
 ```
-
-After running this command, you will be asked to provide the type of hub that will be deployed in the cluster, i.e. `basehub` or `daskhub`.
-
-- If you already know that the there will be daskhubs running in this cluster, then type in `daskhub` and hit ENTER.
-
-  This will generate a specific node pool for dask workers to run on, in the appropriate `.jsonnet` file that will be used with `eksctl`.
-- Otherwise, just hit ENTER and it will default to a basehub infrastructure that you can later amend if daskhubs will be needed by following the guide on [how to add support for daskhubs in an existing cluster](howto:features:daskhub).
 
 This will generate the following files:
 


### PR DESCRIPTION
We have hardcoded hub_type in this command, making it something we can't specify any more.