### PR TITLE
Revert "use oauthenticator 17.2 for pkce-experiment (jupyter-health)"

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.11154.h8a6a8049
+      tag: 0.0.1-0.dev.git.10892.h37c70b2e
     allowNamedServers: true
     config:
       JupyterHub:

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -1,8 +1,8 @@
 # Image lives at quay.io/2i2c/pkce-experiment
-# install oauthenticator 17.2,
-# which adds PKCE support (17.1) and refresh tokens (17.2).
-# experiment no longer needed when base chart is updated to z2jh 4.1.0
-oauthenticator>=17.2,<18
+# install oauthenticator 17.1,
+# which adds PKCE support.
+# experiment no longer needed when base chart is updated to z2jh 4.0.0
+oauthenticator>=17.1,<18
 
 
 # jupyterhub-configurator isn't maintained and its not intended to be developed


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#5217. See PR discussion for context.