### PR TITLE
[nasa-veda:prod] Go back to using custom homepage from veda-hub-homepage

### DIFF
--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -13,9 +13,8 @@ basehub:
           secretName: https-auto-tls
     custom:
       homepage:
-        gitRepoBranch: "bootstrap5-nasa-veda-prod"
-        # FIXME: use this repository again once the changes in the bootstrap5-nasa-veda-prod branch of 2i2c-org/default-hub-homepage have been ported to it
-        # gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
+        gitRepoBranch: "master"
+        gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod


### PR DESCRIPTION
Please make sure https://github.com/2i2c-org/infrastructure/pull/5415 and https://github.com/NASA-IMPACT/veda-hub-homepage/pull/8 have been merged first