### PR TITLE
aws-ce-grafana-backend: add per hub repeating component panel, and cache better

### DIFF
--- a/helm-charts/aws-ce-grafana-backend/mounted-files/cache.py
+++ b/helm-charts/aws-ce-grafana-backend/mounted-files/cache.py
@@ -1,0 +1,32 @@
+"""
+It seems Python doesn't provide a built in way to cache function calls, so this
+implements an answer from stackoverflow by user McToel from
+https://stackoverflow.com/a/73026174/2220152.
+
+A limitation of this is implementation is that it can't be used on functions
+accepting lists etc, even if the functions we have only have lists with hashable
+content that could be compared and concluded equal.
+"""
+
+import time
+from functools import lru_cache
+
+
+def ttl_lru_cache(seconds_to_live: int, maxsize: int = 128):
+    """
+    Time aware lru caching
+    """
+
+    def wrapper(func):
+
+        @lru_cache(maxsize)
+        def inner(__ttl, *args, **kwargs):
+            # Note that __ttl is not passed down to func,
+            # as it's only used to trigger cache miss after some time
+            return func(*args, **kwargs)
+
+        return lambda *args, **kwargs: inner(
+            time.time() // seconds_to_live, *args, **kwargs
+        )
+
+    return wrapper

--- a/helm-charts/aws-ce-grafana-backend/mounted-files/query.py
+++ b/helm-charts/aws-ce-grafana-backend/mounted-files/query.py
@@ -23,8 +23,6 @@ aws_ce_client = boto3.client("ce")
 
 @functools.cache
 def _get_component_name(service_name):
-    print(f"test {service_name}")
-    logger.info(f"test {service_name}")
     if service_name in SERVICE_COMPONENT_MAP:
         return SERVICE_COMPONENT_MAP[service_name]
     else:

--- a/helm-charts/aws-ce-grafana-backend/mounted-files/webserver.py
+++ b/helm-charts/aws-ce-grafana-backend/mounted-files/webserver.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timedelta, timezone
 from flask import Flask, request
 
 from .query import (
+    query_hub_names,
     query_total_costs,
     query_total_costs_per_component,
     query_total_costs_per_hub,
@@ -13,7 +14,7 @@ app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_from_to_in_query_params():
+def _parse_from_to_in_query_params():
     """
     Parse "from" and "to" query parameters, expected to arrive as YYYY-MM-DD
     strings.
@@ -48,22 +49,30 @@ def ready():
     return ("", 204)
 
 
+@app.route("/hub-names")
+def hub_names():
+    from_date, to_date = _parse_from_to_in_query_params()
+
+    return query_hub_names(from_date, to_date)
+
+
 @app.route("/total-costs")
 def total_costs():
-    from_date, to_date = parse_from_to_in_query_params()
+    from_date, to_date = _parse_from_to_in_query_params()
 
     return query_total_costs(from_date, to_date)
 
 
 @app.route("/total-costs-per-hub")
 def total_costs_per_hub():
-    from_date, to_date = parse_from_to_in_query_params()
+    from_date, to_date = _parse_from_to_in_query_params()
 
     return query_total_costs_per_hub(from_date, to_date)
 
 
 @app.route("/total-costs-per-component")
 def total_costs_per_component():
-    from_date, to_date = parse_from_to_in_query_params()
+    from_date, to_date = _parse_from_to_in_query_params()
+    hub_name = request.args.get("hub")
 
-    return query_total_costs_per_component(from_date, to_date)
+    return query_total_costs_per_component(from_date, to_date, hub_name)


### PR DESCRIPTION
- fixes #4786 
- fixes #4850

From https://grafana.openscapes.2i2c.cloud/d/edw06h7udjwg0b/testing-cost-attribution-dashboard?orgId=1:
![image](https://github.com/user-attachments/assets/b9352231-d5c2-49d8-aec3-cc3c08cd5f53)
