### PR TITLE
[cryocloud] Add `csdms-2025-workshop` team to auth allowlist

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -134,6 +134,7 @@ basehub:
                   allowed_groups: &regular_allowed_groups
                     - CryoInTheCloud:CryoCloudAdvanced
                     - CryoInTheCloud:CryoCloudUser
+                    - CryoInTheCloud:csdms-2025-workshop
                     - 2i2c-org:hub-access-for-2i2c-staff
                   kubespawner_override:
                     mem_guarantee: 1991244775

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -56,6 +56,7 @@ basehub:
           allowed_organizations:
             - CryoInTheCloud:cryoclouduser
             - CryoInTheCloud:cryocloudadvanced
+            - CryoInTheCloud:csdms-2025-workshop
           scope:
             - read:org
         Authenticator:


### PR DESCRIPTION
Ref: https://2i2c.freshdesk.com/a/tickets/3295

As @jnywong pointed out in discussion, we must also grant access to a particular profile(s). This likely needs to be decided by CryoCloud, and then `regular_allowed_groups` be updated.