### PR TITLE
Update the rsync cmd again

### DIFF
--- a/docs/howto/filesystem-management/data-transfer.md
+++ b/docs/howto/filesystem-management/data-transfer.md
@@ -56,7 +56,7 @@ export SERVER_IP=<nfs_service_ip>
    ```
 
    ```bash
-   ls /root-homes/${HUB_NAME}/ | parallel -j4 rsync -ah --progress /root-homes/${HUB_NAME}/{}/ /dest-fs/{}/
+   ls /root-homes/${HUB_NAME} | parallel -j4 rsync -ah --progress /root-homes/${HUB_NAME}/{} /dest-fs/${HUB_NAME}/
    ```
 
    ```{admonition} Monitoring tips


### PR DESCRIPTION
Without this, the command errors out because it cannot create two layes of directories if they don't exist.

See https://www.linuxquestions.org/questions/slackware-14/rsync-having-trouble-creating-directories-4175611946/#post5748368