### PR TITLE
Add an 'exec promql' feature to the deployer command

### DIFF
--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -6,6 +6,7 @@ import deployer.commands.debug  # noqa: F401
 import deployer.commands.deployer  # noqa: F401
 import deployer.commands.exec.cloud  # noqa: F401
 import deployer.commands.exec.infra_components  # noqa: F401
+import deployer.commands.exec.promql  # noqa: F401
 import deployer.commands.generate.billing.cost_table  # noqa: F401
 import deployer.commands.generate.cryptnono_config  # noqa: F401
 import deployer.commands.generate.dedicated_cluster.aws  # noqa: F401

--- a/deployer/commands/exec/promql.py
+++ b/deployer/commands/exec/promql.py
@@ -48,6 +48,7 @@ def promql(
     else:
         if len(result) == 0:
             print("No data returned")
+            return
 
         column_names = list(result[0]["metric"].keys())
 

--- a/deployer/commands/exec/promql.py
+++ b/deployer/commands/exec/promql.py
@@ -1,0 +1,66 @@
+import json
+
+import requests
+import typer
+from rich.console import Console
+from rich.table import Table
+from ruamel.yaml import YAML
+from yarl import URL
+
+from deployer.cli_app import exec_app
+from deployer.infra_components.cluster import Cluster
+
+# Without `pure=True`, I get an exception about str / byte issues
+yaml = YAML(typ="safe", pure=True)
+
+
+@exec_app.command()
+def promql(
+    cluster_name: str = typer.Argument(help="Name of the Cluster to Query"),
+    query: str = typer.Argument(help="PromQL query to execute"),
+    output_json: bool = typer.Option(
+        False, "--json", help="Output JSON rather than pretty table"
+    ),
+):
+    """
+    Execute a PromQL query against a cluster's prometheus instance
+    """
+
+    cluster = Cluster.from_name(cluster_name)
+
+    promql_api = URL(f"{cluster.get_external_prometheus_url()}/api/v1/query")
+
+    query_api = promql_api.with_query({"query": query})
+
+    resp = requests.get(str(query_api), auth=cluster.get_cluster_prometheus_creds())
+    resp.raise_for_status()
+
+    result = resp.json()["data"]["result"]
+
+    if output_json:
+        data = []
+        for entry in result:
+            row = entry["metric"].copy()
+            row["value"] = entry["value"][1]
+            data.append(row)
+
+        print(json.dumps(data))
+    else:
+        if len(result) == 0:
+            print("No data returned")
+
+        column_names = list(result[0]["metric"].keys())
+
+        table = Table()
+        for cn in column_names:
+            table.add_column(cn, justify="left")
+        table.add_column("value", justify="right", no_wrap=True)
+
+        for entry in result:
+            row = []
+            for cn in column_names:
+                row.append(entry["metric"][cn])
+            row.append(entry["value"][1])
+            table.add_row(*row)
+
+        Console().print(table)


### PR DESCRIPTION
This executes arbitrary promql queries against any of our cluster prometheuses and instantly gives you response for the last time we have data for.

This helped me determine what limits per user directories on the hubs should have.

![image](https://github.com/user-attachments/assets/7527af6f-03ae-4a37-bd96-130474d54e65)

Requires https://github.com/2i2c-org/infrastructure/pull/6121, and was the inspiration for a lot of the cleanup there