### PR TITLE
[nasa-ghg] Add ghg buckets access

### DIFF
--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -68,7 +68,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::podaac-ops-cumulus-public/*",
               "arn:aws:s3:::podaac-ops-cumulus-protected",
               "arn:aws:s3:::podaac-ops-cumulus-protected/*",
+              "arn:aws:s3:::ghg-ssim",
               "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm",
               "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },
@@ -121,7 +123,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::nsidc-cumulus-prod-protected/*",
               "arn:aws:s3:::ornl-cumulus-prod-protected",
               "arn:aws:s3:::ornl-cumulus-prod-protected/*",
+              "arn:aws:s3:::ghg-ssim",
               "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm",
               "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },
@@ -178,7 +182,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::podaac-ops-cumulus-public/*",
               "arn:aws:s3:::podaac-ops-cumulus-protected",
               "arn:aws:s3:::podaac-ops-cumulus-protected/*",
+              "arn:aws:s3:::ghg-ssim",
               "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm",
               "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },

--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -67,7 +67,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::podaac-ops-cumulus-public",
               "arn:aws:s3:::podaac-ops-cumulus-public/*",
               "arn:aws:s3:::podaac-ops-cumulus-protected",
-              "arn:aws:s3:::podaac-ops-cumulus-protected/*"
+              "arn:aws:s3:::podaac-ops-cumulus-protected/*",
+              "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },
           {
@@ -118,7 +120,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::nsidc-cumulus-prod-protected",
               "arn:aws:s3:::nsidc-cumulus-prod-protected/*",
               "arn:aws:s3:::ornl-cumulus-prod-protected",
-              "arn:aws:s3:::ornl-cumulus-prod-protected/*"
+              "arn:aws:s3:::ornl-cumulus-prod-protected/*",
+              "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },
           {
@@ -173,7 +177,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::podaac-ops-cumulus-public",
               "arn:aws:s3:::podaac-ops-cumulus-public/*",
               "arn:aws:s3:::podaac-ops-cumulus-protected",
-              "arn:aws:s3:::podaac-ops-cumulus-protected/*"
+              "arn:aws:s3:::podaac-ops-cumulus-protected/*",
+              "arn:aws:s3:::ghg-ssim/*",
+              "arn:aws:s3:::ghg-retrieval-algorithm/*"
             ]
           },
           {


### PR DESCRIPTION
# Description
Add bucket access to ghg prod, staging, and binder hub for the following buckets
```
"arn:aws:s3:::ghg-ssim/*",
"arn:aws:s3:::ghg-retrieval-algorithm/*",
```