### PR TITLE
Add "User Group Diagnostics" Grafana dashboard

### DIFF
--- a/grafana-dashboards/group.jsonnet
+++ b/grafana-dashboards/group.jsonnet
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S jsonnet -J ../vendor
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v11.1.0/main.libsonnet';
+local dashboard = grafonnet.dashboard;
+local ts = grafonnet.panel.timeSeries;
+local prometheus = grafonnet.query.prometheus;
+
+local common = import './common.libsonnet';
+
+local memoryUsage =
+  common.tsOptions
+  + ts.new('Memory Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per group memory usage
+
+      Requires https://github.com/2i2c-org/jupyterhub-groups-exporter to
+      be set up.
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          container_memory_working_set_bytes{name!="", pod=~"jupyter-.*", namespace=~"$hub"}
+            * on (namespace, pod) group_left(annotation_hub_jupyter_org_username, usergroup)
+            group(
+                kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~".*", pod=~"jupyter-.*"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+            * on (namespace, annotation_hub_jupyter_org_username) group_left(usergroup)
+            group(
+              label_replace(jupyterhub_user_group_info{namespace=~"$hub", username=~".*", usergroup=~"$user_group"},
+                "annotation_hub_jupyter_org_username", "$1", "username", "(.+)")
+            ) by (annotation_hub_jupyter_org_username, usergroup, namespace)
+        ) by (usergroup, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ usergroup }} - ({{ namespace }})'),
+  ]);
+
+
+local cpuUsage =
+  common.tsOptions
+  + ts.new('CPU Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per group CPU usage
+
+      Requires https://github.com/2i2c-org/jupyterhub-groups-exporter to
+      be set up.
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          # exclude name="" because the same container can be reported
+          # with both no name and `name=k8s_...`,
+          # in which case sum() by (pod) reports double the actual metric
+          irate(container_cpu_usage_seconds_total{name!="", pod=~"jupyter-.*"}[5m])
+          * on (namespace, pod) group_left(annotation_hub_jupyter_org_username)
+          group(
+              kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~".*"}
+          ) by (pod, namespace, annotation_hub_jupyter_org_username)
+          * on (namespace, annotation_hub_jupyter_org_username) group_left(usergroup)
+          group(
+            label_replace(jupyterhub_user_group_info{namespace=~"$hub", username=~".*", usergroup=~"$user_group"},
+              "annotation_hub_jupyter_org_username", "$1", "username", "(.+)")
+          ) by (annotation_hub_jupyter_org_username, usergroup, namespace)
+        ) by (usergroup, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ usergroup }} - ({{ namespace }})'),
+  ]);
+
+local memoryRequests =
+  common.tsOptions
+  + ts.new('Memory Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per group memory requests
+
+      Requires https://github.com/2i2c-org/jupyterhub-groups-exporter to
+      be set up.
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="memory", namespace=~"$hub", pod=~"jupyter-.*"}  * on (namespace, pod)
+          group_left(annotation_hub_jupyter_org_username) group(
+            kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~".*"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+          * on (namespace, annotation_hub_jupyter_org_username) group_left(usergroup)
+          group(
+            label_replace(jupyterhub_user_group_info{namespace=~"$hub", username=~".*", usergroup=~"$user_group"},
+              "annotation_hub_jupyter_org_username", "$1", "username", "(.+)")
+          ) by (annotation_hub_jupyter_org_username, usergroup, namespace)
+        ) by (usergroup, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ usergroup }} - ({{ namespace }})'),
+  ]);
+
+local cpuRequests =
+  common.tsOptions
+  + ts.new('CPU Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per group CPU requests
+
+      Requires https://github.com/2i2c-org/jupyterhub-groups-exporter to
+      be set up.
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="cpu", namespace=~"$hub", pod=~"jupyter-.*"} * on (namespace, pod)
+          group_left(annotation_hub_jupyter_org_username) group(
+            kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~".*"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+          * on (namespace, annotation_hub_jupyter_org_username) group_left(usergroup)
+          group(
+            label_replace(jupyterhub_user_group_info{namespace=~"$hub", username=~".*", usergroup=~"$user_group"},
+              "annotation_hub_jupyter_org_username", "$1", "username", "(.+)")
+          ) by (annotation_hub_jupyter_org_username, usergroup, namespace)
+        ) by (usergroup, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ usergroup }} - ({{ namespace }})'),
+  ]);
+
+dashboard.new('User Group Diagnostics Dashboard')
++ dashboard.withTags(['jupyterhub'])
++ dashboard.withUid('group-diagnostics-dashboard')
++ dashboard.withEditable(true)
++ dashboard.withVariables([
+  common.variables.prometheus,
+  common.variables.hub,
+  common.variables.user_group,
+])
++ dashboard.withPanels(
+  grafonnet.util.grid.makeGrid(
+    [
+      memoryUsage,
+      cpuUsage,
+      memoryRequests,
+      cpuRequests,
+    ],
+    panelWidth=24,
+    panelHeight=12,
+  )
+)

--- a/grafana-dashboards/user.jsonnet
+++ b/grafana-dashboards/user.jsonnet
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S jsonnet -J ../vendor
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v11.1.0/main.libsonnet';
+local dashboard = grafonnet.dashboard;
+local ts = grafonnet.panel.timeSeries;
+local prometheus = grafonnet.query.prometheus;
+
+local common = import './common.libsonnet';
+
+local memoryUsage =
+  common.tsOptions
+  + ts.new('Memory Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per user memory usage
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          container_memory_working_set_bytes{name!="", pod=~"jupyter-.*", namespace=~"$hub"}
+            * on (namespace, pod) group_left(annotation_hub_jupyter_org_username)
+            group(
+                kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~"$user_name", pod=~"jupyter-.*"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+        ) by (annotation_hub_jupyter_org_username, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ annotation_hub_jupyter_org_username }} - ({{ namespace }})'),
+  ]);
+
+
+local cpuUsage =
+  common.tsOptions
+  + ts.new('CPU Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per user CPU usage
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          # exclude name="" because the same container can be reported
+          # with both no name and `name=k8s_...`,
+          # in which case sum() by (pod) reports double the actual metric
+          irate(container_cpu_usage_seconds_total{name!="", pod=~"jupyter-.*"}[5m])
+          * on (namespace, pod) group_left(annotation_hub_jupyter_org_username)
+          group(
+              kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~"$user_name"}
+          ) by (pod, namespace, annotation_hub_jupyter_org_username)
+        ) by (annotation_hub_jupyter_org_username, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ annotation_hub_jupyter_org_username }} - ({{ namespace }})'),
+  ]);
+
+local homedirSharedUsage =
+  common.tsOptions
+  + ts.new('Home Directory Usage (on shared home directories)')
+  + ts.panelOptions.withDescription(
+    |||
+      Per user home directory size, when using a shared home directory.
+
+      Requires https://github.com/yuvipanda/prometheus-dirsize-exporter to
+      be set up.
+
+      Similar to server pod names, user names will be *encoded* here
+      using the escapism python library (https://github.com/minrk/escapism).
+      You can unencode them with the following python snippet:
+
+      from escapism import unescape
+      unescape('<escaped-username>', '-')
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        max(
+          dirsize_total_size_bytes{namespace=~"$hub"}
+        ) by (directory, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ directory }} - ({{ namespace }})'),
+  ]);
+
+local memoryRequests =
+  common.tsOptions
+  + ts.new('Memory Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per-user memory requests
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="memory", namespace=~"$hub", pod=~"jupyter-.*"}  * on (namespace, pod)
+          group_left(annotation_hub_jupyter_org_username) group(
+            kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~"$user_name"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+        ) by (annotation_hub_jupyter_org_username, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ annotation_hub_jupyter_org_username }} - ({{ namespace }})'),
+  ]);
+
+local cpuRequests =
+  common.tsOptions
+  + ts.new('CPU Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per user CPU requests
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="cpu", namespace=~"$hub", pod=~"jupyter-.*"} * on (namespace, pod)
+          group_left(annotation_hub_jupyter_org_username) group(
+            kube_pod_annotations{namespace=~"$hub", annotation_hub_jupyter_org_username=~"$user_name"}
+            ) by (pod, namespace, annotation_hub_jupyter_org_username)
+        ) by (annotation_hub_jupyter_org_username, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ annotation_hub_jupyter_org_username }} - ({{ namespace }})'),
+  ]);
+
+dashboard.new('User Diagnostics Dashboard (test)')
++ dashboard.withTags(['jupyterhub'])
++ dashboard.withUid('user-diagnostics-dashboard')
++ dashboard.withEditable(true)
++ dashboard.withVariables([
+  common.variables.prometheus,
+  common.variables.hub,
+  common.variables.user_name,
+])
++ dashboard.withPanels(
+  grafonnet.util.grid.makeGrid(
+    [
+      memoryUsage,
+      cpuUsage,
+      homedirSharedUsage,
+      memoryRequests,
+      cpuRequests,
+    ],
+    panelWidth=24,
+    panelHeight=12,
+  )
+)


### PR DESCRIPTION
This PR adds a new "User Group Diagnostics" Grafana dashboard that complements the "User Diagnostics Dashboard" to show resource usage aggregated by user group.

Requires [jupyterhub-groups-exporter](https://github.com/2i2c-org/jupyterhub-groups-exporter) to be set up on the hub. 

For this to universally work across all our infrastructure, I decided to separate the user group dashboard entirely from user name based aggregation. This is because if I combined both user name and user group into one dashboard/PromQL query, then it would break the dashboard for hubs that do not have [jupyterhub-groups-exporter](https://github.com/2i2c-org/jupyterhub-groups-exporter) set up because the `jupyterhub_user_group_info` metric is unavailable to the PromQL. Therefore, if a hub does not have [jupyterhub-groups-exporter](https://github.com/2i2c-org/jupyterhub-groups-exporter) set up, then the "User Diagnostics" dashboard will work as normal but the "User Group Diagnostics" dashboard will show no data.

Ref: https://github.com/2i2c-org/infrastructure/issues/5983