### PR TITLE
gridsst: Put dask workers into their own nodepool per hub and tag them

### DIFF
--- a/eksctl/gridsst.jsonnet
+++ b/eksctl/gridsst.jsonnet
@@ -174,7 +174,18 @@ local daskNodes = [
     // A not yet fully established policy is being developed about using a single
     // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
     //
-    { instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }},
+    {
+        namePrefix: "dask-staging",
+        labels+: { "2i2c/hub-name": "staging" },
+        tags+: { "2i2c:hub-name": "staging" },
+        instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }
+    },
+    {
+        namePrefix: "dask-prod",
+        labels+: { "2i2c/hub-name": "prod" },
+        tags+: { "2i2c:hub-name": "prod" },
+        instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }
+    },
 ];
 
 
@@ -293,6 +304,9 @@ local daskNodes = [
             },
             labels+: {
                 "k8s.dask.org/node-purpose": "worker"
+            },
+            tags+: {
+                "2i2c:node-purpose": "worker"
             },
             taints+: {
                 "k8s.dask.org_dedicated" : "worker:NoSchedule",


### PR DESCRIPTION
Fixes #5149 