### PR TITLE
Pass the correct number of args to delete_client in deployer cilogon-client subcommand

### DIFF
--- a/deployer/commands/cilogon.py
+++ b/deployer/commands/cilogon.py
@@ -504,7 +504,7 @@ def delete(
             )
             return
 
-    delete_client(admin_id, admin_secret, cluster_name, hub_name, client_id)
+    delete_client(admin_id, admin_secret, client_id)
 
     # Delete client credentials from config file also if file exists
     if Path(config_filename).is_file():


### PR DESCRIPTION
Fixes a bug when deleting a CILogon client