### PR TITLE
HHMI: Enable jupyterhub-home-nfs on hubs

### DIFF
--- a/config/clusters/hhmi/daskhub-common.values.yaml
+++ b/config/clusters/hhmi/daskhub-common.values.yaml
@@ -253,5 +253,7 @@ basehub:
 
   jupyterhub-home-nfs:
     enabled: true
+    prometheusExporter:
+      enabled: true
     gke:
       enabled: true

--- a/config/clusters/hhmi/daskhub-common.values.yaml
+++ b/config/clusters/hhmi/daskhub-common.values.yaml
@@ -250,3 +250,8 @@ basehub:
           #
           admin_users:
             - colliand
+
+  jupyterhub-home-nfs:
+    enabled: true
+    gke:
+      enabled: true

--- a/config/clusters/hhmi/prod.values.yaml
+++ b/config/clusters/hhmi/prod.values.yaml
@@ -16,3 +16,7 @@ basehub:
       config:
         CILogonOAuthenticator:
           oauth_callback_url: https://hhmi.2i2c.cloud/hub/oauth_callback
+
+  jupyterhub-home-nfs:
+    gke:
+      volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-prod

--- a/config/clusters/hhmi/staging.values.yaml
+++ b/config/clusters/hhmi/staging.values.yaml
@@ -16,3 +16,7 @@ basehub:
       config:
         CILogonOAuthenticator:
           oauth_callback_url: https://staging.hhmi.2i2c.cloud/hub/oauth_callback
+
+  jupyterhub-home-nfs:
+    gke:
+      volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-staging


### PR DESCRIPTION
- related to #5653 