### PR TITLE
Switch VEDA staging hub from EFS to jupyter-home-nfs server

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -217,3 +217,4 @@ basehub:
       volumeId: vol-0a1246ee2e07372d0
     quotaEnforcer:
       hardQuota: "10" # in GB
+      path: "/export/staging"

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: staging-service.staging.svc.cluster.local
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -1,7 +1,7 @@
 basehub:
   nfs:
     pv:
-      serverIP: 10.100.116.104
+      serverIP: 10.100.88.130
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -1,7 +1,7 @@
 basehub:
   nfs:
     pv:
-      serverIP: staging-service.staging.svc.cluster.local
+      serverIP: 10.100.116.104
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-staging

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,6 +26,6 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyter-home-nfs
-    version: 0.0.2
+    version: 0.0.5
     repository: oci://ghcr.io/sunu/jupyter-home-nfs
     condition: jupyter-home-nfs.enabled


### PR DESCRIPTION
Changes include:
- Switch storage provider of VEDA staging hub from EFS to the in-cluster NFS server provided by jupyter-home-nfs
- Upgrade jupyter-home-nfs to the latest version
  - the new version supports specifying the parent path of the home directories for enforcing storage quota. (earlier the quota enforcement path was hard-coded to be `/export/`). For the staging hub, we set it to `/export/staging`.
  - The new version adds 'nfs' to k8s resource names, no longer relying only on Helm release names for identification