### PR TITLE
catalyst-af: create hub-specific nodegroups

### DIFF
--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -25,9 +25,48 @@ local nodeAz = "af-south-1a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.xlarge", nameSuffix: "b", volumeSize: 400 },
-    { instanceType: "r5.4xlarge", volumeSize: 400 },
-    { instanceType: "r5.16xlarge", volumeSize: 400 },
+    {
+        instanceType: "r5.xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        volumeSize: 400,
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
 ];
 local daskNodes = [];
 

--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -38,7 +38,7 @@ local daskNodes = [];
     metadata+: {
         name: "catalystproject-africa",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/catalystproject-africa.jsonnet
+++ b/eksctl/catalystproject-africa.jsonnet
@@ -108,7 +108,7 @@ local daskNodes = [];
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'b',
+            nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {


### PR DESCRIPTION
- fixes #5091 
- sub-task of #5074 