### PR TITLE
support chart: disable ingress-nginx admission webhook being troublesome

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -46,6 +46,17 @@ ingress-nginx:
     # use this type of config.
     # https://github.com/kubernetes/ingress-nginx/issues/7837
     allowSnippetAnnotations: true
+    admissionWebhooks:
+      # Disabled as cert-manager in EKS 1.30 ran into the following issue
+      # working with Ingress objects with the webhook not working out, with an
+      # error message including this:
+      #
+      #   err="Internal error occurred: failed calling webhook \"validate.nginx.ingress.kubernetes.io\": failed to call webhook: Post \"https://support-ingress-nginx-controller-admission.support.svc:443/networking/v1/ingresses?timeout=10s\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
+      #
+      # Disabling this shouldn't be an issue, it just helps catch invalid
+      # configurations beyond what the k8s api-server will catch.
+      #
+      enabled: false
 
 # prometheus is responsible for collecting metrics and informing grafana about
 # the metrics on request. It comes with several dependency charts, where we


### PR DESCRIPTION
The ingress-nginx chart provides a k8s validation webhook for ingress resources, meaning that it will get contacted whenever an ingress resources is being created/updated.

But, connecting to it can fail, as it does in a new k8s 1.30 cluster it seems. Due to that, I've disabled it systematically to avoid issues.

The drawback is that if we make some esoteric changes, such as modifying a ingress annotation like `nginx.ingress.kubernetes.io/configuration-snippet:`, we won't get quick validation if its an seemingly acceptable change. The upside is that we don't get issues with connectivity to the webhook.

---

This was found to be practically needed for #4762.