### PR TITLE
Revert "feat: update node types in Project Pythia BinderHub on Jetstream2"

### DIFF
--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -35,7 +35,7 @@ jupyterhub:
       limit: 8G
       guarantee: 8G
     nodeSelector:
-      capi.stackhpc.com/node-group: user-m3-large
+      capi.stackhpc.com/node-group: user-m3-quad
     storage:
       type: none
       extraVolumeMounts: []
@@ -80,7 +80,7 @@ jupyterhub:
   prePuller:
     hook:
       nodeSelector:
-        capi.stackhpc.com/node-group: user-m3-large
+        capi.stackhpc.com/node-group: user-m3-quad
   hub:
     nodeSelector:
       capi.stackhpc.com/node-group: core
@@ -120,7 +120,7 @@ binderhub-service:
   dockerApi:
     nodeSelector:
       hub.jupyter.org/node-purpose:
-      capi.stackhpc.com/node-group: user-m3-large
+      capi.stackhpc.com/node-group: user-m3-quad
   config:
     GitHubRepoProvider:
       allowed_specs:
@@ -143,7 +143,7 @@ binderhub-service:
       node_selector:
         # Schedule builder pods to run on user nodes only
         hub.jupyter.org/node-purpose:
-        capi.stackhpc.com/node-group: user-m3-large
+        capi.stackhpc.com/node-group: user-m3-quad
   extraEnv:
   - name: JUPYTERHUB_API_TOKEN
     valueFrom:

--- a/terraform/openstack/projects/projectpythia-binder.tfvars
+++ b/terraform/openstack/projects/projectpythia-binder.tfvars
@@ -1,12 +1,12 @@
 prefix = "binder-pythia"
 
 notebook_nodes = {
-  "m3.large" : {
+  "m3.quad" : {
     min : 1,
     max : 100,
-    # 16 CPU, 60 RAM
+    # 4 CPU, 15 RAM
     # https://docs.jetstream-cloud.org/general/instance-flavors/#jetstream2-cpu
-    machine_type : "m3.large",
+    machine_type : "m3.quad",
     labels = {
       "hub.jupyter.org/node-purpose" = "user",
       "k8s.dask.org/node-purpose"    = "scheduler",


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#6189

It turns out that we don't run Terraform in our deploy process, so this would have failed at runtime.