### PR TITLE
Dynamically name CI/CD jobs so the cluster/hub is more easily identifiable

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -198,6 +198,7 @@ jobs:
   upgrade-support:
     runs-on: ubuntu-latest
     needs: [generate-jobs]
+    name: "support-${{ matrix.jobs.cluster_name }}-${{ matrix.jobs.provider }}"
 
     # We declare outputs indicating the job failed status of a specific job
     # variation. We are currently required to do this in a hardcoded fashion,
@@ -423,6 +424,7 @@ jobs:
   upgrade-staging:
     runs-on: ubuntu-latest
     needs: [reset-jobs]
+    name: "${{ matrix.jobs.cluster_name }}-${{ matrix.jobs.hub_name }}-${{ matrix.jobs.provider }}"
     if: |
       !cancelled() &&
       (github.event_name == 'push' && contains(github.ref, 'main')) &&
@@ -600,6 +602,7 @@ jobs:
   upgrade-prod:
     runs-on: ubuntu-latest
     needs: [filter-failed-staging]
+    name: "${{ matrix.jobs.cluster_name }}-${{ matrix.jobs.hub_name }}-${{ matrix.jobs.provider }}"
     if: |
       !cancelled() &&
       (github.event_name == 'push' && contains(github.ref, 'main')) &&


### PR DESCRIPTION
- fixes #5437 