### PR TITLE
Use the correct domain of project-pythia's binderhub

### DIFF
--- a/config/clusters/projectpythia-binder/cluster.yaml
+++ b/config/clusters/projectpythia-binder/cluster.yaml
@@ -9,7 +9,7 @@ support:
 hubs:
   - name: binderhub
     display_name: "Project Pythis BinderHub on Jetstream2"
-    domain: hub.jetstream2.2i2c.cloud
+    domain: hub.binder-pythia.jetstream2.2i2c.cloud
     helm_chart: basehub
     helm_chart_values_files:
       - binderhub.values.yaml


### PR DESCRIPTION
Pagerduty was alerting because of this