### PR TITLE
Automatically add the infintiy plugin and datasource to all Grafana instances

### DIFF
--- a/docs/howto/cost-attribution/aws.md
+++ b/docs/howto/cost-attribution/aws.md
@@ -223,18 +223,6 @@ Finally deploy the support chart:
 deployer deploy-support $CLUSTER_NAME
 ```
 
-### 5. Manually install plugin and add datasource to Grafana
-
-A cost attribution dashboard should be deployed via a GitHub workflow with
-automation, but the dashboard requires the Infinity plugin to be installed
-together with one data source of the Infinity plugin's kind to be added.
-
-1. Login to Grafana instance as the admin user
-2. Navigate to the `plugins/yesoreyeram-infinity-datasource` path (Plugins ->
-   Search for infinity)
-3. First press the "Install" button, and then press the "Add new datasource"
-   button
-
 ## Troubleshooting
 
 If you don't see data in the cost attribution dashboard, you may want to look to

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -402,6 +402,9 @@ grafana:
       token_url: https://github.com/login/oauth/access_token
       api_url: https://api.github.com/user
 
+  plugins:
+    - yesoreyeram-infinity-datasource
+
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -415,6 +418,10 @@ grafana:
           access: proxy
           isDefault: false
           editable: false
+        - name: yesoreyeram-infinity-datasource
+          type: yesoreyeram-infinity-datasource
+          isDefault: false
+          editable: true
 
 # cryptnono kills processes attempting to mine the cryptocurrency Monero in the
 # k8s cluster.


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/4962

I checked this working by manually deploying to the 2i2c-aws-us cluster's grafana