### PR TITLE
Enable nginx-ingress metrics collection

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -25,6 +25,14 @@ cluster-autoscaler:
 #
 ingress-nginx:
   controller:
+    # Enable collecting prometheus metrics
+    metrics:
+      enabled: true
+
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "10254"
+
     podLabels:
       # nginx-ingress controllers need to be allowed proxy traffic onwards to
       # JupyterHub's proxy pod (and only the proxy pod) in clusters with


### PR DESCRIPTION
The issues reported in https://2i2c.freshdesk.com/a/tickets/3183 hit us in a blind spot - even though I was paying attention, I couldn't see the specific kinds of issues the users were seeing. It was 403s not in the hub side but on the singleuser side (potentially fixed via https://github.com/2i2c-org/utoronto-image/pull/67).

This enabled collecting nginx metrics at the ingress level, which gives us a broad swath of metrics that would've helped me catch this issue as it was happening.