### PR TITLE
VEDA: Bump up the version of jupyterhub-home-nfs on VEDA staging

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -87,3 +87,5 @@ basehub:
     quotaEnforcer:
       hardQuota: "10" # in GB
       path: "/export/staging"
+    prometheusExporter:
+      enabled: true

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,6 +26,6 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 0.0.6
+    version: 0.0.7
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled


### PR DESCRIPTION
Also adds Prometheus exporter to report disk usage.

Related to https://github.com/2i2c-org/infrastructure/issues/5062