### PR TITLE
bump oauthenticator to 17.3 in pkce-experiment

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.11169.h1e0fa323
+      tag: 0.0.1-0.dev.git.11270.hac9ace7f
     allowNamedServers: true
     config:
       JupyterHub:

--- a/helm-charts/images/hub/pkce-requirements.txt
+++ b/helm-charts/images/hub/pkce-requirements.txt
@@ -1,9 +1,8 @@
 # Image lives at quay.io/2i2c/pkce-experiment
-# install oauthenticator 17.1,
-# which adds PKCE support.
-# experiment no longer needed when base chart is updated to z2jh 4.0.0
-# Experiment with https://github.com/jupyterhub/oauthenticator/pull/780 and oauthenticator 17.2
-git+https://github.com/minrk/oauthenticator@refresh-skip
+# install oauthenticator 17.3,
+# which adds PKCE and refresh_token support
+# experiment no longer needed when base chart is updated to z2jh 4.1.0
+oauthenticator>=17.3,<18
 
 
 # jupyterhub-configurator isn't maintained and its not intended to be developed


### PR DESCRIPTION
for refresh_user_hook, no longer needs to install from an open PR

needs manual step from 2i2c folks to publish the image, then we can bump `hub.image.tag` in jupyter-health [here](https://github.com/2i2c-org/infrastructure/blob/5589b061195d80c0bdaed831b264243d9ca66430/config/clusters/jupyter-health/common.values.yaml#L46)