### PR TITLE
Roll out jupyterhub-fancy-profiles to all hubs

### DIFF
--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
           custom_html: <a href="https://www.dfg.de/">DFG</a>, <a href="https://www.cessda.eu/">CESSDA</a>, <a href="https://www.gesis.org/">GESIS</a>, FKZ/Project number <a href="https://gepris.dfg.de/gepris/projekt/460234259?language=en">460234259</a>
   singleuser:
     profileList:
-      - display_name: "Only Profile Available, this info is not shown in the UI"
+      - display_name: Choose your environment and resources
         slug: only-choice
         profile_options:
           image:

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -115,9 +115,6 @@ jupyterhub:
   hub:
     # Allows for multiple concurrent demos
     allowNamedServers: true
-    image:
-      name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.10263.hc87b65cf"
     config:
       JupyterHub:
         authenticator_class: github
@@ -130,11 +127,6 @@ jupyterhub:
           - CYGNSS-VEDA:cygnss-iwg
         scope:
           - read:org
-
-    extraConfig:
-      enable-fancy-profiles: |
-        from jupyterhub_fancy_profiles import setup_ui
-        setup_ui(c)
 
 binderhub-service:
   enabled: true

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -20,7 +20,7 @@ basehub:
       nodeSelector:
         2i2c/hub-name: staging
       profileList:
-        - display_name: "Only Profile Available, this info is not shown in the UI"
+        - display_name: Choose your environment and resources
           slug: only-choice
           profile_options:
             image:

--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -13,16 +13,9 @@ basehub:
         gitRepoBranch: "staging"
         gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
     hub:
-      image:
-        name: quay.io/2i2c/dynamic-image-building-experiment
-        tag: "0.0.1-0.dev.git.10263.hc87b65cf"
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.ghg.2i2c.cloud/hub/oauth_callback
-      extraConfig:
-        enable-fancy-profiles: |
-          from jupyterhub_fancy_profiles import setup_ui
-          setup_ui(c)
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -43,9 +43,6 @@ basehub:
             name: "NASA"
             url: https://www.earthdata.nasa.gov/esds
     hub:
-      image:
-        name: quay.io/2i2c/dynamic-image-building-experiment
-        tag: 0.0.1-0.dev.git.10730.h0ce7d704
       allowNamedServers: true
       config:
         JupyterHub:
@@ -74,10 +71,6 @@ basehub:
             - slesaad
             - wildintellect
             - amarouane-ABDELHAK
-      extraConfig:
-        enable-fancy-profiles: |
-          from jupyterhub_fancy_profiles import setup_ui
-          setup_ui(c)
     singleuser:
       cloudMetadata:
         blockWithIptables: false

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -149,9 +149,6 @@ jupyterhub:
 
   hub:
     allowNamedServers: true
-    image:
-      name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.10263.hc87b65cf"
     config:
       JupyterHub:
         authenticator_class: github
@@ -165,11 +162,6 @@ jupyterhub:
       Authenticator:
         admin_users:
           - kyttmacmanus # Kytt MacManus, added as part of https://2i2c.freshdesk.com/a/tickets/1454
-
-    extraConfig:
-      enable-fancy-profiles: |
-        from jupyterhub_fancy_profiles import setup_ui
-        setup_ui(c)
 
 binderhub-service:
   enabled: true

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -44,7 +44,7 @@ jupyterhub:
       SCRATCH_BUCKET: s3://opensci-scratch-sciencecore/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://opensci-persistent-sciencecore/$(JUPYTERHUB_USER)
     profileList:
-      - display_name: "Only Profile Available, this info is not shown in the UI"
+      - display_name: Choose your environment and resources
         slug: only-choice
         profile_options:
           image:

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -111,9 +111,6 @@ jupyterhub:
 
   hub:
     allowNamedServers: true
-    image:
-      name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -29,7 +29,7 @@ jupyterhub:
           url: ""
   singleuser:
     profileList:
-      - display_name: "Only Profile Available, this info is not shown in the UI"
+      - display_name: Choose your environment and resources
         slug: only-choice
         profile_options:
           image:

--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -41,9 +41,6 @@ jupyterhub:
 
   hub:
     allowNamedServers: true
-    image:
-      name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
     config:
       JupyterHub:
         authenticator_class: github
@@ -51,10 +48,6 @@ jupyterhub:
         admin_users:
           - jmunroe
           - ktyle
-    extraConfig:
-      enable-fancy-profiles: |
-        from jupyterhub_fancy_profiles import setup_ui
-        setup_ui(c)
 
   scheduling:
     userScheduler:

--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -59,7 +59,7 @@ jupyterhub:
       GH_SCOPED_CREDS_CLIENT_ID: "Iv23liaEC5WLtjKehTtK"
       GH_SCOPED_CREDS_APP_URL: "https://github.com/apps/2i2c-project-pythia-push-access"
     profileList:
-      - display_name: "Only Profile Available, this info is not shown in the UI"
+      - display_name: Choose your environment and resources
         slug: only-choice
         profile_options:
           image:

--- a/config/clusters/strudel/common.values.yaml
+++ b/config/clusters/strudel/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
       enabled: true
   singleuser:
     profileList:
-      - display_name: "Only Profile Available, this info is not shown in the UI"
+      - display_name: Choose your environment and resources
         slug: only-choice
         profile_options:
           image:

--- a/config/clusters/strudel/common.values.yaml
+++ b/config/clusters/strudel/common.values.yaml
@@ -38,16 +38,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      # Authenticator:
-      #   admin_users:
-      #     - user1
-    image:
-      name: quay.io/2i2c/dynamic-image-building-experiment
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
-    extraConfig:
-      enable-fancy-profiles: |
-        from jupyterhub_fancy_profiles import setup_ui
-        setup_ui(c)
   scheduling:
     userScheduler:
       enabled: true

--- a/docs/howto/features/imagebuilding.md
+++ b/docs/howto/features/imagebuilding.md
@@ -43,7 +43,7 @@ jupyterhub:
     jupyterhub:
       singleuser:
         profileList:
-          - display_name: "Only Profile Available, this info is not shown in the UI"
+          - display_name: Choose your environment and resources
             slug: only-choice
             profile_options:
               image:

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     version: 3.3.7
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.276.h00ba998
+    version: 0.1.0-0.dev.git.282.he1ac64b
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled
     # If bumping the version of dask-gateway, please also bump the default version set

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.10853.hf249a530"
+      tag: "0.0.1-0.dev.git.10856.h1a21a6f0"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.10856.h1a21a6f0"
+      tag: "0.0.1-0.dev.git.10858.hac4e7a41"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1592,6 +1592,10 @@ jupyterhub:
           # https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.post_auth_hook
           c.Authenticator.post_auth_hook = salt_username
 
+      07-enable-fancy-profiles: |
+        from jupyterhub_fancy_profiles import setup_ui
+        setup_ui(c)
+
       # Initially copied from https://github.com/dask/helm-chart/blob/main/daskhub/values.yaml
       daskhub-01-add-dask-gateway-values: |
         # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.8663.h049aa2c2"
+      tag: "0.0.1-0.dev.git.10850.h8a05d672"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.10850.h8a05d672"
+      tag: "0.0.1-0.dev.git.10853.hf249a530"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-jupyterhub-fancy-profiles==0.3.8
+jupyterhub-fancy-profiles==0.3.9

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-jupyterhub-fancy-profiles==0.3.7
+jupyterhub-fancy-profiles==0.3.8

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -8,3 +8,6 @@
 # ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
 #
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
+
+# Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
+jupyterhub-fancy-profiles==0.3.6

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-jupyterhub-fancy-profiles==0.3.6
+jupyterhub-fancy-profiles==0.3.7


### PR DESCRIPTION
- Put it into the default hub image
- Move setting up fancy profiles to basehub
- Remove all uses of the custom dynamic imagebuilding hub image
- Use a better display name for hubs with only one profile

Fixes https://github.com/2i2c-org/infrastructure/issues/5082
