### PR TITLE
kitware: upgrade to k8s v1.30 and add hub-specific nodegroups

### DIFF
--- a/config/clusters/kitware/prod.values.yaml
+++ b/config/clusters/kitware/prod.values.yaml
@@ -12,3 +12,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://kitware.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    nodeSelector:
+      2i2c/hub-name: staging

--- a/config/clusters/kitware/staging.values.yaml
+++ b/config/clusters/kitware/staging.values.yaml
@@ -12,3 +12,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.kitware.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    nodeSelector:
+      2i2c/hub-name: staging

--- a/eksctl/kitware.jsonnet
+++ b/eksctl/kitware.jsonnet
@@ -50,7 +50,7 @@ local daskNodes = [];
     metadata+: {
         name: "kitware",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/kitware.jsonnet
+++ b/eksctl/kitware.jsonnet
@@ -25,13 +25,64 @@ local nodeAz = "us-west-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.xlarge" },
-    { instanceType: "r5.4xlarge" },
-    { instanceType: "r5.16xlarge" },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
     {
       instanceType: "g4dn.xlarge",
+      namePrefix: "nb-staging",
+      labels+: { "2i2c/hub-name": "staging" },
       tags+: {
-          "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
+        "2i2c:hub-name": "staging",
+        "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
+      },
+      taints+: {
+          "nvidia.com/gpu": "present:NoSchedule"
+      },
+      // Allow provisioning GPUs across all AZs, to prevent situation where all
+      // GPUs in a single AZ are in use and no new nodes can be spawned
+      availabilityZones: masterAzs,
+    },
+    {
+      instanceType: "g4dn.xlarge",
+      namePrefix: "nb-prod",
+      labels+: { "2i2c/hub-name": "prod" },
+      tags+: {
+        "2i2c:hub-name": "prod",
+        "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
       },
       taints+: {
           "nvidia.com/gpu": "present:NoSchedule"

--- a/eksctl/kitware.jsonnet
+++ b/eksctl/kitware.jsonnet
@@ -160,6 +160,7 @@ local daskNodes = [];
                 "hub.jupyter.org/node-purpose": "user",
                 "k8s.dask.org/node-purpose": "scheduler"
             },
+            tags+: { "2i2c:node-purpose": "user" },
             taints+: {
                 "hub.jupyter.org_dedicated": "user:NoSchedule",
                 "hub.jupyter.org/dedicated": "user:NoSchedule"

--- a/eksctl/kitware.jsonnet
+++ b/eksctl/kitware.jsonnet
@@ -132,7 +132,7 @@ local daskNodes = [];
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {
@@ -145,6 +145,7 @@ local daskNodes = [];
                 "hub.jupyter.org/node-purpose": "core",
                 "k8s.dask.org/node-purpose": "core"
             },
+            tags+: { "2i2c:node-purpose": "core" },
         },
     ] + [
         ng + {


### PR DESCRIPTION
- fixes #5094 
- sub-task of #5074 