### PR TITLE
nasa-cryo: Enabling cost allocation

### DIFF
--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -99,3 +99,11 @@ hub_cloud_permissions = {
     },
   },
 }
+
+active_cost_allocation_tags = [
+  "2i2c:hub-name",
+  "2i2c.org/cluster-name",
+  "alpha.eksctl.io/cluster-name",
+  "kubernetes.io/cluster/nasa-cryo",
+  "kubernetes.io/created-for/pvc/namespace",
+]


### PR DESCRIPTION
- fixes #4874 

### 2024-10-03

This PR currently fails because the nasa-cryo-hubs AWS account is a linked account via our AWS SSO signin, and cost allocation tags are only available at the payer account level.

Visit this URL to see: https://us-east-1.console.aws.amazon.com/billing/home?region=us-west-2#/tags

Terraform error:

```
│ Error: updating Cost Explorer Cost Allocation Tag (kubernetes.io/cluster/nasa-cryo): operation error Cost Explorer: UpdateCostAllocationTagsStatus, https response error StatusCode: 400, RequestID: 9e32aa56-2236-44a7-9fef-282910a934ea, api error AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
│ 
│   with aws_ce_cost_allocation_tag.cost_allocation_tags["kubernetes.io/cluster/nasa-cryo"],
│   on cost-allocation.tf line 2, in resource "aws_ce_cost_allocation_tag" "cost_allocation_tags":
│    2: resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
│ 
╵
╷
│ Error: updating Cost Explorer Cost Allocation Tag (kubernetes.io/created-for/pvc/namespace): operation error Cost Explorer: UpdateCostAllocationTagsStatus, https response error StatusCode: 400, RequestID: 376d02cb-4606-4abe-9f22-ab55491d50b3, api error AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
│ 
│   with aws_ce_cost_allocation_tag.cost_allocation_tags["kubernetes.io/created-for/pvc/namespace"],
│   on cost-allocation.tf line 2, in resource "aws_ce_cost_allocation_tag" "cost_allocation_tags":
│    2: resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
│ 
╵
╷
│ Error: updating Cost Explorer Cost Allocation Tag (2i2c.org/cluster-name): operation error Cost Explorer: UpdateCostAllocationTagsStatus, https response error StatusCode: 400, RequestID: ad097fbc-767e-4c9f-8f5f-a536082cbb97, api error AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
│ 
│   with aws_ce_cost_allocation_tag.cost_allocation_tags["2i2c.org/cluster-name"],
│   on cost-allocation.tf line 2, in resource "aws_ce_cost_allocation_tag" "cost_allocation_tags":
│    2: resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
│ 
╵
╷
│ Error: updating Cost Explorer Cost Allocation Tag (alpha.eksctl.io/cluster-name): operation error Cost Explorer: UpdateCostAllocationTagsStatus, https response error StatusCode: 400, RequestID: b894e903-a5ea-48b1-98b5-7234f2c997e1, api error AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
│ 
│   with aws_ce_cost_allocation_tag.cost_allocation_tags["alpha.eksctl.io/cluster-name"],
│   on cost-allocation.tf line 2, in resource "aws_ce_cost_allocation_tag" "cost_allocation_tags":
│    2: resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
│ 
╵
╷
│ Error: updating Cost Explorer Cost Allocation Tag (2i2c:hub-name): operation error Cost Explorer: UpdateCostAllocationTagsStatus, https response error StatusCode: 400, RequestID: 31e55d03-c7bf-4c86-a1ed-4b650ccb19c8, api error AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
│ 
│   with aws_ce_cost_allocation_tag.cost_allocation_tags["2i2c:hub-name"],
│   on cost-allocation.tf line 2, in resource "aws_ce_cost_allocation_tag" "cost_allocation_tags":
│    2: resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
```
