### PR TITLE
jupyter-health: upgrade to k8s v1.30 and create hub-specific nodegroups

### DIFF
--- a/config/clusters/jupyter-health/prod.values.yaml
+++ b/config/clusters/jupyter-health/prod.values.yaml
@@ -11,3 +11,6 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://jupyter-health.2i2c.cloud/hub/oauth_callback
+  singleuser:
+    nodeSelector:
+      2i2c/hub-name: staging

--- a/config/clusters/jupyter-health/prod.values.yaml
+++ b/config/clusters/jupyter-health/prod.values.yaml
@@ -13,4 +13,4 @@ jupyterhub:
         oauth_callback_url: https://jupyter-health.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
-      2i2c/hub-name: staging
+      2i2c/hub-name: prod

--- a/config/clusters/jupyter-health/staging.values.yaml
+++ b/config/clusters/jupyter-health/staging.values.yaml
@@ -47,3 +47,6 @@ jupyterhub:
             spawner.environment["CHCS_CLIENT_ID"] = "Ima7rx8D6eko0PzlU1jK28WBUT2ZweZj7mqVG2wm"
 
         c.Spawner.auth_state_hook = auth_state_env
+  singleuser:
+    nodeSelector:
+      2i2c/hub-name: staging

--- a/eksctl/jupyter-health.jsonnet
+++ b/eksctl/jupyter-health.jsonnet
@@ -25,9 +25,42 @@ local nodeAz = "us-east-2a";
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
-    { instanceType: "r5.xlarge" },
-    { instanceType: "r5.4xlarge" },
-    { instanceType: "r5.16xlarge" },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.4xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+    },
+    {
+        instanceType: "r5.16xlarge",
+        namePrefix: "nb-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+    },
 ];
 local daskNodes = [];
 

--- a/eksctl/jupyter-health.jsonnet
+++ b/eksctl/jupyter-health.jsonnet
@@ -115,6 +115,7 @@ local daskNodes = [];
                 "hub.jupyter.org/node-purpose": "core",
                 "k8s.dask.org/node-purpose": "core"
             },
+            tags+: { "2i2c:node-purpose": "core" },
         },
     ] + [
         ng + {
@@ -130,6 +131,7 @@ local daskNodes = [];
                 "hub.jupyter.org/node-purpose": "user",
                 "k8s.dask.org/node-purpose": "scheduler"
             },
+            tags+: { "2i2c:node-purpose": "user" },
             taints+: {
                 "hub.jupyter.org_dedicated": "user:NoSchedule",
                 "hub.jupyter.org/dedicated": "user:NoSchedule"

--- a/eksctl/jupyter-health.jsonnet
+++ b/eksctl/jupyter-health.jsonnet
@@ -38,7 +38,7 @@ local daskNodes = [];
     metadata+: {
         name: "jupyter-health",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
     },
     availabilityZones: masterAzs,
     iam: {

--- a/eksctl/jupyter-health.jsonnet
+++ b/eksctl/jupyter-health.jsonnet
@@ -102,7 +102,7 @@ local daskNodes = [];
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             ssh: {

--- a/eksctl/jupyter-health.jsonnet
+++ b/eksctl/jupyter-health.jsonnet
@@ -71,7 +71,7 @@ local daskNodes = [];
     metadata+: {
         name: "jupyter-health",
         region: clusterRegion,
-        version: "1.29",
+        version: "1.30",
         tags+: {
             "ManagedBy": "2i2c",
             "2i2c.org/cluster-name": $.metadata.name,


### PR DESCRIPTION
- fixes #5093 
- sub-task of #5074 