### PR TITLE
[2i2c, ohw] Update Python image

### DIFF
--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -26,7 +26,7 @@ basehub:
           description: "~2 CPU, ~8G RAM"
           default: true
           kubespawner_override:
-            image: "ghcr.io/oceanhackweek/python:b07027b"
+            image: "ghcr.io/oceanhackweek/python:c881ad5"
             default_url: "/lab"
             mem_limit: 8G
             mem_guarantee: 4G


### PR DESCRIPTION
A final Python image update, to leave the OHW hub in a cleaner and more up-to-date state after the end of the OHW-in-spanish event.

xref https://github.com/oceanhackweek/jupyter-image/pull/102 and #5052

@jnywong would you be able to do this one last PR? No rush.