### PR TITLE
utoronto: add 2i2c staff as admins also in r hubs

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -7,8 +7,10 @@ jupyterhub:
     config:
       Authenticator:
         admin_users:
+          # 2i2c staff below, a list maintained in default-common r-common
           - "yuvi.panda@utoronto.ca"
           - "georgiana.elena@utoronto.ca"
           - "chris.holdgraf@utoronto.ca"
           - "davidy.liu@utoronto.ca"
+          - "erik.sundell@utoronto.ca"
           - "csadminsundelle@utoronto.ca"

--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -10,6 +10,14 @@ jupyterhub:
         # Ensures container working dir is homedir
         # https://github.com/2i2c-org/infrastructure/issues/2559
         working_dir: /home/rstudio
+      Authenticator:
+        admin_users:
+          # 2i2c staff below, a list maintained in default-common r-common
+          - "yuvi.panda@utoronto.ca"
+          - "georgiana.elena@utoronto.ca"
+          - "chris.holdgraf@utoronto.ca"
+          - "erik.sundell@utoronto.ca"
+          - "csadminsundelle@utoronto.ca"
   singleuser:
     defaultUrl: /rstudio
     image:


### PR DESCRIPTION
I want to be a jupyterhub admin to debug an issue for a user in the r-prod hub, as requested via support in https://2i2c.freshdesk.com/a/tickets/220