### PR TITLE
[2i2c-aws-us] Enable jupyterhub-home-nfs and storage quotas

### DIFF
--- a/config/clusters/2i2c-aws-us/basehub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/basehub-common.values.yaml
@@ -14,10 +14,14 @@ nfs:
       - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
       - retrans=2
       - noresvport
-    serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
     baseShareName: /
 
 jupyterhub:
   scheduling:
     userScheduler:
       enabled: true
+
+jupyterhub-home-nfs:
+  enabled: true
+  eks:
+    enabled: true

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -60,3 +60,6 @@ basehub:
   jupyterhub-home-nfs:
     eks:
       volumeId: vol-002bff088152dd5e9
+    quotaEnforcer:
+      hardQuota: "10" # in GB
+      path: "/export/dask-staging"

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -5,6 +5,12 @@ basehub:
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-dask-staging
+  jupyterhub-home-nfs:
+    eks:
+      volumeId: vol-002bff088152dd5e9
+    quotaEnforcer:
+      hardQuota: "10" # in GB
+      path: "/export/dask-staging"
   jupyterhub:
     ingress:
       hosts: [dask-staging.aws.2i2c.cloud]
@@ -56,10 +62,3 @@ basehub:
           extraPodConfig:
             nodeSelector:
               2i2c/hub-name: dask-staging
-
-  jupyterhub-home-nfs:
-    eks:
-      volumeId: vol-002bff088152dd5e9
-    quotaEnforcer:
-      hardQuota: "10" # in GB
-      path: "/export/dask-staging"

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -53,3 +53,7 @@ basehub:
           extraPodConfig:
             nodeSelector:
               2i2c/hub-name: dask-staging
+
+  jupyterhub-home-nfs:
+    eks:
+      volumeId: vol-002bff088152dd5e9

--- a/config/clusters/2i2c-aws-us/dask-staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/dask-staging.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: 10.100.135.254
   userServiceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-dask-staging

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -17,8 +17,15 @@ basehub:
         - noresvport
       serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
       baseShareName: /
+
   dask-gateway:
     enabled: true
+
+  jupyterhub-home-nfs:
+    enabled: true
+    eks:
+      enabled: true
+
   jupyterhub:
     scheduling:
       userScheduler:

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -15,7 +15,6 @@ basehub:
         - soft # We pick soft over hard, so NFS lockups don't lead to hung processes
         - retrans=2
         - noresvport
-      serverIP: fs-0b70db2b65209a77d.efs.us-west-2.amazonaws.com
       baseShareName: /
 
   dask-gateway:

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: 10.100.221.109
   userServiceAccount:
     annotations:
       # When we renamed this hub, we did so at a DNS level and not an infrastructure
@@ -8,6 +11,9 @@ basehub:
   jupyterhub-home-nfs:
     eks:
       volumeId: vol-0a55e84bbf716b456
+    quotaEnforcer:
+      hardQuota: "20" # in GB
+      path: "/export/showcase"
 
   jupyterhub:
     ingress:

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -5,6 +5,10 @@ basehub:
       # level. No terraform config was touched. Hence the kubernetes annotations retain
       # the original hub name.
       eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-showcase
+  jupyterhub-home-nfs:
+    eks:
+      volumeId: vol-0a55e84bbf716b456
+
   jupyterhub:
     ingress:
       hosts: [showcase.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -1,6 +1,18 @@
+nfs:
+  pv:
+    serverIP: 10.100.60.182
+
 userServiceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::790657130469:role/2i2c-aws-us-staging
+
+jupyterhub-home-nfs:
+  eks:
+    volumeId: vol-063f53806dd18c4a6
+  quotaEnforcer:
+    hardQuota: "10" # in GB
+    path: "/export/staging"
+
 jupyterhub:
   ingress:
     hosts: [staging.aws.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -17,6 +17,30 @@ grafana:
           - grafana.aws.2i2c.cloud
 
 prometheus:
+  alertmanager:
+    enabled: true
+    config:
+      route:
+        group_wait: 10s
+        group_interval: 5m
+        receiver: pagerduty
+        repeat_interval: 3h
+        routes:
+          - receiver: pagerduty
+            match:
+              channel: pagerduty
+              cluster: 2i2c-aws-us
+              namespace: staging
+          - receiver: pagerduty
+            match:
+              channel: pagerduty
+              cluster: 2i2c-aws-us
+              namespace: dask-staging
+          - receiver: pagerduty
+            match:
+              channel: pagerduty
+              cluster: 2i2c-aws-us
+              namespace: showcase
   server:
     ingress:
       enabled: true
@@ -28,6 +52,42 @@ prometheus:
             - prometheus.aws.2i2c.cloud
     persistentVolume:
       size: 500Gi
+  serverFiles:
+    alerting_rules.yml:
+      groups:
+        - name: 2i2c-aws-us staging volume full
+          rules:
+            - alert: staging-jupyterhub-home-nfs-ebs-full
+              expr: node_filesystem_avail_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="staging"} / node_filesystem_size_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="staging"} < 0.1
+              for: 15m
+              labels:
+                severity: critical
+                channel: pagerduty
+                cluster: 2i2c-aws-us
+              annotations:
+                summary: "jupyterhub-home-nfs volume full in namespace {{ $labels.namespace }}"
+        - name: 2i2c-aws-us dask-staging jupyterhub-home-nfs volume full
+          rules:
+            - alert: dask-staging-jupyterhub-home-nfs-ebs-full
+              expr: node_filesystem_avail_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="dask-staging"} / node_filesystem_size_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="dask-staging"} < 0.1
+              for: 15m
+              labels:
+                severity: critical
+                channel: pagerduty
+                cluster: 2i2c-aws-us
+              annotations:
+                summary: "jupyterhub-home-nfs volume full in namespace {{ $labels.namespace }}"
+        - name: 2i2c-aws-us showcase jupyterhub-home-nfs volume full
+          rules:
+            - alert: showcase-jupyterhub-home-nfs-ebs-full
+              expr: node_filesystem_avail_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="showcase"} / node_filesystem_size_bytes{mountpoint="/shared-volume", component="shared-volume-metrics", namespace="showcase"} < 0.1
+              for: 15m
+              labels:
+                severity: critical
+                channel: pagerduty
+                cluster: 2i2c-aws-us
+              annotations:
+                summary: "jupyterhub-home-nfs volume full in namespace {{ $labels.namespace }}"
 
 aws-ce-grafana-backend:
   enabled: true

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -53,7 +53,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "dask-staging" }
   }
   "showcase" = {
-    size        = 100 # in GB
+    size        = 500 # in GB
     type        = "gp3"
     name_suffix = "showcase"
     tags        = { "2i2c:hub-name" : "showcase" }

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -38,3 +38,24 @@ hub_cloud_permissions = {
     ],
   },
 }
+
+ebs_volumes = {
+  "staging" = {
+    size        = 100 # in GB
+    type        = "gp3"
+    name_suffix = "staging"
+    tags        = { "2i2c:hub-name" : "staging" }
+  }
+  "dask-staging" = {
+    size        = 100 # in GB
+    type        = "gp3"
+    name_suffix = "dask-staging"
+    tags        = { "2i2c:hub-name" : "dask-staging" }
+  }
+  "showcase" = {
+    size        = 100 # in GB
+    type        = "gp3"
+    name_suffix = "showcase"
+    tags        = { "2i2c:hub-name" : "showcase" }
+  }
+}

--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -59,3 +59,5 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "showcase" }
   }
 }
+
+enable_nfs_backup = true


### PR DESCRIPTION
This deploys juptyerhub-home-nfs to the three hubs in the 2i2c-aws-us cluster, setups storage quotas for users and enables pageduty alerting for when disks are full.

I've migrated all data, but haven't wiped out yet the original ebs volume. 

Fixes https://github.com/2i2c-org/infrastructure/issues/5657