### PR TITLE
openscapes: re-create node pools to get all relevant tags

### DIFF
--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -25,13 +25,13 @@ local nodeAz = "us-west-2b";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { 
+    {
         instanceType: "r5.xlarge",
         namePrefix: "nb-staging",
         labels+: { "2i2c/hub-name": "staging" },
         tags+: { "2i2c:hub-name": "staging" }
     },
-    { 
+    {
         instanceType: "r5.4xlarge",
         namePrefix: "nb-staging",
         labels+: { "2i2c/hub-name": "staging" },
@@ -43,13 +43,20 @@ local notebookNodes = [
         labels+: { "2i2c/hub-name": "staging" },
         tags+: { "2i2c:hub-name": "staging" }
     },
-    { 
+    {
+        // FIXME: tainted, to be deleted when empty, replaced by equivalent already
         instanceType: "r5.xlarge",
         namePrefix: "nb-prod",
         labels+: { "2i2c/hub-name": "prod" },
         tags+: { "2i2c:hub-name": "prod" }
     },
-    { 
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-prod-a",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" }
+    },
+    {
         instanceType: "r5.4xlarge",
         namePrefix: "nb-prod",
         labels+: { "2i2c/hub-name": "prod" },
@@ -61,13 +68,13 @@ local notebookNodes = [
         labels+: { "2i2c/hub-name": "prod" },
         tags+: { "2i2c:hub-name": "prod" }
     },
-    { 
+    {
         instanceType: "r5.xlarge",
         namePrefix: "nb-workshop",
         labels+: { "2i2c/hub-name": "workshop" },
         tags+: { "2i2c:hub-name": "workshop" }
     },
-    { 
+    {
         instanceType: "r5.4xlarge",
         namePrefix: "nb-workshop",
         labels+: { "2i2c/hub-name": "workshop" },
@@ -149,7 +156,7 @@ local daskNodes = [
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/helm-charts/aws-ce-grafana-backend/mounted-files/const.py
+++ b/helm-charts/aws-ce-grafana-backend/mounted-files/const.py
@@ -73,6 +73,11 @@ FILTER_ATTRIBUTABLE_COSTS = {
                 "MatchOptions": ["EQUALS"],
             },
         },
+        # FIXME: The inclusion of tags 2i2c:hub-name and 2i2c:node-purpose below
+        #        in this filter is a patch to capture openscapes data from 1st
+        #        July and up to 24th September 2024, and can be removed once
+        #        that date range is considered irrelevant.
+        #
         {
             "Not": {
                 "Tags": {


### PR DESCRIPTION
Ensures 2i2c.org/cluster-name tag is applied to node pools, which
enables us to filter based on two less tags specifically for openscapes.
