### PR TITLE
Testing upgrade from jupyterhub 3.3.7 to 4.0.0-beta.4

### DIFF
--- a/config/clusters/2i2c-aws-us/itcoocean.values.yaml
+++ b/config/clusters/2i2c-aws-us/itcoocean.values.yaml
@@ -73,7 +73,7 @@ jupyterhub:
         volumeMounts:
           - name: home
             mountPath: /home/jovyan
-            subPath: "{username}"
+            subPath: "{escaped_username}"
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -117,7 +117,7 @@ jupyterhub:
     allowNamedServers: true
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.10263.hc87b65cf"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -15,6 +15,9 @@ staticWebsite:
     enabled: false
 
 jupyterhub:
+  debug:
+    enabled: true
+
   ingress:
     hosts:
       - staging.2i2c.cloud

--- a/config/clusters/hhmi/daskhub-common.values.yaml
+++ b/config/clusters/hhmi/daskhub-common.values.yaml
@@ -82,7 +82,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home

--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.10694.h38ededaf
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     allowNamedServers: true
     config:
       JupyterHub:

--- a/config/clusters/jupyter-meets-the-earth/daskhub-common.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/daskhub-common.values.yaml
@@ -76,7 +76,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             - name: home
               mountPath: /home/jovyan/shared
               subPath: _shared

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -107,7 +107,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home

--- a/config/clusters/nasa-esdis/common.values.yaml
+++ b/config/clusters/nasa-esdis/common.values.yaml
@@ -76,7 +76,7 @@ jupyterhub:
               volumeMounts:
                 - name: home
                   mountPath: /home/jovyan
-                  subPath: "{username}"
+                  subPath: "{escaped_username}"
                 # mounted without readonly attribute here,
                 # so we can chown it appropriately
                 - name: home
@@ -93,7 +93,7 @@ jupyterhub:
               volumeMounts:
                 - name: home
                   mountPath: /home/jovyan
-                  subPath: "{username}"
+                  subPath: "{escaped_username}"
               securityContext:
                 runAsUser: 1000
                 runAsGroup: 1000

--- a/config/clusters/nasa-esdis/staging.values.yaml
+++ b/config/clusters/nasa-esdis/staging.values.yaml
@@ -36,7 +36,7 @@ jupyterhub:
                       volumeMounts:
                         - name: home
                           mountPath: /home/jovyan
-                          subPath: "{username}"
+                          subPath: "{escaped_username}"
                         # mounted without readonly attribute here,
                         # so we can chown it appropriately
                         - name: home
@@ -53,7 +53,7 @@ jupyterhub:
                       volumeMounts:
                         - name: home
                           mountPath: /home/jovyan
-                          subPath: "{username}"
+                          subPath: "{escaped_username}"
                       securityContext:
                         runAsUser: 1000
                         runAsGroup: 1000

--- a/config/clusters/nasa-esdis/staging.values.yaml
+++ b/config/clusters/nasa-esdis/staging.values.yaml
@@ -109,7 +109,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.10263.hc87b65cf"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     config:
       GitHubOAuthenticator:
         oauth_callback_url: "https://staging.esdis.2i2c.cloud/hub/oauth_callback"

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -101,7 +101,7 @@ basehub:
                 volumeMounts:
                   - name: home
                     mountPath: /home/jovyan
-                    subPath: "{username}"
+                    subPath: "{escaped_username}"
                   # mounted without readonly attribute here,
                   # so we can chown it appropriately
                   - name: home
@@ -119,7 +119,7 @@ basehub:
                 volumeMounts:
                   - name: home
                     mountPath: /home/jovyan
-                    subPath: "{username}"
+                    subPath: "{escaped_username}"
                 securityContext:
                   runAsUser: 1000
                   runAsGroup: 1000

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -15,7 +15,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/dynamic-image-building-experiment
-        tag: "0.0.1-0.dev.git.10263.hc87b65cf"
+        tag: "0.0.1-0.dev.git.10722.h6ed14882"
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.ghg.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -69,7 +69,7 @@ basehub:
                         volumeMounts:
                           - name: home
                             mountPath: /home/jovyan
-                            subPath: "{username}"
+                            subPath: "{escaped_username}"
                           # mounted without readonly attribute here,
                           # so we can chown it appropriately
                           - name: home
@@ -87,7 +87,7 @@ basehub:
                         volumeMounts:
                           - name: home
                             mountPath: /home/jovyan
-                            subPath: "{username}"
+                            subPath: "{escaped_username}"
                         securityContext:
                           runAsUser: 1000
                           runAsGroup: 1000

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -45,7 +45,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/dynamic-image-building-experiment
-        tag: 0.0.1-0.dev.git.9829.h282c5c35
+        tag: "0.0.1-0.dev.git.10722.h6ed14882"
       allowNamedServers: true
       config:
         JupyterHub:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -98,7 +98,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home
@@ -158,7 +158,7 @@ basehub:
                         volumeMounts:
                           - name: home
                             mountPath: /home/jovyan
-                            subPath: "{username}"
+                            subPath: "{escaped_username}"
                         securityContext:
                           runAsUser: 1000
                           runAsGroup: 1000

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -165,7 +165,7 @@ basehub:
           oauth_callback_url: https://staging.hub.openveda.cloud/hub/oauth_callback
       image:
         name: quay.io/2i2c/dynamic-image-building-experiment
-        tag: 0.0.1-0.dev.git.10263.hc87b65cf
+        tag: "0.0.1-0.dev.git.10722.h6ed14882"
     ingress:
       hosts: [staging.hub.openveda.cloud]
       tls:

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -22,7 +22,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home
@@ -68,7 +68,7 @@ basehub:
                         volumeMounts:
                           - name: home
                             mountPath: /home/jovyan
-                            subPath: "{username}"
+                            subPath: "{escaped_username}"
                         securityContext:
                           runAsUser: 1000
                           runAsGroup: 1000

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -151,7 +151,7 @@ jupyterhub:
     allowNamedServers: true
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.10263.hc87b65cf"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -113,7 +113,7 @@ jupyterhub:
     allowNamedServers: true
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/pchub/common.values.yaml
+++ b/config/clusters/pchub/common.values.yaml
@@ -66,7 +66,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
             # Mounted without readonly attribute here,
             # so we can chown it appropriately
             - name: home
@@ -84,7 +84,7 @@ basehub:
           volumeMounts:
             - name: home
               mountPath: /home/jovyan
-              subPath: "{username}"
+              subPath: "{escaped_username}"
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     allowNamedServers: true
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/strudel/common.values.yaml
+++ b/config/clusters/strudel/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
       #     - user1
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     extraConfig:
       enable-fancy-profiles: |
         from jupyterhub_fancy_profiles import setup_ui

--- a/docs/howto/features/imagebuilding.md
+++ b/docs/howto/features/imagebuilding.md
@@ -21,7 +21,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
 ```
 
 ## Connect with `jupyterhub-fancy-profiles`

--- a/docs/howto/features/per-user-db.md
+++ b/docs/howto/features/per-user-db.md
@@ -68,7 +68,7 @@ jupyterhub:
         volumeMounts:
           - name: home
             mountPath: /home/jovyan
-            subPath: "{username}"
+            subPath: "{escaped_username}"
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
@@ -132,7 +132,7 @@ jupyterhub:
           # that load data into the db from disk work
           - name: home
             mountPath: /home/jovyan
-            subPath: "{username}"
+            subPath: "{escaped_username}"
           - name: postgres-db
             mountPath: /var/lib/postgresql/data
             # postgres recommends against mounting a volume directly here

--- a/docs/topic/infrastructure/storage-layer.md
+++ b/docs/topic/infrastructure/storage-layer.md
@@ -149,7 +149,7 @@ jupyterhub:
         volumeMounts:
           - name: home
             mountPath: /home/jovyan
-            subPath: "{username}"
+            subPath: "{escaped_username}"
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     # images/hub/Dockerfile, and will also involve manually building and pushing
     # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
     # be found in the Dockerfile's comments.
-    version: 3.3.7
+    version: 4.0.0-beta.4
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
     version: 0.1.0-0.dev.git.276.h00ba998

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10722.h6ed14882"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1056,8 +1056,8 @@ jupyterhub:
         # jupyterhub chart will autogenerate a secret with appropriate keys.
         # It's not used if binderhub-service is not enabled.
         display: false
-        url: http://binderhub:8090
-        oauth_no_confirm: true
+        # url: http://binderhub:8090
+        # oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
       tag: "0.0.1-0.dev.git.10722.h6ed14882"

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -552,7 +552,7 @@ jupyterhub:
         volumeMounts:
           - name: home
             mountPath: /home/jovyan
-            subPath: "{username}"
+            subPath: "{escaped_username}"
           # Mounted without readonly attribute here,
           # so we can chown it appropriately
           - name: home
@@ -772,7 +772,7 @@ jupyterhub:
       type: static
       static:
         pvcName: home-nfs
-        subPath: "{username}"
+        subPath: "{escaped_username}"
       extraVolumes:
         - name: dev-shm
           emptyDir:
@@ -797,7 +797,7 @@ jupyterhub:
         # problem by openscapes)
         - name: home
           mountPath: /home/rstudio
-          subPath: "{username}"
+          subPath: "{escaped_username}"
         - name: home
           mountPath: /home/rstudio/shared
           subPath: _shared

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -12,7 +12,7 @@
 # `chartpress --push --builder docker-buildx --platform linux/amd64`
 # Ref: https://cloudolife.com/2022/03/05/Infrastructure-as-Code-IaC/Container/Docker/Docker-buildx-support-multiple-architectures-images/
 #
-FROM jupyterhub/k8s-hub:3.3.7
+FROM jupyterhub/k8s-hub:4.0.0-beta.4
 
 # chartpress.yaml defines multiple hub images differentiated only by a
 # requirements.txt file with dependencies, this build argument allows us to


### PR DESCRIPTION
I'm using 2i2c infra (2i2c cluster's staging hub) during open source work to check that z2jh 4.0.0-beta.4 is mature enough to be released as 4.0.0. Part of #4970.

The changes made here reflect the kind of changes we may want to roll out systematically at some point. This PR isn't meant to be merged as we don't have a system to install different helm chart versions for different hubs. Instead, I'm just manually deploying this to 2i2c cluster's staging hub to and doing manual checks that for example users home folders remain accessible and servers aren't getting restarted during upgrade.

## Issues observed

- https://github.com/jupyterhub/jupyterhub/issues/4929
  - Mitigated for 2i2c in https://github.com/2i2c-org/infrastructure/pull/4981, but we also need to handle https://github.com/2i2c-org/infrastructure/issues/4939 unless its fixed
  - Fixed by https://github.com/jupyterhub/jupyterhub/pull/4930, released with jupyterhub 5.2.1
  - Included in z2jh via https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3551, released with chart and image version `4.0.0-beta.4.git.6815.hcfafef2a`
- (not important) https://github.com/jupyterhub/jupyterhub/issues/4928
- Downgrading after upgrade couldn't be done without first replacing the jupyterhub.sqlite file with a backup.
  This can be manually handled by `kubectl debug <hub pod name> -it --copy-to=test-debug --image=ubuntu -c hub -- /bin/bash` and then looking at `/srv/jupyterhub for sqlite backup files and using a backup instead of the one named `jupyterhub.sqlite`

## What seem to work

Besides the issues, it seems that:

- kubespawner v7
  - nfs storage access was retained as intented by updating `subPath: "{username}"` to `subPath: "{escaped_username}"`
  - user servers running while the upgrade was made with JupyterHub 3, 4, and 5 in their images were accessible after jupyterhub was successfully restarted
- oauthenticator v17:
  - cilogon with google as an idp seem to work fine

