### PR TITLE
2i2c-uk, lis: Increase size of persistent disk

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -42,7 +42,7 @@ persistent_disks = {
     name_suffix = "staging"
   },
   "lis" = {
-    size        = 350 # in GB
+    size        = 400 # in GB
     name_suffix = "lis"
   }
 }


### PR DESCRIPTION
Resolves a pagerduty notification https://2i2c-org.pagerduty.com/incidents/Q3GF2IS9GLMX9N?utm_campaign=channel&utm_source=slack