### PR TITLE
[nasa-ghg] update qgis image on ghg hub to match version on veda

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -157,7 +157,7 @@ basehub:
                   kubespawner_override:
                     default_url: /desktop
                     # Built from https://github.com/2i2c-org/nasa-qgis-image
-                    image: quay.io/2i2c/nasa-qgis-image:d76118ea0c15
+                    image: quay.io/2i2c/nasa-qgis-image:607df3f5c661
             resource_allocation:
               display_name: Resource Allocation
               choices:


### PR DESCRIPTION
Updates the QGIS image on the GHG hub to match the version used on the VEDA hub, to enable the "Open dataset in QGIS by xyz layer" feature, to support https://github.com/NASA-IMPACT/veda-ui/pull/1299/

This should be a pretty safe update and will allow us to test the open in QGIS feature on the GHG hub.

cc @slesaad @sunu @sgibson91 