### PR TITLE
Fix the URL for the grafana-dashboards repository

### DIFF
--- a/grafana-dashboards/README.md
+++ b/grafana-dashboards/README.md
@@ -1,7 +1,7 @@
 # About these grafana dashboard files
 
 These are dashboard definitions as jsonnet templates. They are deployed using a
-Python script from https://github.com/jupyterhub/grafana-dashboard, which can be
+Python script from https://github.com/jupyterhub/grafana-dashboards, which can be
 done via the deployer command:
 
 ```bash
@@ -14,7 +14,7 @@ specifically the jsonnet binary built using golang called go-jsonnet.
 To just render the jsonnet templates, which is relevant during development, you
 can:
 
-1. Clone https://github.com/jupyterhub/grafana-dashboard somewhere
+1. Clone https://github.com/jupyterhub/grafana-dashboards somewhere
 2. Go to that folder, and then run something like:
    ```bash
    jsonnet -J vendor /some/path/2i2c-org/infrastructure/grafana-dashboards/cloud-cost-aws.jsonnet


### PR DESCRIPTION
[`https://github.com/jupyterhub/grafana-dashboards`](https://github.com/jupyterhub/grafana-dashboards) instead of [`https://github.com/jupyterhub/grafana-dashboard`](https://github.com/jupyterhub/grafana-dashboard)