### PR TITLE
Revert "Bump size of prometheus PV on clusters that had 10% or less disk space"

### DIFF
--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -10,9 +10,6 @@ redirects:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/jupyter-health/support.values.yaml
+++ b/config/clusters/jupyter-health/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/kitware/support.values.yaml
+++ b/config/clusters/kitware/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/nasa-esdis/support.values.yaml
+++ b/config/clusters/nasa-esdis/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/nmfs-openscapes/support.values.yaml
+++ b/config/clusters/nmfs-openscapes/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/pchub/support.values.yaml
+++ b/config/clusters/pchub/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/projectpythia/support.values.yaml
+++ b/config/clusters/projectpythia/support.values.yaml
@@ -3,9 +3,6 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
-    # Size increased as part of https://github.com/2i2c-org/infrastructure/issues/4632
-    persistentVolume:
-      size: 500Gi
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#4806

I think I did my calculations wrong in #4632 and these clusters didn't need their disk size bumping