### PR TITLE
[earthscope] Add a new profile option

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -143,7 +143,7 @@ basehub:
       cloudMetadata:
         blockWithIptables: false
       profileList:
-        - display_name: "Shared Small: 1-4 CPU, 8-32 GB"
+        - display_name: "Shared Small: 1-4 CPU, 7.2 GB"
           description: "A shared machine, the recommended option until you experience a limitation."
           allowed_groups:
             - geolab
@@ -190,7 +190,57 @@ basehub:
           kubespawner_override:
             mem_guarantee: 7.234G
             cpu_guarantee: 0.1
-            mem_limit: null
+            mem_limit: 7.234G
+            node_selector:
+              node.kubernetes.io/instance-type: r5.xlarge
+        - display_name: "Shared Small: 1-4 CPU, 7-14 GB"
+          description: "A shared machine, the recommended option until you experience a limitation."
+          allowed_groups:
+            - geolab
+            - geolab:dev
+            - geolab:power
+          profile_options: &profile_options
+            image:
+              display_name: Image
+              unlisted_choice:
+                enabled: True
+                display_name: "Custom image"
+                validation_regex: "^.+:.+$"
+                validation_message: "Must be a publicly available docker image, of form <image-name>:<tag>"
+                kubespawner_override:
+                  image: "{value}"
+              choices:
+                geolab-general:
+                  display_name: GeoLab
+                  slug: geolab-general
+                  kubespawner_override:
+                    image: public.ecr.aws/earthscope-dev/geolab:td-dev-dd5851e6
+                mt-shortcourse:
+                  display_name: MT-ShortCourse
+                  slug: mt-shortcourse
+                  kubespawner_override:
+                    image: public.ecr.aws/earthscope-dev/geolab_default:mt_shortcourse-1a6a2fbd
+                jupyter-scipy:
+                  display_name: Jupyter
+                  slug: jupyter-scipy
+                  kubespawner_override:
+                    # FIXME: use quay.io/ for tags after 2023-10-20
+                    image: jupyter/scipy-notebook:2023-06-27
+                rocker-geospatial:
+                  display_name: RStudio
+                  slug: rocker-geospatial
+                  kubespawner_override:
+                    image: rocker/binder:4.3
+                    image_pull_policy: Always
+                    # Launch into RStudio after the user logs in
+                    default_url: /rstudio
+                    # Ensures container working dir is homedir
+                    # https://github.com/2i2c-org/infrastructure/issues/2559
+                    working_dir: /home/rstudio
+          kubespawner_override:
+            mem_guarantee: 7.234G
+            cpu_guarantee: 0.1
+            mem_limit: 14.468G
             node_selector:
               node.kubernetes.io/instance-type: r5.xlarge
         - display_name: "Small: 4 CPU, 32 GB"


### PR DESCRIPTION
Earthscope hub uses a legacy resource sharing setup, where they don't have any memory limits. In practice, this means that if the users are consistently using more memory than the guarantee, it may result and lots of kernels being killed, which is what I suspect happened during the workshop a couple of days ago.

This adds limits to their shared small profile like this:
- one with guarantee of 7.2 and a limit of 14
- one with a guarantee of 7.2 and a limit of 7.2

If they need ore, than they could use the dedicated machine option 