### PR TITLE
Bump `requires-python` of `2i2c-deployer` to `>=3.13`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Deploy JupyterHubs for the 2i2c Infrastructure"
 version = "0.0.1"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.hatch.metadata.hooks.requirements_txt]


### PR DESCRIPTION
This isn't capped, because `requires-python` isn't designed for upper-bound caps.