### PR TITLE
[2i2c, ohw]: IMPORTANT! update access as soon as possible

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -79,6 +79,7 @@ basehub:
             - Intercoonecta:ohwes24-organizers
             - Intercoonecta:ohwes24-mentor-helper-presenter
             - Intercoonecta:ohwes24-participants-tallerintermed
+            - Intercoonecta:ohwes24-participants-hackaton
             - oceanhackweek:ohw24-organizers
             - oceanhackweek:ohw24-project-mentors
             - oceanhackweek:ohw24-tutorial-presenters


### PR DESCRIPTION
We started the event an hour ago, but I only now discovered that I had not added the appropriate GitHub team of participants to the `ohw.values.yaml` file!!! That was after everyone was reporting being unabled to enter the hub.

~~This PR adds the team. **Please accept the PR as soon as you can.** Obviously, it'll be disruptive to the event, but the disruption is necessary.~~

Thank you!!

Updates for 2024 OceanHackWeek (OHW)-in-Spanish November event.

@jnywong

xref https://github.com/2i2c-org/infrastructure/issues/5052