### PR TITLE
cert-manager: upgrade from v1.13.6 to v1.14.7

### DIFF
--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -72,7 +72,7 @@ def deploy_support(
     # "kubectl apply" will be done on CRDs but sometimes more is needed.
     #
     cert_manager_version: str = typer.Option(
-        "v1.13.6", help="Version of cert-manager to install"
+        "v1.14.7", help="Version of cert-manager to install"
     ),
     debug: bool = typer.Option(
         False,


### PR DESCRIPTION
Followup to #4764, as I want to rule out issues observed in new nmfs-openscapes setup relates to cert-manager not support k8s 1.30.