### PR TITLE
add writeable shared directory for users

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -69,6 +69,13 @@ jupyterhub:
     cloudMetadata:
       blockWithIptables: false
     defaultUrl: /lab
+    storage:
+      extraVolumeMounts:
+        # A shared folder readable & writeable by everyone
+        - name: home
+          mountPath: /home/jovyan/shared-public
+          subPath: _shared-public
+          readOnly: false
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: "Iv23lio8dJq5euL8Y2kF"
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/nmfs-openscapes-github-push-access


### PR DESCRIPTION
I don't how to fix the ownership however in our main hub. The workshop hub yaml has this line
https://github.com/2i2c-org/infrastructure/blob/e56e9680767a9785702ac7a95ed738c30067595f/config/clusters/nmfs-openscapes/workshop.values.yaml#L44-L49

But the main hub does not have this line.