### PR TITLE
Update python image on NASA-Openscapes

### DIFF
--- a/config/clusters/openscapes/common.values.yaml
+++ b/config/clusters/openscapes/common.values.yaml
@@ -89,7 +89,7 @@ basehub:
                   display_name: Python
                   description: Python datascience environment
                   kubespawner_override:
-                    image: openscapes/python:07980b9
+                    image: openscapes/python:f7d3d14
                 02-R:
                   display_name: R
                   description: R (with RStudio) + Python environment

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -54,7 +54,7 @@ basehub:
           description: Python datascience environment
           default: true
           kubespawner_override:
-            image: openscapes/python:39dffde
+            image: openscapes/python:f7d3d14
           profile_options: &profile_options
             requests: &profile_options_resource_allocation
               display_name: Resource Allocation


### PR DESCRIPTION
Updates the default Python image on NASA Openscapes prod and workshop hubs. Has been tested by users using "bring your own image"