### PR TITLE
Automatically set resource requests on non-staging hubs only

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -14,29 +14,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "20" # in GB
       path: "/export/showcase"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
   jupyterhub:
     ingress:
       hosts: [showcase.2i2c.cloud]

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -15,30 +15,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "35" # in GB
     path: "/export/lis"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    enabled: true
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 jupyterhub:
   ingress:
     hosts: [ds.lis.2i2c.cloud]

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -50,29 +50,6 @@ jupyterhub-home-nfs:
     # The default quota is 10GB per user. Uncomment below variable to edit this.
     # hardQuota: "10" # in GB
     path: "/export/demo"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 nfs:
   pv:
     serverIP: 10.3.243.135

--- a/config/clusters/2i2c/imagebuilding-demo.values.yaml
+++ b/config/clusters/2i2c/imagebuilding-demo.values.yaml
@@ -147,29 +147,6 @@ jupyterhub-home-nfs:
     # The default quota is 10GB per user. Uncomment below variable to edit this.
     # hardQuota: "10" # in GB
     path: "/export/imagebuilding-demo"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 nfs:
   pv:
     serverIP: 10.3.248.156

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -57,29 +57,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "20" # in GB
     path: "/export/mtu"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 nfs:
   pv:
     serverIP: 10.3.244.132

--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -60,29 +60,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "20" # in GB
     path: "/export/temple"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 nfs:
   pv:
     serverIP: 10.3.243.151

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -51,29 +51,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "20" # in GB
     path: "/export/ucmerced"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 nfs:
   pv:
     serverIP: 10.3.252.119

--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -11,29 +11,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "250" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
   jupyterhub:
     ingress:
       hosts: [ciroh.awi.2i2c.cloud]

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -11,29 +11,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "250" # in GB
       path: "/export/workshop"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
   jupyterhub:
     custom:
       jupyterhubConfigurator:

--- a/config/clusters/climatematch/prod.values.yaml
+++ b/config/clusters/climatematch/prod.values.yaml
@@ -8,29 +8,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "10" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 
 jupyterhub:
   ingress:

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -50,26 +50,3 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "200" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -42,29 +42,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "150" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
     eks:
       volumeId: vol-06f3c3dc2ded0cd06
   nfs:

--- a/config/clusters/hhmi/prod.values.yaml
+++ b/config/clusters/hhmi/prod.values.yaml
@@ -26,26 +26,3 @@ basehub:
     quotaEnforcer:
       hardQuota: 2 # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M

--- a/config/clusters/jupyter-health/prod.values.yaml
+++ b/config/clusters/jupyter-health/prod.values.yaml
@@ -12,29 +12,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "10" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 jupyterhub:
   ingress:
     hosts: [jupyter-health.2i2c.cloud]

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -52,26 +52,3 @@ basehub:
     quotaEnforcer:
       hardQuota: 250 # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -72,26 +72,3 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "100" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -39,26 +39,3 @@ basehub:
     quotaEnforcer:
       hardQuota: "350" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M

--- a/config/clusters/nasa-ghg/prod.values.yaml
+++ b/config/clusters/nasa-ghg/prod.values.yaml
@@ -49,29 +49,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "50" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
   nfs:
     pv:
       serverIP: 10.100.13.73

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -52,26 +52,3 @@ basehub:
     quotaEnforcer:
       hardQuota: "200" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -41,29 +41,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "64" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 
 binderhub-service:
   config:

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -223,28 +223,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "4" # in GB
     path: "/export/workshop"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
+
 binderhub-service:
   enabled: false

--- a/config/clusters/openscapes/prod.values.yaml
+++ b/config/clusters/openscapes/prod.values.yaml
@@ -36,29 +36,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "100" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
     eks:
       volumeId: vol-0cddd71981a7ff6ba
   nfs:

--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -167,29 +167,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "16" # in GB
       path: "/export/workshop"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
     eks:
       volumeId: vol-03afdfb4245b63dfb
 jupyterhub-home-nfs:

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -8,29 +8,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "10" # in GB
     path: "/export/climaterisk"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 jupyterhub:
   ingress:
     hosts: [climaterisk.opensci.2i2c.cloud]

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -13,29 +13,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "10" # in GB
     path: "/export/sciencecore"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 jupyterhub:
   ingress:
     hosts:

--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -8,29 +8,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "10" # in GB
     path: "/export/prod"
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
 jupyterhub:
   ingress:
     hosts: [projectpythia.2i2c.cloud]

--- a/config/clusters/reflective/prod.values.yaml
+++ b/config/clusters/reflective/prod.values.yaml
@@ -39,26 +39,3 @@ jupyterhub-home-nfs:
     path: "/export/prod"
     # Default per-user quota is 10GB. Uncomment below line to change this.
     # hardQuota: "10" # in GB
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M

--- a/config/clusters/reflective/workshop.values.yaml
+++ b/config/clusters/reflective/workshop.values.yaml
@@ -71,26 +71,3 @@ jupyterhub-home-nfs:
     path: "/export/workshop"
     # Default per-user quota is 10GB. Uncomment below line to change this.
     # hardQuota: "10" # in GB
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -8,29 +8,6 @@ basehub:
     quotaEnforcer:
       hardQuota: "10" # in GB
       path: "/export/prod"
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 20M
-        limits:
-          cpu: 0.04
-          memory: 30M
-    nfsServer:
-      resources:
-        requests:
-          cpu: 0.2
-          memory: 2G
-        limits:
-          cpu: 0.4
-          memory: 6G
-    prometheusExporter:
-      resources:
-        requests:
-          cpu: 0.02
-          memory: 15M
-        limits:
-          cpu: 0.04
-          memory: 20M
   jupyterhub:
     ingress:
       hosts: [smithsonian.2i2c.cloud]

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -84,6 +84,7 @@ class Hub:
             for p in self.spec["helm_chart_values_files"]
         ) as values_files, ExitStack() as jsonnet_stack:
 
+            chart_dir = HELM_CHARTS_DIR / self.spec["helm_chart"]
             cmd = [
                 "helm",
                 "upgrade",
@@ -91,7 +92,16 @@ class Hub:
                 "--create-namespace",
                 f"--namespace={self.spec['name']}",
                 self.spec["name"],
-                HELM_CHARTS_DIR.joinpath(self.spec["helm_chart"]),
+                chart_dir
+            ]
+
+            # Add on rendered jsonnet values.yaml file for the chart
+            rendered_values_path = jsonnet_stack.enter_context(
+                render_jsonnet(chart_dir / "values.jsonnet", self.cluster.spec["name"], self.spec["name"])
+            )
+
+            cmd += [
+                "--values", rendered_values_path
             ]
 
             if dry_run:

--- a/deployer/utils/jsonnet.py
+++ b/deployer/utils/jsonnet.py
@@ -47,9 +47,10 @@ def render_jsonnet(jsonnet_file: Path, cluster_name: str, hub_name: str | None):
     ]
     if hub_name is not None:
         command += ["--ext-str", f'2I2C_VARS.HUB_NAME="{hub_name}"']
-    # Resolve the path to the jsonnet file itself, so std.thisFile
-    # is a full path
-    command += [jsonnet_file.resolve()]
+    # Make the jsonnet file passed be an absolute path, but do not *resolve*
+    # it - so symlinks are resolved by jsonnet rather than us. This is important
+    # for daskhub compatibility.
+    command += [jsonnet_file.absolute()]
 
     print(f"Rendering jsonnet file {jsonnet_file} with the command: ", end="")
     # We print it without the temporary filename so deployers can reuse the command

--- a/docs/howto/features/storage-quota.md
+++ b/docs/howto/features/storage-quota.md
@@ -166,44 +166,6 @@ deployer deploy $CLUSTER_NAME $HUB_NAME
 
 Once this is deployed, the hub will automatically enforce the storage quota for each user. If a user's home directory exceeds the quota, the user's pod may not be able to start successfully.
 
-## Enforcing resource constraints on `jupyterhub-home-nfs` components
-
-We also need to apply some resource constraints to the `jupyterhub-home-nfs` containers to ensure they do not take up more than required and cost our communities money.
-
-```{attention}
-We are only applying these requests and limits to production hubs presently.
-Staging hubs should be left unset.
-This is why we are adding these values here, instead of in the basehub values.
-```
-
-```yaml
-jupyterhub-home-nfs:
-  quotaEnforcer:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 20M
-      limits:
-        cpu: 0.04
-        memory: 30M
-  nfsServer:
-    resources:
-      requests:
-        cpu: 0.2
-        memory: 2G
-      limits:
-        cpu: 0.4
-        memory: 6G
-  prometheusExporter:
-    resources:
-      requests:
-        cpu: 0.02
-        memory: 15M
-      limits:
-        cpu: 0.04
-        memory: 20M
-```
-
 ## Increasing the size of the disk used by the NFS server
 
 If the disk used by the NFS server is close to being full, we may need to increase its size. This can be done by following the instructions in [](howto:increase-disk-size).

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -1,0 +1,56 @@
+local hub_name = std.extVar("2I2C_VARS.HUB_NAME");
+
+// Assume we are a staging hub if the word 'staging' is in the
+// name of the hub.
+local is_staging = std.member(hub_name, "staging");
+
+local emitDaskHubCompatibleConfig(basehubConfig) =
+    // Handle legacy 'daskhub' type hubs
+    // Note: This relies on `jsonnet` being called with absolute path to
+    // the file, and the symlink from helm-charts/daskhub/values.jsonnet
+    local isDaskHub = std.splitLimitR(std.thisFile, "/", 3)[2] == "daskhub";
+
+    if isDaskHub then {"basehub": basehubConfig} else basehubConfig;
+
+local jupyterhubHomeNFSResources = {
+  quotaEnforcer: {
+    resources: {
+      requests: {
+        cpu: 0.02,
+        memory: '20M',
+      },
+      limits: {
+        cpu: 0.04,
+        memory: '30M',
+      },
+    },
+  },
+  nfsServer: {
+    resources: {
+      requests: {
+        cpu: 0.2,
+        memory: '2G',
+      },
+      limits: {
+        cpu: 0.4,
+        memory: '6G',
+      },
+    },
+  },
+  prometheusExporter: {
+    resources: {
+      requests: {
+        cpu: 0.02,
+        memory: '15M',
+      },
+      limits: {
+        cpu: 0.04,
+        memory: '20M',
+      },
+    },
+  },
+};
+
+emitDaskHubCompatibleConfig({
+  'jupyterhub-home-nfs': if is_staging then {} else jupyterhubHomeNFSResources,
+})

--- a/helm-charts/daskhub/values.jsonnet
+++ b/helm-charts/daskhub/values.jsonnet
@@ -1,0 +1,1 @@
+../basehub/values.jsonnet


### PR DESCRIPTION
Just for jupyterhub-home-nfs. This PR introduces:

1. A values.jsonnet file for basehub
2. A compatibility shim for legacy daskhub helm chart
3. Resource requests are set for jupyterhub-home-nfs *only* on staging.

This prevents yet another copy paste step during the jupyterhub-home-nfs transition, and makes further resource tuning easier - we only gotta change in one place

Follow-up to https://github.com/2i2c-org/infrastructure/pull/6049

This PR itself should be a no-op