### PR TITLE
2i2c: Migrate temple to jupyterhub-home-nfs and clean-up config

### DIFF
--- a/config/clusters/2i2c/basehub-common.values.yaml
+++ b/config/clusters/2i2c/basehub-common.values.yaml
@@ -5,9 +5,7 @@ nfs:
     mountOptions:
       - soft
       - noatime
-    serverIP: 10.234.45.250
-    # MUST HAVE TRAILING SLASH
-    baseShareName: /homes/homes/
+    baseShareName: /
 jupyterhub-home-nfs:
   enabled: true
   gke:

--- a/config/clusters/2i2c/binderhub-ui-demo.values.yaml
+++ b/config/clusters/2i2c/binderhub-ui-demo.values.yaml
@@ -1,3 +1,9 @@
+nfs:
+  enabled: false
+  pv:
+    enabled: false
+jupyterhub-home-nfs:
+  enabled: false
 jupyterhub:
   ingress:
     hosts:
@@ -41,6 +47,7 @@ jupyterhub:
       type: none
       extraVolumeMounts: []
     initContainers: []
+    profileList: []
   hub:
     redirectToServer: false
     services:

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -53,4 +53,3 @@ jupyterhub-home-nfs:
 nfs:
   pv:
     serverIP: 10.3.243.135
-    baseShareName: /

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -148,4 +148,3 @@ jupyterhub-home-nfs:
 nfs:
   pv:
     serverIP: 10.3.248.156
-    baseShareName: /

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -60,4 +60,3 @@ jupyterhub-home-nfs:
 nfs:
   pv:
     serverIP: 10.3.244.132
-    baseShareName: /

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -75,4 +75,3 @@ jupyterhub-home-nfs:
 nfs:
   pv:
     serverIP: 10.3.249.107
-    baseShareName: /

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -60,3 +60,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "20" # in GB
     path: "/export/temple"
+nfs:
+  pv:
+    serverIP: 10.3.243.151

--- a/config/clusters/2i2c/ucmerced-common.values.yaml
+++ b/config/clusters/2i2c/ucmerced-common.values.yaml
@@ -1,6 +1,3 @@
-nfs:
-  pv:
-    baseShareName: /
 jupyterhub:
   custom:
     2i2c:


### PR DESCRIPTION
- related to #5650 