### PR TITLE
Update ohw.values.yaml, remove ohw24 participants

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -80,8 +80,6 @@ basehub:
             - Intercoonecta:ohwes24-mentor-helper-presenter
             - Intercoonecta:ohwes24-participants-tallerintermed
             - oceanhackweek:ohw24-organizers
-            - oceanhackweek:ohw24-participants-australia
-            - oceanhackweek:ohw24-participants-bigelow
             - oceanhackweek:ohw24-project-mentors
             - oceanhackweek:ohw24-tutorial-presenters
           scope:


### PR DESCRIPTION
Updates for 2024 OHW24-in-Spanish events.

Remove ohw24-participants teams from previous OHW24 event, from August

xref https://github.com/2i2c-org/infrastructure/issues/4883 and https://github.com/oceanhackweek/jupyter-image/pull/94