### PR TITLE
[tf, gcp]: Permit enabling automated backups of persistent disks via snapshots

### DIFF
--- a/docs/howto/filesystem-management/filesystem-backups/enable-backups.md
+++ b/docs/howto/filesystem-management/filesystem-backups/enable-backups.md
@@ -120,14 +120,14 @@ persistent_disks = {
 }
 ```
 
-Backups must be explicitly _disabled_ by adding `enable_nfs_backups = false`, like so:
+Backups must be explicitly _disabled_ by adding `disable_nfs_backups = true`, like so:
 
 ```
 persistent_disks = {
   "staging" = {
-    size        = 1
-    name_suffix = "staging"
-    enable_nfs_backups = false
+    size                = 1
+    name_suffix         = "staging"
+    disable_nfs_backups = true
   }
 }
 ```

--- a/docs/howto/filesystem-management/filesystem-backups/enable-backups.md
+++ b/docs/howto/filesystem-management/filesystem-backups/enable-backups.md
@@ -37,6 +37,8 @@ terraform apply -var-file=projects/$CLUSTER_NAME.tfvars
 (howto:filesystem-backups:enable:gcp)=
 ## GCP
 
+### Backup Filestores
+
 1. **Create relevant resources via terraform.**
 
    Our terraform configuration supports creating the relevant resources to support
@@ -90,7 +92,7 @@ terraform apply -var-file=projects/$CLUSTER_NAME.tfvars
 This will have successfully enabled automatic backups of GCP Filestores for this
 cluster.
 
-### Verify successful backups on GCP
+#### Verify successful backups of GCP Filestores
 
 We manually verify that backups are being successfully created and cleaned up on a regular schedule.
 
@@ -104,3 +106,34 @@ where:
 - `<project-name>` is the name of the GCP project the Filestore is located in
 - `<region>` is the GCP region the Filestore is located in, e.g., `us-central1`
 - `<filestore-name>` is the name of the Filestore instance
+
+### Backup persistent disks
+
+Backups of persistent disks are automatically enabled when defining a disk in `.tfvars` file, such as:
+
+```
+persistent_disks = {
+  "staging" = {
+    size        = 1
+    name_suffix = "staging"
+  }
+}
+```
+
+Backups must be explicitly _disabled_ by adding `enable_nfs_backups = false`, like so:
+
+```
+persistent_disks = {
+  "staging" = {
+    size        = 1
+    name_suffix = "staging"
+    enable_nfs_backups = false
+  }
+}
+```
+
+By default, snapshots of the disk will be scheduled to be taken at `00:00 UTC` every day, and a maximum of 5 snapshots will be retained.
+
+```{warning}
+It is not currently possible to define a backup cadence other than daily
+```

--- a/terraform/gcp/persistent-disks.tf
+++ b/terraform/gcp/persistent-disks.tf
@@ -20,7 +20,7 @@ output "persistent_disk_id_map" {
 }
 
 resource "google_compute_resource_policy" "snapshot_schedule" {
-  for_each = { for k, v in var.persistent_disks : k => v if v.enable_nfs_backups }
+  for_each = { for k, v in var.persistent_disks : k => v if v.disable_nfs_backups != true }
 
   name    = "hub-nfs-homedirs-${each.value.name_suffix}-snapshot-schedule"
   region  = var.region
@@ -40,7 +40,7 @@ resource "google_compute_resource_policy" "snapshot_schedule" {
 }
 
 resource "google_compute_disk_resource_policy_attachment" "snapshot_schedule_policy_attachment" {
-  for_each = { for k, v in var.persistent_disks : k => v if v.enable_nfs_backups }
+  for_each = { for k, v in var.persistent_disks : k => v if v.disable_nfs_backups != true }
 
   name = google_compute_resource_policy.snapshot_schedule[each.value.name_suffix].name
   disk = google_compute_disk.nfs_homedirs[each.value.name_suffix].name

--- a/terraform/gcp/persistent-disks.tf
+++ b/terraform/gcp/persistent-disks.tf
@@ -18,3 +18,33 @@ resource "google_compute_disk" "nfs_homedirs" {
 output "persistent_disk_id_map" {
   value = { for pd in values(google_compute_disk.nfs_homedirs)[*] : pd.name => pd.id }
 }
+
+resource "google_compute_resource_policy" "snapshot_schedule" {
+  for_each = { for k, v in var.persistent_disks : k => v if v.enable_nfs_backups }
+
+  name    = "hub-nfs-homedirs-${each.value.name_suffix}-snapshot-schedule"
+  region  = var.region
+  project = var.project_id
+
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "00:00"
+      }
+    }
+    retention_policy {
+      max_retention_days = each.value.max_retention_days
+    }
+  }
+}
+
+resource "google_compute_disk_resource_policy_attachment" "snapshot_schedule_policy_attachment" {
+  for_each = { for k, v in var.persistent_disks : k => v if v.enable_nfs_backups }
+
+  name = google_compute_resource_policy.snapshot_schedule["${each.value.name_suffix}"].name
+  disk = google_compute_disk.nfs_homedirs["${each.value.name_suffix}"].name
+
+  project = var.project_id
+  zone    = var.zone
+}

--- a/terraform/gcp/persistent-disks.tf
+++ b/terraform/gcp/persistent-disks.tf
@@ -42,8 +42,8 @@ resource "google_compute_resource_policy" "snapshot_schedule" {
 resource "google_compute_disk_resource_policy_attachment" "snapshot_schedule_policy_attachment" {
   for_each = { for k, v in var.persistent_disks : k => v if v.enable_nfs_backups }
 
-  name = google_compute_resource_policy.snapshot_schedule["${each.value.name_suffix}"].name
-  disk = google_compute_disk.nfs_homedirs["${each.value.name_suffix}"].name
+  name = google_compute_resource_policy.snapshot_schedule[each.value.name_suffix].name
+  disk = google_compute_disk.nfs_homedirs[each.value.name_suffix].name
 
   project = var.project_id
   zone    = var.zone

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -356,12 +356,12 @@ variable "enable_filestore_backups" {
 
 variable "persistent_disks" {
   type = map(object({
-    size               = number
-    type               = optional(string, "pd-balanced")
-    name_suffix        = optional(string, null)
-    enable_nfs_backups = optional(bool, true)
-    max_retention_days = optional(number, 5)
-    tags               = optional(map(string), {})
+    size                = number
+    type                = optional(string, "pd-balanced")
+    name_suffix         = optional(string, null)
+    disable_nfs_backups = optional(bool, false)
+    max_retention_days  = optional(number, 5)
+    tags                = optional(map(string), {})
   }))
   default     = {}
   description = <<-EOT
@@ -371,7 +371,7 @@ variable "persistent_disks" {
   server to store home directories for users.
 
   By default, daily backups of these disks will be enabled with a max retention
-  period of 5 days. To opt out, set enable_nfs_backups = false.
+  period of 5 days. To opt out, set disable_nfs_backups = true.
   EOT
 }
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -356,10 +356,12 @@ variable "enable_filestore_backups" {
 
 variable "persistent_disks" {
   type = map(object({
-    size        = number
-    type        = optional(string, "pd-balanced")
-    name_suffix = optional(string, null)
-    tags        = optional(map(string), {})
+    size               = number
+    type               = optional(string, "pd-balanced")
+    name_suffix        = optional(string, null)
+    enable_nfs_backups = optional(bool, true)
+    max_retention_days = optional(number, 5)
+    tags               = optional(map(string), {})
   }))
   default     = {}
   description = <<-EOT
@@ -367,6 +369,9 @@ variable "persistent_disks" {
 
   This provisions a managed compute disk that can be used by jupyterhub-home-nfs
   server to store home directories for users.
+
+  By default, daily backups of these disks will be enabled with a max retention
+  period of 5 days. To opt out, set enable_nfs_backups = false.
   EOT
 }
 


### PR DESCRIPTION
- fixes #5471 

I have made this `OPT OUT` when defining the disk. Default settings are daily backups with a max of 5 backups retained.

This has been applied to the disk associated with LEAP staging.