### PR TITLE
Bump version of AWS terraform provider

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -3,19 +3,19 @@ terraform {
 
   required_providers {
     aws = {
-      # ref: https://registry.terraform.io/providers/hashicorp/aws/latest
+      # https://registry.terraform.io/providers/hashicorp/aws/latest
       source  = "hashicorp/aws"
-      version = "~> 5.57"
+      version = "~> 5.89"
     }
 
     mysql = {
-      # ref: https://registry.terraform.io/providers/petoju/mysql/latest
+      # https://registry.terraform.io/providers/petoju/mysql/latest
       source  = "petoju/mysql"
       version = "~> 3.0"
     }
 
     random = {
-      # ref: https://registry.terraform.io/providers/hashicorp/random/latest
+      # https://registry.terraform.io/providers/hashicorp/random/latest
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
@@ -26,10 +26,9 @@ terraform {
   }
 }
 
-# ref: https://registry.terraform.io/providers/hashicorp/random/latest/docs
+# https://registry.terraform.io/providers/hashicorp/random/latest/docs
 provider "random" {}
 
-# ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 provider "aws" {
   region = var.region
 


### PR DESCRIPTION
I was unable to apply https://github.com/2i2c-org/infrastructure/pull/5619, with the error:

```
│ Error: Resource instance managed by newer provider version
│
│ The current state of aws_s3_bucket_lifecycle_configuration.user_bucket_expiry["scratch-staging"] was created by a newer provider version than is
│ currently selected. Upgrade the aws provider to work with this state.
```

This is a follow-up to https://github.com/2i2c-org/infrastructure/pull/5050