### PR TITLE
MAAP: test group shared directories on staging

### DIFF
--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -20,7 +20,13 @@ jupyterhub:
         command:
           - sh
           - -c
-          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
+          - >
+            id &&
+            chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public /home/jovyan/shared-group &&
+            if [ -d "/home/jovyan/shared-group" ] && [ "$(ls -A /home/jovyan/shared-group)" ]; then
+              chown 1000:1000 /home/jovyan/shared-group/* || true;
+            fi &&
+            ls -lhd /home/jovyan
         securityContext:
           runAsUser: 0
         volumeMounts:
@@ -35,6 +41,9 @@ jupyterhub:
           - name: home
             mountPath: /home/jovyan/shared-public
             subPath: _shared-public
+          - name: home
+            mountPath: /home/jovyan/shared-group
+            subPath: _shared-group
 
     profileList:
       - display_name: Choose your environment and resources

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -252,6 +252,53 @@ jupyterhub:
           - CPU:XXL
           - CPU:XXXL
           - GPU:T4
+    extraConfig:
+      00-volumes-and-volume-mounts-as-dict: |
+        # The base jupyterhub config in zero-to-jupyterhub defines
+        # volumes and volume_mounts as lists.
+        # But we can't add new volumes or volume_mounts to the list
+        # as that replaces the entire list.
+        # So we convert them to dictionaries, which allows us to
+        # add new volumes and volume_mounts as needed.
+        if isinstance(c.KubeSpawner.volumes, list):
+          existing_volumes = c.KubeSpawner.volumes
+          c.KubeSpawner.volumes = {}
+          for volume in existing_volumes:
+            c.KubeSpawner.volumes[volume["name"]] = volume
+        if isinstance(c.KubeSpawner.volume_mounts, list):
+          existing_volume_mounts = c.KubeSpawner.volume_mounts
+          c.KubeSpawner.volume_mounts = {}
+          for idx, volume_mount in enumerate(existing_volume_mounts):
+            c.KubeSpawner.volume_mounts[f"{idx}-{volume_mount['name']}"] = volume_mount
+      01-group-shared-directories: |
+        c.KubeSpawner.group_overrides = {
+          "00-group-CPU-L-extra-volume-mounts": {
+            "groups": ["CPU:L"],
+            "spawner_override": {
+              "volume_mounts": {
+                "00-group-CPU-L-shared-dir": {
+                  "name": "home",
+                  "mountPath": "/home/jovyan/shared-group/CPU_L",
+                  "subPath": "_shared-group/CPU_L",
+                  "readOnly": False
+                },
+              }
+            },
+          },
+          "01-group-GPU-T4-extra-volume-mounts": {
+            "groups": ["GPU:T4"],
+            "spawner_override": {
+              "volume_mounts": {
+                "00-group-GPU-T4-shared-dir": {
+                  "name": "home",
+                  "mountPath": "/home/jovyan/shared-group/GPU_T4",
+                  "subPath": "_shared-group/GPU_T4",
+                  "readOnly": False
+                },
+              }
+            },
+          }
+        }
   ingress:
     hosts: [staging.hub.maap.2i2c.cloud]
     tls:


### PR DESCRIPTION
@yuvipanda Would you mind taking a look and letting me know if this seems reasonable?

I’ve added an `extraConfig` block that converts `volumes` and `volume_mounts` from lists to dictionaries so that we can add new entries without replacing the existing values.

It works ok based on my testing, but I’m wondering whether this change should instead live upstream in zero-to-jupyterhub, where these fields are currently defined as lists.

Related to https://github.com/NASA-IMPACT/veda-jupyterhub/issues/66