### PR TITLE
Destroy and recreate catalystproject-africa EBS volumes

### DIFF
--- a/config/clusters/catalystproject-africa/aibst.values.yaml
+++ b/config/clusters/catalystproject-africa/aibst.values.yaml
@@ -29,4 +29,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "50" # in GB
   eks:
-    volumeId: vol-06a16472044aa6ebc
+    volumeId: vol-05810452a41759168

--- a/config/clusters/catalystproject-africa/bhki.values.yaml
+++ b/config/clusters/catalystproject-africa/bhki.values.yaml
@@ -34,4 +34,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "350" # in GB
   eks:
-    volumeId: vol-0d045995f74632549
+    volumeId: vol-010d4c82c22dd5e69

--- a/config/clusters/catalystproject-africa/bon.values.yaml
+++ b/config/clusters/catalystproject-africa/bon.values.yaml
@@ -30,4 +30,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-015975b7cf4ff6f74
+    volumeId: vol-09dc8201c516e2e70

--- a/config/clusters/catalystproject-africa/kush.values.yaml
+++ b/config/clusters/catalystproject-africa/kush.values.yaml
@@ -29,4 +29,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-0dd3949e267cd806b
+    volumeId: vol-0de5b955b6bd6dfc6

--- a/config/clusters/catalystproject-africa/molerhealth.values.yaml
+++ b/config/clusters/catalystproject-africa/molerhealth.values.yaml
@@ -29,4 +29,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "350" # in GB
   eks:
-    volumeId: vol-0565144a04545ca05
+    volumeId: vol-0818b363dec5d022f

--- a/config/clusters/catalystproject-africa/must.values.yaml
+++ b/config/clusters/catalystproject-africa/must.values.yaml
@@ -37,4 +37,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-06f70de4da8137046
+    volumeId: vol-0b664c61a6ac96c73

--- a/config/clusters/catalystproject-africa/nm-aist.values.yaml
+++ b/config/clusters/catalystproject-africa/nm-aist.values.yaml
@@ -37,4 +37,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-0919166247adeb423
+    volumeId: vol-0335f8d2d1795a035

--- a/config/clusters/catalystproject-africa/staging.values.yaml
+++ b/config/clusters/catalystproject-africa/staging.values.yaml
@@ -32,4 +32,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-072df08df0e6623c8
+    volumeId: vol-0b6a28a6eec8fdb3f

--- a/config/clusters/catalystproject-africa/uvri.values.yaml
+++ b/config/clusters/catalystproject-africa/uvri.values.yaml
@@ -31,4 +31,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-0a5a743a0a8b387c8
+    volumeId: vol-048173ffd8e87f1d3

--- a/config/clusters/catalystproject-africa/wits.values.yaml
+++ b/config/clusters/catalystproject-africa/wits.values.yaml
@@ -29,4 +29,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     hardQuota: "1" # in GB
   eks:
-    volumeId: vol-081131f51aad5db07
+    volumeId: vol-0c891ce78c5d76b2b

--- a/terraform/aws/projects/catalystproject-africa.tfvars
+++ b/terraform/aws/projects/catalystproject-africa.tfvars
@@ -34,7 +34,7 @@ hub_cloud_permissions = {
 
 ebs_volumes = {
   "uvri" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "uvri"
     tags        = { "2i2c:hub-name" : "uvri" }
@@ -52,7 +52,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "must" }
   },
   "nm-aist" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "nm-aist"
     tags        = { "2i2c:hub-name" : "nm-aist" }
@@ -64,7 +64,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "molerhealth" }
   },
   "staging" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name" : "staging" }
@@ -76,19 +76,19 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "aibst" }
   },
   "kush" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "kush"
     tags        = { "2i2c:hub-name" : "kush" }
   },
   "wits" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "wits"
     tags        = { "2i2c:hub-name" : "wits" }
   },
   "bon" = {
-    size        = 1
+    size        = 8
     type        = "gp3"
     name_suffix = "bon"
     tags        = { "2i2c:hub-name" : "bon" }


### PR DESCRIPTION
Because I had missed a manual step when I did this previously (since fixed by https://github.com/2i2c-org/infrastructure/pull/6094), the volumes had become unusable. This recreates them after I made a few attempts at recovering them and failed.

Ref https://github.com/2i2c-org/infrastructure/issues/5658