### PR TITLE
add allusers to nmfs-openscapes

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -48,14 +48,14 @@ jupyterhub:
         funded_by:
           name: NOAA Fisheries
           url: https://www.fisheries.noaa.gov
-      singleuserAdmin:
-        extraVolumeMounts:
-          - name: home
-            mountPath: /home/jovyan/allusers
-            readOnly: false
-          - name: home
-            mountPath: /home/rstudio/allusers
-            readOnly: false
+    singleuserAdmin:
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/allusers
+          readOnly: false
+        - name: home
+          mountPath: /home/rstudio/allusers
+          readOnly: false
   singleuser:
     cloudMetadata:
       blockWithIptables: false

--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -48,6 +48,14 @@ jupyterhub:
         funded_by:
           name: NOAA Fisheries
           url: https://www.fisheries.noaa.gov
+      singleuserAdmin:
+        extraVolumeMounts:
+          - name: home
+            mountPath: /home/jovyan/allusers
+            readOnly: false
+          - name: home
+            mountPath: /home/rstudio/allusers
+            readOnly: false
   singleuser:
     cloudMetadata:
       blockWithIptables: false

--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -56,6 +56,15 @@ jupyterhub:
         - name: home
           mountPath: /home/rstudio/allusers
           readOnly: false
+        # mounts below are copied from basehub's values that we override by
+        # specifying extraVolumeMounts (lists get overridden when helm values
+        # are combined)
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
+        - name: home
+          mountPath: /home/rstudio/shared-readwrite
+          subPath: _shared
   singleuser:
     cloudMetadata:
       blockWithIptables: false


### PR DESCRIPTION
@eeholmes and I realized the NMFS Openscapes hub doesn't have the allusers directory mounted. This adds it. Thanks!