### PR TITLE
Increase the Binder Ram allocation

### DIFF
--- a/config/clusters/nasa-ghg/binder.values.yaml
+++ b/config/clusters/nasa-ghg/binder.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
       2i2c/hub-name: binder
     memory:
       guarantee: 1G
-      limit: 2G
+      limit: 8G
     cpu:
       limit: 1
     storage:


### PR DESCRIPTION
Some examples require significantly more memory than 2GB to even attempt. For at least 1 demo in June we need to try with more ram. Can discuss with user later if we can turn it back down.

Is this the only place that needs to be changed to allow the Binder launched instances to have more ram?

@batpad @yuvipanda @GeorgianaElena 