### PR TITLE
[2i2c, ohw] New R and Python images

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -26,7 +26,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/python:37f83fb"
+            image: "ghcr.io/oceanhackweek/python:2f04c57"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G
@@ -35,7 +35,7 @@ basehub:
         - display_name: "R en RStudio"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/r:13f3be6"
+            image: "ghcr.io/oceanhackweek/r:6db529b"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
Updates for 2024 OHW24-in-Spanish November event.

- R: extensive overhauls, including upgrading core components (rstudio-server, Python, pangeo-notebook, etc). https://github.com/oceanhackweek/jupyter-image/pull/97
- Python: add 2 packages. https://github.com/oceanhackweek/jupyter-image/pull/99

@jnywong 

xref https://github.com/2i2c-org/infrastructure/issues/5052