### PR TITLE
Provision EBS disk for nasa veda prod home directories

### DIFF
--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -218,6 +218,12 @@ ebs_volumes = {
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name" : "staging" }
+  },
+  "prod" = {
+    size        = 3000  # 3TB
+    type        = "gp3"
+    name_suffix = "prod"
+    tags        = { "2i2c:hub-name" : "prod" }
   }
 }
 

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -220,7 +220,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 3000  # 3TB
+    size        = 3000 # 3TB
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -220,7 +220,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 3000 # 3TB
+    size        = 2000 # 2TB
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }


### PR DESCRIPTION
Related to https://github.com/2i2c-org/infrastructure/issues/4857.

Creates a 3 TB EBS disk for `jupyterhub-home-nfs` to store the VEDA prod hub home directories.