### PR TITLE
Add name of cluster into name of validation matrix job for easier identification

### DIFF
--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -198,6 +198,7 @@ jobs:
   validate-helm-charts-values-files:
     runs-on: ubuntu-latest
     needs: [generate-clusters-to-validate]
+    name: "validate-${{ matrix.jobs.cluster_name }}"
     if: |
       needs.generate-clusters-to-validate.outputs.continue_workflow &&
       (needs.generate-clusters-to-validate.outputs.cluster_matrix != '[]')


### PR DESCRIPTION
Mimics setup in deploy-hubs workflow