### PR TITLE
Terraform config to provision EBS volumes for jupyter-home-nfs

### DIFF
--- a/terraform/aws/ebs-volumes.tf
+++ b/terraform/aws/ebs-volumes.tf
@@ -1,0 +1,20 @@
+resource "aws_ebs_volume" "nfs_home_dirs" {
+  for_each = var.ebs_volumes
+
+  availability_zone = var.cluster_nodes_location
+  size              = each.value.size
+  type              = each.value.type
+  encrypted         = true
+
+  tags = merge(each.value.tags, {
+    Name = each.value.name_suffix == null ? "hub-nfs-home-dirs" : "hub-nfs-home-dirs-${each.value.name_suffix}"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "ebs_volume_id_map" {
+  value = { for vol in values(aws_ebs_volume.nfs_home_dirs)[*] : vol.tags["Name"] => vol.id }
+}

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -211,3 +211,12 @@ hub_cloud_permissions = {
     },
   },
 }
+
+ebs_volumes = {
+  "staging" = {
+    size        = 100
+    type        = "gp3"
+    name_suffix = "staging"
+    tags        = {}
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -313,3 +313,19 @@ variable "enable_aws_ce_grafana_backend_iam" {
   Create an IAM role with attached policy to permit read use of AWS Cost Explorer API.
   EOT
 }
+
+variable "ebs_volumes" {
+  type = map(object({
+    size        = number
+    type        = string
+    name_suffix = optional(string, null)
+    tags        = optional(map(string), {})
+  }))
+  default = {}
+  description = <<-EOT
+  Deploy one or more AWS ElasticBlockStore volumes.
+
+  This provisions a managed EBS volume that can be used by jupyter-home-nfs server
+  to store home directories for users.
+  EOT
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -321,7 +321,7 @@ variable "ebs_volumes" {
     name_suffix = optional(string, null)
     tags        = optional(map(string), {})
   }))
-  default = {}
+  default     = {}
   description = <<-EOT
   Deploy one or more AWS ElasticBlockStore volumes.
 


### PR DESCRIPTION
The jupyterhub-home-nfs helm chart expects an EBS volume to be available to act as in-cluster NFS server, but won't create it itself. This PR adds the ability to optionally provision an EBS volume to be used to store user home directories.

Addresses https://github.com/2i2c-org/infrastructure/issues/4735

Not entirely sure if I'm getting the Terraform syntax right here. Would really appreciate any feedback.

cc @sgibson91 @batpad 