### PR TITLE
Provide easier redirection of logged out home page

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -26,20 +26,6 @@ basehub:
         add_staff_user_ids_of_type: "google"
       jupyterhubConfigurator:
         enabled: false
-      homepage:
-        templateVars:
-          org:
-            url: https://www.earthscope.org/
-            logo_url: https://github.com/2i2c-org/infrastructure/assets/7579677/589da909-86c2-4440-a42b-e3f1b59f49d5
-          designed_by:
-            name: "2i2c"
-            url: https://2i2c.org
-          operated_by:
-            name: "2i2c"
-            url: https://2i2c.org
-          funded_by:
-            name: "EarthScope Consortium"
-            url: https://www.earthscope.org/
     hub:
       extraConfig:
         001-username-claim: |

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -13,6 +13,17 @@ basehub:
         templateVars:
           org:
             name: "EarthScope"
+            url: https://www.earthscope.org/
+            logo_url: https://github.com/2i2c-org/infrastructure/assets/7579677/589da909-86c2-4440-a42b-e3f1b59f49d5
+          designed_by:
+            name: "2i2c"
+            url: https://2i2c.org
+          operated_by:
+            name: "2i2c"
+            url: https://2i2c.org
+          funded_by:
+            name: "EarthScope Consortium"
+            url: https://www.earthscope.org/
     hub:
       config:
         GenericOAuthenticator:

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -13,8 +13,7 @@ basehub:
     custom:
       homepage:
         templateVars:
-          org:
-            name: "EarthScope staging"
+          redirect_to: https://www.earthscope.org/data/geolab/
     hub:
       config:
         GenericOAuthenticator:

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -13,6 +13,7 @@ basehub:
     custom:
       homepage:
         templateVars:
+          # To login to earthscope staging, now use https://staging.geolab.earthscope.cloud/hub/oauth_login
           redirect_to: https://www.earthscope.org/data/geolab/
     hub:
       config:

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -24,24 +24,8 @@ jupyterhub:
       add_staff_user_ids_to_admin_users: true
       add_staff_user_ids_of_type: google
     homepage:
-      # Everyone hitting the home page directly is redirected to
-      # https://datatools.utoronto.ca as the unified home page. The various parameters
-      # here under templateVars are no-op - UToronto manages the unified homepage themselves.
-      gitRepoBranch: "utoronto"
       templateVars:
-        org:
-          name: University of Toronto
-          logo_url: https://raw.githubusercontent.com/2i2c-org/default-hub-homepage/utoronto-prod/extra-assets/images/home-hero.png
-          url: https://www.utoronto.ca/
-        designed_by:
-          name: 2i2c
-          url: https://2i2c.org
-        operated_by:
-          name: 2i2c
-          url: https://2i2c.org
-        funded_by:
-          name: University of Toronto
-          url: https://www.utoronto.ca/
+        redirect_to: https://datatools.utoronto.ca
   singleuser:
     cpu:
       # Each node has about 8 CPUs total, and if we limit users to no more than

--- a/docs/howto/features/login-page.md
+++ b/docs/howto/features/login-page.md
@@ -31,3 +31,37 @@ jupyterhub:
           name: Some Funder
           url: https://some-funding.org
 ```
+
+## Redirect the logged out page to a different URL
+
+Sometimes communities want to maintain their own landing page in their own content management
+systems, consistent with their styling and practices. We can redirect the default logged out
+home page (what users see when they go to the hub but haven't logged in) to any such URL easily.
+
+Use the following config:
+
+```yaml
+jupyterhub:
+  custom:
+    homepage:
+      templateVars:
+        redirect_to: <full URL to redirect to>
+```
+
+If you specify a `redirect_to` URL, you can't specify the other parameters mentioned earlier.
+
+The page maintained by the community should contain a "Login" link that points to an appropriately
+constructed URL. The following are some common URL constructions:
+
+1. `https://<domain-of-the-hub>/hub/oauth_login` will ask the user to log in if
+   necessary, and send them to the default configured experience for the hub (such
+   as a profile list, JupyterLab, or RStudio). This is the most common URL to use.
+2. `https://<domain-of-the-hub>/hub/user-redirect/lab` is valid only on hubs that don't
+   offer the user a profile list to choose from, and will send them to JupyterLab after
+   logging in. Alternatively, you can use `https://<domain-of-the-hub>/hub/user-redirect/rstudio`
+   to send them to RStudio (if it's installed in your image) after login,
+   `https://<domain-of-the-hub>/hub/user-redirect/tree` for classic Jupyter Notebook,
+   or `https://<domain-of-the-hub>/hub/user-redirect/desktop` for Linux Desktop (if available in
+   your image)
+3. A link generated with the [nbgitpuller Link Generator](https://nbgitpuller.readthedocs.io/en/latest/link.html)
+   may also be used if you want to send the user to a particular repository pulled in by nbgitpuller.

--- a/docs/howto/features/login-page.md
+++ b/docs/howto/features/login-page.md
@@ -65,3 +65,19 @@ constructed URL. The following are some common URL constructions:
    your image)
 3. A link generated with the [nbgitpuller Link Generator](https://nbgitpuller.readthedocs.io/en/latest/link.html)
    may also be used if you want to send the user to a particular repository pulled in by nbgitpuller.
+
+### Staging Hub Considerations
+
+We would like staging hubs to have the same configuration as production hubs to the extent possible.
+So if you're redirecting your production hub's home page, you should redirect the staging hub's as well.
+There are two ways to approach this:
+
+1. Redirect the staging and production hubs to the same community page. This works fine, but makes it *really*
+   confusing to log in to the staging hub to test anything, as the login link in the community maintained page is
+   probably pointing to the *production* hub! Anyone wanting to login to the staging hub will have to use a manually
+   constructed link (via formats specified above).
+
+2. Ask the community to maintain two different pages - one for staging and one for production. And redirect each
+   hub appropriately.
+
+Option (2) is preferred to minimize confusion.

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -409,12 +409,12 @@ properties:
                 then:
                   oneOf:
                     - required:
-                      - redirect_to
+                        - redirect_to
                     - required:
-                      - org
-                      - designed_by
-                      - operated_by
-                      - funded_by
+                        - org
+                        - designed_by
+                        - operated_by
+                        - funded_by
                 properties:
                   enabled:
                     type: boolean

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -407,17 +407,24 @@ properties:
                     enabled:
                       const: true
                 then:
-                  required:
-                    - org
-                    - designed_by
-                    - operated_by
-                    - funded_by
+                  oneOf:
+                    - required:
+                      - redirect_to
+                    - required:
+                      - org
+                      - designed_by
+                      - operated_by
+                      - funded_by
                 properties:
                   enabled:
                     type: boolean
                     description: |
                       Set to false to not provide homepage information on hubs that do not
                       have a homepage, such as unauthenticated binderhubs.
+                  redirect_to:
+                    type: string
+                    description: |
+                      When set, the unauthenticated home page will simply do a JS redirect to this URL.
                   learn_more:
                     type: string
                     description: |


### PR DESCRIPTION
- Introduces functionality to redirect the logged out home page directly without having to make a separate git branch
- Incorporates https://github.com/2i2c-org/default-hub-homepage/pull/44
- Switches utoronto to use the new functionality
- Switches earthscope staging hub to use this new functionality.

Ref https://github.com/2i2c-org/infrastructure/issues/5679