### PR TITLE
Add nasa-eodc-scratch bucket access

### DIFF
--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -83,7 +83,7 @@ hub_cloud_permissions = {
               "arn:aws:s3:::nasa-disasters",
               "arn:aws:s3:::nasa-disasters/*",
               "arn:aws:s3:::nasa-eodc-scratch",
-              "arn:aws:s3:::nasa-eodc-scratch/*",
+              "arn:aws:s3:::nasa-eodc-scratch/*"
             ]
           },
           {

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -81,7 +81,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::sport-lis",
               "arn:aws:s3:::sport-lis/*",
               "arn:aws:s3:::nasa-disasters",
-              "arn:aws:s3:::nasa-disasters/*"
+              "arn:aws:s3:::nasa-disasters/*",
+              "arn:aws:s3:::nasa-eodc-scratch",
+              "arn:aws:s3:::nasa-eodc-scratch/*",
             ]
           },
           {


### PR DESCRIPTION
👋🏽 I have been using this bucket for the NASA icehunk work so would like to add it permanently to the list of allowed buckets