### PR TITLE
[veda-binder] Bring back imagebuilding config

### DIFF
--- a/config/clusters/nasa-veda/binder.values.yaml
+++ b/config/clusters/nasa-veda/binder.values.yaml
@@ -114,6 +114,9 @@ binderhub-service:
       auth_enabled: false
       enable_api_only_mode: false
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/veda-binder-
+    DockerRegistry:
+      url: &url https://quay.io
+      username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
     - name: JUPYTERHUB_API_TOKEN
       valueFrom:
@@ -128,3 +131,6 @@ binderhub-service:
     # appended to binderhub's URL instead of the hub's
     - name: JUPYTERHUB_BASE_URL
       value: "https://hub.binder.openveda.cloud"
+  buildPodsRegistryCredentials:
+    server: *url
+    username: *username


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/5422