### PR TITLE
Add Nix flake for the development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 # code-owner: @agoose77
-# This flake sets up an FSH dev-shell that installs all the required 
+# This flake sets up an FSH dev-shell that installs all the required
 # packages for running deployer, and then installs the tool in the virtual environment
 # It is not best-practice for the nix-way of distributing this code,
 # but its purpose is to get an environment up and running.
@@ -39,18 +39,18 @@
             awscli2
             azure-cli
             terraform
-	    eksctl
+            eksctl
           ]);
           runScript = "${pkgs.writeShellScriptBin "runScript" (''
-set -e
-if [[ ! -d .venv ]]; then
-  ${pkgs.python3.interpreter} -m venv .venv
-  source .venv/bin/activate
-  python -m pip install -e .[dev]
-else
-  source .venv/bin/activate
-fi
-set +e
+              set -e
+              if [[ ! -d .venv ]]; then
+                ${pkgs.python3.interpreter} -m venv .venv
+                source .venv/bin/activate
+                python -m pip install -e .[dev]
+              else
+                source .venv/bin/activate
+              fi
+              set +e
             ''
             + script)}/bin/runScript";
         })

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+# code-owner: @agoose77
+# This flake sets up an FSH dev-shell that installs all the required 
+# packages for running deployer, and then installs the tool in the virtual environment
+# It is not best-practice for the nix-way of distributing this code,
+# but its purpose is to get an environment up and running.
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      envWithScript = script:
+        (pkgs.buildFHSUserEnv {
+          name = "2i2c-env";
+          targetPkgs = pkgs: (with pkgs; [
+            python3
+            python3Packages.pip
+            python3Packages.virtualenv
+            pythonManylinuxPackages.manylinux2014Package
+            cmake
+            ninja
+            gcc
+            pre-commit
+            # Infra packages
+            go-jsonnet
+            helm
+            kubectl
+            sops
+            google-cloud-sdk
+            awscli2
+            azure-cli
+            terraform
+	    eksctl
+          ]);
+          runScript = "${pkgs.writeShellScriptBin "runScript" (''
+set -e
+if [[ ! -d .venv ]]; then
+  ${pkgs.python3.interpreter} -m venv .venv
+  source .venv/bin/activate
+  python -m pip install -e .[dev]
+else
+  source .venv/bin/activate
+fi
+set +e
+            ''
+            + script)}/bin/runScript";
+        })
+        .env;
+    in {
+      devShell = envWithScript "bash";
+    });
+}


### PR DESCRIPTION
This PR adds a Nix flake that I am using to maintain this development environment locally. I spoke to @yuvipanda about the possibility of including this, given that I am using it to set up this environment on multiple machines.

To use this flake:
```shell
nix develop .
```