### PR TITLE
basehub: increase memory limit for dirsize-reporter

### DIFF
--- a/helm-charts/basehub/templates/home-dirsize-reporter.yaml
+++ b/helm-charts/basehub/templates/home-dirsize-reporter.yaml
@@ -46,7 +46,7 @@ spec:
               cpu: 0.01
             limits:
               cpu: 0.05
-              memory: 256Mi
+              memory: 512Mi
           args:
             - dirsize-exporter
             - /shared-volume


### PR DESCRIPTION
I opted to just increase the memory limit.

If we would have increased the request, it would notably impacted requested memory in cloudbank etc or other places where they have a few hubs per cluster which could drive cloud costs by forcing additional core nodes. Stability of this is something I figured is less important then ending up with more core nodes to ensure this never crashes.