### PR TITLE
Stop using `--wait` with helm deployments

### DIFF
--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -12,6 +12,7 @@ from deployer.utils.file_acquisition import (
     get_decrypted_files,
 )
 from deployer.utils.rendering import print_colour
+from deployer.utils.helm import wait_for_deployments_daemonsets
 
 
 class Cluster:
@@ -86,7 +87,6 @@ class Cluster:
                 "--install",
                 "--create-namespace",
                 "--namespace=support",
-                "--wait",
                 "support",
                 str(support_dir),
             ]
@@ -100,6 +100,8 @@ class Cluster:
             print_colour(f"Running {' '.join([str(c) for c in cmd])}")
             subprocess.check_call(cmd)
 
+
+        wait_for_deployments_daemonsets("support")
         print_colour("Done!")
 
     def auth_kubeconfig(self):

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -11,8 +11,8 @@ from deployer.utils.file_acquisition import (
     get_decrypted_file,
     get_decrypted_files,
 )
-from deployer.utils.rendering import print_colour
 from deployer.utils.helm import wait_for_deployments_daemonsets
+from deployer.utils.rendering import print_colour
 
 
 class Cluster:
@@ -99,7 +99,6 @@ class Cluster:
 
             print_colour(f"Running {' '.join([str(c) for c in cmd])}")
             subprocess.check_call(cmd)
-
 
         wait_for_deployments_daemonsets("support")
         print_colour("Done!")

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -10,6 +10,7 @@ from deployer.utils.file_acquisition import (
     get_decrypted_files,
 )
 from deployer.utils.rendering import print_colour
+from deployer.utils.helm import wait_for_deployments_daemonsets
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)
@@ -81,7 +82,6 @@ class Hub:
                 "upgrade",
                 "--install",
                 "--create-namespace",
-                "--wait",
                 f"--namespace={self.spec['name']}",
                 self.spec["name"],
                 HELM_CHARTS_DIR.joinpath(self.spec["helm_chart"]),
@@ -101,3 +101,6 @@ class Hub:
             # into a string first
             print_colour(f"Running {' '.join([str(c) for c in cmd])}")
             subprocess.check_call(cmd)
+
+        if not dry_run:
+            wait_for_deployments_daemonsets(self.spec["name"])

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -9,8 +9,8 @@ from deployer.utils.file_acquisition import (
     get_decrypted_file,
     get_decrypted_files,
 )
-from deployer.utils.rendering import print_colour
 from deployer.utils.helm import wait_for_deployments_daemonsets
+from deployer.utils.rendering import print_colour
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)

--- a/deployer/utils/helm.py
+++ b/deployer/utils/helm.py
@@ -1,5 +1,6 @@
+from subprocess import check_call, check_output
+
 from .rendering import print_colour
-from subprocess import check_output, check_call
 
 
 def wait_for_deployments_daemonsets(name: str):
@@ -7,8 +8,7 @@ def wait_for_deployments_daemonsets(name: str):
     Wait for all deployments and daemonsets to be fully rolled out
     """
     print_colour(
-        f"Waiting for all deployments and daemonsets in {name} to be ready",
-        "green"
+        f"Waiting for all deployments and daemonsets in {name} to be ready", "green"
     )
     deployments_and_daemonsets = (
         check_output(

--- a/deployer/utils/helm.py
+++ b/deployer/utils/helm.py
@@ -1,0 +1,38 @@
+from .rendering import print_colour
+from subprocess import check_output, check_call
+
+
+def wait_for_deployments_daemonsets(name: str):
+    """
+    Wait for all deployments and daemonsets to be fully rolled out
+    """
+    print_colour(
+        f"Waiting for all deployments and daemonsets in {name} to be ready",
+        "green"
+    )
+    deployments_and_daemonsets = (
+        check_output(
+            [
+                "kubectl",
+                "get",
+                f"--namespace={name}",
+                "--output=name",
+                "deployments,daemonsets",
+            ],
+        )
+        .strip()
+        .split()
+    )
+
+    for d in deployments_and_daemonsets:
+        check_call(
+            [
+                "kubectl",
+                "rollout",
+                "status",
+                f"--namespace={name}",
+                "--timeout=10m",
+                "--watch",
+                d,
+            ],
+        )


### PR DESCRIPTION
While working on https://github.com/2i2c-org/infrastructure/pull/5809, I finally got frustrated enough with our usage of `--wait` that I've ripped it out.

The major issue with `--wait` is that if the deployment fails (because of a typo in config for example), you *must* wait for the 5min timeout or helm can get into an inconsistent state. This sucks when prototyping.

I stole the code we use in the mybinder.org deployment repo instead (https://github.com/jupyterhub/mybinder.org-deploy/blob/main/deploy.py#L273).

It also seems faster, but the most important capability here is that it's cancellable.