### PR TITLE
nmfs-openscapes: enable cost attribution tags

### DIFF
--- a/terraform/aws/projects/nmfs-openscapes.tfvars
+++ b/terraform/aws/projects/nmfs-openscapes.tfvars
@@ -47,3 +47,11 @@ hub_cloud_permissions = {
     },
   },
 }
+
+active_cost_allocation_tags = [
+  "2i2c:hub-name",
+  "2i2c.org/cluster-name",
+  "alpha.eksctl.io/cluster-name",
+  "kubernetes.io/cluster/{var_cluster_name}",
+  "kubernetes.io/created-for/pvc/namespace",
+]


### PR DESCRIPTION
This sets us up to get cost attribution without needing to backfill details later. Will save us some time later in case we want it.