### PR TITLE
Fix excessive grouping of alerts

### DIFF
--- a/helm-charts/support/enc-support.secret.values.yaml
+++ b/helm-charts/support/enc-support.secret.values.yaml
@@ -6,8 +6,7 @@ prometheus:
       receivers:
         - name: ENC[AES256_GCM,data:PuB35BjALacz,iv:39j9vTvzB1IB2pEZi+psoAv9FDMikOjrxps6+yxpLEQ=,tag:9apUjoupQkG6W9hsaZ6QHg==,type:str]
           pagerduty_configs:
-            - ENC[AES256_GCM,data:X91fQd0gulxQkTtfMk48RK4EQ0gHJXrBaUeEGZmNYiGZWuGFm7Hf7Cj+yO4Fg51vzqMDwGIVhP3LH80PQbzjo96qJjzVJwAF7SK30eTj9iEcOg==,iv:ymurqszkJ2xB5dj66EAuytARi9mS2oKMdxfbnRzwgP4=,tag:4fYp5OKFiLm2usIqPNN1lQ==,type:comment]
-            - service_key: ENC[AES256_GCM,data:bCMB2VURBRRPvrV542HQMUGHs9kicvwcD0maVqxuH2I=,iv:NTewUsy4xZNsA9xWVr1Yd62Z2ubtOVMe86erwstXgu4=,tag:DfPqZP1fR/sTNJfVuaCSwA==,type:str]
+            - routing_key: ENC[AES256_GCM,data:wecu/x0cTsUODGxoDbIh35sPvZI5NyMxtKeM3Hrvyno=,iv:IdZQ6BPbzXGO+evAlYB50G8fxgLajIPWu0utRovYxpk=,tag:V451xfOWo4bDyOhFfa31mw==,type:str]
 sops:
   kms: []
   gcp_kms:
@@ -17,8 +16,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2024-12-18T10:09:21Z"
-  mac: ENC[AES256_GCM,data:FLVIB1iZCSfuCwAiL0wBVHik2kO2xfR9iV0TgW2skPWMNJA+RWPhyHk8Ma3SsH/7iSOR8acwrFZ0b6DBhAtTtQEV1DGdSm9LvdHE2hkG7oFZzkdXYaC2YcwwkVJzfEmwZIn7OECXTL2W2I/5ZUEcs0bUW/5YlKmMzphtt9DL5o4=,iv:NdMEKBn90DyGgkrNYG8VKhhe4S+H57XM6AgAqJWA1q4=,tag:0lLWwN5M9jXmV8EzP/Y7nw==,type:str]
+  lastmodified: "2025-06-12T18:52:58Z"
+  mac: ENC[AES256_GCM,data:ahK7S2ODVfck7PZrYXpwTMpqKT69hGxZ8S8l2CKTwVJUW5yMm8eWYhr1nXYB888Y7YE5fJUPcG2QBqZeylNMLH31Hmt3NDjXG3+oLh5kT5swP2RapviNZomsFsNm12Hjh2Eu8GUH5mSXhG+aT4kum/WzQFpdOLUQ0Pc7POcsLKQ=,iv:hlWxkEr95eS0cYZb6CaIPpbtGsbav2APYZKdmV+AS5A=,tag:4a1noB2f2yFCU62fOksg1Q==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.1

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -72,10 +72,11 @@ local makePodRestartAlert = function(
           group_interval: '5m',
           receiver: 'pagerduty',
           group_by: [
-            # Deliver alerts individually for each alert as well as each namespace
-            # an alert is for. We don't specify "cluster" here because each alertmanager
-            # only handles one cluster
-            "alertname", "namespace"
+            // Deliver alerts individually for each alert as well as each namespace
+            // an alert is for. We don't specify "cluster" here because each alertmanager
+            // only handles one cluster
+            'alertname',
+            'namespace',
           ],
           repeat_interval: '3h',
           routes: [


### PR DESCRIPTION
We have one alertmanager per cluster, and one alert that may fire for many different namespaces. Without explicitly specifying group_by, all these were being rolled out into one single incident on pagerduty, instead of individiual incidents. We explicitly specify the common labels to group on instead.

Also modify the pod restart alert to only pick the labels we care about.

Also switch to using the v2 Events API for talking to pagerduty, rather than the v1 Events API. Per https://www.pagerduty.com/docs/guides/prometheus-integration-guide/, using `routing_key` in alertmanager instead of `service_key` triggers API version change, and per https://developer.pagerduty.com/docs/introduction, V2 API is preferred.

Fixes https://github.com/2i2c-org/infrastructure/issues/6197