### PR TITLE
[earthscope] Unify jupyterhub-groups-exporter configuration

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -141,6 +141,15 @@ basehub:
             - google-oauth2|108516754518362587599 # Yuvi
             - google-oauth2|117859169473992122769 # Georgiana
             - google-oauth2|117322480787655244438 # Jenny
+      services:
+        jupyterhub-groups-exporter: {}
+      loadRoles:
+        jupyterhub-groups-exporter:
+          services:
+            - jupyterhub-groups-exporter
+          scopes:
+            - users
+            - groups
     singleuser:
       cloudMetadata:
         blockWithIptables: false
@@ -284,3 +293,12 @@ basehub:
     enabled: true
     eks:
       enabled: true
+  jupyterhub-groups-exporter:
+    enabled: true
+    config:
+      groupsExporter:
+        update_exporter_interval: 3600
+        allowed_groups:
+          - geolab
+          - geolab:dev
+          - geolab:power

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -22,15 +22,6 @@ basehub:
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.earthscope.org
-      services:
-        jupyterhub-groups-exporter: {}
-      loadRoles:
-        jupyterhub-groups-exporter:
-          services:
-            - jupyterhub-groups-exporter
-          scopes:
-            - users
-            - groups
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod
@@ -56,12 +47,3 @@ basehub:
   nfs:
     pv:
       serverIP: 10.100.182.228
-  jupyterhub-groups-exporter:
-    enabled: true
-    config:
-      groupsExporter:
-        update_exporter_interval: 3600
-        allowed_groups:
-          - geolab
-          - geolab:dev
-          - geolab:power

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -25,15 +25,6 @@ basehub:
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.dev.earthscope.org
-      services:
-        jupyterhub-groups-exporter: {}
-      loadRoles:
-        jupyterhub-groups-exporter:
-          services:
-            - jupyterhub-groups-exporter
-          scopes:
-            - users
-            - groups
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging
@@ -56,12 +47,3 @@ basehub:
   nfs:
     pv:
       serverIP: 10.100.217.166
-  jupyterhub-groups-exporter:
-    enabled: true
-    config:
-      groupsExporter:
-        update_exporter_interval: 3600
-        allowed_groups:
-          - geolab
-          - geolab:dev
-          - geolab:power


### PR DESCRIPTION
Unify groups-exporter config into `common.values.yaml` file.

Follow up to https://github.com/2i2c-org/infrastructure/pull/6068 and https://github.com/2i2c-org/infrastructure/pull/6055