### PR TITLE
fix: upgrade pangeo gpu for ISCE3 compatibility

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -272,13 +272,13 @@ basehub:
                   default: false
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "quay.io/pangeo/pytorch-notebook:2024.08.18"
+                    image: "quay.io/pangeo/pytorch-notebook:2024.11.11"
                 tensorflow2:
                   display_name: Pangeo Tensorflow2 ML Notebook
                   default: true
                   slug: "tensorflow2"
                   kubespawner_override:
-                    image: "quay.io/pangeo/ml-notebook:2024.08.18"
+                    image: "quay.io/pangeo/ml-notebook:2024.11.11"
           kubespawner_override:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility


### PR DESCRIPTION
Latest ISCE3 needs a newer Pangeo version for conda install to work easily.
https://github.com/conda-forge/isce3-feedstock/pull/72

Since the GPU images/workers are an experimental feature upgrading to latest release is fine and not disruptive to current users.