### PR TITLE
victor: disable jupyterhub configurator

### DIFF
--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -20,6 +20,8 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: "github"
+      jupyterhubConfigurator:
+        enabled: false
       homepage:
         gitRepoBranch: "victor"
         templateVars:


### PR DESCRIPTION
Followup to #4870 where the configurator's image choice becomes ignored.