### PR TITLE
Change ordering of query & clustername in exec promql

### DIFF
--- a/deployer/commands/exec/promql.py
+++ b/deployer/commands/exec/promql.py
@@ -16,8 +16,8 @@ yaml = YAML(typ="safe", pure=True)
 
 @exec_app.command()
 def promql(
-    cluster_name: str = typer.Argument(help="Name of the Cluster to Query"),
     query: str = typer.Argument(help="PromQL query to execute"),
+    cluster_name: str = typer.Argument(help="Name of the Cluster to Query"),
     output_json: bool = typer.Option(
         False, "--json", help="Output JSON rather than pretty table"
     ),


### PR DESCRIPTION
This allows us to use `xargs` as a way to run a query across all our clusters:

```bash
deployer config get-clusters | xargs -L1 deployer exec promql 'kube_pod_labels{pod=~".*shell.*"}'
```

This query checked if there's a pod with name 'shell' running in *any* of our clusters.

Ref https://github.com/2i2c-org/meta/issues/2244