### PR TITLE
Jupyterhub home nfs/resources

### DIFF
--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -39,3 +39,26 @@ basehub:
     quotaEnforcer:
       hardQuota: "350" # in GB
       path: "/export/prod"
+      resources:
+        requests:
+          cpu: 0.01
+          memory: 10M
+        limits:
+          cpu: 0.02
+          memory: 15M
+    nfsServer:
+      resources:
+        requests:
+          cpu: 0.1
+          memory: 1G
+        limits:
+          cpu: 0.2
+          memory: 3G
+    prometheusExporter:
+      resources:
+        requests:
+          cpu: 0.01
+          memory: 7M
+        limits:
+          cpu: 0.02
+          memory: 10M

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -41,24 +41,24 @@ basehub:
       path: "/export/prod"
       resources:
         requests:
-          cpu: 0.01
-          memory: 10M
-        limits:
           cpu: 0.02
-          memory: 15M
+          memory: 20M
+        limits:
+          cpu: 0.04
+          memory: 30M
     nfsServer:
       resources:
         requests:
-          cpu: 0.1
-          memory: 1G
-        limits:
           cpu: 0.2
-          memory: 3G
+          memory: 2G
+        limits:
+          cpu: 0.4
+          memory: 6G
     prometheusExporter:
       resources:
         requests:
-          cpu: 0.01
-          memory: 7M
-        limits:
           cpu: 0.02
-          memory: 10M
+          memory: 15M
+        limits:
+          cpu: 0.04
+          memory: 20M

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -29,6 +29,29 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "64" # in GB
     path: "/export/prod"
+    resources:
+      requests:
+        cpu: 0.01
+        memory: 10M
+      limits:
+        cpu: 0.02
+        memory: 15M
+  nfsServer:
+    resources:
+      requests:
+        cpu: 0.1
+        memory: 1G
+      limits:
+        cpu: 0.2
+        memory: 3G
+  prometheusExporter:
+    resources:
+      requests:
+        cpu: 0.01
+        memory: 7M
+      limits:
+        cpu: 0.02
+        memory: 10M
 
 binderhub-service:
   config:

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -31,27 +31,27 @@ jupyterhub-home-nfs:
     path: "/export/prod"
     resources:
       requests:
-        cpu: 0.01
-        memory: 10M
-      limits:
         cpu: 0.02
-        memory: 15M
+        memory: 20M
+      limits:
+        cpu: 0.04
+        memory: 30M
   nfsServer:
     resources:
       requests:
-        cpu: 0.1
-        memory: 1G
-      limits:
         cpu: 0.2
-        memory: 3G
+        memory: 2G
+      limits:
+        cpu: 0.4
+        memory: 6G
   prometheusExporter:
     resources:
       requests:
-        cpu: 0.01
-        memory: 7M
-      limits:
         cpu: 0.02
-        memory: 10M
+        memory: 15M
+      limits:
+        cpu: 0.04
+        memory: 20M
 
 binderhub-service:
   config:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1655,27 +1655,3 @@ jupyterhub:
 
 jupyterhub-home-nfs:
   enabled: false
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.1
-        memory: 1G
-      limits:
-        cpu: 0.2
-        memory: 3G
-  quotaEnforcer:
-    resources:
-      requests:
-        cpu: 0.01
-        memory: 10M
-      limits:
-        cpu: 0.02
-        memory: 15M
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.01
-        memory: 7M
-      limits:
-        cpu: 0.02
-        memory: 10M


### PR DESCRIPTION
- related to #5569 

---

- Removes jupyterhub-home-nfs resource constraints from basehub, and only applies that to prod hubs of CryoCloud (as that's where our grafana charts tracking the metrics are) and NMFS Openscapes (as they reported the initial problem with the first set of contraints)
- Doubles the original contraints

Verifying that the constraints are only set on the prod hubs, not staging:

```
kubectl -n $HUB_NAME get pod ${HUB_NAME}-nfs-deployment-<HASH> -o yaml | grep "resources:" -A6
```

Output for staging should show:

```
resources: {}
[...]
```

Output for prod should show:

```
resources:
  requests:
    [...]
  limits:
    [...]
```
