### PR TITLE
awi-ciroh: delete 3TB filestore instance that wasn't migrated to

### DIFF
--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -8,11 +8,6 @@ enable_logging         = false
 
 filestores = {
   "filestore" = { capacity_gb : 9216 },
-  # Requested in: https://2i2c.freshdesk.com/a/tickets/2170
-  "filestore_b" = {
-    name_suffix : "b",
-    capacity_gb : 3072,
-  }
 }
 
 # Cloud costs for this project are not passed through by 2i2c


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/4844 we introduced a 3TB filestore instance to migrate to, but we never succeeded and we are now to hold off doing something according to latest message in https://2i2c.freshdesk.com/a/tickets/2170. So, I figure we need to cleanup this now.