### PR TITLE
5 aws clusters: enable cost attribution system

### DIFF
--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -39,3 +39,11 @@ cluster-autoscaler:
   autoDiscovery:
     clusterName: earthscope
   awsRegion: us-east-2
+
+aws-ce-grafana-backend:
+  enabled: true
+  envBasedConfig:
+    clusterName: earthscope
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::762698921361:role/aws_ce_grafana_backend_iam_role

--- a/config/clusters/jupyter-meets-the-earth/support.values.yaml
+++ b/config/clusters/jupyter-meets-the-earth/support.values.yaml
@@ -40,3 +40,11 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.jmte.2i2c.cloud
+
+aws-ce-grafana-backend:
+  enabled: true
+  envBasedConfig:
+    clusterName: jupyter-meets-the-earth
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::286354552638:role/aws_ce_grafana_backend_iam_role

--- a/config/clusters/nasa-ghg/support.values.yaml
+++ b/config/clusters/nasa-ghg/support.values.yaml
@@ -32,3 +32,11 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.nasa-ghg.2i2c.cloud
+
+aws-ce-grafana-backend:
+  enabled: true
+  envBasedConfig:
+    clusterName: nasa-ghg-hub
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::597746869805:role/aws_ce_grafana_backend_iam_role

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -41,3 +41,11 @@ prometheus:
         - secretName: prometheus-tls
           hosts:
             - prometheus.nasa-veda.2i2c.cloud
+
+aws-ce-grafana-backend:
+  enabled: true
+  envBasedConfig:
+    clusterName: nasa-veda
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/aws_ce_grafana_backend_iam_role

--- a/config/clusters/nmfs-openscapes/support.values.yaml
+++ b/config/clusters/nmfs-openscapes/support.values.yaml
@@ -40,3 +40,11 @@ cluster-autoscaler:
   autoDiscovery:
     clusterName: nmfs-openscapes
   awsRegion: us-west-2
+
+aws-ce-grafana-backend:
+  enabled: true
+  envBasedConfig:
+    clusterName: nmfs-openscapes
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::891612562472:role/aws_ce_grafana_backend_iam_role

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -25,21 +25,30 @@ local nodeAz = "us-east-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { 
+    // FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
+    {
         instanceType: "r5.xlarge",
         tags+: {
             "earthscope:application:name": "geolab",
             "earthscope:application:owner": "research-onramp-to-the-cloud"
         },
     },
-    { 
+    {
+        instanceType: "r5.xlarge",
+        nameSuffix: "b",
+        tags+: {
+            "earthscope:application:name": "geolab",
+            "earthscope:application:owner": "research-onramp-to-the-cloud"
+        },
+    },
+    {
         instanceType: "r5.4xlarge",
         tags+: {
             "earthscope:application:name": "geolab",
             "earthscope:application:owner": "research-onramp-to-the-cloud"
         },
     },
-    { 
+    {
         instanceType: "r5.16xlarge",
         tags+: {
             "earthscope:application:name": "geolab",
@@ -74,7 +83,7 @@ local daskNodes = [
     metadata+: {
         name: "earthscope",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
         tags+: {
             "ManagedBy": "2i2c",
             "earthscope:application:name": "geolab",
@@ -110,7 +119,7 @@ local daskNodes = [
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
@@ -124,7 +133,6 @@ local daskNodes = [
                 "k8s.dask.org/node-purpose": "core"
             },
             tags+: {
-                "ManagedBy": "2i2c",
                 "earthscope:application:name": "geolab",
                 "earthscope:application:owner": "research-onramp-to-the-cloud"
             },
@@ -143,9 +151,6 @@ local daskNodes = [
                 "hub.jupyter.org/node-purpose": "user",
                 "k8s.dask.org/node-purpose": "scheduler"
             },
-            tags+: {
-                "ManagedBy": "2i2c",
-            },
             taints+: {
                 "hub.jupyter.org_dedicated": "user:NoSchedule",
                 "hub.jupyter.org/dedicated": "user:NoSchedule"
@@ -163,9 +168,6 @@ local daskNodes = [
             },
             labels+: {
                 "k8s.dask.org/node-purpose": "worker"
-            },
-            tags+: {
-                "ManagedBy": "2i2c",
             },
             taints+: {
                 "k8s.dask.org_dedicated" : "worker:NoSchedule",

--- a/eksctl/jupyter-meets-the-earth.jsonnet
+++ b/eksctl/jupyter-meets-the-earth.jsonnet
@@ -81,7 +81,7 @@ local daskNodes = [
     metadata+: {
         name: "jupyter-meets-the-earth",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-ghg.jsonnet
+++ b/eksctl/nasa-ghg.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [
     metadata+: {
         name: "nasa-ghg-hub",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -43,13 +43,6 @@ local notebookNodes = [
         labels+: { "2i2c/hub-name": "staging" },
         tags+: { "2i2c:hub-name": "staging" }
     },
-    // FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
-    {
-        instanceType: "r5.xlarge",
-        namePrefix: "nb-prod",
-        labels+: { "2i2c/hub-name": "prod" },
-        tags+: { "2i2c:hub-name": "prod" }
-    },
     {
         instanceType: "r5.xlarge",
         namePrefix: "nb-prod",

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -14,12 +14,16 @@ default_budget_alert = {
   "enabled" : false,
 }
 
+enable_aws_ce_grafana_backend_iam = true
+
 user_buckets = {
   "scratch-staging" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "staging" },
   },
   "scratch" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "prod" },
   },
 }
 

--- a/terraform/aws/projects/jupyter-meets-the-earth.tfvars
+++ b/terraform/aws/projects/jupyter-meets-the-earth.tfvars
@@ -6,15 +6,19 @@ default_budget_alert = {
   "enabled" : false,
 }
 
+enable_aws_ce_grafana_backend_iam = true
+
 user_buckets = {
   "scratch-staging" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "staging" },
   },
   // IMPORTANT: This bucket isn't used, they are instead using s3://jmte-scratch
   //            that doesn't have a delete_after policy setup etc, but maybe
   //            they want to have.
   "scratch" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "prod" },
   },
 }
 

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -6,12 +6,16 @@ default_budget_alert = {
   "enabled" : false,
 }
 
+enable_aws_ce_grafana_backend_iam = true
+
 user_buckets = {
   "scratch-staging" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "staging" },
   },
   "scratch" : {
-    "delete_after" : 7
+    "delete_after" : 7,
+    "tags" : { "2i2c:hub-name" : "prod" },
   },
 }
 

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -6,18 +6,20 @@ default_budget_alert = {
   "enabled" : false,
 }
 
+enable_aws_ce_grafana_backend_iam = true
+
 user_buckets = {
   "scratch-staging" : {
     "delete_after" : 7,
-    "tags" : { "2i2c:hub-name" : "staging" }
+    "tags" : { "2i2c:hub-name" : "staging" },
   },
   "scratch" : {
     "delete_after" : 7,
-    "tags" : { "2i2c:hub-name" : "prod" }
+    "tags" : { "2i2c:hub-name" : "prod" },
   },
   "scratch-binder" : {
     "delete_after" : 1,
-    "tags" : { "2i2c:hub-name" : "binder" }
+    "tags" : { "2i2c:hub-name" : "binder" },
   },
 }
 

--- a/terraform/aws/projects/nmfs-openscapes.tfvars
+++ b/terraform/aws/projects/nmfs-openscapes.tfvars
@@ -6,6 +6,8 @@ default_budget_alert = {
   "enabled" : false,
 }
 
+enable_aws_ce_grafana_backend_iam = true
+
 disable_cluster_wide_filestore = true
 filestores = {
   "staging" = {


### PR DESCRIPTION
Fixes five remaining clusters for https://github.com/2i2c-org/infrastructure/issues/4878:

nmfs-openscapes was a truly standalone account, but earthscope,
jupyter-meets-the-earth, nasa-ghg, nasa-veda, were not standalone
accounts. This means that we have failed to enable the cost allocation
tags and need to followup with the community about this.