### PR TITLE
[jupyter-health] Update the hub hub image with one that has JupyterHub 5

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -43,7 +43,7 @@ jupyterhub:
     #
     image:
       name: quay.io/2i2c/pkce-experiment
-      tag: 0.0.1-0.dev.git.11270.hac9ace7f
+      tag: 0.0.1-0.dev.git.11432.h4b995d69
     allowNamedServers: true
     config:
       JupyterHub:


### PR DESCRIPTION
Follow-up to #5292 