### PR TITLE
Set allow_all to true to preserve desired behaviour of tmpauthenticator in a JupyterHub 5 setup

### DIFF
--- a/config/clusters/dubois/ephemeral.values.yaml
+++ b/config/clusters/dubois/ephemeral.values.yaml
@@ -15,6 +15,8 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: tmp
+      Authenticator:
+        allow_all: True
   custom:
     singleuserAdmin:
       # Turn off trying to mount shared-readwrite folder for admins

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -105,3 +105,5 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: tmp
+      Authenticator:
+        allow_all: True

--- a/docs/howto/features/ephemeral.md
+++ b/docs/howto/features/ephemeral.md
@@ -38,6 +38,8 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: tmp
+      Authenticator:
+        allow_all: True
 ```
 
 


### PR DESCRIPTION
Related to https://github.com/2i2c-org/infrastructure/pull/5385 and #5292 