### PR TITLE
Revert "Turn off cron of support chart updates"

### DIFF
--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -10,6 +10,8 @@ on:
           as to which subcharts need bumping to which versions will be printed to stdout.
         default: false
         required: false
+  schedule:
+    - cron: "0 0 1 * *" # Run first of every month at 00:00 UTC
 
 env:
   team_reviewers: engineering

--- a/.github/workflows/bump-helm-versions.yaml
+++ b/.github/workflows/bump-helm-versions.yaml
@@ -11,7 +11,7 @@ on:
         default: false
         required: false
   schedule:
-    - cron: "0 0 1 * *" # Run first of every month at 00:00 UTC
+  - cron: 0 0 1 * *     # Run first of every month at 00:00 UTC
 
 env:
   team_reviewers: engineering


### PR DESCRIPTION
In https://github.com/2i2c-org/infrastructure/issues/4484, I was relying on our internal engineering calendar to do support chart updates.

However, in the transition to the P&S team, we have switched back to automatically creating issues instead. This lets us
automatically create PRs, and merge them after taking a quick look.

This is in response to me trying to eliminate the 'class of problems' reported in https://2i2c.freshdesk.com/a/tickets/3454 and https://2i2c.freshdesk.com/a/tickets/3449 with GPU instances not starting up for 2 communities. Restarting the cluster autoscaler fixed the issue, implying that the cluster autoscaler had a bug that was causing this. We aren't on the latest version, and we should be. This lets us get back on to a more regular cadence here.

I'll also do a manual trigger of this workflow, and update everything now.

Reverts 2i2c-org/infrastructure#4497