### PR TITLE
docs: standardise HUB_NAME/HUB convention

### DIFF
--- a/docs/howto/prepare-for-events/exam.md
+++ b/docs/howto/prepare-for-events/exam.md
@@ -21,7 +21,7 @@ This page documents what we do to prep, based on our prior experiences.
       - 🔲 Access and login to the cluster grafana
       - 🔲 Access and login to the cloud console
       - 🔲 Test access to Logs Explorer for container logs if on GCP
-      - 🔲 Test that running `deployer use-cluster-credentials $CLUSTER` and then `kubectl get pods -A` work
+      - 🔲 Test that running `deployer use-cluster-credentials $CLUSTER_NAME` and then `kubectl get pods -A` work
 
 3. **Ensure user pods have a guaranteed quality of service class**
 

--- a/docs/sre-guide/support/reset-shared-password.md
+++ b/docs/sre-guide/support/reset-shared-password.md
@@ -7,9 +7,9 @@ Some hubs have [shared password authentication](../../hub-deployment-guide/confi
 1. A community will usually indicate that they require a shared password reset for an event through FreshDesk support.
 1. Acknowledge receipt of the request and confirm the password to be used and the implementation date, as well as event details.
 1. Open an [Event for a community](https://github.com/2i2c-org/infrastructure/issues/new?template=07_event-hub.yaml) issue in the infrastructure repository and follow the instructions. Remember to add the event to the [Hub Events calendar](https://calendar.google.com/calendar/u/2?cid=Y19rdDg0c2g3YW5tMHNsb2NqczJzdTNqdnNvY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
-1. Add a sub-issue of the event issue to reset the shared password. This sub-issue should be titled "[`$CLUSTER`, `$HUB`] Reset shared password".
+1. Add a sub-issue of the event issue to reset the shared password. This sub-issue should be titled "[`$CLUSTER_NAME`, `$HUB`] Reset shared password".
 1. Add the sub-issue to the GH project board with the "End date" set to the date.
-1. Before the "End date", reset the shared password and update the issue with the new password by using the `sops` command to edit the password key of the `config/clusters/$CLUSTER/${HUB}.secret.values.yaml` file
+1. Before the "End date", reset the shared password and update the issue with the new password by using the `sops` command to edit the password key of the `config/clusters/$CLUSTER_NAME/${HUB}.secret.values.yaml` file
 
    ```bash
     sops edit enc-$HUB.secret.values.yaml

--- a/docs/sre-guide/support/reset-shared-password.md
+++ b/docs/sre-guide/support/reset-shared-password.md
@@ -7,12 +7,12 @@ Some hubs have [shared password authentication](../../hub-deployment-guide/confi
 1. A community will usually indicate that they require a shared password reset for an event through FreshDesk support.
 1. Acknowledge receipt of the request and confirm the password to be used and the implementation date, as well as event details.
 1. Open an [Event for a community](https://github.com/2i2c-org/infrastructure/issues/new?template=07_event-hub.yaml) issue in the infrastructure repository and follow the instructions. Remember to add the event to the [Hub Events calendar](https://calendar.google.com/calendar/u/2?cid=Y19rdDg0c2g3YW5tMHNsb2NqczJzdTNqdnNvY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
-1. Add a sub-issue of the event issue to reset the shared password. This sub-issue should be titled "[`$CLUSTER_NAME`, `$HUB`] Reset shared password".
+1. Add a sub-issue of the event issue to reset the shared password. This sub-issue should be titled "[`$CLUSTER_NAME`, `$HUB_NAME`] Reset shared password".
 1. Add the sub-issue to the GH project board with the "End date" set to the date.
-1. Before the "End date", reset the shared password and update the issue with the new password by using the `sops` command to edit the password key of the `config/clusters/$CLUSTER_NAME/${HUB}.secret.values.yaml` file
+1. Before the "End date", reset the shared password and update the issue with the new password by using the `sops` command to edit the password key of the `config/clusters/$CLUSTER_NAME/${HUB_NAME}.secret.values.yaml` file
 
    ```bash
-    sops edit enc-$HUB.secret.values.yaml
+    sops edit enc-$HUB_NAME.secret.values.yaml
    ```
 
    :::{note}

--- a/docs/topic/monitoring-alerting/prometheus.md
+++ b/docs/topic/monitoring-alerting/prometheus.md
@@ -14,6 +14,6 @@ can be used to check scrape targets and the metrics explorer to examine
 available metrics.
 
 ```
-deployer use-cluster-credentials $CLUSTER
+deployer use-cluster-credentials $CLUSTER_NAME
 kubectl port-forward -n support deploy/support-prometheus-server 9090:9090
 ```

--- a/docs/topic/monitoring-alerting/uptime-checks.md
+++ b/docs/topic/monitoring-alerting/uptime-checks.md
@@ -91,6 +91,6 @@ HUB=staging
 POLICY=$(gcloud alpha monitoring policies list  --filter "displayName ~ staging" --format='value(name)')
 # echo $POLICY 
 # projects/two-eye-two-see/alertPolicies/12673409021288629743
-gcloud alpha monitoring snoozes create --display-name="Uptime Check Disabled $HUB" --criteria-policies="$POLICY" --start-time="$(date -Iseconds)" --end-time="+PT7D"
+gcloud alpha monitoring snoozes create --display-name="Uptime Check Disabled $HUB_NAME" --criteria-policies="$POLICY" --start-time="$(date -Iseconds)" --end-time="+PT7D"
 # Created snooze [projects/two-eye-two-see/snoozes/3009021608334458880].
 ```


### PR DESCRIPTION
A few documents mix `HUB` and `HUB_NAME`, `CLUSTER` and `CLUSTER_NAME`. By majority, I'm taking `HUB_NAME` and `CLUSTER_NAME` as the preferred options.

This is a docs-only PR.