### PR TITLE
[dubois] Have ephemeral hub's display name be unique

### DIFF
--- a/config/clusters/dubois/cluster.yaml
+++ b/config/clusters/dubois/cluster.yaml
@@ -40,7 +40,7 @@ hubs:
       - prod.values.yaml
       - enc-prod.secret.values.yaml
   - name: ephemeral
-    display_name: Dubois
+    display_name: Dubois ephemeral
     domain: dubois.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:


### PR DESCRIPTION
This fixes the current documentation build failure.
Example: https://readthedocs.org/projects/2i2c-pilot-hubs/builds/26559130/.

It looks like the display name is used as an index in the hubs table and must be unique