### PR TITLE
Collect GPU usage metrics with prometheus

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -62,5 +62,6 @@ dependencies:
   # Provide metrics about GPU usage
   # https://github.com/NVIDIA/dcgm-exporter
   - name: dcgm-exporter
-    version: 3.6.1
+    version: 4.8.1
     repository: https://nvidia.github.io/dcgm-exporter/helm-charts
+    condition: dcgm-exporter.enabled

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -58,3 +58,9 @@ dependencies:
     version: "v1.1.1"
     repository: https://2i2c.org/jupyterhub-cost-monitoring/
     condition: jupyterhub-cost-monitoring.enabled
+
+  # Provide metrics about GPU usage
+  # https://github.com/NVIDIA/dcgm-exporter
+  - name: dcgm-exporter
+    version: 3.6.1
+    repository: https://nvidia.github.io/dcgm-exporter/helm-charts

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -42,6 +42,9 @@ properties:
   global:
     type: object
     additionalProperties: true
+  dcgm-exporter:
+    type: object
+    additionalProperties: true
 
   # These provide values for objects we create, so we validate their schema
   # to the best of our ability.

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -461,6 +461,20 @@ jupyterhub-cost-monitoring:
     cpu: 5m
     memory: 100Mi
 
+dcgm-exporter:
+  serviceMonitor:
+    enabled: false
+  podAnnotations:
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "12121"
+    prometheus.io/scrape: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Equal
+    value: present
+    effect: NoSchedule
+
+
 # Configuration of templates provided directly by this chart
 # -------------------------------------------------------------------------------
 #

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -462,6 +462,7 @@ jupyterhub-cost-monitoring:
     memory: 100Mi
 
 dcgm-exporter:
+  enabled: false
   serviceMonitor:
     enabled: false
   podAnnotations:


### PR DESCRIPTION
We use [prometheus node exporter](https://github.com/prometheus/node_exporter), deployed as part of our prometheus chart, to collect metrics about CPU and memory usage.

This deploys NVIDIA's [dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter) which collects information about GPU usage.

As we work towards more cost monitoring and usage monitoring, collecting this information should allow us to help users get more bang for the buck from their GPU use. Since we only collect information after the exporters are deployed, this starts the information collection process even if it's not directly visible to end users.

Works towards https://2i2c.productboard.com/entity-detail/features/30046512, initially requested as part of https://2i2c.freshdesk.com/a/tickets/2545.