### PR TITLE
Add pagerduty and prometheus integration info to support chart secrets

### DIFF
--- a/helm-charts/support/enc-support.secret.values.yaml
+++ b/helm-charts/support/enc-support.secret.values.yaml
@@ -1,16 +1,20 @@
 grafana:
-  adminPassword: ENC[AES256_GCM,data:vuzbI2lRpVSihmzQmQ38BD7N2rKSQ5YR4UcgsyKWsQGQBA5yfZvVj8osDOjEYVoZLDijRI6IJHfqZ4SaFMMg8w==,iv:U9m6wTNVVJDiHufBeaD0nBPMTjleDu2pKcR8G83/H1s=,tag:BDflHP0IzmNSRt5j2k9nrg==,type:str]
+  adminPassword: ENC[AES256_GCM,data:B+8/JqM4p6FytAp+8Ec4qzVKANZTVGuaHKMm7vyamhA2Wid5VBiRfIzghPXRxOakPtp8iTXqdO0I/AVu+HQDuA==,iv:ojVQ9u+cCGJeo/e8MbX4LKfKejXq/kjB2wtpjpNsCHA=,tag:Uggw1CS1+fmQdN0GsLhN9w==,type:str]
+pagerduty-prometheus-integration:
+  integrationName: ENC[AES256_GCM,data:REEthqjPY3MEnA==,iv:KTals1+rPcGMAlT8zR5f6Y5RbhWuR9+QkxFQ59L7u/U=,tag:PynUx7lYUgcEmsLsnP+Z3g==,type:str]
+  integrationKey: ENC[AES256_GCM,data:RRwGXmQghrayoyHGnuPgnH7mkTA68m10ZHyCOn6fJMw=,iv:gLrxOnT6hvAKHSpC6x2mZxfHL/8O00QJU+BBMFo77S0=,tag:bE0YoHvelMLFDWUwSDDPvA==,type:str]
+  integrationUrl: ENC[AES256_GCM,data:+7kaZ0QGYlyrUpjBBDyZVvnZPIbyjBOUP8FP8DhwhVcSpIdOJn4Koq8NvVJxuTMBgbJiIn3JuVB1bkJCUIVqfW0=,iv:L5QgYp3IvKmwd1GZuv7n0nIXwcrtKeGx7wY+XSDvjjw=,tag:zFhdkN4XXmnaV8xyuW5+fQ==,type:str]
 sops:
   kms: []
   gcp_kms:
     - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2021-06-16T12:29:14Z"
-      enc: CiQA4OM7eOWv40yySpNyEbCz1opatQP5+t5LrofdgGRay6VmYBgSSQB6TpsYWgnbo18yEE/gn9tYk5gkuqm/Jg3DPAXDWmyDDb819DrTw17vDUc/yBxmRrxaCVfsefMLV5PSejDvszU8WGwJgYUq01Y=
+      created_at: "2024-12-05T10:40:02Z"
+      enc: CiUA4OM7eJ4G+2WdZ9oThEMrrlJSek0IrnRDykmPQYXW99zmb8HQEkkAnGhyNt6qUGehjrI1ovZKXU0p+cr5JwiFBA8PQs/3FR4Rdcy1ZX45Ed0sModB4VvWQlG9WgMC+75fzStuUUZUDtGsV9xvZeM0
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2021-06-16T12:32:16Z"
-  mac: ENC[AES256_GCM,data:XTX8q2v21rNSzFqIUegqpk0Ne2erEKbxm42LnEu+lpGIdQ4dw1ebsri8WslalOAxklZYPXut+zOV6E0gyoiLmJO9dblj/HgdInDqf42AjS91RUSGXQH2otz6ajmU0GrUHehSAVRC7tRKqgp819NudNmcgfdF32N9g1W1Mab0z8s=,iv:FPv2Jjxgsa0mk+n9eOoaAvtCTY2RDOyjB0BY+bz2hv4=,tag:qgoq9CduOQbQcX5Vr8sXoA==,type:str]
+  lastmodified: "2024-12-05T10:40:02Z"
+  mac: ENC[AES256_GCM,data:6rssn9qvZh2ekypkcMmGhoNwGjhGqs85Ld1R1zkIpwx670rTubJlvmFsyslGuqU4JJJ1aJ8A/KKtlMJMjhyGpLGA1krKWf9tgV0E3G/GAk2kR6h/lbdCfPhR+DsHdOAlWuHZTFz2bJuBKboi1znoNoOSKI+32WU6kFNnkcEqgTI=,iv:EAfU8mGbWegtCqu0M4DAjy29cEOJBMgM8/32vRAZf4Y=,tag:E0FtNKt80cRcw9kRXMjW7w==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.9.1


### PR DESCRIPTION
This information could be used by prometheus alertmanager to send automatic alerts

Set up following these instructions: https://www.pagerduty.com/docs/guides/prometheus-integration-guide/

related to #5062 