### PR TITLE
(Re-)Increase size of prometheus disk for nmfs-openscapes and pchub

### DIFF
--- a/config/clusters/nmfs-openscapes/support.values.yaml
+++ b/config/clusters/nmfs-openscapes/support.values.yaml
@@ -3,6 +3,9 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    # Bumped as part of https://github.com/2i2c-org/infrastructure/issues/4632
+    persistentVolume:
+      size: 500Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/pchub/support.values.yaml
+++ b/config/clusters/pchub/support.values.yaml
@@ -3,6 +3,9 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    # Bumped as part of https://github.com/2i2c-org/infrastructure/issues/4632
+    persistentVolume:
+      size: 500Gi
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
These disks had already been bumped to 500GB and reverting the change failed (#5360) so may as well leave them as is