### PR TITLE
Remove SSH access from disasters cluster

### DIFF
--- a/eksctl/disasters.jsonnet
+++ b/eksctl/disasters.jsonnet
@@ -196,7 +196,7 @@ local daskNodes = [
     [
         ng + {
             namePrefix: 'core',
-            nameSuffix: 'a',
+            nameSuffix: 'b',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
             instanceType: "r5.xlarge",

--- a/eksctl/disasters.jsonnet
+++ b/eksctl/disasters.jsonnet
@@ -193,9 +193,6 @@ local daskNodes = [
             nameSuffix: 'a',
             nameIncludeInstanceType: false,
             availabilityZones: [nodeAz],
-            ssh: {
-                publicKeyPath: 'ssh-keys/disasters.key.pub'
-            },
             instanceType: "r5.xlarge",
             minSize: 1,
             maxSize: 6,
@@ -214,9 +211,6 @@ local daskNodes = [
             minSize: 0,
             maxSize: 500,
             instanceType: n.instanceType,
-            ssh: {
-                publicKeyPath: 'ssh-keys/disasters.key.pub'
-            },
             labels+: {
                 "hub.jupyter.org/node-purpose": "user",
                 "k8s.dask.org/node-purpose": "scheduler"
@@ -236,9 +230,6 @@ local daskNodes = [
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
-            ssh: {
-                publicKeyPath: 'ssh-keys/disasters.key.pub'
-            },
             labels+: {
                 "k8s.dask.org/node-purpose": "worker"
             },

--- a/eksctl/disasters.jsonnet
+++ b/eksctl/disasters.jsonnet
@@ -66,7 +66,10 @@ local notebookNodes = [
     {
       instanceType: "g4dn.xlarge",
       namePrefix: "gpu-staging",
-      labels+: { "2i2c/hub-name": "staging" },
+      labels+: { 
+        "2i2c/hub-name": "staging",
+        "2i2c/has-gpu": "true",
+      },
       tags+: {
         "2i2c:hub-name": "staging",
         "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"
@@ -81,7 +84,10 @@ local notebookNodes = [
     {
       instanceType: "g4dn.xlarge",
       namePrefix: "gpu-prod",
-      labels+: { "2i2c/hub-name": "prod" },
+      labels+: {
+        "2i2c/hub-name": "prod",
+        "2i2c/has-gpu": "true",
+      },
       tags+: {
         "2i2c:hub-name": "prod",
         "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu": "1"


### PR DESCRIPTION
- fixes #5703

There were no active users on this cluster, so I did a recreation update, rather than rolling, hence why the names of the user nodegroups have not changed. https://infrastructure.2i2c.org/howto/upgrade-cluster/aws/#performing-re-creation-upgrades