### PR TITLE
Make deploying a container registry on Azure opt-in

### DIFF
--- a/terraform/azure/projects/pchub.tfvars
+++ b/terraform/azure/projects/pchub.tfvars
@@ -18,6 +18,7 @@
 tenant_id                      = "f1123d69-0c31-44db-ab9f-fa856d721d49"
 subscription_id                = "4ca0b08a-26e1-482f-bca6-f4eb0926124a"
 resourcegroup_name             = "2i2c-pchub"
+create_container_registry      = true
 global_container_registry_name = "2i2cpchub"
 global_storage_account_name    = "2i2cpchub"
 location                       = "westeurope"

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -9,6 +9,7 @@
 tenant_id                      = "78aac226-2f03-4b4d-9037-b46d56c55210"
 subscription_id                = "ead3521a-d994-4a44-a68d-b16e35642d5b"
 resourcegroup_name             = "2i2c-utoronto-cluster"
+create_container_registry      = true
 global_container_registry_name = "2i2cutorontohubregistry"
 global_storage_account_name    = "2i2cutorontohubstorage"
 location                       = "canadacentral"

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -70,10 +70,19 @@ variable "k8s_version_prefixes" {
   EOT
 }
 
+variable "create_container_registry" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Create a container registry for image storage, e.g., for binder deployments.
+  EOT
+}
+
 variable "global_container_registry_name" {
   type        = string
+  default     = null
   description = <<-EOT
-  Name of container registry to use for our image.
+  Name of container registry to use for image storage.
 
   This needs to be globally unique across all of Azure (ugh?)
   and not contain dashes or underscores.


### PR DESCRIPTION
I don't think we actually want to deploy a container registry on Azure every time we create a new cluster, unless we specifically know we'll be deploying a binder-like hub to it and don't want to use quay.io as a registry. Therefore, let's make the container registry creation opt-in, but make it a noop for existing deployments.