### PR TITLE
[cloudbank] Fix authentication for staff

### DIFF
--- a/config/clusters/cloudbank/elac.values.yaml
+++ b/config/clusters/cloudbank/elac.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: github
+      add_staff_user_ids_of_type: google
     homepage:
       templateVars:
         org:

--- a/config/clusters/cloudbank/sierra.values.yaml
+++ b/config/clusters/cloudbank/sierra.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: google
+      add_staff_user_ids_of_type: github
     homepage:
       templateVars:
         org:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1686,7 +1686,7 @@ jupyterhub:
         # Appends 2i2c staff access by GitHub team membership by default for GitHub authenticated hubs.
         if c.JupyterHub.authenticator_class == "github" and type(c.GitHubOAuthenticator.allowed_organizations) == list:
           c.GitHubOAuthenticator.allowed_organizations.append("2i2c-org:hub-access-for-2i2c-staff")
-        else:
+        elif c.JupyterHub.authenticator_class == "github":
           print("No GitHubOAuthenticator.allowed_organizations found, setting to ['2i2c-org:hub-access-for-2i2c-staff']")
           c.GitHubOAuthenticator.allowed_organizations = ["2i2c-org:hub-access-for-2i2c-staff"]
 


### PR DESCRIPTION
I was investigating at why cloudbank health checks in the CI/CD were failing after https://github.com/2i2c-org/infrastructure/pull/6032 was merged and noticed that staff login for a couple of hubs needed updating.

Added a conditional if statement for `extraConfig.09-2i2c-add-staff-gh-team`.