### PR TITLE
add a shared folder writeable by all

### DIFF
--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -53,8 +53,16 @@ jupyterhub:
           - name: home
             mountPath: /home/jovyan
             subPath: "{escaped_username}"
+          - name: home
+            mountPath: /home/jovyan/shared-public
+            subPath: _shared-public
     storage:
-      extraVolumeMounts: []
+      extraVolumeMounts:
+        # A shared folder readable & writeable by everyone
+        - name: home
+          mountPath: /home/jovyan/shared-public
+          subPath: _shared-public
+          readOnly: false
     defaultUrl: /lab
     nodeSelector:
       2i2c/hub-name: workshop


### PR DESCRIPTION
Currently the shared folder on our workshop hub is not accessible by anyone. The workshop hub doesn't have admin class, so even our workshop organizers cannot access it.  We would like everyone (in workshops) to be able to access a shared folder with read and write access. Yes, that means they could delete things. That's ok.

I think this is what is needed in this file but I am not 100% sure.

I looked at this code on CryoCloud, and adapted.
https://github.com/2i2c-org/infrastructure/blob/cd7efb44d0d271d10c4c1643c697600ed133d9fa/config/clusters/nasa-cryo/common.values.yaml#L85-L118

fyi @ateucher