### PR TITLE
nmfs-openscapes: create hub-specific nodegroups

### DIFF
--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -13,6 +13,8 @@ jupyterhub:
       - hosts: [nmfs-openscapes.2i2c.cloud]
         secretName: https-auto-tls
   singleuser:
+    nodeSelector:
+      2i2c/hub-name: prod
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent/$(JUPYTERHUB_USER)

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -13,6 +13,8 @@ jupyterhub:
       - hosts: [staging.nmfs-openscapes.2i2c.cloud]
         secretName: https-auto-tls
   singleuser:
+    nodeSelector:
+      2i2c/hub-name: staging
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch-staging/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent-staging/$(JUPYTERHUB_USER)

--- a/eksctl/nmfs-openscapes.jsonnet
+++ b/eksctl/nmfs-openscapes.jsonnet
@@ -25,9 +25,42 @@ local nodeAz = "us-west-2b";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.xlarge" },
-    { instanceType: "r5.4xlarge" },
-    { instanceType: "r5.16xlarge" },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
 ];
 local daskNodes = [];
 


### PR DESCRIPTION
- fixes #5089 
- sub-task of #5074 