### PR TITLE
Set quotaEnforcer.path for staging hubs too

### DIFF
--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -13,8 +13,8 @@ local emitDaskHubCompatibleConfig(basehubConfig) =
   if isDaskHub then { basehub: basehubConfig } else basehubConfig;
 
 local jupyterhubHomeNFSResources = {
-  # The + is required so this will merge correctly with other config
-  # when needed
+  // The + is required so this will merge correctly with other config
+  // when needed
   quotaEnforcer+: {
     resources: {
       requests: {


### PR DESCRIPTION
Without this, it was only being set for non-staging hubs. So staging hubs now have a quota set on the entire directory, instead of for each user. We will have to unset that quota somehow.

Ref https://github.com/2i2c-org/infrastructure/issues/6129