### PR TITLE
Revert "No-op change to AWI-CIROH staging"

### DIFF
--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -138,8 +138,8 @@ basehub:
     hub:
       config:
         KubeSpawner:
-          # Requested as part of https://2i2c.freshdesk.com/a/tickets/1607
-          # to make it easier to test custom images
+          # Requested as part of https://2i2c.freshdesk.com/a/tickets/1607, to
+          # make it easier to test custom images
           image_pull_policy: Always
         GitHubOAuthenticator:
           oauth_callback_url: "https://staging.ciroh.awi.2i2c.cloud/hub/oauth_callback"


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#5924

Testing to see if https://github.com/2i2c-org/infrastructure/pull/5925
worked.