### PR TITLE
Enable jupyterhub-home-nfs for VEDA prod hub

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -301,3 +301,10 @@ basehub:
       KubernetesBuildExecutor:
         node_selector:
           node.kubernetes.io/instance-type: r5.xlarge
+
+  jupyterhub-home-nfs:
+    enabled: true
+    eks:
+      enabled: true
+    prometheusExporter:
+      enabled: true

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -52,3 +52,10 @@ basehub:
     buildPodsRegistryCredentials:
       server: *url
       username: *username
+
+  jupyterhub-home-nfs:
+    eks:
+      volumeId: vol-0063ecd342e052ef5
+    quotaEnforcer:
+      hardQuota: "200" # in GB
+      path: "/export/prod"

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -79,12 +79,8 @@ basehub:
       username: *username
 
   jupyterhub-home-nfs:
-    enabled: true
     eks:
-      enabled: true
       volumeId: vol-0a1246ee2e07372d0
     quotaEnforcer:
       hardQuota: "10" # in GB
       path: "/export/staging"
-    prometheusExporter:
-      enabled: true


### PR DESCRIPTION
Related to https://github.com/2i2c-org/infrastructure/issues/4857 and https://github.com/2i2c-org/infrastructure/issues/4835.

The largest user directory is 196GB right now. So I've set the quota to 200GB.