### PR TITLE
Explicitly document that the default cloud provider is AWS

### DIFF
--- a/docs/hub-deployment-guide/runbooks/phase1/index.md
+++ b/docs/hub-deployment-guide/runbooks/phase1/index.md
@@ -18,6 +18,11 @@ The following lists the information that needs to be available to the engineer b
 - Community Representatives
 - Technical Contacts added to Airtable?
 
+## Default cloud provider
+
+*If* the community has no particular preference for a cloud
+provider, we will default to using AWS.
+
 ## Outputs
 
 At the end of Phase 1, all engineers should have access to the cloud account where the new cluster and hub will be deployed to.


### PR DESCRIPTION
GKE is a superior experience, but unfortunately Google's Customer Support leaves a lot to be desired. EKS has mostly caught up, and EFS is doing much better than GCP Filestore.

This is one (but not the primary outcome) from
https://github.com/2i2c-org/infrastructure/issues/4993