### PR TITLE
Nasa hubs: update Pangeo images to 2024.08.18-v1

### DIFF
--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -61,7 +61,7 @@ jupyterhub:
         description: Pangeo based notebook with a Python environment
         default: true
         kubespawner_override:
-          image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5
+          image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2024.08.18-v1
           init_containers:
             # Need to explicitly fix ownership here, as otherwise these directories will be owned
             # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -145,7 +145,7 @@ jupyterhub:
           # Launch people directly into the Linux desktop when they start
           default_url: /desktop
           # Built from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51
-          image: quay.io/2i2c/nasa-qgis-image:0d0765090250
+          image: quay.io/2i2c/nasa-qgis-image:d76118ea0c15
         profile_options: *profile_options
   scheduling:
     userScheduler:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -227,7 +227,7 @@ basehub:
           kubespawner_override:
             default_url: /desktop
             # Built from https://github.com/2i2c-org/nasa-qgis-image
-            image: quay.io/2i2c/nasa-qgis-image:0d0765090250
+            image: quay.io/2i2c/nasa-qgis-image:d76118ea0c15
           profile_options: *profile_options
         - display_name: "Bring your own image"
           description: Specify your own docker image (must have python and jupyterhub installed in it)

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -86,7 +86,7 @@ basehub:
             - US-GHG-Center:ghg-trial-access
             - 2i2c-org:hub-access-for-2i2c-staff
           kubespawner_override:
-            image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:53b6fd1256f5
+            image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2024.08.18-v1
             init_containers:
               # Need to explicitly fix ownership here, as otherwise these directories will be owned
               # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -141,7 +141,7 @@ basehub:
                   display_name: Modified Pangeo Notebook
                   description: Pangeo based notebook with a Python environment
                   kubespawner_override:
-                    image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:6fcf6cfa3192
+                    image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2024.08.18-v1
                     init_containers:
                       # Need to explicitly fix ownership here, as otherwise these directories will be owned
                       # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
This PR:

 - Updates the nasa-veda, nasa-ghg and nasa-esdis hubs to use an updated image based on the Pangeo base image [`2024.08.18`](https://github.com/pangeo-data/pangeo-docker-images/releases/tag/2024.08.18)
 - Also updates the nasa-ghg and nasa-esdis to use the updated QGIS image as per https://github.com/NASA-IMPACT/veda-jupyterhub/issues/52#issuecomment-2283692907

To test:

 - On any of the hubs / staging VEDA hub, use this custom image: `public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2024.08.18-v1`

I did a basic test and things seemed fine - and the image was also tested by @jsignell .

@jsignell if you're able to give a 👍 here, I'll move the PR out of draft and I think we can merge.

cc @wildintellect @sunu 