### PR TITLE
feat: update node types in Project Pythia BinderHub on Jetstream2

### DIFF
--- a/config/clusters/2i2c-jetstream2/staging.values.yaml
+++ b/config/clusters/2i2c-jetstream2/staging.values.yaml
@@ -36,7 +36,7 @@ jupyterhub:
   prePuller:
     hook:
       nodeSelector:
-        capi.stackhpc.com/node-group: user-m3-large
+        capi.stackhpc.com/node-group: user-m3-quad
   ingress:
     hosts: [staging.js.2i2c.cloud]
     tls:
@@ -72,7 +72,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /lab
     nodeSelector:
-      capi.stackhpc.com/node-group: user-m3-large
+      capi.stackhpc.com/node-group: user-m3-quad
     profileList:
     - display_name: Choose your environment and resources
       slug: only-choice

--- a/config/clusters/2i2c-jetstream2/staging.values.yaml
+++ b/config/clusters/2i2c-jetstream2/staging.values.yaml
@@ -36,7 +36,7 @@ jupyterhub:
   prePuller:
     hook:
       nodeSelector:
-        capi.stackhpc.com/node-group: user-m3-quad
+        capi.stackhpc.com/node-group: user-m3-large
   ingress:
     hosts: [staging.js.2i2c.cloud]
     tls:
@@ -72,7 +72,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /lab
     nodeSelector:
-      capi.stackhpc.com/node-group: user-m3-quad
+      capi.stackhpc.com/node-group: user-m3-large
     profileList:
     - display_name: Choose your environment and resources
       slug: only-choice

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -35,7 +35,7 @@ jupyterhub:
       limit: 8G
       guarantee: 8G
     nodeSelector:
-      capi.stackhpc.com/node-group: user-m3-quad
+      capi.stackhpc.com/node-group: user-m3-large
     storage:
       type: none
       extraVolumeMounts: []
@@ -80,7 +80,7 @@ jupyterhub:
   prePuller:
     hook:
       nodeSelector:
-        capi.stackhpc.com/node-group: user-m3-quad
+        capi.stackhpc.com/node-group: user-m3-large
   hub:
     nodeSelector:
       capi.stackhpc.com/node-group: core
@@ -120,7 +120,7 @@ binderhub-service:
   dockerApi:
     nodeSelector:
       hub.jupyter.org/node-purpose:
-      capi.stackhpc.com/node-group: user-m3-quad
+      capi.stackhpc.com/node-group: user-m3-large
   config:
     GitHubRepoProvider:
       allowed_specs:
@@ -143,7 +143,7 @@ binderhub-service:
       node_selector:
         # Schedule builder pods to run on user nodes only
         hub.jupyter.org/node-purpose:
-        capi.stackhpc.com/node-group: user-m3-quad
+        capi.stackhpc.com/node-group: user-m3-large
   extraEnv:
   - name: JUPYTERHUB_API_TOKEN
     valueFrom:

--- a/terraform/openstack/projects/projectpythia-binder.tfvars
+++ b/terraform/openstack/projects/projectpythia-binder.tfvars
@@ -1,12 +1,12 @@
 prefix = "binder-pythia"
 
 notebook_nodes = {
-  "m3.quad" : {
+  "m3.large" : {
     min : 1,
     max : 100,
     # 4 CPU, 15 RAM
     # https://docs.jetstream-cloud.org/general/instance-flavors/#jetstream2-cpu
-    machine_type : "m3.quad",
+    machine_type : "m3.large",
     labels = {
       "hub.jupyter.org/node-purpose" = "user",
       "k8s.dask.org/node-purpose"    = "scheduler",

--- a/terraform/openstack/projects/projectpythia-binder.tfvars
+++ b/terraform/openstack/projects/projectpythia-binder.tfvars
@@ -4,7 +4,7 @@ notebook_nodes = {
   "m3.large" : {
     min : 1,
     max : 100,
-    # 4 CPU, 15 RAM
+    # 16 CPU, 60 RAM
     # https://docs.jetstream-cloud.org/general/instance-flavors/#jetstream2-cpu
     machine_type : "m3.large",
     labels = {


### PR DESCRIPTION
I didn't touch the staging Jetstream2 hub — I am not sure where the infrastructure-as-code is for that. My hunch is that we have imperatively built that configuration, rather than e.g. using Terraform.

@GeorgianaElena can you help me figure out a couple of questions?

1. I'm guessing that the `capi.stackhpc.com/node-group` label is set by the infrastructure. How does it normalise from the actual node-group name, which contains dots? i.e. from `"user-${each.key}"` where I assume that `${each.key}` contains dots, how do we end up with `"user-m3-large"` not `"user-m3.large"`?
2. Am I correct that the staging hub doesn't have infra-as-code in this repo?

Thanks!