### PR TITLE
Migrate nmfs-openscapes staging hub to use EBS volumes for NFS with per-user quotas

### DIFF
--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -1,6 +1,6 @@
 nfs:
   pv:
-    serverIP: fs-0bb8ced2e0be85846.efs.us-west-2.amazonaws.com
+    serverIP: 10.100.15.21
 
 userServiceAccount:
   annotations:

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -20,3 +20,12 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.nmfs-openscapes.2i2c.cloud/hub/oauth_callback
+
+jupyterhub-home-nfs:
+  enabled: true
+  eks:
+    enabled: true
+    volumeId: vol-08dafa2e06872afbd
+  quotaEnforcer:
+    hardQuota: "0.1" # in GB
+    path: "/export/staging"


### PR DESCRIPTION
- fixes #5069 