### PR TITLE
[2i2c, ohw] Update R image

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -35,7 +35,7 @@ basehub:
         - display_name: "R en RStudio"
           description: "~2 CPU, ~8G RAM"
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/r:b07027b"
+            image: "ghcr.io/oceanhackweek/r:d690195"
             default_url: "/rstudio"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
Updates for 2024 OceanHackWeek (OHW)-in-Spanish November event.

See PR https://github.com/oceanhackweek/jupyter-image/pull/101

@jnywong

xref https://github.com/2i2c-org/infrastructure/issues/5052