### PR TITLE
nasa-ghg: re-generate deployer credentials

### DIFF
--- a/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
+++ b/config/clusters/nasa-ghg/enc-deployer-credentials.secret.json
@@ -1,25 +1,20 @@
 {
     "AccessKey": {
-        "AccessKeyId": "ENC[AES256_GCM,data:n0mEHWHWNFCXwJTucw/a5KssLvA=,iv:zhdDtmIWcgT7+3XIRx8t12vojeNKV22HiK0/Z96qukw=,tag:tqkSBvoD63wRhTOoqYyivg==,type:str]",
-        "SecretAccessKey": "ENC[AES256_GCM,data:CuIdrZgtxaBJj+drouWKu9ya356nGObHr1L0M6AGOOXF0XMT9Mcfcw==,iv:AS+mzHltdLuGtCSqGrcVGWgMCVJjfoi8u6B1F8Yowao=,tag:pTaJNDvp5/qtWjU1Ixw8uQ==,type:str]",
-        "UserName": "ENC[AES256_GCM,data:DbeuWH/8UAz5kl5+j5KoWpS9Us5AxDU=,iv:BdcY8ouLF6Aq1ETQq8CQO8qS4RW6kyZrEgQ0tR4oDE0=,tag:zwPQSKpg3fu4ku3JKtYm9Q==,type:str]"
+        "AccessKeyId": "ENC[AES256_GCM,data:4bhW7BaC7eHeDXTCTZC9bdaI5pM=,iv:SMUDszqw1LMNAdUFQg2XoToN+FGyjoVpAYLhxiS8/lM=,tag:2B4+ec94xG77l9QHFI8cSw==,type:str]",
+        "SecretAccessKey": "ENC[AES256_GCM,data:ezQBktUmIMWQ7qJqn4tMBDKPFXabrxS1J2DTT5HIwc/IhzqmXHGk5g==,iv:tA7qOFcVD6O9T1D/zp0yAxEPXUBX9WjDjBVO1Fonfjk=,tag:4inY+4ZOqWJVlJxdhrf7Ng==,type:str]",
+        "UserName": "ENC[AES256_GCM,data:HZ4Tv5nnx6WGFbwU4nvy4Maz60HcFR8=,iv:+K/z8o4ESZJ4bApJnjgPlu2i/ocD+sG2d7aOk0jsP8w=,tag:V4vOaeCZybgGxrTg0ah31g==,type:str]"
     },
     "sops": {
-        "kms": null,
         "gcp_kms": [
             {
                 "resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-                "created_at": "2025-04-16T16:31:10Z",
-                "enc": "CiUA4OM7eAA44531rd9T4WmCv3wFM1WRHjj7A7MLQoTNyWlz9kRjEkkAWOWv8GhWLplGY4/RSMmVpgEL4Qu0f3mnZSW2dTbxMuc2NmT5h92CbuyyK67tmoeYnOXIxCNE8/v6csFs5XOm/DDaVnyuNylw"
+                "created_at": "2025-05-02T10:33:30Z",
+                "enc": "CiUA4OM7eKfr1fv6v4CuXLwmYxgb16PQhK5ihHkdHjj8eos9lQTTEkkAWOWv8MTK24mRN7J/dnjfrNCKp4Oabrf64rU67Z4X/QIUz36neQ5kmnIKT6iU1tBKGm16rMSEXX+BUPgzQLB//TBYkEQn/X0o"
             }
         ],
-        "azure_kv": null,
-        "hc_vault": null,
-        "age": null,
-        "lastmodified": "2025-04-16T16:31:10Z",
-        "mac": "ENC[AES256_GCM,data:Y2QNEf3dt1yF31xnxgB54CBdw4xlZm/sAfBfygta4XxGDDBnHTAcxOvbDtc9cYeDIEd8DIjQmsmhOgARuG+EdKxy34r6MsFVNBuT2qPmRfrA3XbU0PeqdRuSy/NtrW4zLinnIAG1BnbJ4rh/mhCDBlv5JFmWBtDsaDGjDww/tVw=,iv:7Kn2p0/2KsM/4eCkcEHS1KFudN+3s7zIBxMkHp12OQ4=,tag:cRTzFrI+7VmrTf8Oeny9Ag==,type:str]",
-        "pgp": null,
+        "lastmodified": "2025-05-02T10:33:30Z",
+        "mac": "ENC[AES256_GCM,data:jP7jlrdXg6n+51eUs48WanDWnMJOyyh6dOW0w4xi/dbdu3myMN2rBWRAmyTWQHcphHkGWYBeadxG+4iD0F5RdxJKqPlpeI7LUDyI2NE5+nzzrVVV+fJSSZJGfLNYxECI/jg5W/uBfifCc78wRkMuwp1EcxYWVffDUA+3/JgU9uI=,iv:OMl/iKPQFVrm3q4mPVksf67TolszB96zINV1nlS+zu8=,tag:euatAdATiJATs0bHUHg66w==,type:str]",
         "unencrypted_suffix": "_unencrypted",
-        "version": "3.9.1"
+        "version": "3.10.2"
     }
 }


### PR DESCRIPTION
I was investigating a support ticket and something weird happened in the middle and the deployer creds disappeared. Probably I deleted them by mistake? Either way, this regenerates creds and fixes deployer access.