### PR TITLE
nmfs-openscapes: revert use of r7i instead of r5 and hub dedicated nodes

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -123,67 +123,67 @@ jupyterhub:
               mem_1_9:
                 display_name: 1.9 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 1986618368
-                  mem_limit: 1986618368
+                  mem_guarantee: 1991244775
+                  mem_limit: 1991244775
                   cpu_guarantee: 0.2328125
                   cpu_limit: 3.725
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.xlarge
+                    node.kubernetes.io/instance-type: r5.xlarge
                 default: true
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 3973236736
-                  mem_limit: 3973236736
+                  mem_guarantee: 3982489550
+                  mem_limit: 3982489550
                   cpu_guarantee: 0.465625
                   cpu_limit: 3.725
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.xlarge
+                    node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 7946473472
-                  mem_limit: 7946473472
+                  mem_guarantee: 7964979101
+                  mem_limit: 7964979101
                   cpu_guarantee: 0.93125
                   cpu_limit: 3.725
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.xlarge
+                    node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 15892946944
-                  mem_limit: 15892946944
+                  mem_guarantee: 15929958203
+                  mem_limit: 15929958203
                   cpu_guarantee: 1.8625
                   cpu_limit: 3.725
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.xlarge
-              mem_29_6:
-                display_name: 29.6 GB RAM, upto 3.7 CPUs
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_29_7:
+                display_name: 29.7 GB RAM, upto 3.7 CPUs
                 kubespawner_override:
-                  mem_guarantee: 31785893888
-                  mem_limit: 31785893888
+                  mem_guarantee: 31859916406
+                  mem_limit: 31859916406
                   cpu_guarantee: 3.725
                   cpu_limit: 3.725
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.xlarge
-              mem_60_3:
-                display_name: 60.3 GB RAM, upto 15.6 CPUs
+                    node.kubernetes.io/instance-type: r5.xlarge
+              mem_60_6:
+                display_name: 60.6 GB RAM, upto 15.6 CPUs
                 kubespawner_override:
-                  mem_guarantee: 64792780800
-                  mem_limit: 64792780800
+                  mem_guarantee: 65094448840
+                  mem_limit: 65094448840
                   cpu_guarantee: 7.8475
                   cpu_limit: 15.695
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.4xlarge
-              mem_120_7:
-                display_name: 120.7 GB RAM, upto 15.6 CPUs
+                    node.kubernetes.io/instance-type: r5.4xlarge
+              mem_121_2:
+                display_name: 121.2 GB RAM, upto 15.6 CPUs
                 kubespawner_override:
-                  mem_guarantee: 129585561600
-                  mem_limit: 129585561600
+                  mem_guarantee: 130188897681
+                  mem_limit: 130188897681
                   cpu_guarantee: 15.695
                   cpu_limit: 15.695
                   node_selector:
-                    node.kubernetes.io/instance-type: r7i.4xlarge
+                    node.kubernetes.io/instance-type: r5.4xlarge
   hub:
     allowNamedServers: true
     config:

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -13,8 +13,6 @@ jupyterhub:
       - hosts: [nmfs-openscapes.2i2c.cloud]
         secretName: https-auto-tls
   singleuser:
-    nodeSelector:
-      2i2c.org/hub-name: prod
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent/$(JUPYTERHUB_USER)

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -13,8 +13,6 @@ jupyterhub:
       - hosts: [staging.nmfs-openscapes.2i2c.cloud]
         secretName: https-auto-tls
   singleuser:
-    nodeSelector:
-      2i2c.org/hub-name: staging
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch-staging/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent-staging/$(JUPYTERHUB_USER)

--- a/eksctl/nmfs-openscapes.jsonnet
+++ b/eksctl/nmfs-openscapes.jsonnet
@@ -25,42 +25,9 @@ local nodeAz = "us-west-2b";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    {
-        instanceType: "r7i.xlarge",
-        namePrefix: "nb-staging",
-        labels+: { "2i2c.org/hub-name": "staging" },
-        tags+: { "2i2c:hub-name": "staging" },
-    },
-    {
-        instanceType: "r7i.4xlarge",
-        namePrefix: "nb-staging",
-        labels+: { "2i2c.org/hub-name": "staging" },
-        tags+: { "2i2c:hub-name": "staging" },
-    },
-    {
-        instanceType: "r7i.16xlarge",
-        namePrefix: "nb-staging",
-        labels+: { "2i2c.org/hub-name": "staging" },
-        tags+: { "2i2c:hub-name": "staging" },
-    },
-    {
-        instanceType: "r7i.xlarge",
-        namePrefix: "nb-prod",
-        labels+: { "2i2c.org/hub-name": "prod" },
-        tags+: { "2i2c:hub-name": "prod" },
-    },
-    {
-        instanceType: "r7i.4xlarge",
-        namePrefix: "nb-prod",
-        labels+: { "2i2c.org/hub-name": "prod" },
-        tags+: { "2i2c:hub-name": "prod" },
-    },
-    {
-        instanceType: "r7i.16xlarge",
-        namePrefix: "nb-prod",
-        labels+: { "2i2c.org/hub-name": "prod" },
-        tags+: { "2i2c:hub-name": "prod" },
-    },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.4xlarge" },
+    { instanceType: "r5.16xlarge" },
 ];
 local daskNodes = [];
 
@@ -132,7 +99,7 @@ local daskNodes = [];
             ssh: {
                 publicKeyPath: 'ssh-keys/nmfs-openscapes.key.pub'
             },
-            instanceType: "r7i.xlarge",
+            instanceType: "r5.xlarge",
             minSize: 1,
             maxSize: 6,
             labels+: {


### PR DESCRIPTION
- fixes #4817