### PR TITLE
new: additional oauth2 config for earthscope-sdk support

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -45,6 +45,7 @@ basehub:
         001-username-claim: |
           from oauthenticator.generic import GenericOAuthenticator
           from traitlets import List, Unicode
+          from urllib.parse import urlparse
 
           class CustomGenericOAuthenticator(GenericOAuthenticator):
             # required_scopes functionality comes in from https://github.com/jupyterhub/oauthenticator/pull/719
@@ -90,14 +91,25 @@ basehub:
               resp["groups"] = resp["auth_state"]["scope"]
               return resp
 
+          def get_base_url(url):
+              parts = urlparse(url)
+              return f"{parts.scheme}://{parts.netloc}"
+
           def populate_token(spawner, auth_state):
             # For our deployment-service-check health check user, there is no auth_state.
             # So these env variables need not be set.
             if auth_state:
+              base_url = get_base_url(spawner.token_url)
+              scope_str = " ".join(spawner.scope)
+
               token_env = {
-                'AUTH0_ACCESS_TOKEN': auth_state.get("access_token", ""),
-                'AUTH0_ID_TOKEN': auth_state.get("id_token", ""),
-                'AUTH0_REFRESH_TOKEN': auth_state.get('refresh_token', '')
+                'ES_OAUTH2__AUDIENCE': spawner.extra_authorize_params.get("audience", ""),
+                'ES_OAUTH2__CLIENT_ID': spawner.client_id,
+                'ES_OAUTH2__DOMAIN': base_url,
+                'ES_OAUTH2__SCOPE': scope_str,
+                'ES_OAUTH2__ACCESS_TOKEN': auth_state.get("access_token", ""),
+                'ES_OAUTH2__ID_TOKEN': auth_state.get("id_token", ""),
+                'ES_OAUTH2__REFRESH_TOKEN': auth_state.get('refresh_token', '')
               }
               spawner.environment.update(token_env)
 

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -95,13 +95,13 @@ basehub:
             # For our deployment-service-check health check user, there is no auth_state.
             # So these env variables need not be set.
             if auth_state:
-              url_parts = urlparse(spawner.token_url)
+              url_parts = urlparse(spawner.authenticator.token_url)
               base_url = f"{url_parts.scheme}://{url_parts.netloc}"
-              scope_str = " ".join(spawner.scope)
+              scope_str = " ".join(spawner.authenticator.scope)
 
               token_env = {
-                'ES_OAUTH2__AUDIENCE': spawner.extra_authorize_params.get("audience", ""),
-                'ES_OAUTH2__CLIENT_ID': spawner.client_id,
+                'ES_OAUTH2__AUDIENCE': spawner.authenticator.extra_authorize_params.get("audience", ""),
+                'ES_OAUTH2__CLIENT_ID': spawner.authenticator.client_id,
                 'ES_OAUTH2__DOMAIN': base_url,
                 'ES_OAUTH2__SCOPE': scope_str,
                 'ES_OAUTH2__ACCESS_TOKEN': auth_state.get("access_token", ""),

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -91,15 +91,12 @@ basehub:
               resp["groups"] = resp["auth_state"]["scope"]
               return resp
 
-          def get_base_url(url):
-              parts = urlparse(url)
-              return f"{parts.scheme}://{parts.netloc}"
-
           def populate_token(spawner, auth_state):
             # For our deployment-service-check health check user, there is no auth_state.
             # So these env variables need not be set.
             if auth_state:
-              base_url = get_base_url(spawner.token_url)
+              url_parts = urlparse(spawner.token_url)
+              base_url = f"{url_parts.scheme}://{url_parts.netloc}"
               scope_str = " ".join(spawner.scope)
 
               token_env = {


### PR DESCRIPTION
Hello,

I would like to add more of our oauth2 configuration into our container environment so that our SDK can automatically configure itself for the appropriate environment (staging vs. prod).

Based on our discussion with @yuvipanda on 2025/1/14, I put together this PR with the understanding that `spawner` is an instance of `CustomGenericOAuthenticator`. If this is not the case, please help me to achieve the following:

### New environment variables:

`ES_OAUTH2__AUDIENCE`: exact value from
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/common.values.yaml#L126

`ES_OAUTH2__CLIENT_ID`: exact value from
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/enc-staging.secret.values.yaml#L6

`ES_OAUTH2__DOMAIN`:just the base URL from, (i.e. https://login-dev.earthscope.org)
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/staging.values.yaml#L21

`ES_OAUTH2__SCOPE`: not entirely necessary, but values from this array concatenated as a single, space-delimited string
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/common.values.yaml#L113

### Rename env vars:

`ES_OAUTH2__ACCESS_TOKEN`: just rename env var
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/common.values.yaml#L98

`ES_OAUTH2__ID_TOKEN`: just rename env 
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/common.values.yaml#L99

`ES_OAUTH2__REFRESH_TOKEN`: just rename env var
https://github.com/2i2c-org/infrastructure/blob/d96a692e33500e28f3e4a29731826f9298a1f32d/config/clusters/earthscope/common.values.yaml#L100