### PR TITLE
Update estimate for shared billing task

### DIFF
--- a/.github/workflows/recurrent-get-billing-data.yaml
+++ b/.github/workflows/recurrent-get-billing-data.yaml
@@ -82,5 +82,5 @@ jobs:
           fields: Status,Estimate,Start date,End date
           github_token: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
           project_url: https://github.com/orgs/2i2c-org/projects/57
-          values: Up Next,2,${{ env.start_date_as_iso }},${{ env.end_date_as_iso }}
+          values: Up Next,1,${{ env.start_date_as_iso }},${{ env.end_date_as_iso }}
           resource_url: ${{ env.shared_issue }}


### PR DESCRIPTION
Now that there's only shared clusters on GCP, this task should be sized as an effort of 1 rathern than 2.