### PR TITLE
Migrate NASA disasters hub to use Keycloak Auth

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -20,8 +20,7 @@ jupyterhub:
     daskhubSetup:
       enabled: true
     2i2c:
-      add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: "github"
+      add_staff_user_ids_to_admin_users: false
     jupyterhubConfigurator:
       enabled: false
     homepage:
@@ -43,18 +42,51 @@ jupyterhub:
     allowNamedServers: true
     config:
       JupyterHub:
-        authenticator_class: github
+        authenticator_class: generic-oauth
+      Authenticator:
+        # Set for us by Keycloak
+        admin_users: []
+        enable_auth_state: true
+      GenericOAuthenticator:
+        scope:
+          - basic
+          - profile
+          - openid
+
+          - jupyterhub:admin
+
+          - jupyterhub:cpu:xs
+          - jupyterhub:cpu:s
+          - jupyterhub:cpu:m
+          - jupyterhub:cpu:l
+          - jupyterhub:cpu:xl
+          - jupyterhub:cpu:xxl
+          - jupyterhub:cpu:xxxl
+          - jupyterhub:gpu:t4
+        username_claim: preferred_username
+        manage_groups: true
+        auth_state_groups_key: scope
+        admin_groups:
+          - jupyterhub:admin
+        # Being granted *any* jupyterhub related scope should allow you
+        # to login
+        allowed_groups:
+          - jupyterhub:admin
+
+          - jupyterhub:cpu:xs
+          - jupyterhub:cpu:s
+          - jupyterhub:cpu:m
+          - jupyterhub:cpu:l
+          - jupyterhub:cpu:xl
+          - jupyterhub:cpu:xxl
+          - jupyterhub:cpu:xxxl
+          - jupyterhub:gpu:t4
       GitHubOAuthenticator:
         populate_teams_in_auth_state: true
         # allowed_organizations:
         #   - todo
         scope:
           - read:org
-      Authenticator:
-        enable_auth_state: true
-        admin_users:
-          - freitagb
-          - slesaad
   singleuser:
     cloudMetadata:
       blockWithIptables: false
@@ -163,6 +195,8 @@ jupyterhub:
             choices:
               mem_1_9:
                 display_name: 1.9 GB RAM, upto 3.7 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:xs
                 kubespawner_override:
                   mem_guarantee: 1991244775
                   mem_limit: 1991244775
@@ -173,6 +207,8 @@ jupyterhub:
                 default: true
               mem_3_7:
                 display_name: 3.7 GB RAM, upto 3.7 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:s
                 kubespawner_override:
                   mem_guarantee: 3982489550
                   mem_limit: 3982489550
@@ -182,6 +218,8 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_7_4:
                 display_name: 7.4 GB RAM, upto 3.7 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:m
                 kubespawner_override:
                   mem_guarantee: 7964979101
                   mem_limit: 7964979101
@@ -191,6 +229,8 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_14_8:
                 display_name: 14.8 GB RAM, upto 3.7 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:l
                 kubespawner_override:
                   mem_guarantee: 15929958203
                   mem_limit: 15929958203
@@ -200,6 +240,8 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_29_7:
                 display_name: 29.7 GB RAM, upto 3.7 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:xl
                 kubespawner_override:
                   mem_guarantee: 31859916406
                   mem_limit: 31859916406
@@ -209,6 +251,8 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.xlarge
               mem_60_6:
                 display_name: 60.6 GB RAM, upto 15.6 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:xxl
                 kubespawner_override:
                   mem_guarantee: 65094448840
                   mem_limit: 65094448840
@@ -218,6 +262,8 @@ jupyterhub:
                     node.kubernetes.io/instance-type: r5.4xlarge
               mem_121_2:
                 display_name: 121.2 GB RAM, upto 15.6 CPUs
+                allowed_groups:
+                  - jupyterhub:cpu:xxxl
                 kubespawner_override:
                   mem_guarantee: 130188897681
                   mem_limit: 130188897681
@@ -229,7 +275,7 @@ jupyterhub:
         description: "Start a container on a dedicated node with a GPU"
         slug: "gpu"
         allowed_groups:
-          - 2i2c-org:hub-access-for-2i2c-staff
+          - jupyterhub:gpu:t4
         profile_options:
           image:
             display_name: Environment

--- a/config/clusters/disasters/enc-prod.secret.values.yaml
+++ b/config/clusters/disasters/enc-prod.secret.values.yaml
@@ -1,20 +1,23 @@
 jupyterhub:
-    hub:
-        config:
-            GitHubOAuthenticator:
-                client_id: ENC[AES256_GCM,data:4kbayvi5Mu2Wgxn9lwUOvWFB+CE=,iv:qqJh4IukTAFTLAIsjn5abawWvHVNy7rxA2MMbI6Z2t0=,tag:UanGHE1KENCuzjAxyvkrrQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:it77m3mDhmS5btFxklk43X8UQJLeKs6kAmdwIZ3nD+QVc7JUElmJoA==,iv:tkFxRijR43p1qXpTEVwc/ipgM/Tu088NlJE9b2oJ8Pk=,tag:Yc6Tj7IMDIhymh3sy0qp1g==,type:str]
+  hub:
+    config:
+      GenericOAuthenticator:
+        client_id: ENC[AES256_GCM,data:oYzapak8/NgbS7HqVq3Uid5NYYE=,iv:2ly+HnNSRmJCOZTmtYTleZQxiK/dFHbjt1zaH7ZMvEc=,tag:8HH5hLG7GsPcaM611mcPJA==,type:str]
+        client_secret: ENC[AES256_GCM,data:yrUPvUKTjVxN/0MD3/0noQ==,iv:sfGSZnDfgkr2Aykmd/9AMBnQVhZgOTxOlKBqh+qA7ao=,tag:gxoOzl4AMAQgTxb5Eo6XOQ==,type:str]
+      GitHubOAuthenticator:
+        client_id: ENC[AES256_GCM,data:4kbayvi5Mu2Wgxn9lwUOvWFB+CE=,iv:qqJh4IukTAFTLAIsjn5abawWvHVNy7rxA2MMbI6Z2t0=,tag:UanGHE1KENCuzjAxyvkrrQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:it77m3mDhmS5btFxklk43X8UQJLeKs6kAmdwIZ3nD+QVc7JUElmJoA==,iv:tkFxRijR43p1qXpTEVwc/ipgM/Tu088NlJE9b2oJ8Pk=,tag:Yc6Tj7IMDIhymh3sy0qp1g==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2024-08-28T17:11:51Z"
-          enc: CiUA4OM7eE42MAnJnSRbSgcixhYQanLcxwpkon6oodvg2vfsHlPuEkkA5dG1Q+XBCcm6hV3EDD8c3e85Wdjkcv5CgftsEAzTcvFNGuijE6dUcPxi8yRhjELV8cHYPOwXuFUkdlq3L6LekDrzZoda9fjH
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-03-20T15:09:32Z"
-    mac: ENC[AES256_GCM,data:aPabEoT2Z8Pyyn1z/3e3RsqgV0me+yiNavxjOqzd+PyV+ZsBvkbkEOtjp7gT/O+hsamHy1Cd0yrZwRGpTSFNhjeulw9xAJTnbUhFDl9N8/hPiYO55bjJLWPR7wva+Tv/6uXcqK7THiG1SfXwY07fmcMOsN0V4o9fZ+4g1jCKhkk=,iv:s4KPuRulLzVprj75N4ULWyhOg2vSQg/PjaQmJlWVWJM=,tag:l+Y1EGn5UCWxfOn2KbghxA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.0
+  kms: []
+  gcp_kms:
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2024-08-28T17:11:51Z"
+      enc: CiUA4OM7eE42MAnJnSRbSgcixhYQanLcxwpkon6oodvg2vfsHlPuEkkA5dG1Q+XBCcm6hV3EDD8c3e85Wdjkcv5CgftsEAzTcvFNGuijE6dUcPxi8yRhjELV8cHYPOwXuFUkdlq3L6LekDrzZoda9fjH
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2025-04-01T17:35:40Z"
+  mac: ENC[AES256_GCM,data:cy6oP4nOLBA9XNONurFTJsLQWqBYGwXMSunZLLC1oTDqa9/mDzkCDZqZMInHiNonzs5Kp/GgIbzWAaoL5B7edI/8U87mM22WLb+mWRO+2JjinRkW3okUf8aAuHXNTp1UEedmbCfxiCjaVBqvMQ91XchBinyEme8YW9INtF2ELMU=,iv:iZ/uKBvH5ChiIW2+OP/uUTErIUxXMwCcMeAfN4rogdQ=,tag:pagigdeZJTer4ikuMpi2tA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.1

--- a/config/clusters/disasters/enc-staging.secret.values.yaml
+++ b/config/clusters/disasters/enc-staging.secret.values.yaml
@@ -1,20 +1,23 @@
 jupyterhub:
-    hub:
-        config:
-            GitHubOAuthenticator:
-                client_id: ENC[AES256_GCM,data:GbLiW8Ef8NRtrDdid8ea+CcfZMQ=,iv:MIWiopg/D7oPFuFiXmZs7jVZGTHWymS3Lhgr8NWxrcs=,tag:nyE56wmEH+DcuLFUWc/K8A==,type:str]
-                client_secret: ENC[AES256_GCM,data:AvuO1x/tSoTFgPvTkaV0n3rg57CNyoElOP9oWzIlYRTL4mdFca910w==,iv:67pdCHbb6EaUjEqN/waeoLOg7yEjQ89QEx+UKLM4PUs=,tag:4Eyxa6Rn480epWMdhGa0mg==,type:str]
+  hub:
+    config:
+      GenericOAuthenticator:
+        client_id: ENC[AES256_GCM,data:YHokggCghwqFOeq91iPIq8PEyeE=,iv:msgZUmCaKiAvUNarO3RaDz/wjDplS0IE6FhhF4h1e2k=,tag:0erY3hPKnSHDfhpIQnW9zA==,type:str]
+        client_secret: ENC[AES256_GCM,data:n6Ssa3A2k+ZGS9kfIDkTmA==,iv:XTMI8FmUBfd+Mj1Vk8MJ5EUqua/Gv6+WmEujLLzcLo4=,tag:l6EKYao1fYLhzJTYjQ+Vgg==,type:str]
+      GitHubOAuthenticator:
+        client_id: ENC[AES256_GCM,data:GbLiW8Ef8NRtrDdid8ea+CcfZMQ=,iv:MIWiopg/D7oPFuFiXmZs7jVZGTHWymS3Lhgr8NWxrcs=,tag:nyE56wmEH+DcuLFUWc/K8A==,type:str]
+        client_secret: ENC[AES256_GCM,data:AvuO1x/tSoTFgPvTkaV0n3rg57CNyoElOP9oWzIlYRTL4mdFca910w==,iv:67pdCHbb6EaUjEqN/waeoLOg7yEjQ89QEx+UKLM4PUs=,tag:4Eyxa6Rn480epWMdhGa0mg==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2024-08-28T17:11:51Z"
-          enc: CiUA4OM7eE42MAnJnSRbSgcixhYQanLcxwpkon6oodvg2vfsHlPuEkkA5dG1Q+XBCcm6hV3EDD8c3e85Wdjkcv5CgftsEAzTcvFNGuijE6dUcPxi8yRhjELV8cHYPOwXuFUkdlq3L6LekDrzZoda9fjH
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-03-20T14:22:51Z"
-    mac: ENC[AES256_GCM,data:g/UJcyVDi1ipEZPGdfEYvdX7XgeDfr3gPGQt98Y+H0/Zis+zm8FOz9GbjzHWzI79nwk/mI/aHb7MlTsdv0ZUURfQUWZCmowdA4yuSdJu9N8P1XQXr8JTpislm55uPS+0NHndgEwW+NpqgrhAwLTT3Jd/MSlAc7fmurAs5ci15sk=,iv:NH1izSRnFUZbfoNApo2Hd84+4oPGtor8KNxHmYqJeN0=,tag:gkZ7eIvZ5QCHod7INstYfw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.0
+  kms: []
+  gcp_kms:
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2024-08-28T17:11:51Z"
+      enc: CiUA4OM7eE42MAnJnSRbSgcixhYQanLcxwpkon6oodvg2vfsHlPuEkkA5dG1Q+XBCcm6hV3EDD8c3e85Wdjkcv5CgftsEAzTcvFNGuijE6dUcPxi8yRhjELV8cHYPOwXuFUkdlq3L6LekDrzZoda9fjH
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2025-04-01T16:46:46Z"
+  mac: ENC[AES256_GCM,data:F3IW/y3PZnAxbY1JrRRqmNpTjmOaXuAwCu6rdBdW839NsRhqP+WbWX99US1WukFHLLJhvA6+qBsbypeqgI3sh83MKflskl+7cbKb9JPRlyKEanoHGpI3rtctw1JFXrU/5xkerOU2wPcVJgwf2UIR3xy4ZL0Vt+I/3yRyg631ts8=,iv:bBED7h2S4HUXPMs3XoVeEFmPDOLjLrKGiFumQrdDJaA=,tag:wlq5tiAVVdusQQWPhOuh1w==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.1

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -10,6 +10,11 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://hub.disasters.2i2c.cloud/hub/oauth_callback
+      GenericOAuthenticator:
+        oauth_callback_url: https://hub.disasters.2i2c.cloud/hub/oauth_callback
+        token_url: https://auth.openveda.cloud//realms/veda/protocol/openid-connect/token
+        authorize_url: https://auth.openveda.cloud/realms/veda/protocol/openid-connect/auth
+        userdata_url: https://auth.openveda.cloud/realms/veda/protocol/openid-connect/userinfo
   ingress:
     hosts: [hub.disasters.2i2c.cloud]
     tls:

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -9,6 +9,11 @@ jupyterhub:
     config:
       GitHubOAuthenticator:
         oauth_callback_url: https://staging.hub.disasters.2i2c.cloud/hub/oauth_callback
+      GenericOAuthenticator:
+        oauth_callback_url: https://staging.hub.disasters.2i2c.cloud/hub/oauth_callback
+        token_url: https://keycloak.delta-backend.xyz/realms/veda/protocol/openid-connect/token
+        authorize_url: https://keycloak.delta-backend.xyz/realms/veda/protocol/openid-connect/auth
+        userdata_url: https://keycloak.delta-backend.xyz/realms/veda/protocol/openid-connect/userinfo
   ingress:
     hosts: [staging.hub.disasters.2i2c.cloud]
     tls:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -249,6 +249,19 @@ jupyterhub:
         auth_state_groups_key: scope
         admin_groups:
           - jupyterhub:admin
+        # Being granted *any* jupyterhub related scope should allow you
+        # to login
+        allowed_groups:
+          - jupyterhub:admin
+
+          - jupyterhub:cpu:xs
+          - jupyterhub:cpu:s
+          - jupyterhub:cpu:m
+          - jupyterhub:cpu:l
+          - jupyterhub:cpu:xl
+          - jupyterhub:cpu:xxl
+          - jupyterhub:cpu:xxxl
+          - jupyterhub:gpu:t4
   ingress:
     hosts: [staging.hub.maap.2i2c.cloud]
     tls:


### PR DESCRIPTION
- sets up allowed_groups correctly for MAAP as well

Fixes https://github.com/2i2c-org/infrastructure/issues/5831