### PR TITLE
Bump pangeo-docker-images from `2025.01.24` to `2025.05.22`

### DIFF
--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -176,21 +176,21 @@ basehub:
                   image: "{value}"
               choices:
                 pangeo:
-                  display_name: Base Pangeo Notebook (2025.01.24)
+                  display_name: Base Pangeo Notebook (2025.05.22)
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2025.01.24"
+                    image: "pangeo/pangeo-notebook:2025.05.22"
                 tensorflow:
-                  display_name: Pangeo Tensorflow ML Notebook (2025.01.24)
+                  display_name: Pangeo Tensorflow ML Notebook (2025.05.22)
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2025.01.24"
+                    image: "pangeo/ml-notebook:2025.05.22"
                 pytorch:
-                  display_name: Pangeo PyTorch ML Notebook (2025.01.24)
+                  display_name: Pangeo PyTorch ML Notebook (2025.05.22)
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2025.01.24"
+                    image: "pangeo/pytorch-notebook:2025.05.22"
                 leap-pangeo-edu:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
@@ -284,21 +284,21 @@ basehub:
                   image: "{value}"
               choices:
                 pangeo:
-                  display_name: Base Pangeo Notebook (2025.01.24)
+                  display_name: Base Pangeo Notebook (2025.05.22)
                   default: true
                   slug: "pangeo"
                   kubespawner_override:
-                    image: "pangeo/pangeo-notebook:2025.01.24"
+                    image: "pangeo/pangeo-notebook:2025.05.22"
                 tensorflow:
-                  display_name: Pangeo Tensorflow ML Notebook (2025.01.24)
+                  display_name: Pangeo Tensorflow ML Notebook (2025.05.22)
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2025.01.24"
+                    image: "pangeo/ml-notebook:2025.05.22"
                 pytorch:
-                  display_name: Pangeo PyTorch ML Notebook (2025.01.24)
+                  display_name: Pangeo PyTorch ML Notebook (2025.05.22)
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2025.01.24"
+                    image: "pangeo/pytorch-notebook:2025.05.22"
                 leap-pangeo-edu:
                   display_name: LEAP Education Notebook (Testing Prototype)
                   slug: "leap_edu"
@@ -348,15 +348,15 @@ basehub:
               unlisted_choice: *profile_list_unlisted_choice
               choices:
                 tensorflow:
-                  display_name: Pangeo Tensorflow ML Notebook (2025.01.24)
+                  display_name: Pangeo Tensorflow ML Notebook (2025.05.22)
                   slug: "tensorflow"
                   kubespawner_override:
-                    image: "pangeo/ml-notebook:2025.01.24"
+                    image: "pangeo/ml-notebook:2025.05.22"
                 pytorch:
-                  display_name: Pangeo PyTorch ML Notebook (2025.01.24)
+                  display_name: Pangeo PyTorch ML Notebook (2025.05.22)
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "pangeo/pytorch-notebook:2025.01.24"
+                    image: "pangeo/pytorch-notebook:2025.05.22"
           kubespawner_override:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -285,7 +285,7 @@ basehub:
                   default: true
                   slug: "pytorch"
                   kubespawner_override:
-                    image: "quay.io/pangeo/pytorch-notebook:2025.01.24"
+                    image: "quay.io/pangeo/pytorch-notebook:2025.05.22"
           kubespawner_override:
             environment:
               NVIDIA_DRIVER_CAPABILITIES: compute,utility

--- a/config/clusters/reflective/common.values.yaml
+++ b/config/clusters/reflective/common.values.yaml
@@ -93,7 +93,7 @@ jupyterhub:
                 display_name: Pangeo Notebook Image
                 description: "Python image with scientific, dask and geospatial tools"
                 kubespawner_override:
-                  image: pangeo/pangeo-notebook:2025.01.24
+                  image: pangeo/pangeo-notebook:2025.05.22
               03-rocker:
                 display_name: Rocker Geospatial with RStudio
                 description: R environment with many geospatial libraries pre-installed


### PR DESCRIPTION
Contains `zarr-python==3.0.8` which fixes a potential data loss bug for zarr-python users, xref https://github.com/pangeo-data/pangeo-docker-images/issues/606 and https://zarr.readthedocs.io/en/v3.0.8/release-notes.html#id1