### PR TITLE
Revert "[nasa-veda:staging] Go back to using custom landing page from veda-hub-homepage "

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -42,8 +42,9 @@ basehub:
           secretName: https-auto-tls
     custom:
       homepage:
-        gitRepoBranch: "staging"
-        gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
+        gitRepoBranch: "bootstrap5-nasa-veda-staging"
+        # FIXME: use this repository again once the changes in the bootstrap5-nasa-veda-staging branch of 2i2c-org/default-hub-homepage have been ported to it
+        # gitRepoUrl: "https://github.com/NASA-IMPACT/veda-hub-homepage"
 
   dask-gateway:
     gateway:


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#5415 as this is breaking staging per https://2i2c.slack.com/archives/C04R9B69T5W/p1737993301071959

cc @slesaad 