### PR TITLE
terraform, gcp: update default k8s version prefixes we check

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -50,8 +50,8 @@ variable "k8s_version_prefixes" {
   # channel, so we may want to remove or add minor versions here over time.
   #
   default = [
-    "1.29.",
-    "1.30.",
+    "1.31.",
+    "1.32.",
     "1.",
   ]
   description = <<-EOT


### PR DESCRIPTION
- related to #5537 