### PR TITLE
eksctl: provision default storage class by default also in k8s 1.30+ - now gp3

### DIFF
--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -91,7 +91,7 @@ local daskNodes = [];
                 name: "vpc-cni",
                 configurationValues: |||
                     enableNetworkPolicy: "true"
-                |||
+                |||,
             },
             { name: "coredns" },
             { name: "kube-proxy" },
@@ -107,6 +107,10 @@ local daskNodes = [];
                 wellKnownPolicies: {
                     ebsCSIController: true,
                 },
+                configurationValues: |||
+                    defaultStorageClass:
+                        enabled: true
+                |||,
             },
         ]
     ],


### PR DESCRIPTION
- fixes #4768