### PR TITLE
Refactoring deployer exec root-homes command

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -384,6 +384,30 @@ setup or an outage), or when taking down a hub.
 All these commands take a cluster and hub name as parameters, and perform appropriate
 authentication before performing their function.
 
+#### `exec hub`
+
+This subcommand gives you an interactive shell on the hub pod itself, so you
+can poke around to see what's going on. Particularly useful if you want to peek
+at the hub db with the `sqlite` command.
+
+#### `exec homes`
+
+This subcommand gives you a shell with the home directories of all the
+users on the given hub in the given cluster mounted under `/home`.
+Very helpful when doing (rare) manual operations on user home directories,
+such as renames.
+
+When you exit the shell, the temporary pod spun up is removed.
+
+#### `exec root-homes`
+
+Similar to `exec homes` but mounts the _entire_ NFS filesystem to `/root-homes`.
+You can optionally mount a secondary NFS share if required, which is useful when migrating data across servers.
+
+#### `exec aws`
+
+This sub-command can exec into a shell with appropriate AWS credentials (including MFA).
+
 #### `exec debug`
 
 This sub-command is useful for debugging.
@@ -409,28 +433,6 @@ Building docker images locally can be *extremely* slow and frustrating. We run a
 in our 2i2c cluster that can be accessed via this command, and speeds up image builds quite a bit!
 Once you run this command, run `export DOCKER_HOST=tcp://localhost:23760` in another terminal to use the faster remote
 docker daemon.
-
-#### `exec shell`
-This exec sub-command can be used to acquire a shell in various places of the infrastructure.
-
-##### `exec shell hub`
-
-This subcommand gives you an interactive shell on the hub pod itself, so you
-can poke around to see what's going on. Particularly useful if you want to peek
-at the hub db with the `sqlite` command.
-
-##### `exec shell homes`
-
-This subcommand gives you a shell with the home directories of all the
-users on the given hub in the given cluster mounted under `/home`.
-Very helpful when doing (rare) manual operations on user home directories,
-such as renames.
-
-When you exit the shell, the temporary pod spun up is removed.
-
-##### `exec shell aws`
-
-This sub-command can exec into a shall with appropriate AWS credentials (including MFA).
 
 ## Running Tests
 

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -40,12 +40,11 @@ def root_homes(
     with open(config_file_path) as f:
         cluster = Cluster(yaml.load(f), config_file_path.parent)
 
-    with cluster.auth():
-        hubs = cluster.hubs
-        hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
-        if not hub:
-            print_colour("Hub does not exist in {cluster_name} cluster}")
-            return
+    hubs = cluster.hubs
+    hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
+    if not hub:
+        print_colour("Hub does not exist in {cluster_name} cluster}")
+        return
 
     server_ip = base_share_name = ""
     for values_file in hub.spec["helm_chart_values_files"]:

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -141,7 +141,7 @@ def root_homes(
 
         with cluster.auth():
             try:
-                # Ask kube-controller to create a pod
+                # Ask api-server to create a pod
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
                 # Exec into pod
                 subprocess.check_call(exec_cmd)

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -23,8 +23,8 @@ UBUNTU_IMAGE = "ubuntu:22.04"
 def root_homes(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
-    rm_pod: bool = typer.Option(
-        False, "--rm", help="Automatically delete the pod after completing"
+    persist: bool = typer.Option(
+        False, "--persist", help="Do not automatically delete the pod after completing. Useful for long-running processes."
     ),
     extra_nfs_server: str = typer.Option(
         None, help="IP address of an extra NFS server to mount"
@@ -144,7 +144,7 @@ def root_homes(
                 # Exec into pod
                 subprocess.check_call(exec_cmd)
             finally:
-                if rm_pod:
+                if not persist:
                     delete_pod(pod_name, hub_name)
 
 

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -193,7 +193,7 @@ def homes(
         "-n",
         hub_name,
         "run",
-        "--rm",  # Remove pod when we're done
+        "--rm",  # Deletes the pod when the process completes, successfully or otherwise
         "-it",  # Give us a shell!
         "--overrides",
         json.dumps(pod),

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -119,14 +119,9 @@ def root_homes(
         },
     }
 
-    # Ask kube-controller to create a pod
-    create_cmd = ["kubectl", "create", "-f"]
-
     # Dump the pod spec to a temporary file
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmpf:
         json.dump(pod, tmpf)
-
-    create_cmd.append(tmpf.name)
 
     # Command to exec into pod
     exec_cmd = [
@@ -142,7 +137,8 @@ def root_homes(
     ]
 
     with cluster.auth():
-        subprocess.check_call(create_cmd)
+        # Ask kube-controller to create a pod
+        subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
         subprocess.check_call(exec_cmd)
 
         # I want to ensure this code runs event if the exec cmd returns an exit code other than 0

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -1,7 +1,7 @@
 import json
 import os
-import tempfile
 import subprocess
+import tempfile
 
 import typer
 from ruamel.yaml import YAML
@@ -23,7 +23,9 @@ UBUNTU_IMAGE = "ubuntu:22.04"
 def root_homes(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
-    rm_pod: bool = typer.Option(False, "--rm", help="Automatically delete the pod after completing"),
+    rm_pod: bool = typer.Option(
+        False, "--rm", help="Automatically delete the pod after completing"
+    ),
     extra_nfs_server: str = typer.Option(
         None, help="IP address of an extra NFS server to mount"
     ),
@@ -128,7 +130,15 @@ def root_homes(
 
     # Command to exec into pod
     exec_cmd = [
-        "kubectl", "-n", hub_name, "exec", "-it", pod_name, "--", "/bin/bash", "-l"
+        "kubectl",
+        "-n",
+        hub_name,
+        "exec",
+        "-it",
+        pod_name,
+        "--",
+        "/bin/bash",
+        "-l",
     ]
 
     with cluster.auth():

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -22,13 +22,13 @@ UBUNTU_IMAGE = "ubuntu:22.04"
 def root_homes(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
-    extra_nfs_server: str = typer.Argument(
+    extra_nfs_server: str = typer.Option(
         None, help="IP address of an extra NFS server to mount"
     ),
-    extra_nfs_base_path: str = typer.Argument(
+    extra_nfs_base_path: str = typer.Option(
         None, help="Path of the extra NFS share to mount"
     ),
-    extra_nfs_mount_path: str = typer.Argument(
+    extra_nfs_mount_path: str = typer.Option(
         None, help="Mount point for the extra NFS share"
     ),
 ):

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -141,6 +141,15 @@ def root_homes(
 
         with cluster.auth():
             try:
+                # We are splitting the previous `kubectl run` command into a
+                # create and exec couplet, because using run meant that the bash
+                # process we start would be assigned PID 1. This is a 'special'
+                # PID and killing it is equivalent to sending a shutdown command
+                # that will cause the pod to restart, killing any processes
+                # running in it. By using create then exec instead, we will be
+                # assigned a PID other than 1 and we can safely exit the pod to
+                # leave long-running processes if required.
+                #
                 # Ask api-server to create a pod
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
                 # Exec into pod

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -23,6 +23,7 @@ UBUNTU_IMAGE = "ubuntu:22.04"
 def root_homes(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
+    rm_pod: bool = typer.Option(False, "--rm", help="Automatically delete the pod after completing"),
     extra_nfs_server: str = typer.Option(
         None, help="IP address of an extra NFS server to mount"
     ),
@@ -134,6 +135,9 @@ def root_homes(
         subprocess.check_call(create_cmd)
         subprocess.check_call(exec_cmd)
 
+        # I want to ensure this code runs event if the exec cmd returns an exit code other than 0
+        if rm_pod:
+            delete_pod(pod_name, hub_name)
 
     # I want to ensure this code runs event if the exec cmd returns an exit code other than 0
     # Delete temporary pod spec file

--- a/docs/howto/features/storage-quota.md
+++ b/docs/howto/features/storage-quota.md
@@ -82,7 +82,7 @@ Here's an example of how to do this:
 
 ```bash
 # Create a throwaway pod with both the existing home directories and the new NFS server mounted
-deployer exec root-homes <cluster_name> <hub_name> --extra_nfs_server=<nfs_service_ip> --extra_nfs_base_path=/ --extra_nfs_mount_path=/new-nfs-volume
+deployer exec root-homes <cluster_name> <hub_name> --extra-nfs-server=<nfs_service_ip> --extra-nfs-base-path=/ --extra-nfs-mount-path=/new-nfs-volume
 
 # Copy the existing home directories to the new NFS server while keeping the original permissions
 rsync -av --info=progress2 /root-homes/<path-to-the-parent-of-user-home-directories> /new-nfs-volume/


### PR DESCRIPTION
- Addresses an action point in https://github.com/2i2c-org/meta/issues/1671
- Splits up the `kubectl run` command into a `create` and `exec` couplet. This means that the bash process we start will not be PID 1, therefore we can safely exit the pod without causing it to restart (which was happening before). This is because PID 1 is special, and killing it is the same as sending a shutdown command which was causing the pod to restart.
- Adds an `--persist` option to NOT cleanup the pod on completion if required
