### PR TITLE
Remove mention of bootstrap5 from branch names

### DIFF
--- a/docs/howto/features/binderhub-ui.md
+++ b/docs/howto/features/binderhub-ui.md
@@ -223,13 +223,13 @@ sops config/clusters/<cluster-name>/enc-<hubname>.secret.values.yaml
 
 If accessing binderhub will require users to login first, then the login page, i.e. the page where users land to login into the hub before actually seeing the binderhub UI must be updated to use a simpler version of it.
 
-This is done by having the hub track the `bootstrap5-no-homepage-subsection` branch of the default homepage repo
+This is done by having the hub track the `no-homepage-subsection` branch of the default homepage repo
 
 ```yaml
 jupyterhub:
   custom:
     homepage:
-      gitRepoBranch: "bootstrap5-no-homepage-subsection"
+      gitRepoBranch: "no-homepage-subsection"
 ```
 
 #### 2. Make sure we don't redirect to singleuser server after login

--- a/docs/hub-deployment-guide/configure-auth/shared-password.md
+++ b/docs/hub-deployment-guide/configure-auth/shared-password.md
@@ -14,7 +14,7 @@ export HUB_NAME=hub_name
 
 The Dummy Authenticator requires presenting the user with a username and password input field, rather than the typical "log in" button.
 This means we cannot use the default homepage template since this will not provide these input fields.
-Instead we use a specialised branch of the homepage repo which allows us to have the username and password input fields, along with providing specific info about and for each community: [`bootstrap5-username-and-password-homepage`](https://github.com/2i2c-org/default-hub-homepage/tree/bootstrap5-username-and-password-homepage).
+Instead we use a specialised branch of the homepage repo which allows us to have the username and password input fields, along with providing specific info about and for each community: [`username-and-password-homepage`](https://github.com/2i2c-org/default-hub-homepage/tree/username-and-password-homepage).
 
 In the `${HUB_NAME}.values.yaml` file, include the following config.
 
@@ -22,7 +22,7 @@ In the `${HUB_NAME}.values.yaml` file, include the following config.
 jupyterhub:
   custom:
     homepage:
-      gitRepoBranch: "bootstrap5-username-and-password-homepage"
+      gitRepoBranch: "username-and-password-homepage"
       templateVars: [...]  # These values are as normal
 ```
 


### PR DESCRIPTION
These branches no longer exist and so using them doesn't work as intended