### PR TITLE
Bump utoronto r image version

### DIFF
--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -20,4 +20,4 @@ jupyterhub:
     defaultUrl: /rstudio
     image:
       name: quay.io/2i2c/utoronto-r-image
-      tag: "5e7aea3c30ff"
+      tag: "e8fb739a9b64"


### PR DESCRIPTION
Including 'retrolab' in the package was causing old and weird versions of jupyterlab and jupyter_server to be installed, causing issues around auth loops (https://github.com/jupyterhub/nbgitpuller/issues/365). Removing retrolab from the packages list fixed it.

Ref https://2i2c.freshdesk.com/a/tickets/2888