### PR TITLE
openscapes: Rm tainted node and suffixed node

### DIFF
--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -43,17 +43,9 @@ local notebookNodes = [
         labels+: { "2i2c/hub-name": "staging" },
         tags+: { "2i2c:hub-name": "staging" }
     },
-    // FIXME: tainted
     {
         instanceType: "r5.xlarge",
         namePrefix: "nb-prod",
-        labels+: { "2i2c/hub-name": "prod" },
-        tags+: { "2i2c:hub-name": "prod" }
-    },
-    {
-        instanceType: "r5.xlarge",
-        namePrefix: "nb-prod",
-        nameSuffix: "b",
         labels+: { "2i2c/hub-name": "prod" },
         tags+: { "2i2c:hub-name": "prod" }
     },


### PR DESCRIPTION
Last bit remaining from https://github.com/2i2c-org/infrastructure/issues/5114
Closes https://github.com/2i2c-org/infrastructure/issues/5114