### PR TITLE
Bump version of cryptnono and unpin old image

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -40,9 +40,9 @@ dependencies:
     condition: cluster-autoscaler.enabled
 
   # cryptnono, counters crypto mining
-  # Source code: https://github.com/cryptnono/cryptnono/
+  # https://github.com/cryptnono/cryptnono/
   - name: cryptnono
-    version: "0.3.1-0.dev.git.146.h6bdf5b7"
+    version: "0.3.1-0.dev.git.153.h8956dbb"
     repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled
 

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
   # cryptnono, counters crypto mining
   # https://github.com/cryptnono/cryptnono/
   - name: cryptnono
-    version: "0.3.1-0.dev.git.153.h8956dbb"
+    version: "0.3.1"
     repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -451,11 +451,6 @@ cryptnono:
         cpu: 5m
         memory: 100Mi
 
-  image:
-    # Brings in https://github.com/cryptnono/cryptnono/pull/33
-    # FIXME: Unset this once that gets merged and we update to the newest cryptnono version
-    tag: 0.3.1-0.dev.git.138.ha4b11b8
-
   detectors:
     execwhacker:
       enabled: true


### PR DESCRIPTION
We had a really old image of cryptnono pinned, causing issues.

https://github.com/cryptnono/cryptnono/issues/44