### PR TITLE
jupyter-health: test oauthenticator 17.2 and skip refresh for the test user

### DIFF
--- a/config/clusters/jupyter-health/staging.values.yaml
+++ b/config/clusters/jupyter-health/staging.values.yaml
@@ -8,6 +8,10 @@ jupyterhub:
       - hosts: [staging.jupyter-health.2i2c.cloud]
         secretName: https-auto-tls
   hub:
+    # FIXME: Experiment to use https://github.com/jupyterhub/oauthenticator/pull/780
+    image:
+      name: quay.io/2i2c/pkce-experiment
+      tag: 0.0.1-0.dev.git.11169.h1e0fa323
     config:
       JupyterHub:
         # Uses CHCS auth provider
@@ -48,6 +52,17 @@ jupyterhub:
             spawner.environment["JHE_CLIENT_ID"] = "Ima7rx8D6eko0PzlU1jK28WBUT2ZweZj7mqVG2wm"
 
         c.Spawner.auth_state_hook = auth_state_env
+
+      skip_refresh_for_test_user.py: |
+        def refresh_user_hook(authenticator, user, auth_state):
+            if user.name == "deployment-service-check":
+                # if this is the user,
+                # refresh_user doesn't make sense
+                # consider it always fresh
+                return True
+            # for all other users, refresh as usual
+            return None
+        c.OAuthenticator.refresh_user_hook = refresh_user_hook
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -2,7 +2,8 @@
 # install oauthenticator 17.1,
 # which adds PKCE support.
 # experiment no longer needed when base chart is updated to z2jh 4.0.0
-oauthenticator>=17.1,<18
+# Experiment with https://github.com/jupyterhub/oauthenticator/pull/780 and oauthenticator 17.2
+git+https://github.com/minrk/oauthenticator@refresh-skip
 
 
 # jupyterhub-configurator isn't maintained and its not intended to be developed


### PR DESCRIPTION
@minrk, how do you feel about experimenting with the changes in https://github.com/jupyterhub/oauthenticator/pull/780 on the jupyter-health staging?

I figured we could do this until that PR is merged and a new version is released with those changes.

I manually deployed this and confirmed that the health check tests work now.