### PR TITLE
Deploy to staging even if there are no prod changes

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -377,8 +377,10 @@ jobs:
       !cancelled() &&
       (github.event_name == 'push' && contains(github.ref, 'main')) &&
       needs.generate-jobs.result == 'success' &&
-      needs.generate-jobs.outputs.staging-jobs != '[]' &&
-      needs.generate-jobs.outputs.prod-jobs != '[]'
+      (
+        needs.generate-jobs.outputs.staging-jobs != '[]' ||
+        needs.generate-jobs.outputs.prod-jobs != '[]'
+      )
     outputs:
       staging-jobs: ${{ steps.reset-jobs.outputs.staging-jobs }}
       prod-jobs: ${{ steps.reset-jobs.outputs.prod-jobs }}


### PR DESCRIPTION
We want to deploy to staging hubs even if there are no prod changes listed, as this allows us to actually test changes to staging.

Reported in https://2i2c.freshdesk.com/a/tickets/3164, validated via https://github.com/2i2c-org/infrastructure/pull/5924