### PR TITLE
support, grafana: disable alerting tab

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -384,6 +384,10 @@ grafana:
       # Because our grafana is behind an nginx ingress, this should match the
       # read timeout set above under `ingress.annotations`.
       timeout: 120
+    unified_alerting:
+      # Disable alerting for now as its not something our community users can
+      # setup. See https://github.com/2i2c-org/infrastructure/issues/4919.
+      enabled: false
     server:
       root_url: ""
       enable_gzip: true


### PR DESCRIPTION
Before as non-admin user|After as non-admin user
-|-
![image](https://github.com/user-attachments/assets/e1caf7b1-391d-4248-a485-6317a57013c7)|![image](https://github.com/user-attachments/assets/b45d447d-c7e4-4fad-875d-43c42725d3d0)