### PR TITLE
Revert terraform version bump

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9"
+  required_version = "~> 1.5"
 
   required_providers {
     aws = {

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = "~> 1.9"
+  required_version = "~> 1.5"
   required_providers {
     azurerm = {
       # FIXME: upgrade to v4, see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9"
+  required_version = "~> 1.5"
 
   backend "gcs" {}
   required_providers {

--- a/terraform/uptime-checks/main.tf
+++ b/terraform/uptime-checks/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9"
+  required_version = "~> 1.5"
   backend "gcs" {
     # This is a separate GCS bucket than what we use for our other terraform state
     # This is less sensitive, so let's keep it separate


### PR DESCRIPTION
Partially reverts https://github.com/2i2c-org/infrastructure/pull/4745, as Terraform 1.9 is not an open source product.