### PR TITLE
VEDA: switch prod hub to jupyterhub-home-nfs

### DIFF
--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: 10.100.52.135
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::444055461661:role/nasa-veda-prod


### PR DESCRIPTION
Addresses https://github.com/2i2c-org/infrastructure/issues/4860

Switching over the VEDA prod hub to use the in-cluster NFS for home dirs, instead of the EFS instance.