### PR TITLE
Add access to ssim-ghg-2025 GitHub team

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -64,6 +64,7 @@ basehub:
             - US-GHG-Center:ghg-external-collaborators
             - US-GHG-Center:ghg-workshop-access
             - US-GHG-Center:ghg-trial-access
+            - US-GHG-Center:ssim-ghg-2025
             - 2i2c-org:hub-access-for-2i2c-staff
           scope:
             - read:org


### PR DESCRIPTION
# Description

Access access to the [`ssim-ghg-2025`](https://github.com/orgs/US-GHG-Center/teams/ssim-ghg-2025) GitHub team to support the [GHG Summer School 2025](https://www.cira.colostate.edu/conferences/rmtgw/).