### PR TITLE
Remove non-functional recovery vault and backup policy for Azure clusters

### DIFF
--- a/terraform/azure/storage.tf
+++ b/terraform/azure/storage.tf
@@ -44,29 +44,3 @@ resource "azurerm_storage_share" "homes" {
 output "azure_fileshare_url" {
   value = azurerm_storage_share.homes.url
 }
-
-# ref: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/recovery_services_vault
-resource "azurerm_recovery_services_vault" "homedir_recovery_vault" {
-  name                = "homedir-recovery-vault"
-  location            = azurerm_resource_group.jupyterhub.location
-  resource_group_name = azurerm_resource_group.jupyterhub.name
-  sku                 = "Standard"
-}
-
-# ref: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/backup_policy_file_share
-resource "azurerm_backup_policy_file_share" "backup_policy" {
-  name                = "homedir-recovery-vault-policy"
-  resource_group_name = azurerm_resource_group.jupyterhub.name
-  recovery_vault_name = azurerm_recovery_services_vault.homedir_recovery_vault.name
-
-  timezone = "Mountain Standard Time"
-
-  backup {
-    frequency = "Daily"
-    time      = "22:00"
-  }
-
-  retention_daily {
-    count = 5
-  }
-}


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/4390#issuecomment-2358036595, @yuvipanda stated that we were no longer pursuing backup of File Shares on Azure. In view of that, I'm removing the config setting up a recovery vault and backup policy from our Azure terraform config because 1) it is non-functioning, and 2) when we get around to deploying something for Queens University, I don't want to run into unexpected permissions issues relating to broken config.