### PR TITLE
cloudbank: Ensure add"staff"user_ids_of_type matches authentication method used

### DIFF
--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "google"
+      add_staff_user_ids_of_type: "github"
     homepage:
       templateVars:
         org:

--- a/config/clusters/cloudbank/merced.values.yaml
+++ b/config/clusters/cloudbank/merced.values.yaml
@@ -12,7 +12,7 @@ jupyterhub:
       limit: 1.5G
   custom:
     2i2c:
-      add_staff_user_ids_of_type: google
+      add_staff_user_ids_of_type: github
       add_staff_user_ids_to_admin_users: true
     homepage:
       templateVars:

--- a/config/clusters/cloudbank/riohondo.values.yaml
+++ b/config/clusters/cloudbank/riohondo.values.yaml
@@ -12,7 +12,7 @@ jupyterhub:
       limit: 1.5G
   custom:
     2i2c:
-      add_staff_user_ids_of_type: google
+      add_staff_user_ids_of_type: github
       add_staff_user_ids_to_admin_users: true
     homepage:
       templateVars:

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "google"
+      add_staff_user_ids_of_type: "github"
     homepage:
       templateVars:
         org:


### PR DESCRIPTION
These cloudbank hubs are using GitHub auth, but 2i2c staff IDs being added were Google IDs which are not compatible