### PR TITLE
HHMI: Migrate hubs to persistent disk storage using jupyterhub-home-nfs

### DIFF
--- a/config/clusters/hhmi/daskhub-common.values.yaml
+++ b/config/clusters/hhmi/daskhub-common.values.yaml
@@ -6,8 +6,7 @@ basehub:
       mountOptions:
         - soft
         - noatime
-      serverIP: 10.55.112.74
-      baseShareName: /homes/
+      baseShareName: /
   dask-gateway:
     enabled: true
   jupyterhub:

--- a/config/clusters/hhmi/prod.values.yaml
+++ b/config/clusters/hhmi/prod.values.yaml
@@ -20,3 +20,6 @@ basehub:
   jupyterhub-home-nfs:
     gke:
       volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-prod
+    quotaEnforcer:
+      hardQuota: 2 # in GB
+      path: "/export/prod"

--- a/config/clusters/hhmi/prod.values.yaml
+++ b/config/clusters/hhmi/prod.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: 10.87.246.71
   jupyterhub:
     ingress:
       hosts:

--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -9,8 +9,8 @@ nfs:
     mountOptions:
       - soft
       - noatime
-    serverIP: 10.55.112.74
-    baseShareName: /homes/
+    serverIP: 10.87.246.71
+    baseShareName: /
     # The spyglass hub will be using the same *shared* directory from the 'prod' hub, so
     # hub admins can *write* to the shared directory there and it'll show up readonly here.
     shareNameOverride: prod

--- a/config/clusters/hhmi/staging.values.yaml
+++ b/config/clusters/hhmi/staging.values.yaml
@@ -20,3 +20,6 @@ basehub:
   jupyterhub-home-nfs:
     gke:
       volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-staging
+    quotaEnforcer:
+      hardQuota: 2 # in GB
+      path: "/export/staging"

--- a/config/clusters/hhmi/staging.values.yaml
+++ b/config/clusters/hhmi/staging.values.yaml
@@ -1,4 +1,7 @@
 basehub:
+  nfs:
+    pv:
+      serverIP: 10.87.253.56
   jupyterhub:
     ingress:
       hosts:


### PR DESCRIPTION
- related to #5653 