### PR TITLE
Allow veda cilogon client

### DIFF
--- a/deployer/commands/cilogon.py
+++ b/deployer/commands/cilogon.py
@@ -317,7 +317,14 @@ def find_duplicated_clients(clients):
     """
     client_names = [c["name"] for c in clients]
     client_names_count = Counter(client_names)
-    return [k for k, v in client_names_count.items() if v > 1]
+    return [
+        print(
+            f"Found a duplicated entry for {k}. Marking the unused client for deletion."
+        )
+        or k
+        for k, v in client_names_count.items()
+        if v > 1
+    ]
 
 
 def find_orphaned_clients(clients):
@@ -356,7 +363,10 @@ def find_orphaned_clients(clients):
                     f"A hub pertaining to client {client['name']} does NOT exist. Marking client for deletion."
                 )
                 clients_to_be_deleted.append(client)
-        else:
+        # This was a client requested to us by the upstream community
+        # that they are using. We should not delete it.
+        # https://github.com/2i2c-org/infrastructure/issues/5496
+        elif client["name"] != "VEDA Auth Prod":
             print(
                 f"A cluster pertaining to client {client['name']} does NOT exist. Marking client for deletion."
             )

--- a/deployer/utils/file_acquisition.py
+++ b/deployer/utils/file_acquisition.py
@@ -255,5 +255,7 @@ def get_cluster_names_list():
     Returns a list of all the clusters currently listed under config/clusters
     """
     return [
-        d.name for d, _, _ in CONFIG_CLUSTERS_PATH.walk() if "templates" not in str(d)
+        d.split("/")[-1]
+        for d, _, _ in os.walk(CONFIG_CLUSTERS_PATH)
+        if "templates" not in d
     ]


### PR DESCRIPTION
This fixes a small issue with the cleanup feature of the `cilogon-client deployer` utility and prevents marking the veda client for cleanup deletion.

This an atypical client for: https://github.com/2i2c-org/infrastructure/issues/5496