### PR TITLE
UToronto: Remove tainted nodepool on old k8s version

### DIFF
--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -51,14 +51,6 @@ node_pools = {
 
   user : [
     {
-      name : "usere8sv5", # FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
-      vm_size : "Standard_E8s_v5",
-      os_disk_size_gb : 200,
-      min : 0,
-      max : 100,
-      kubernetes_version : "1.28.3",
-    },
-    {
       name : "usere8sv5b",
       vm_size : "Standard_E8s_v5",
       os_disk_size_gb : 200,


### PR DESCRIPTION
- related to: #4640 