### PR TITLE
Undo edits to tigera tolerations

### DIFF
--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -86,6 +86,7 @@ class Cluster:
                 [
                     "kubectl",
                     "apply",
+                    "--force-conflicts", # Remove after https://github.com/2i2c-org/infrastructure/issues/5961
                     "--server-side",  # https://github.com/projectcalico/calico/issues/7826
                     "-f",
                     f"https://raw.githubusercontent.com/projectcalico/calico/{tigera_operator_version}/manifests/tigera-operator.yaml",

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -86,7 +86,7 @@ class Cluster:
                 [
                     "kubectl",
                     "apply",
-                    "--force-conflicts", # Remove after https://github.com/2i2c-org/infrastructure/issues/5961
+                    "--force-conflicts",  # Remove after https://github.com/2i2c-org/infrastructure/issues/5961
                     "--server-side",  # https://github.com/projectcalico/calico/issues/7826
                     "-f",
                     f"https://raw.githubusercontent.com/projectcalico/calico/{tigera_operator_version}/manifests/tigera-operator.yaml",

--- a/helm-charts/support/support.values.jsonnet
+++ b/helm-charts/support/support.values.jsonnet
@@ -26,7 +26,7 @@ local cluster_name = cluster.name;
       'alerting_rules.yml': {
         groups: [
           {
-            name: 'home directory full on %s' % [cluster_name],
+            name: 'Home directory disk full on %s' % [cluster_name],
             rules: [
               {
                 alert: 'HomeDirectoryApproachingFull',


### PR DESCRIPTION
This is required for deployment to succeed. Should be removed once https://github.com/2i2c-org/infrastructure/issues/5961 is done.