### PR TITLE
[aws] Document editing the tigera-operator deployment to be able to drain core node

### DIFF
--- a/docs/howto/upgrade-cluster/aws.md
+++ b/docs/howto/upgrade-cluster/aws.md
@@ -183,6 +183,31 @@ kubectl get node --label-columns=alpha.eksctl.io/nodegroup-name
 
 3. *Delete the old node group*
 
+   ````{important}
+   Before draining and deleting the old node group, you need to update the `tigera-operator`
+   deployment and force it to not use the old node group anymore.
+   Otherwise, the the drain process will get stuck.
+
+   This is because `tigera-operator` tolerates all taints by default including
+   `NoSchedule`, and it will recreate itself indefinitely on the tainted node
+   that's being drained even though it's tainted with `NoSchedule`.
+
+   To fix this, you need to edit the `tigera-operator` deployment with:
+
+   ```bash
+   kubectl edit deployment tigera-operator -n tigera-operator
+   ```
+
+   and search after `Exists` and remove the following toleration from that entry:
+
+   ```yaml
+   tolerations:
+     - effect: NoSchedule
+       operator: Exists
+   ```
+   You can now proceed with the drain and delete process.
+   ````
+
    If you added a duplicate renamed node group, then first remove the old node
    group in the `.jsonnet` file.
 


### PR DESCRIPTION
With the addition of calico in our aws deployments, while upgrading 2i2c-aws-us k8s version #5701  I ran into this issue, i.e. not being able to drain the core nodegroup because of tigera-operator kept being scheduled on the tainted node.

Manually editing it to not tolerate this taint fixes the issue. Note that this change is temporary and will be removed with a new hub deployment so no need to redo it while upgrading I believe.