### PR TITLE
fix: correct team names, and allowed orgs

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -60,6 +60,7 @@ basehub:
             - veda-analytics-access:maap-biomass-team
             - Earth-Information-System:eis-fire
             - Earth-Information-System:swot
+            - veda-analytics-access:harvard-data-team
           scope:
             - read:org
         Authenticator:
@@ -252,7 +253,7 @@ basehub:
           description: "Start a container on a dedicated node with a GPU"
           slug: "gpu"
           allowed_groups:
-            - veda-analytics-access:maap-biomass-team
+            - veda-analytics-access:gpu
             - 2i2c-org:hub-access-for-2i2c-staff
             - veda-analytics-access:harvard-data-team
           profile_options:


### PR DESCRIPTION
- Org:teams need to be in allowed orgs before gpu access is allowed
- Incorrect team was in the gpu section, the gpu team isn't listed in allowed orgs because a user needs to belong to one of the other allowed teams. Does this work @yuvipanda ?