### PR TITLE
2i2c, staging: fully disable dex

### DIFF
--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -42,15 +42,19 @@ jupyterhub:
           name: 2i2c
           url: https://2i2c.org
   hub:
-    services:
-      dex:
-        url: http://dex:5556
-        oauth_redirect_uri: https://staging.2i2c.cloud/services/dex/callback
-        oauth_no_confirm: true
-        display: false
-      oauth2-proxy:
-        url: http://dex:9000
-        display: false
+    # FIXME: dex and oauth2-proxy is commented out to avoid error messages until
+    #        its fixed to work again, it also makes jupyterhub 5.2.0 fail to
+    #        start if it can't connect to this during startup.
+    #
+    # services:
+    #   dex:
+    #     url: http://dex:5556
+    #     oauth_redirect_uri: https://staging.2i2c.cloud/services/dex/callback
+    #     oauth_no_confirm: true
+    #     display: false
+    #   oauth2-proxy:
+    #     url: http://dex:9000
+    #     display: false
     config:
       JupyterHub:
         authenticator_class: cilogon


### PR DESCRIPTION
`dex` is part of auth for static webpages etc, but we have disabled it in staging and isn't using it anywhere currently. Anyhow, this PR disables it more fully in the 2i2c cluster's staging hub as it leads to warnings and for jupyterhub 5.2.0 actually also that jupyterhub fails to startup (tracked in https://github.com/jupyterhub/jupyterhub/issues/4929).