### PR TITLE
[nmfs-openscapes] add shared-public directory for staging and prod

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -69,38 +69,6 @@ jupyterhub:
     cloudMetadata:
       blockWithIptables: false
     defaultUrl: /lab
-    storage:
-      extraVolumeMounts:
-        # A shared folder readable & writeable by everyone
-        - name: home
-          mountPath: /home/jovyan/shared-public
-          subPath: _shared-public
-          readOnly: false
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
-          readOnly: true
-    initContainers:
-      - name: volume-mount-ownership-fix
-        image: busybox:1.36.1
-        command:
-          - sh
-          - -c
-          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: home
-            mountPath: /home/jovyan
-            subPath: "{escaped_username}"
-          # Mounted without readonly attribute here,
-          # so we can chown it appropriately
-          - name: home
-            mountPath: /home/jovyan/shared
-            subPath: _shared
-          - name: home
-            mountPath: /home/jovyan/shared-public
-            subPath: _shared-public
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23lio8dJq5euL8Y2kF
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/nmfs-openscapes-github-push-access

--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -76,6 +76,31 @@ jupyterhub:
           mountPath: /home/jovyan/shared-public
           subPath: _shared-public
           readOnly: false
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
+    initContainers:
+      - name: volume-mount-ownership-fix
+        image: busybox:1.36.1
+        command:
+          - sh
+          - -c
+          - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{escaped_username}"
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
+          - name: home
+            mountPath: /home/jovyan/shared
+            subPath: _shared
+          - name: home
+            mountPath: /home/jovyan/shared-public
+            subPath: _shared-public
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23lio8dJq5euL8Y2kF
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/nmfs-openscapes-github-push-access

--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -69,6 +69,13 @@ jupyterhub:
     cloudMetadata:
       blockWithIptables: false
     defaultUrl: /lab
+    storage:
+      extraVolumeMounts:
+        # A shared folder readable & writeable by everyone
+        - name: home
+          mountPath: /home/jovyan/shared-public
+          subPath: _shared-public
+          readOnly: false
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23lio8dJq5euL8Y2kF
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/nmfs-openscapes-github-push-access

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -30,6 +30,38 @@ jupyterhub:
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent/$(JUPYTERHUB_USER)
+    storage:
+      extraVolumeMounts:
+        # A shared folder readable & writeable by everyone
+      - name: home
+        mountPath: /home/jovyan/shared-public
+        subPath: _shared-public
+        readOnly: false
+      - name: home
+        mountPath: /home/jovyan/shared
+        subPath: _shared
+        readOnly: true
+    initContainers:
+    - name: volume-mount-ownership-fix
+      image: busybox:1.36.1
+      command:
+      - sh
+      - -c
+      - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: home
+        mountPath: /home/jovyan
+        subPath: '{escaped_username}'
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
+      - name: home
+        mountPath: /home/jovyan/shared
+        subPath: _shared
+      - name: home
+        mountPath: /home/jovyan/shared-public
+        subPath: _shared-public
   hub:
     config:
       JupyterHub:

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -30,6 +30,38 @@ jupyterhub:
     extraEnv:
       SCRATCH_BUCKET: s3://nmfs-openscapes-scratch-staging/$(JUPYTERHUB_USER)
       PERSISTENT_BUCKET: s3://nmfs-openscapes-persistent-staging/$(JUPYTERHUB_USER)
+    storage:
+      extraVolumeMounts:
+        # A shared folder readable & writeable by everyone
+      - name: home
+        mountPath: /home/jovyan/shared-public
+        subPath: _shared-public
+        readOnly: false
+      - name: home
+        mountPath: /home/jovyan/shared
+        subPath: _shared
+        readOnly: true
+    initContainers:
+    - name: volume-mount-ownership-fix
+      image: busybox:1.36.1
+      command:
+      - sh
+      - -c
+      - id && chown 1000:1000 /home/jovyan /home/jovyan/shared /home/jovyan/shared-public && ls -lhd /home/jovyan
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: home
+        mountPath: /home/jovyan
+        subPath: '{escaped_username}'
+          # Mounted without readonly attribute here,
+          # so we can chown it appropriately
+      - name: home
+        mountPath: /home/jovyan/shared
+        subPath: _shared
+      - name: home
+        mountPath: /home/jovyan/shared-public
+        subPath: _shared-public
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/pull/6096

Adds the configuration to both staging and prod because common also applies to noaa hub. 