### PR TITLE
Use 2i2c-bot PAT token instead

### DIFF
--- a/.github/workflows/project-board-update.yml
+++ b/.github/workflows/project-board-update.yml
@@ -3,15 +3,10 @@ on:
   issues:
     types:
       - labeled
-      # Issues opened by recurrent workflows don't trigger a labeled event
-      # so we check opened issues as well
-      - opened
 
 jobs:
   update-project-board-fields:
-    if: >
-      (github.event.action == "opened" && contains(github.event.issue.labels.*.name, "recurrent")) ||
-      (github.event.action == "labeled" && github.event.label.name == "recurrent")
+    if: github.event.label.name == 'recurrent'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/recurrent-get-billing-data.yaml
+++ b/.github/workflows/recurrent-get-billing-data.yaml
@@ -23,7 +23,7 @@ jobs:
             --title "[Billing] Dedicated clusters: collect billing data for $NEXT_MONTH" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NEXT_MONTH: ${{ env.next_month }}
           BODY: |
@@ -41,7 +41,7 @@ jobs:
             --title "[Billing] Shared clusters: collect billing data for $NEXT_MONTH" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NEXT_MONTH: ${{ env.next_month }}
           BODY: |

--- a/.github/workflows/recurrent-regenerate-smce-creds-issue.yaml
+++ b/.github/workflows/recurrent-regenerate-smce-creds-issue.yaml
@@ -26,7 +26,7 @@ jobs:
             --title "[$DEADLINE] Regenerate SMCE credentials" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GEO_PAT }}
           GH_REPO: ${{ github.repository }}
           DEADLINE: ${{ env.deadline }}
           BODY: |

--- a/.github/workflows/recurrent-regenerate-smce-creds-issue.yaml
+++ b/.github/workflows/recurrent-regenerate-smce-creds-issue.yaml
@@ -26,7 +26,7 @@ jobs:
             --title "[$DEADLINE] Regenerate SMCE credentials" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GEO_PAT }}
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
           DEADLINE: ${{ env.deadline }}
           BODY: |


### PR DESCRIPTION
Otherwise a labeled event is not triggered and it makes filtering these issues in other workflows harder
Ref https://github.com/2i2c-org/infrastructure/issues/4905, follow-up to https://github.com/2i2c-org/infrastructure/pull/5259