### PR TITLE
Collect unescaped usernames on pods

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   - name: prometheus
     # NOTE: CHECK INSTRUCTIONS UNDER prometheus.server.command IN support/values.yaml
     # EACH TIME THIS VERSION IS BUMPED!
-    version: 25.27.0
+    version: 27.7.1
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -92,6 +92,11 @@ prometheus:
       - nodes=[*]
       - services=[app, component]
 
+    # collect pod annotation for usernames, as labels are escaped but annotations
+    # are not. We want unescaped usernames as that's what users know
+    metricAnnotationsAllowList:
+      - pods=[hub.jupyter.org/username]
+
   # prometheus-node-exporter is an optional prometheus chart dependency that we
   # rely on to collect metrics about the nodes
   #


### PR DESCRIPTION
Label values are escaped (due to kubernetes label requirements) https://github.com/jupyterhub/kubespawner/blob/9e994a7ce7507196ec2258460836eef40c98d0e1/kubespawner/spawner.py#L2146, while we want unescaped usernames for filtering. Annotations aren't escaped (https://github.com/jupyterhub/kubespawner/blob/9e994a7ce7507196ec2258460836eef40c98d0e1/kubespawner/spawner.py#L2169) and what we need.

This was added to a recent enough version of kube-state-metrics, so I'm bumping our prometheus chart. That was missed earlier because we don't have an automatic recurring task for upgrading our support charts - tracked already in https://github.com/2i2c-org/infrastructure/issues/5540.

Came out of conversations with Jenny today that we don't have unescaped usernames mapping to pods. With this PR, we do now! Grafana is still using labels, and we'll have to eventually change that.

Ref https://github.com/2i2c-org/infrastructure/issues/5764