### PR TITLE
Fix `tmpauthenticator` for JupyterHub 5

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1054,7 +1054,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.11322.hb977bf05"
+      tag: "0.0.1-0.dev.git.11481.heb8debe10"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1054,7 +1054,7 @@ jupyterhub:
         oauth_no_confirm: true
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: "0.0.1-0.dev.git.11481.heb8debe10"
+      tag: "0.0.1-0.dev.git.11483.he6dd1219b"
     networkPolicy:
       enabled: true
       # interNamespaceAccessLabels=accept makes the hub pod's associated

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -12,4 +12,4 @@ git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compati
 jupyterhub-fancy-profiles==0.4.0
 
 # Bring in latest tmpauthenticator to be compatible with jupyterhub 5
-git+https://github.com/jupyterhub/tmpauthenticator@205ba14610651b96eca1c62bd0d91458d672f0df
+git+https://github.com/yuvipanda/tmpauthenticator@37b8564bdcfd226de0dfb020e847d51e3bdb64de

--- a/helm-charts/images/hub/requirements.txt
+++ b/helm-charts/images/hub/requirements.txt
@@ -10,3 +10,6 @@
 git+https://github.com/yuvipanda/jupyterhub-configurator@backported-jh41-compatibility
 
 jupyterhub-fancy-profiles==0.4.0
+
+# Bring in latest tmpauthenticator to be compatible with jupyterhub 5
+git+https://github.com/jupyterhub/tmpauthenticator@205ba14610651b96eca1c62bd0d91458d672f0df


### PR DESCRIPTION
While `tmpauthenticator` has been fixed to work with JupyterHub 5, no release was made and it's not in z2jh.

I've created a branch of `tmpauthenticator` with only one commit (https://github.com/jupyterhub/tmpauthenticator/compare/main...yuvipanda:tmpauthenticator:v2) that bumps the version. That's what's needed there.

In addition, `allow_all` needs to be explicilty enabled now. I think `tmpauthenticator` should default this to True (as this is the point of `tmpauthenticator`) but don't think we need to work on that right now.

I think the follow-ups here are:

- [ ] Check if we have other hubs using `tmpauthenticator`, and fix their config
- [ ] Merge this PR to make sure our users are doing ok
- [ ] Make a release of `tmpauthenticator` (we can call it 1.1, than 2.0). Note this would be a tactical contribution, rather than a strategic one
- [ ] Use the released version of `tmpauthenticator` in our image
- [ ] Open an issue (or PR) in z2jh to use newer version of `tmpauthenticator`

