### PR TITLE
jupyter-health: add experimental hub image with oauthenticator 17.1

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.10692.hd9c78f75
+      tag: 0.0.1-0.dev.git.10694.h38ededaf
     allowNamedServers: true
     config:
       JupyterHub:

--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -37,6 +37,13 @@ jupyterhub:
           name: "Jupyter Health"
           url: https://www.earthdata.nasa.gov/esds/veda
   hub:
+    # FIXME: Experiment to use oauthenticator 17.1, should be transitioned away
+    #        as part of upgrading to z2jh 4, see
+    #        https://github.com/2i2c-org/infrastructure/pull/4968
+    #
+    image:
+      name: quay.io/2i2c/pkce-experiment
+      tag: 0.0.1-0.dev.git.10692.hd9c78f75
     allowNamedServers: true
     config:
       JupyterHub:

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -28,11 +28,6 @@ charts:
           REQUIREMENTS_FILE: pkce-requirements.txt
         contextPath: images/hub
         dockerfilePath: images/hub/Dockerfile
-  - name: support
-    images:
-      gcp-filestore-backups:
-        imageName: quay.io/2i2c/gcp-filestore-backups
-        valuesPath: gcpFilestoreBackups.image
   - name: aws-ce-grafana-backend
     images:
       aws-ce-grafana-backend:

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -22,6 +22,12 @@ charts:
           REQUIREMENTS_FILE: dynamic-image-building-requirements.txt
         contextPath: images/hub
         dockerfilePath: images/hub/Dockerfile
+      pkce-experiment:
+        imageName: quay.io/2i2c/pkce-experiment
+        buildArgs:
+          REQUIREMENTS_FILE: pkce-requirements.txt
+        contextPath: images/hub
+        dockerfilePath: images/hub/Dockerfile
   - name: support
     images:
       gcp-filestore-backups:

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -3,3 +3,12 @@
 # which adds PKCE support.
 # experiment no longer needed when base chart is updated to z2jh 4.0.0
 oauthenticator>=17.1,<18
+
+# jupyterhub-configurator isn't maintained and its not intended to be developed
+# further. We are using a branch that has forked from the main branch just
+# before a breaking change were made. This allows us to avoid migrating.
+#
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
+#
+git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -1,0 +1,5 @@
+# Image lives at quay.io/2i2c/pkce-experiment
+# install oauthenticator 17.1,
+# which adds PKCE support.
+# experiment no longer needed when base chart is updated to z2jh 4.0.0
+oauthenticator>=17.1,<18


### PR DESCRIPTION
oauthenticator 17.1 adds PKCE, which the Jupyter Health deployment is going to need quite shortly

This experiment is no longer required once JupyterHub chart is updated to >=4.0.0b4

I followed what I could of [the steps for experimental images](https://infrastructure.2i2c.org/howto/custom-jupyterhub-image/#the-experimental-hub-images), but it looks like image registration on Quay.io and building with chartpress are not automated, so must be done by a person with 2i2c.org credentials.

btw, if it's possible to have a sample deployment migrated to the current beta of the chart, I'll volunteer Jupyter Health to be part of that, if that's easier than an experimental hub image. Jupyter Health will soon be using email addresses for login, which is a good exercise for the new kubespawner 7 slug scheme which handles email addresses differently.

---

- fixes #4973 
