### PR TITLE
Fix bug with jupyterhub-fancy-profiles rollout

### DIFF
--- a/config/clusters/2i2c/ucmerced-staging.values.yaml
+++ b/config/clusters/2i2c/ucmerced-staging.values.yaml
@@ -13,14 +13,19 @@ jupyterhub:
         default: true
         kubespawner_override:
           # From https://github.com/SaiUCM/example-inherit-from-community-image
-          image: quay.io/cirt_ucm/jupyter-scipy-xarray:latest
+          # See https://2i2c.freshdesk.com/a/tickets/1612
+          # See https://2i2c.freshdesk.com/a/tickets/1771
+          # See https://2i2c.freshdesk.com/a/tickets/2076
+          # See https://2i2c.freshdesk.com/a/tickets/2138
+          # See https://2i2c.freshdesk.com/a/tickets/2396
+          image: quay.io/cirt_ucm/jupyter-scipy-xarray:0b689eb927fa
           # Launch into JupyterLab after the user logs in
           default_url: /lab
       - display_name: R
         description: Start a R server with tidyverse & Geospatial tools
         kubespawner_override:
           # From https://github.com/2i2c-org/rocker-with-nbgitpuller
-          image: quay.io/2i2c/rocker-with-nbgitpuller:287ea05b2809
+          image: quay.io/2i2c/rocker-with-nbgitpuller:3edc87d73e3d
           default_url: /lab
           # Ensures container working dir is homedir
           # https://github.com/2i2c-org/infrastructure/issues/2559

--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.10694.h38ededaf
+      tag: 0.0.1-0.dev.git.10892.h37c70b2e
     allowNamedServers: true
     config:
       JupyterHub:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1060,7 +1060,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.10858.hac4e7a41"
+      tag: "0.0.1-0.dev.git.10892.h37c70b2e"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -4,14 +4,5 @@
 # experiment no longer needed when base chart is updated to z2jh 4.0.0
 oauthenticator>=17.1,<18
 
-# jupyterhub-configurator isn't maintained and its not intended to be developed
-# further. We are using a branch that has forked from the main branch just
-# before a breaking change were made. This allows us to avoid migrating.
-#
-# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/main
-# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
-#
-git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
-
-# Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-jupyterhub-fancy-profiles==0.3.9
+# Include all the requirements we have for our base hub image
+-r ./requirements.txt

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -4,5 +4,15 @@
 # experiment no longer needed when base chart is updated to z2jh 4.0.0
 oauthenticator>=17.1,<18
 
-# Include all the requirements we have for our base hub image
--r requirements.txt
+
+# jupyterhub-configurator isn't maintained and its not intended to be developed
+# further. We are using a branch that has forked from the main branch just
+# before a breaking change were made. This allows us to avoid migrating.
+#
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/main
+# ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
+#
+git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
+
+# Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
+jupyterhub-fancy-profiles==0.3.10

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -12,3 +12,6 @@ oauthenticator>=17.1,<18
 # ref: https://github.com/yuvipanda/jupyterhub-configurator/commits/backported-jh41-compatibility
 #
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
+
+# Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
+jupyterhub-fancy-profiles==0.3.9

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -5,4 +5,4 @@
 oauthenticator>=17.1,<18
 
 # Include all the requirements we have for our base hub image
--r ./requirements.txt
+-r requirements.txt

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -10,4 +10,4 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 # Brings in https://github.com/yuvipanda/jupyterhub-fancy-profiles
-jupyterhub-fancy-profiles==0.3.9
+jupyterhub-fancy-profiles==0.3.10


### PR DESCRIPTION
- Bring in https://github.com/yuvipanda/jupyterhub-fancy-profiles/pull/94 that fixes https://2i2c.freshdesk.com/a/tickets/2462
- Make ucmerced staging match prod, so we can more easily catch these issues
- Install jupyterhub-fancy-profile in the jupyter-health hub image as well so jupyter-health deployment succeeds

Ref https://github.com/2i2c-org/infrastructure/issues/5082