### PR TITLE
Improve NFS home directory restore documentation

### DIFF
--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -200,18 +200,24 @@ def root_homes(
         tmpf.flush()
 
         with cluster.auth():
-            # If we have an volume to restore from, create PV and PVC first
-            if restore_volume_id:
-                with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as pv_tmpf:
-                    json.dump(pv, pv_tmpf)
-                    pv_tmpf.flush()
-                    subprocess.check_call(["kubectl", "create", "-f", pv_tmpf.name])
-
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as pvc_tmpf:
-                json.dump(pvc, pvc_tmpf)
-                pvc_tmpf.flush()
-                subprocess.check_call(["kubectl", "create", "-f", pvc_tmpf.name])
             try:
+                # If we have an volume to restore from, create PV and PVC first
+                if restore_volume_id:
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".json"
+                    ) as pv_tmpf:
+                        json.dump(pv, pv_tmpf)
+                        pv_tmpf.flush()
+                        subprocess.check_call(["kubectl", "create", "-f", pv_tmpf.name])
+
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".json"
+                    ) as pvc_tmpf:
+                        json.dump(pvc, pvc_tmpf)
+                        pvc_tmpf.flush()
+                        subprocess.check_call(
+                            ["kubectl", "create", "-f", pvc_tmpf.name]
+                        )
                 # We are splitting the previous `kubectl run` command into a
                 # create and exec couplet, because using run meant that the bash
                 # process we start would be assigned PID 1. This is a 'special'

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -204,8 +204,8 @@ def root_homes(
             if restore_volume_id:
                 with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as pv_tmpf:
                     json.dump(pv, pv_tmpf)
-                pv_tmpf.flush()
-                subprocess.check_call(["kubectl", "create", "-f", pv_tmpf.name])
+                    pv_tmpf.flush()
+                    subprocess.check_call(["kubectl", "create", "-f", pv_tmpf.name])
 
             with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as pvc_tmpf:
                 json.dump(pvc, pvc_tmpf)

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -224,8 +224,18 @@ def root_homes(
                 # Ask api-server to create a pod
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
 
-                # FIXME: Add a wait condition so that the pod is Running before
-                #        we exec into it, otherwise the exec will fail
+                # wait for the pod to be ready
+                subprocess.check_call(
+                    [
+                        "kubectl",
+                        "wait",
+                        "-n",
+                        hub_name,
+                        f"pod/{pod_name}",
+                        "--for=condition=Ready",
+                        "--timeout=90s",
+                    ]
+                )
 
                 # Exec into pod
                 subprocess.check_call(exec_cmd)

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -227,13 +227,14 @@ def root_homes(
                 subprocess.check_call(exec_cmd)
             finally:
                 if not persist:
+                    delete_pod(pod_name, hub_name)
                     # Clean up PV and PVC if we created them
                     if restore_volume_id:
                         subprocess.check_call(
                             ["kubectl", "-n", hub_name, "delete", "pvc", pv_name]
                         )
                         subprocess.check_call(["kubectl", "delete", "pv", pv_name])
-                    delete_pod(pod_name, hub_name)
+
 
 
 @exec_app.command()

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -45,9 +45,6 @@ def root_homes(
     additional_volume_mount_path: str = typer.Option(
         "/additional-volume", help="Mount point for the volume"
     ),
-    additional_volume_size: str = typer.Option(
-        default="100Gi", help="Size of the volume"
-    ),
 ):
     """
     Pop an interactive shell with the entire nfs file system of the given cluster mounted on /root-homes
@@ -101,7 +98,12 @@ def root_homes(
             "kind": "PersistentVolume",
             "metadata": {"name": pv_name},
             "spec": {
-                "capacity": {"storage": additional_volume_size},
+                # We intentionally set the size to 1Mi to avoid having to
+                # specify and match the size of the underlying disk
+                # This doesn't trigger a resize of the underlying disk
+                # as long as the size matches the specified capacity
+                # of the PVC.
+                "capacity": {"storage": "1Mi"},
                 "volumeMode": "Filesystem",
                 "accessModes": ["ReadWriteOnce"],
                 "persistentVolumeReclaimPolicy": "Retain",
@@ -133,7 +135,12 @@ def root_homes(
                 "accessModes": ["ReadWriteOnce"],
                 "volumeName": pv_name,
                 "storageClassName": "",
-                "resources": {"requests": {"storage": "120Gi"}},
+                # We intentionally set the size to 1Mi to avoid having to
+                # specify and match the size of the underlying disk
+                # This doesn't trigger a resize of the underlying disk
+                # as long as the size matches the specified capacity
+                # of the PV.
+                "resources": {"requests": {"storage": "1Mi"}},
             },
         }
 

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -225,6 +225,7 @@ def root_homes(
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
 
                 # wait for the pod to be ready
+                print_colour("Waiting for the pod to be ready...", "yellow")
                 subprocess.check_call(
                     [
                         "kubectl",

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -223,7 +223,7 @@ def root_homes(
                 #
                 # Ask api-server to create a pod
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
-                
+
                 # FIXME: Add a wait condition so that the pod is Running before
                 #        we exec into it, otherwise the exec will fail
 
@@ -238,7 +238,6 @@ def root_homes(
                             ["kubectl", "-n", hub_name, "delete", "pvc", pv_name]
                         )
                         subprocess.check_call(["kubectl", "delete", "pv", pv_name])
-
 
 
 @exec_app.command()

--- a/deployer/commands/exec/infra_components.py
+++ b/deployer/commands/exec/infra_components.py
@@ -223,6 +223,10 @@ def root_homes(
                 #
                 # Ask api-server to create a pod
                 subprocess.check_call(["kubectl", "create", "-f", tmpf.name])
+                
+                # FIXME: Add a wait condition so that the pod is Running before
+                #        we exec into it, otherwise the exec will fail
+
                 # Exec into pod
                 subprocess.check_call(exec_cmd)
             finally:

--- a/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
+++ b/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
@@ -28,7 +28,7 @@ Please follow AWS's guidance for [restoring EBS volumes from a snapshot](https:/
 Once we have created a new EBS volume from the snapshot, we can use the `deployer exec root-homes` command to mount the new EBS volume to a pod along with the existing NFS home directories volume.
 
 ```bash
-deployer exec root-homes $CLUSTER_NAME $HUB_NAME --restore-volume-id=<new-ebs-volume-id> --restore-mount-path=/restore-volume --restore-volume-size=100Gi
+deployer exec root-homes $CLUSTER_NAME $HUB_NAME --additional-volume-id=<new-ebs-volume-id> --additional-volume-mount-path=/restore-volume
 ```
 
 Now, the NFS home directories volume is mounted to the pod along with the new EBS volume. We can now copy the contents from the restored EBS volume to the NFS home directories volume.

--- a/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
+++ b/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
@@ -25,18 +25,24 @@ To restore a home directory from a snapshot, we need to create a new EBS volume 
 Please follow AWS's guidance for [restoring EBS volumes from a snapshot](https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/restore.html#restore-files) to create a new EBS volume from the snapshot.
 ```
 
-Once we have created a new EBS volume from the snapshot, we need to mount it to the EC2 instance attached to the existing EBS volume containing the NFS home directories. To do this, we need to find the instance ID of the EC2 instance attached to the existing EBS volume. This involves the following steps:
-
-1. Go to the EBS volumes page in the AWS console
-2. Find the volume ID of the existing EBS volume containing the NFS home directories
-3. Click on the volume ID and find the instance ID in the "Attached resources" section
-4. Once we have the instance ID, we can mount the new EBS volume to the EC2 instance by following the steps outlined in the [Attaching an Amazon EBS volume to an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-attaching-volume.html) guide.
-
-Once we have mounted the new EBS volume to the EC2 instance, we can copy the contents from the restored EBS volume to the NFS home directories volume. This can be done by running the following commands on the EC2 instance:
+Once we have created a new EBS volume from the snapshot, we can use the `deployer exec` command to mount the new EBS volume to a pod along with the existing NFS home directories volume.
 
 ```bash
-# Copy the contents from the restored EBS volume to the NFS home directories volume
-rsync -av --info=progress2 </restored-volume/path-to-home-directories/> </existing-volume/path-to-home-directories/>
+deployer exec root-homes <cluster_name> <hub_name> --restore-volume-id=<new-ebs-volume-id> --restore-mount-path=/restore-volume --restore-volume-size=100Gi
+```
+
+Now, the NFS home directories volume is mounted to the pod along with the new EBS volume. We can now copy the contents from the restored EBS volume to the NFS home directories volume.
+
+If we want to do a full restore and/or we are restoring data to a new and empty NFS home directories volume, we can use the following command to copy everything from the restored EBS volume to the NFS home directories volume.
+
+```bash
+rsync -av --info=progress2 /restore-volume/ /root-homes/
+```
+
+If we want to do a partial restore and we are restoring only a subset of the data to an existing NFS home directories volume, we can use the following command to copy only the necessary data from the restored EBS volume to the NFS home directories volume.
+
+```bash
+rsync -av --info=progress2 /restore-volume/<path-to-restore> /root-homes/<path-to-restore>
 ```
 
 Once we have copied the contents from the restored EBS volume to the NFS home directories volume, we can delete the EBS volume that was created from the snapshot.

--- a/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
+++ b/docs/howto/filesystem-management/filesystem-backups/restore-filesystem.md
@@ -25,10 +25,10 @@ To restore a home directory from a snapshot, we need to create a new EBS volume 
 Please follow AWS's guidance for [restoring EBS volumes from a snapshot](https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/restore.html#restore-files) to create a new EBS volume from the snapshot.
 ```
 
-Once we have created a new EBS volume from the snapshot, we can use the `deployer exec` command to mount the new EBS volume to a pod along with the existing NFS home directories volume.
+Once we have created a new EBS volume from the snapshot, we can use the `deployer exec root-homes` command to mount the new EBS volume to a pod along with the existing NFS home directories volume.
 
 ```bash
-deployer exec root-homes <cluster_name> <hub_name> --restore-volume-id=<new-ebs-volume-id> --restore-mount-path=/restore-volume --restore-volume-size=100Gi
+deployer exec root-homes $CLUSTER_NAME $HUB_NAME --restore-volume-id=<new-ebs-volume-id> --restore-mount-path=/restore-volume --restore-volume-size=100Gi
 ```
 
 Now, the NFS home directories volume is mounted to the pod along with the new EBS volume. We can now copy the contents from the restored EBS volume to the NFS home directories volume.


### PR DESCRIPTION
Also adds the option to mount an EBS volume to a pod through the `deployer exec root-homes` command.

Follow up for https://github.com/2i2c-org/infrastructure/pull/5286. Related to https://github.com/2i2c-org/infrastructure/issues/5061.

@yuvipanda @sgibson91 - This is still a draft and I haven't really tested this but does the overall approach look ok?