### PR TITLE
[jupyter-health] Enable jupyterhub-groups-exporter

### DIFF
--- a/config/clusters/jupyter-health/common.values.yaml
+++ b/config/clusters/jupyter-health/common.values.yaml
@@ -21,6 +21,12 @@ jupyterhub-home-nfs:
   prometheusExporter:
     enabled: true
 
+jupyterhub-groups-exporter:
+  enabled: true
+  config:
+    groupsExporter:
+      update_exporter_interval: 3600
+
 jupyterhub:
   custom:
     2i2c:
@@ -84,6 +90,15 @@ jupyterhub:
           - "20005" # Moslehi Lab
           - "20006" # Olgin Lab
           - "20026" # BIDS - URAP
+    services:
+      jupyterhub-groups-exporter: {}
+    loadRoles:
+      jupyterhub-groups-exporter:
+        services:
+          - jupyterhub-groups-exporter
+        scopes:
+          - users
+          - groups
     extraConfig:
       # get organization membership for managed groups:
       managed_organizations.py: |


### PR DESCRIPTION
Ref: https://github.com/2i2c-org/infrastructure/issues/5983