### PR TITLE
deployer: respect deployer:skip-deploy-hubs, :deploy-hubs, :deploy-support labels

### DIFF
--- a/deployer/commands/generate/helm_upgrade/decision.py
+++ b/deployer/commands/generate/helm_upgrade/decision.py
@@ -118,9 +118,14 @@ def generate_hub_matrix_jobs(
             matrix_job["hub_name"] = hub["name"]
 
             if upgrade_all_hubs_on_all_clusters:
-                matrix_job["reason_for_redeploy"] = (
-                    "Core infrastructure has been modified"
-                )
+                if pr_labels and "deployer:deploy-hubs" in pr_labels:
+                    matrix_job["reason_for_redeploy"] = (
+                        "deployer:deploy-hubs label detected"
+                    )
+                else:
+                    matrix_job["reason_for_redeploy"] = (
+                        "Core infrastructure has been modified"
+                    )
 
             matrix_jobs.append(matrix_job)
 
@@ -221,9 +226,14 @@ def generate_support_matrix_jobs(
             matrix_job["upgrade_support"] = True
 
             if upgrade_support_on_all_clusters:
-                matrix_job["reason_for_support_redeploy"] = (
-                    "Support helm chart has been modified"
-                )
+                if pr_labels and "deployer:deploy-support" in pr_labels:
+                    matrix_job["reason_for_support_redeploy"] = (
+                        "deployer:deploy-support label detected"
+                    )
+                else:
+                    matrix_job["reason_for_support_redeploy"] = (
+                        "Support helm chart has been modified"
+                    )
 
             matrix_jobs.append(matrix_job)
 

--- a/deployer/commands/generate/helm_upgrade/jobs.py
+++ b/deployer/commands/generate/helm_upgrade/jobs.py
@@ -29,7 +29,7 @@ def helm_upgrade_jobs(
     ),
     pr_labels: str = typer.Argument(
         "[]",
-        help="JSON formatted list of PR labels, where 'deployer:skip-deploy' and 'deployer:skip-deploy-hubs' are respected.",
+        help="JSON formatted list of PR labels, where 'deployer:skip-deploy', 'deployer:skip-deploy-hubs', 'deployer:deploy-support', and 'deployer:deploy-hubs' are respected.",
     ),
 ):
     """
@@ -44,6 +44,11 @@ def helm_upgrade_jobs(
         upgrade_support_on_all_clusters,
         upgrade_all_hubs_on_all_clusters,
     ) = discover_modified_common_files(changed_filepaths)
+
+    if "deployer:deploy-support" in pr_labels:
+        upgrade_support_on_all_clusters = True
+    if "deployer:deploy-hubs" in pr_labels:
+        upgrade_all_hubs_on_all_clusters = True
 
     # Convert changed filepaths into absolute Posix Paths
     changed_filepaths = [


### PR DESCRIPTION
I want `deployer:deploy-support` to trigger support re-deploy when bumping cert manager version. It wasn't triggered in #4764 because it only re-deploys on support chart changes.

Merging this will test `deployer:deploy-support` label, here goes!