### PR TITLE
[nasa-veda:staging] Go back to using custom landing page from veda-hub-homepage 

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -42,9 +42,8 @@ basehub:
           secretName: https-auto-tls
     custom:
       homepage:
-        gitRepoBranch: "bootstrap5-nasa-veda-staging"
-        # FIXME: use this repository again once the changes in the bootstrap5-nasa-veda-staging branch of 2i2c-org/default-hub-homepage have been ported to it
-        # gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
+        gitRepoBranch: "staging"
+        gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
 
   dask-gateway:
     gateway:


### PR DESCRIPTION
# Description
Fixing [this](https://github.com/2i2c-org/infrastructure/blob/main/config/clusters/nasa-veda/staging.values.yaml#L45-L47) since the [porting](https://github.com/NASA-IMPACT/veda-hub-homepage/pull/5) has been done

Doing staging and prod separately to make sure all is well in staging first.
