### PR TITLE
Restore some custom hub login pages to use the original branch

### DIFF
--- a/config/clusters/2i2c/binderhub-ui-demo.values.yaml
+++ b/config/clusters/2i2c/binderhub-ui-demo.values.yaml
@@ -15,7 +15,7 @@ jupyterhub:
     binderhubUI:
       enabled: true
     homepage:
-      gitRepoBranch: "bootstrap5-no-homepage-subsection"
+      gitRepoBranch: "no-homepage-subsections"
       templateVars:
         org:
           name: Demo binderhub UI with binderhub-service

--- a/config/clusters/2i2c/ohw.values.yaml
+++ b/config/clusters/2i2c/ohw.values.yaml
@@ -53,7 +53,7 @@ basehub:
       jupyterhubConfigurator:
         enabled: false
       homepage:
-        gitRepoBranch: "bootstrap5-2i2c-ohw"
+        gitRepoBranch: "2i2c-ohw"
         templateVars:
           org:
             name: OceanHackWeek en español

--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -15,7 +15,7 @@ jupyterhub:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: "github"
     homepage:
-      gitRepoBranch: "bootstrap5-catalystproject-ES"
+      gitRepoBranch: "catalystproject-ES"
       templateVars:
         designed_by:
           name: "2i2c"

--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -27,7 +27,7 @@ basehub:
       jupyterhubConfigurator:
         enabled: false
       homepage:
-        gitRepoBranch: "bootstrap5-openscapes"
+        gitRepoBranch: "openscapes"
         templateVars:
           org:
             name: NASA Openscapes

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -9,7 +9,7 @@ basehub:
       jupyterhubConfigurator:
         enabled: false
       homepage:
-        gitRepoBranch: "bootstrap5-username-and-password-homepage"
+        gitRepoBranch: "username-and-password-homepage"
     ingress:
       hosts: [workshop.openscapes.2i2c.cloud]
       tls:

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -26,7 +26,7 @@ jupyterhub:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: github
     homepage:
-      gitRepoBranch: "bootstrap5-no-homepage-subsection"
+      gitRepoBranch: "no-homepage-subsections"
       templateVars:
         org:
           name: Ephemeral Interactive Computing for NASA Communities

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
         secretName: https-auto-tls
   custom:
     homepage:
-      gitRepoBranch: "bootstrap5-username-and-password-homepage"
+      gitRepoBranch: "username-and-password-homepage"
       templateVars:
         org:
           name: ScienceCore:climaterisk

--- a/config/clusters/victor/common.values.yaml
+++ b/config/clusters/victor/common.values.yaml
@@ -23,7 +23,7 @@ basehub:
       jupyterhubConfigurator:
         enabled: false
       homepage:
-        gitRepoBranch: "bootstrap5-victor"
+        gitRepoBranch: "victor"
         templateVars:
           org:
             name: VICTOR


### PR DESCRIPTION
This is so we can cleanup the ones we created for the bootstrap5 migration and not create confusion between what it's used and what not.

Ref: https://github.com/2i2c-org/infrastructure/issues/5368