### PR TITLE
Add pod restart alert for pod names containing groups-exporter substring

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -10,6 +10,8 @@ on:
           as to which subcharts need bumping to which versions will be printed to stdout.
         default: false
         required: false
+  schedule:
+    - cron: "0 0 1 * *" # Run first of every month at 00:00 UTC
 
 env:
   team_reviewers: engineering

--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -11,7 +11,7 @@ on:
         default: false
         required: false
   schedule:
-    - cron: "0 0 1 * *" # Run first of every month at 00:00 UTC
+  - cron: 0 0 1 * *     # Run first of every month at 00:00 UTC
 
 env:
   team_reviewers: engineering

--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -28,7 +28,6 @@ basehub:
         extraVolumeMounts:
         - name: home
           mountPath: /home/jovyan/allusers
-          readOnly: true
           # mounts below are copied from basehub's values that we override by
           # specifying extraVolumeMounts (lists get overridden when helm values
           # are combined)

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -39,7 +39,7 @@ jupyterhub:
       jupyterHub:
         authenticator_class: dummy
   singleuser:
-    defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2FScienceCore%2Fclimaterisk&urlpath=lab%2Ftree%2Fclimaterisk%2Fbook%2F00_Introduction_Setup%2F00_Getting_NASA_EarthData_Credentials.ipynb&branch=notebooks
+    defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2FScienceCore%2Fclimaterisk&urlpath=lab%2Ftree%2Fclimaterisk%2Fbook%2FStartup.ipynb&branch=notebooks
     image:
       name: quay.io/2i2c/sciencecore-climaterisk-image
       tag: 09c3a11f1698

--- a/deployer/commands/exec/promql.py
+++ b/deployer/commands/exec/promql.py
@@ -16,8 +16,8 @@ yaml = YAML(typ="safe", pure=True)
 
 @exec_app.command()
 def promql(
-    cluster_name: str = typer.Argument(help="Name of the Cluster to Query"),
     query: str = typer.Argument(help="PromQL query to execute"),
+    cluster_name: str = typer.Argument(help="Name of the Cluster to Query"),
     output_json: bool = typer.Option(
         False, "--json", help="Output JSON rather than pretty table"
     ),

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -1,0 +1,40 @@
+# Managing alerts configured with Jsonnet
+
+In addition to [](#uptime-checks), we also have a set of alerts that are configured in support deployments using [](#topic/jsonnet).
+
+## Configuration
+
+We use the [Prometheus alert manager](https://prometheus.io/docs/alerting/latest/overview/) to set up alerts that are defined in the `helm-charts/support/values.jsonnet` file.
+
+At the time of writing, we have the following classes of alerts:
+
+1. when a persistent volume claim (PVC) is approaching full capacity
+2. when a pod has restarted in the last hour.
+
+When an alert threshold is crossed, an automatic notification is sent to PagerDuty and the `#pagerduty-notifications` channel on the 2i2c Slack.
+
+## When a PVC is approaching full capacity
+
+We monitor the capacity of the following volumes:
+
+- home directories
+- hub database
+- prometheus database
+
+The alert is triggered when the volume is more than 90% full.
+
+To resolve the alert, follow the guidance below
+
+- [](../../howto/filesystem-management/increase-disk-size.md)
+- **TODO: add instructions for hub database**
+- [](../../sre-guide/prometheus-disk-resize.md)
+
+## When a pod has restarted in the last hour
+
+We monitor pod restarts for the following services:
+
+- `jupyterhub-groups-exporter`
+
+If a pod has restarted in the last hour, it may indicate an issue with the service or its configuration. Check the logs of the pod to identify any errors or issues that may have caused the restart. If necessary, redeploy the service or adjust its configuration to resolve the issue.
+
+If you have taken the above actions and the issue persists, then open a GitHub issue capturing the details of the problem for consideration by the wider 2i2c team.

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -9,7 +9,7 @@ We use the [Prometheus alert manager](https://prometheus.io/docs/alerting/latest
 At the time of writing, we have the following classes of alerts:
 
 1. when a persistent volume claim (PVC) is approaching full capacity
-2. when a pod has restarted in the last hour.
+2. when a pod has restarted.
 
 When an alert threshold is crossed, an automatic notification is sent to PagerDuty and the `#pagerduty-notifications` channel on the 2i2c Slack.
 
@@ -29,12 +29,20 @@ To resolve the alert, follow the guidance below
 - **TODO: add instructions for hub database**
 - [](../../sre-guide/prometheus-disk-resize.md)
 
-## When a pod has restarted in the last hour
+## When a pod has restarted
 
 We monitor pod restarts for the following services:
 
 - `jupyterhub-groups-exporter`
 
-If a pod has restarted in the last hour, it may indicate an issue with the service or its configuration. Check the logs of the pod to identify any errors or issues that may have caused the restart. If necessary, redeploy the service or adjust its configuration to resolve the issue.
+If a pod has restarted, it may indicate an issue with the service or its configuration. Check the logs of the pod to identify any errors or issues that may have caused the restart. If necessary, redeploy the service or adjust its configuration to resolve the issue.
 
-If you have taken the above actions and the issue persists, then open a GitHub issue capturing the details of the problem for consideration by the wider 2i2c team.
+Once the pod is stable, ensure that the alert is resolved by checking whether the pod has been running without restarts, e.g. by running the following command:
+
+```bash
+$ kubectl -n <namespace> get pod
+NAME                                                 READY   STATUS    RESTARTS      AGE
+staging-groups-exporter-deployment-9b4c6749c-sgfcc   1/1     Running   0   10m
+```
+
+If you have taken the above actions and the issue persists, then open a GitHub issue capturing the details of the problem for consideration by the wider 2i2c team. See [](#uptime-checks) on how to snooze an alert in the meantime.

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -35,7 +35,7 @@ We monitor pod restarts for the following services:
 
 - `jupyterhub-groups-exporter`
 
-If a pod has restarted, it may indicate an issue with the service or its configuration. Check the logs of the pod to identify any errors or issues that may have caused the restart. If necessary, redeploy the service or adjust its configuration to resolve the issue.
+If a pod has restarted, it may indicate an issue with the service or its configuration. Check the logs of the pod to identify any errors or issues that may have caused the restart. If necessary, add more error handling to the code, redeploy the service or adjust its configuration to resolve the issue.
 
 Once the pod is stable, ensure that the alert is resolved by checking whether the pod has been running without restarts, e.g. by running the following command:
 

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -26,7 +26,7 @@ The alert is triggered when the volume is more than 90% full.
 To resolve the alert, follow the guidance below
 
 - [](../../howto/filesystem-management/increase-disk-size.md)
-- **TODO: add instructions for hub database**
+- To be documented, see [GH issue](https://github.com/2i2c-org/infrastructure/issues/6187)
 - [](../../sre-guide/prometheus-disk-resize.md)
 
 ## When a pod has restarted

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -1,4 +1,4 @@
-# Managing alerts configured with Jsonnet
+# Manage alerts configured with Jsonnet
 
 In addition to [](#uptime-checks), we also have a set of alerts that are configured in support deployments using [](#topic/jsonnet).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ howto/image-management/index
 howto/filesystem-management/index
 howto/prepare-for-events/index.md
 howto/manage-domains/index.md
+howto/manage-alerts/index.md
 howto/grafana-github-auth.md
 howto/regenerate-smce-creds.md
 howto/troubleshoot/index.md

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -15,13 +15,13 @@ dependencies:
   - name: prometheus
     # NOTE: CHECK INSTRUCTIONS UNDER prometheus.server.command IN support/values.yaml
     # EACH TIME THIS VERSION IS BUMPED!
-    version: 27.16.0
+    version: 27.20.0
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.
   # https://github.com/grafana/helm-charts/tree/main/charts/grafana
   - name: grafana
-    version: 8.5.2
+    version: 9.2.2
     repository: https://grafana.github.io/helm-charts
 
   # ingress-nginx for a k8s Ingress resource controller that routes traffic from
@@ -29,20 +29,20 @@ dependencies:
   # that references this controller.
   # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
   - name: ingress-nginx
-    version: 4.11.5
+    version: 4.12.3
     repository: https://kubernetes.github.io/ingress-nginx
 
   # cluster-autoscaler for k8s clusters where it doesn't come out of the box (EKS)
   # https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
   - name: cluster-autoscaler
-    version: 9.43.0
+    version: 9.46.6
     repository: https://kubernetes.github.io/autoscaler
     condition: cluster-autoscaler.enabled
 
   # cryptnono, counters crypto mining
   # https://github.com/cryptnono/cryptnono/
   - name: cryptnono
-    version: "0.3.1"
+    version: "0.3.2-0.dev.git.156.hdab4ec8"
     repository: https://cryptnono.github.io/cryptnono/
     condition: cryptnono.enabled
 

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -105,7 +105,7 @@ local makePodRestartAlert = function(
           ),
           makePodRestartAlert(
             'GroupsExporterPodRestarted',
-            'jupyterhub-groups-exporter pod has restarted cluster:%s:{{ $labels.namespace }}' % [cluster_name],
+            'jupyterhub-groups-exporter pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
             'groups-exporter',
           ),
         ],

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -46,8 +46,8 @@ local makePodRestartAlert = function(
     {
       alert: name,
       expr: |||
-        # Count container restarts with pod name containing 'pod_name_substring' in 1 hour.
-        sum(rate(kube_pod_container_status_restarts_total{pod=~".*%s.*"}[1h])) by (namespace) * 3600 >= 1
+        # Count total container restarts with pod name containing 'pod_name_substring'.
+        kube_pod_container_status_restarts_total{pod=~'.*%s.*'} >= 1
       ||| % [pod_name_substring],
       'for': '5m',
       labels: {
@@ -105,7 +105,7 @@ local makePodRestartAlert = function(
           ),
           makePodRestartAlert(
             'GroupsExporterPodRestarted',
-            'jupyterhub-groups-exporter pod has restarted: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
+            'jupyterhub-groups-exporter pod has restarted cluster:%s:{{ $labels.namespace }}' % [cluster_name],
             'groups-exporter',
           ),
         ],


### PR DESCRIPTION
Would like some guidance on how i can test this alert without merging into `main`.

Closes https://github.com/2i2c-org/infrastructure/issues/6176