### PR TITLE
Add alert for when hub db directory is about to be full

### DIFF
--- a/deployer/utils/jsonnet.py
+++ b/deployer/utils/jsonnet.py
@@ -43,10 +43,10 @@ def render_jsonnet(jsonnet_file: Path, cluster_name: str, hub_name: str | None):
         "--jpath",
         str(jsonnet_file.parent),
         "--ext-str",
-        f'2I2C_VARS.CLUSTER_NAME="{cluster_name}"',
+        f"2I2C_VARS.CLUSTER_NAME={cluster_name}",
     ]
     if hub_name is not None:
-        command += ["--ext-str", f'2I2C_VARS.HUB_NAME="{hub_name}"']
+        command += ["--ext-str", f"2I2C_VARS.HUB_NAME={hub_name}"]
     # Make the jsonnet file passed be an absolute path, but do not *resolve*
     # it - so symlinks are resolved by jsonnet rather than us. This is important
     # for daskhub compatibility.

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -1,5 +1,43 @@
 local cluster_name = std.extVar("2I2C_VARS.CLUSTER_NAME");
 
+local makePVCApproachingFullAlert = function(
+  name,
+  summary,
+  persistentvolumeclaim,
+) {
+      # Structure is documented in https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+      name: name,
+      rules: [
+        {
+          alert: name,
+          expr: |||
+            # We use min() here for two reasons:
+            # 1. kubelet_volume_stats_* is reported once per each node the PVC is mounted on, which can be
+            #    multiple nodes if the PVC is ReadWriteMany (like any NFS mount). We only want alerts once per
+            #    PVC, rather than once per node.
+            # 2. This metric has a *ton* of labels, that can be cluttering and hard to use on pagerduty. We use
+            #    min() to select only the labels we care about, which is the namespace it is on.
+            #
+            # We could have used any aggregating function, but use min because we expect the numbers on the
+            # PVC to be the same on all nodes.
+            min(kubelet_volume_stats_available_bytes{persistentvolumeclaim='%s'}) by (namespace)
+            /
+            min(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim='%s'}) by (namespace)
+            < 0.1
+          ||| % [persistentvolumeclaim, persistentvolumeclaim],
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+            channel: 'pagerduty',
+            cluster: cluster_name,
+          },
+          annotations: {
+            summary: summary
+          },
+        },
+      ],
+};
+
 {
   prometheus: {
     alertmanager: {
@@ -24,24 +62,16 @@ local cluster_name = std.extVar("2I2C_VARS.CLUSTER_NAME");
     serverFiles: {
       'alerting_rules.yml': {
         groups: [
-          {
-            name: 'Home directory disk full on %s' % [cluster_name],
-            rules: [
-              {
-                alert: 'HomeDirectoryApproachingFull',
-                expr: "node_filesystem_avail_bytes{mountpoint='/shared-volume', component='shared-volume-metrics'} / node_filesystem_size_bytes{mountpoint='/shared-volume', component='shared-volume-metrics'} < 0.1",
-                'for': '15m',
-                labels: {
-                  severity: 'critical',
-                  channel: 'pagerduty',
-                  cluster: cluster_name,
-                },
-                annotations: {
-                  summary: 'Home Directory about to be full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
-                },
-              },
-            ],
-          },
+          makePVCApproachingFullAlert(
+            'HomeDirectoryDiskApproachingFull',
+            'Home Directory Disk about to be full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
+            'home-nfs',
+          ),
+          makePVCApproachingFullAlert(
+            'HubDatabaseDiskApproachingFull',
+            'Hub Database Disk about to be full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
+            'hub-db-dir',
+          ),
         ],
       },
     },

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -27,8 +27,6 @@ local makePVCApproachingFullAlert = function(
           ||| % [persistentvolumeclaim, persistentvolumeclaim],
           'for': '5m',
           labels: {
-            severity: 'critical',
-            channel: 'pagerduty',
             cluster: cluster_name,
           },
           annotations: {
@@ -51,9 +49,13 @@ local makePVCApproachingFullAlert = function(
           routes: [
             {
               receiver: 'pagerduty',
-              match: {
-                channel: 'pagerduty',
-              },
+              matchers: [
+                # We want to match all alerts, but not add additional labels as they
+                # clutter the view. So we look for the presence of the 'cluster' label, as that
+                # is present on all alerts we have. This makes the 'cluster' label *required* for
+                # all alerts if they need to come to pagerduty.
+                "cluster =~ .*"
+              ]
             },
           ],
         },


### PR DESCRIPTION
After merging https://github.com/2i2c-org/infrastructure/pull/6050, I noticed that the utoronto staging hub was consistently failing the health check. I investigated, and noticed that the hub disk db is full! This is more prevalant on Azure because we also store hub logs in there.

This could have also totally happened to a prod hub there, and would have caused an outage - and it actually has in the past. We would like outages like this to be prevented, by having alerts show up before the actual issue.

This PR does the following:

1. Add an alert for the hub db directory approaching fullness
2. Change the existing home directory alert to use the same metrics as hub db directory alert. This removes dependency on the extra shared-dir node exporter we run for alerts!
3. Use a jsonnet function to generate the alert rule, so we can more easily generate disk dir fullness alerts without having to duplicate the config.
4. Change the set of labels added to the alert so only actually helpful labels are set.

Cleaning up the labels is extremely helpful. Alert before:

<img width="673" alt="Screenshot 2025-05-15 at 1 46 13 PM" src="https://github.com/user-attachments/assets/1c1ac212-fbe3-4021-94b0-fefa4163c174" />

Alert after:
<img width="669" alt="Screenshot 2025-05-15 at 4 07 57 PM" src="https://github.com/user-attachments/assets/53315303-ec70-4f9d-bec8-b33de5402acc" />
