### PR TITLE
Fix gcpFilestoreBackups syntax in 2i2c cluster's support config

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -63,5 +63,6 @@ gcpFilestoreBackups:
     - pilot-hubs-homedirs
   project: two-eye-two-see
   zone: us-central1-b
-  annotations:
-    iam.gke.io/gcp-service-account: pilot-hubs-filestore-backup@two-eye-two-see.iam.gserviceaccount.com
+  serviceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: pilot-hubs-filestore-backup@two-eye-two-see.iam.gserviceaccount.com

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -64,5 +64,6 @@ gcpFilestoreBackups:
   project: two-eye-two-see
   zone: us-central1-b
   serviceAccount:
+    name: gcp-filestore-backups-sa
     annotations:
       iam.gke.io/gcp-service-account: pilot-hubs-filestore-backup@two-eye-two-see.iam.gserviceaccount.com

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -56,6 +56,6 @@ dependencies:
   # gcpFilestoreBackups runs regular backups of GCP Filestore Instances hosting
   # home directories within the cloud project.
   - name: gcpFilestoreBackups
-    version: "0.0.1-0.dev.git.53.h8b9558e"
+    version: "0.0.1-0.dev.git.56.h1b790c6"
     repository: https://2i2c.org/gcp-filestore-backups
     condition: gcpFilestoreBackups.enabled

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -173,54 +173,11 @@ properties:
             type: string
             description: |
               Name of the StorageClass to create
+  # Enables https://github.com/2i2c-org/gcp-filestore-backups to regularly backup
+  # GCP Filestore instances
   gcpFilestoreBackups:
     type: object
-    additionalProperties: false
-    required:
-      - enabled
-      - image
-    # Require options to be set *only* if gcpFilestoreBackups is enabled
-    if:
-      properties:
-        enabled:
-          const: true
-    then:
-      required:
-        - filestoreNames
-        - project
-        - zone
-        - annotations
-    properties:
-      enabled:
-        type: boolean
-        description: |
-          Enable automatic daily backups of GCP Filestores
-      image:
-        type: string
-        description: |
-          The image name and tag to use for the gcp-filestore-backups pod.
-          Will be set by chartpress.
-      filestoreNames:
-        type: array
-        description: |
-          The name of one or more GCP Filestores to backup as a list
-      project:
-        type: string
-        description: |
-          The GCP project the Filestore and backups are stored in
-      zone:
-        type: string
-        description: |
-          The GCP zone the Filestore and backups are stored in, e.g., us-central1-b
-      annotations:
-        type: object
-        additionalProperties: true
-        description: |
-          Dictionary of annotations that can be applied to the service account.
-
-          When used with GKE and Workload Identity, you need to set the
-          annotation with the key "iam.gke.io/gcp-service-account" to the email
-          address of the Google Service Account whose credentials it should have.
+    additionalProperties: true
   global:
     type: object
     additionalProperties: true


### PR DESCRIPTION
- towards https://github.com/2i2c-org/infrastructure/issues/4706
- resolves failed validation in https://github.com/2i2c-org/infrastructure/pull/4798