### PR TITLE
Revert "[pre-commit.ci] pre-commit autoupdate"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 repos:
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0 # Don't upgrade, v4 causes "No files matching [...]" issues
     hooks:
       - id: prettier
 


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#5215

Realised the error described in the comment _does_ still persist, but only if the hooks are installed locally, e.g. you have run `pre-commit install` and they automatically execute whenever you run `git commit`. (I don't usually do this but unwittingly ran it while testing.)