### PR TITLE
Update url for billing issue template

### DIFF
--- a/.github/workflows/recurrent-get-billing-data.yaml
+++ b/.github/workflows/recurrent-get-billing-data.yaml
@@ -32,7 +32,7 @@ jobs:
           NEXT_MONTH: ${{ env.next_month }}
           BODY: |
             ### Context
-            - Dedicated clusters [instructions](https://infrastructure.2i2c.org/howto/bill/#communities-with-dedicated-cloud-accounts)  
+            - Dedicated clusters [instructions](https://infrastructure.2i2c.org/howto/budgeting-billing/bill/#communities-with-dedicated-cloud-accounts)  
 
             ### Definition of Done
             - [ ] Billing data is collected according to instructions.


### PR DESCRIPTION
Fix the url to point to https://infrastructure.2i2c.org/howto/budgeting-billing/bill/#communities-with-dedicated-cloud-accounts