### PR TITLE
Add cmd to update an eksctl file based on the template and enable ebs metrics for 2i2c-aws-us

### DIFF
--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -22,6 +22,7 @@ import deployer.commands.grafana.central_grafana  # noqa: F401
 import deployer.commands.grafana.deploy_dashboards  # noqa: F401
 import deployer.commands.grafana.tokens  # noqa: F401
 import deployer.commands.transform.cost_table  # noqa: F401
+import deployer.commands.update.eksctl  # noqa: F401
 import deployer.commands.validate.config  # noqa: F401
 import deployer.commands.verify_backups  # noqa: F401
 import deployer.keys.decrypt_age  # noqa: F401

--- a/deployer/cli_app.py
+++ b/deployer/cli_app.py
@@ -20,6 +20,7 @@ grafana_app = typer.Typer(pretty_exceptions_show_locals=False)
 validate_app = typer.Typer(pretty_exceptions_show_locals=False)
 transform_app = typer.Typer(pretty_exceptions_show_locals=False)
 verify_backups_app = typer.Typer(pretty_exceptions_show_locals=False)
+update_app = typer.Typer(pretty_exceptions_show_locals=False)
 
 app.add_typer(
     generate_app,
@@ -57,6 +58,11 @@ app.add_typer(
     transform_app,
     name="transform",
     help="Programmatically transform datasets, such as cost tables for billing purposes.",
+)
+app.add_typer(
+    update_app,
+    name="update",
+    help="Update existing resources, such as clusters or configurations.",
 )
 app.add_typer(
     verify_backups_app,

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -120,9 +120,9 @@ def aws(
         "staging",
         prompt="The list of hubs that will be deployed in the cluster separated by a comma. Example: staging, prod.",
     ),
-    dask_nodes: bool = typer.Option(
-        False,
-        prompt='If this cluster needs dask nodes, please type "y", otherwise hit ENTER.',
+    dask_hubs: bool = typer.Option(
+        "",
+        prompt="The list of hubs that will be have dask enabled",
     ),
     force: bool = typer.Option(
         False,
@@ -148,10 +148,13 @@ def aws(
         # Also store the provider, as it's useful for some jinja templates
         # to differentiate between them when rendering the configuration
         "provider": "aws",
-        "dask_nodes": dask_nodes,
+        "dask_nodes": True if dask_hubs else False,
         "cluster_name": cluster_name,
         "cluster_region": cluster_region,
         "hubs": hubs.replace(
+            ",", " "
+        ).split(),  # Convert the comma separated string to a list
+        "dask_hubs": dask_hubs.replace(
             ",", " "
         ).split(),  # Convert the comma separated string to a list
         "sign_in_url": sign_in_url,

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -39,7 +39,7 @@ def get_infra_files_to_be_created(cluster_name):
     ]
 
 
-def generate_eksctl(cluster_name):
+def generate_eksctl(cluster_name, vars):
     with open(REPO_ROOT_PATH / "eksctl/template.jsonnet") as f:
         # jsonnet files have `}}` in there, which causes jinja2 to
         # freak out. So we use different delimiters.
@@ -62,7 +62,7 @@ def generate_infra_files(vars):
     cluster_name = vars["cluster_name"]
 
     print_colour("Generating the eksctl jsonnet file...", "yellow")
-    jsonnet_file_path = generate_eksctl(cluster_name)
+    jsonnet_file_path = generate_eksctl(cluster_name, vars)
     print_colour(f"{jsonnet_file_path} created")
 
     print_colour("Generating the terraform infrastructure file...", "yellow")

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -39,8 +39,7 @@ def get_infra_files_to_be_created(cluster_name):
     ]
 
 
-def generate_infra_files(vars):
-    cluster_name = vars["cluster_name"]
+def generate_eksctl(cluster_name):
     with open(REPO_ROOT_PATH / "eksctl/template.jsonnet") as f:
         # jsonnet files have `}}` in there, which causes jinja2 to
         # freak out. So we use different delimiters.
@@ -53,10 +52,17 @@ def generate_infra_files(vars):
             variable_end_string=">>",
         )
 
-    print_colour("Generating the eksctl jsonnet file...", "yellow")
     jsonnet_file_path = REPO_ROOT_PATH / "eksctl" / f"{cluster_name}.jsonnet"
     with open(jsonnet_file_path, "w") as f:
         f.write(jsonnet_template.render(**vars))
+    return jsonnet_file_path
+
+
+def generate_infra_files(vars):
+    cluster_name = vars["cluster_name"]
+
+    print_colour("Generating the eksctl jsonnet file...", "yellow")
+    jsonnet_file_path = generate_eksctl(cluster_name)
     print_colour(f"{jsonnet_file_path} created")
 
     print_colour("Generating the terraform infrastructure file...", "yellow")

--- a/deployer/commands/generate/dedicated_cluster/aws.py
+++ b/deployer/commands/generate/dedicated_cluster/aws.py
@@ -120,9 +120,13 @@ def aws(
         "staging",
         prompt="The list of hubs that will be deployed in the cluster separated by a comma. Example: staging, prod.",
     ),
-    dask_hubs: bool = typer.Option(
+    dask_hubs: str = typer.Option(
         "",
         prompt="The list of hubs that will be have dask enabled",
+    ),
+    gpu_hubs: str = typer.Option(
+        "",
+        prompt="The list of hubs that will be have a gpu",
     ),
     force: bool = typer.Option(
         False,
@@ -148,13 +152,17 @@ def aws(
         # Also store the provider, as it's useful for some jinja templates
         # to differentiate between them when rendering the configuration
         "provider": "aws",
-        "dask_nodes": True if dask_hubs else False,
         "cluster_name": cluster_name,
         "cluster_region": cluster_region,
         "hubs": hubs.replace(
             ",", " "
         ).split(),  # Convert the comma separated string to a list
+        "dask_nodes": True if dask_hubs else False,
         "dask_hubs": dask_hubs.replace(
+            ",", " "
+        ).split(),  # Convert the comma separated string to a list
+        "gpu_nodes": True if gpu_hubs else False,
+        "gpu_hubs": gpu_hubs.replace(
             ",", " "
         ).split(),  # Convert the comma separated string to a list
         "sign_in_url": sign_in_url,

--- a/deployer/commands/update/eksctl.py
+++ b/deployer/commands/update/eksctl.py
@@ -20,7 +20,6 @@ def eksctl(
     Update the eksctl config file for an existing cluster based on the template file
     """
     # These are the variables needed by the templates used to generate the support files
-    print_colour("Updating the eksctl jsonnet file...", "yellow")
     cluster = Cluster.from_name(cluster_name)
     provider = cluster.spec["provider"]
     if provider != "aws":
@@ -28,7 +27,8 @@ def eksctl(
             f"Cluster {cluster_name} is not an AWS cluster, cannot update eksctl config",
             "red",
         )
-        raise typer.Exit(code=1)
+        exit(1)
+    print_colour("Updating the eksctl jsonnet file...", "yellow")
     hubs = []
     dask_hubs = []
     for hub in cluster.hubs:

--- a/deployer/commands/update/eksctl.py
+++ b/deployer/commands/update/eksctl.py
@@ -11,6 +11,10 @@ def eksctl(
     cluster_name: str = typer.Argument(
         ..., help="Name of the cluster to update its eksctl config"
     ),
+    gpu_hubs: str = typer.Option(
+        "",
+        prompt="The list of hubs that will be have a gpu",
+    ),
 ):
     """
     Update the eksctl config file for an existing cluster based on the template file
@@ -37,6 +41,8 @@ def eksctl(
         "cluster_name": cluster_name,
         "cluster_region": cluster.spec["aws"]["region"],
         "hubs": hubs,
+        "gpu_nodes": True if gpu_hubs else False,
+        "gpu_hubs": gpu_hubs.replace(",", " ").split() if gpu_hubs else [],
     }
     jsonnet_file_path = generate_eksctl(cluster_name, vars)
     print_colour(f"{jsonnet_file_path} Updated")

--- a/deployer/commands/update/eksctl.py
+++ b/deployer/commands/update/eksctl.py
@@ -26,13 +26,14 @@ def eksctl(
         )
         raise typer.Exit(code=1)
     hubs = []
-    dask_nodes = False
+    dask_hubs = []
     for hub in cluster.hubs:
         hubs.append(hub.spec["name"])
         if hub.get_hub_types().get("type") == "daskhub":
-            dask_nodes = True
+            dask_hubs.append(hub.spec["name"])
     vars = {
-        "dask_nodes": dask_nodes,
+        "dask_nodes": True if dask_hubs else False,
+        "dask_hubs": dask_hubs,
         "cluster_name": cluster_name,
         "cluster_region": cluster.spec["aws"]["region"],
         "hubs": hubs,

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -40,10 +40,6 @@ class Hub:
         Available types are:
         - basehub
         - daskhub
-        - binderhub-ui
-        - imagebuilding
-        - authenticated
-        The return values is a list as some hubs may have more than one characteristic.
         """
         characteristics = {
             "type": "basehub",

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -34,6 +34,71 @@ class Hub:
         self.cluster = cluster
         self.spec = spec
 
+    def get_hub_types(self):
+        """
+        Return a dict of hub characteristics that this hub is using.
+        Available types are:
+        - basehub
+        - daskhub
+        - binderhub-ui
+        - imagebuilding
+        - authenticated
+        The return values is a list as some hubs may have more than one characteristic.
+        """
+        characteristics = {
+            "type": "basehub",
+            "legacy_daskhub": False,
+            "binderhub_ui": False,
+            "imagebuilding": False,
+            "authenticated": False,
+        }
+        dask_gateway = False
+        daskhub_setup = False
+        binderhub_ui = False
+        binderhub_service = False
+
+        # Check if the hub is using the legacy daskhub helm chart
+        if self.spec["helm_chart"] == "daskhub":
+            characteristics["type"] = "daskhub"
+            characteristics["legacy_daskhub"] = True
+        # Go through the values files and check for other characteristics
+        for values_file in self.spec["helm_chart_values_files"]:
+            if "enc-" not in values_file:
+                config_filename = self.cluster.config_dir / values_file
+                with open(config_filename) as f:
+                    config = yaml.load(f)
+                    # If its a legacy daskhub, the config will be nested under the "basehub" key
+                    if "daskhub" in characteristics["type"]:
+                        config = config.get("basehub", {})
+                    else:
+                        if config.get("dask-gateway", {}).get("enabled", False):
+                            dask_gateway = True
+                        if (
+                            config.get("jupyterhub", {})
+                            .get("custom", {})
+                            .get("daskhubSetup", {})
+                            .get("enabled", False)
+                        ):
+                            daskhub_setup = True
+                    if (
+                        config.get("jupyterhub", {})
+                        .get("custom", {})
+                        .get("binderhubUI", {})
+                        .get("enabled", False)
+                    ):
+                        binderhub_ui = True
+                    if config.get("binderhub-service", {}).get("enabled", False):
+                        binderhub_service = True
+        if dask_gateway and daskhub_setup:
+            characteristics["type"] = "daskhub"
+        if binderhub_ui and binderhub_service:
+            characteristics["binderhub-ui"] = True
+        # If it just has the binderhub-service enabled, but not the binderhub-ui,
+        # then we consider it an imagebuilding hub
+        elif binderhub_service:
+            characteristics["imagebuilding"] = True
+        return characteristics
+
     def deploy(self, dask_gateway_version, debug, dry_run):
         """
         Deploy this hub

--- a/eksctl/2i2c-aws-us.jsonnet
+++ b/eksctl/2i2c-aws-us.jsonnet
@@ -103,7 +103,6 @@ local notebookNodes = [
   },
 ];
 
-
 local daskNodes = [
   // Node definitions for dask worker nodes. Config here is merged
   // with our dask worker node definition, which uses spot instances.
@@ -125,12 +124,6 @@ local daskNodes = [
     namePrefix: 'dask-showcase',
     labels+: { '2i2c/hub-name': 'showcase' },
     tags+: { '2i2c:hub-name': 'showcase' },
-    instancesDistribution+: { instanceTypes: ['r5.4xlarge'] },
-  },
-  {
-    namePrefix: 'dask-ncar-cisl',
-    labels+: { '2i2c/hub-name': 'ncar-cisl' },
-    tags+: { '2i2c:hub-name': 'ncar-cisl' },
     instancesDistribution+: { instanceTypes: ['r5.4xlarge'] },
   },
 ];
@@ -172,9 +165,6 @@ local daskNodes = [
           //
           name: 'vpc-cni',
           attachPolicyARNs: ['arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'],
-          // FIXME: enabling network policy enforcement didn't work as of
-          //        August 2024, what's wrong isn't clear.
-          //
           // configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
           configurationValues: |||
             enableNetworkPolicy: "false"
@@ -192,10 +182,16 @@ local daskNodes = [
           wellKnownPolicies: {
             ebsCSIController: true,
           },
+          // We enable detailed metrics collection to watch for issues with
+          // jupyterhub-home-nfs
           // configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
           configurationValues: |||
             defaultStorageClass:
                 enabled: true
+            controller:
+                enableMetrics: true
+            node:
+                enableMetrics: true
           |||,
         },
       ]
@@ -231,12 +227,12 @@ local daskNodes = [
             'hub.jupyter.org/node-purpose': 'user',
             'k8s.dask.org/node-purpose': 'scheduler',
           },
-          tags+: {
-            '2i2c:node-purpose': 'user',
-          },
           taints+: {
             'hub.jupyter.org_dedicated': 'user:NoSchedule',
             'hub.jupyter.org/dedicated': 'user:NoSchedule',
+          },
+          tags+: {
+            '2i2c:node-purpose': 'user',
           },
         } + n
         for n in notebookNodes

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -1,14 +1,3 @@
-{#-
-    This file is a jinja2 template of a jsonnet template of a eksctl's cluster
-    configuration file, which in turn is to be used with the eksctl CLI to both
-    update and initialize an AWS EKS based cluster.
-
-    This jinja2 template is used by the deployer script's generate-aws-cluster
-    command as part of creating new clusters.
-
-    References:
-    - https://infrastructure.2i2c.org/hub-deployment-guide/new-cluster/new-cluster/#generate-cluster-files
--#}
 /*
     This file is a jsonnet template of a eksctl's cluster configuration file,
     that is used with the eksctl CLI to both update and initialize an AWS EKS
@@ -24,12 +13,12 @@
     References:
     - https://eksctl.io/usage/schema/
 */
-local ng = import "./libsonnet/nodegroup.jsonnet";
+local ng = import './libsonnet/nodegroup.jsonnet';
 
 // place all cluster nodes here
-local clusterRegion = "<< cluster_region >>";
-local masterAzs = ["<< cluster_region >>a", "<< cluster_region >>b", "<< cluster_region >>c"];
-local nodeAz = "<< cluster_region >>a";
+local clusterRegion = '<< cluster_region >>';
+local masterAzs = ['<< cluster_region >>a', '<< cluster_region >>b', '<< cluster_region >>c'];
+local nodeAz = '<< cluster_region >>a';
 
 // Node definitions for notebook nodes. Config here is merged
 // with our notebook node definition.
@@ -37,47 +26,47 @@ local nodeAz = "<< cluster_region >>a";
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
 <% for hub in hubs %>
-    // << hub >>
-    {
-        instanceType: "r5.xlarge",
-        namePrefix: "nb-<< hub >>",
-        labels+: { "2i2c/hub-name": "<< hub >>" },
-        tags+: { "2i2c:hub-name": "<< hub >>" },
-    },
-    {
-        instanceType: "r5.4xlarge",
-        namePrefix: "nb-<< hub >>",
-        labels+: { "2i2c/hub-name": "<< hub >>" },
-        tags+: { "2i2c:hub-name": "<< hub >>" },
-    },
-    {
-        instanceType: "r5.16xlarge",
-        namePrefix: "nb-<< hub >>",
-        labels+: { "2i2c/hub-name": "<< hub >>" },
-        tags+: { "2i2c:hub-name": "<< hub >>" },
-    },
+  // << hub >>
+  {
+    instanceType: 'r5.xlarge',
+    namePrefix: 'nb-<< hub >>',
+    labels+: { '2i2c/hub-name': '<< hub >>' },
+    tags+: { '2i2c:hub-name': '<< hub >>' },
+  },
+  {
+    instanceType: 'r5.4xlarge',
+    namePrefix: 'nb-<< hub >>',
+    labels+: { '2i2c/hub-name': '<< hub >>' },
+    tags+: { '2i2c:hub-name': '<< hub >>' },
+  },
+  {
+    instanceType: 'r5.16xlarge',
+    namePrefix: 'nb-<< hub >>',
+    labels+: { '2i2c/hub-name': '<< hub >>' },
+    tags+: { '2i2c:hub-name': '<< hub >>' },
+  },
 <% endfor %>
 ];
 
 <% if dask_nodes %>
 local daskNodes = [
-    // Node definitions for dask worker nodes. Config here is merged
-    // with our dask worker node definition, which uses spot instances.
-    // A `node.kubernetes.io/instance-type label is set to the name of the
-    // *first* item in instanceDistribution.instanceTypes, to match
-    // what we do with notebook nodes. Pods can request a particular
-    // kind of node with a nodeSelector
-    //
-    // A not yet fully established policy is being developed about using a single
-    // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
-    //
+  // Node definitions for dask worker nodes. Config here is merged
+  // with our dask worker node definition, which uses spot instances.
+  // A `node.kubernetes.io/instance-type label is set to the name of the
+  // *first* item in instanceDistribution.instanceTypes, to match
+  // what we do with notebook nodes. Pods can request a particular
+  // kind of node with a nodeSelector
+  //
+  // A not yet fully established policy is being developed about using a single
+  // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+  //
 <% for hub in hubs %>
-    {
-        namePrefix: "dask-<< hub >>",
-        labels+: { "2i2c/hub-name": "<< hub >>" },
-        tags+: { "2i2c:hub-name": "<< hub >>" },
-        instancesDistribution+: { instanceTypes: ["r5.4xlarge"] }
-    },
+  {
+    namePrefix: 'dask-<< hub >>',
+    labels+: { '2i2c/hub-name': '<< hub >>' },
+    tags+: { '2i2c:hub-name': '<< hub >>' },
+    instancesDistribution+: { instanceTypes: ['r5.4xlarge'] },
+  },
 <% endfor %>
 ];
 <% else %>
@@ -86,138 +75,142 @@ local daskNodes = [];
 
 
 {
-    apiVersion: 'eksctl.io/v1alpha5',
-    kind: 'ClusterConfig',
-    metadata+: {
-        name: "<< cluster_name >>",
-        region: clusterRegion,
-        {#
-            version should be the latest support version by the eksctl CLI, see
-            https://eksctl.io/getting-started/ for a list of supported versions.
-        -#}
-        version: "1.32",
-        tags+: {
-            "ManagedBy": "2i2c",
-            "2i2c.org/cluster-name": $.metadata.name,
-        },
+  apiVersion: 'eksctl.io/v1alpha5',
+  kind: 'ClusterConfig',
+  metadata+: {
+    name: '<< cluster_name >>',
+    region: clusterRegion,
+    {#
+        version should be the latest support version by the eksctl CLI, see
+        https://eksctl.io/getting-started/ for a list of supported versions.
+    -#}
+    version: '1.32',
+    tags+: {
+      ManagedBy: '2i2c',
+      '2i2c.org/cluster-name': $.metadata.name,
     },
-    availabilityZones: masterAzs,
-    iam: {
-        withOIDC: true,
-    },
-    // If you add an addon to this config, run the create addon command.
-    //
-    //    eksctl create addon --config-file=<< cluster_name >>.eksctl.yaml
-    //
-    addons: [
-        { version: "latest", tags: $.metadata.tags } + addon
-        for addon in
-        [
-            { name: "coredns" },
-            { name: "kube-proxy" },
-            {
-                // vpc-cni is a Amazon maintained container networking interface
-                // (CNI), where a CNI is required for k8s networking. The aws-node
-                // DaemonSet in kube-system stems from installing this.
-                //
-                // Related docs: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
-                //               https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-                //
-                name: "vpc-cni",
-                attachPolicyARNs: ["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"],
-                # configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
-                configurationValues: |||
-                    enableNetworkPolicy: "false"
-                |||,
-            },
-            {
-                // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
-                // couple to AWS EBS based storage, without it expect to see pods
-                // mounting a PVC failing to schedule and PVC resources that are
-                // unbound.
-                //
-                // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
-                //
-                name: "aws-ebs-csi-driver",
-                wellKnownPolicies: {
-                    ebsCSIController: true,
-                },
-                # We enable detailed metrics collection to watch for issues with
-                # jupyterhub-home-nfs
-                # configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
-                configurationValues: |||
-                    defaultStorageClass:
-                        enabled: true
-                    controller:
-                        enableMetrics: true
-                    node:
-                        enableMetrics: true
-                |||,
-            },
-        ]
-    ],
-    nodeGroups: [
-    n + {clusterName: $.metadata.name} for n in
-    [
-        ng + {
-            namePrefix: 'core',
-            nameSuffix: 'a',
-            nameIncludeInstanceType: false,
-            availabilityZones: [nodeAz],
-            instanceType: "r5.xlarge",
-            minSize: 1,
-            maxSize: 6,
-            labels+: {
-                "hub.jupyter.org/node-purpose": "core",
-                "k8s.dask.org/node-purpose": "core",
-            },
-            tags+: {
-                "2i2c:node-purpose": "core"
-            },
+  },
+  availabilityZones: masterAzs,
+  iam: {
+    withOIDC: true,
+  },
+  // If you add an addon to this config, run the create addon command.
+  //
+  //    eksctl create addon --config-file=<< cluster_name >>.eksctl.yaml
+  //
+  addons: [
+    { version: 'latest', tags: $.metadata.tags } + addon
+    for addon in
+      [
+        { name: 'coredns' },
+        { name: 'kube-proxy' },
+        {
+          // vpc-cni is a Amazon maintained container networking interface
+          // (CNI), where a CNI is required for k8s networking. The aws-node
+          // DaemonSet in kube-system stems from installing this.
+          //
+          // Related docs: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
+          //               https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+          //
+          name: 'vpc-cni',
+          attachPolicyARNs: ['arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'],
+          // configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
+          configurationValues: |||
+            enableNetworkPolicy: "false"
+          |||,
         },
-    ] + [
-        ng + {
-            namePrefix: 'nb',
-            availabilityZones: [nodeAz],
-            minSize: 0,
-            maxSize: 500,
-            instanceType: n.instanceType,
-            labels+: {
-                "hub.jupyter.org/node-purpose": "user",
-                "k8s.dask.org/node-purpose": "scheduler"
-            },
-            taints+: {
-                "hub.jupyter.org_dedicated": "user:NoSchedule",
-                "hub.jupyter.org/dedicated": "user:NoSchedule",
-            },
-            tags+: {
-                "2i2c:node-purpose": "user"
-            },
-        } + n for n in notebookNodes
-    ] + ( if daskNodes != null then
-        [
-        ng + {
-            namePrefix: 'dask',
-            availabilityZones: [nodeAz],
-            minSize: 0,
-            maxSize: 500,
-            labels+: {
-                "k8s.dask.org/node-purpose": "worker"
-            },
-            taints+: {
-                "k8s.dask.org_dedicated" : "worker:NoSchedule",
-                "k8s.dask.org/dedicated" : "worker:NoSchedule",
-            },
-            tags+: {
-                "2i2c:node-purpose": "worker"
-            },
-            instancesDistribution+: {
+        {
+          // aws-ebs-csi-driver ensures that our PVCs are bound to PVs that
+          // couple to AWS EBS based storage, without it expect to see pods
+          // mounting a PVC failing to schedule and PVC resources that are
+          // unbound.
+          //
+          // Related docs: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+          //
+          name: 'aws-ebs-csi-driver',
+          wellKnownPolicies: {
+            ebsCSIController: true,
+          },
+          // We enable detailed metrics collection to watch for issues with
+          // jupyterhub-home-nfs
+          // configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
+          configurationValues: |||
+            defaultStorageClass:
+                enabled: true
+            controller:
+                enableMetrics: true
+            node:
+                enableMetrics: true
+          |||,
+        },
+      ]
+  ],
+  nodeGroups: [
+    n { clusterName: $.metadata.name }
+    for n in
+      [
+        ng {
+          namePrefix: 'core',
+          nameSuffix: 'a',
+          nameIncludeInstanceType: false,
+          availabilityZones: [nodeAz],
+          instanceType: 'r5.xlarge',
+          minSize: 1,
+          maxSize: 6,
+          labels+: {
+            'hub.jupyter.org/node-purpose': 'core',
+            'k8s.dask.org/node-purpose': 'core',
+          },
+          tags+: {
+            '2i2c:node-purpose': 'core',
+          },
+        },
+      ] + [
+        ng {
+          namePrefix: 'nb',
+          availabilityZones: [nodeAz],
+          minSize: 0,
+          maxSize: 500,
+          instanceType: n.instanceType,
+          labels+: {
+            'hub.jupyter.org/node-purpose': 'user',
+            'k8s.dask.org/node-purpose': 'scheduler',
+          },
+          taints+: {
+            'hub.jupyter.org_dedicated': 'user:NoSchedule',
+            'hub.jupyter.org/dedicated': 'user:NoSchedule',
+          },
+          tags+: {
+            '2i2c:node-purpose': 'user',
+          },
+        } + n
+        for n in notebookNodes
+      ] + (
+        if daskNodes != null then
+          [
+            ng {
+              namePrefix: 'dask',
+              availabilityZones: [nodeAz],
+              minSize: 0,
+              maxSize: 500,
+              labels+: {
+                'k8s.dask.org/node-purpose': 'worker',
+              },
+              taints+: {
+                'k8s.dask.org_dedicated': 'worker:NoSchedule',
+                'k8s.dask.org/dedicated': 'worker:NoSchedule',
+              },
+              tags+: {
+                '2i2c:node-purpose': 'worker',
+              },
+              instancesDistribution+: {
                 onDemandBaseCapacity: 0,
                 onDemandPercentageAboveBaseCapacity: 0,
-                spotAllocationStrategy: "capacity-optimized",
-            },
-        } + n for n in daskNodes
-        ] else []
-    )
-    ]
+                spotAllocationStrategy: 'capacity-optimized',
+              },
+            } + n
+            for n in daskNodes
+          ] else []
+      )
+  ],
 }

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -46,6 +46,29 @@ local notebookNodes = [
     tags+: { '2i2c:hub-name': '<< hub >>' },
   },
 <% endfor %>
+<% if gpu_nodes %>
+<% for hub in gpu_hubs %>
+  {
+    instanceType: 'g4dn.xlarge',
+    namePrefix: 'gpu-<< hub >>',
+    minSize: 0,
+    labels+: {
+      '2i2c/hub-name': '<< hub >>',
+      '2i2c/has-gpu': 'true',
+    },
+    tags+: {
+      'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      '2i2c:hub-name': '<< hub >>',
+    },
+    taints+: {
+      'nvidia.com/gpu': 'present:NoSchedule',
+    },
+    // Allow provisioning GPUs across all AZs, to prevent situation where all
+    // GPUs in a single AZ are in use and no new nodes can be spawned
+    availabilityZones: masterAzs,
+  },
+<% endfor %>
+<% endif %>
 ];
 
 <% if dask_nodes %>

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -60,7 +60,7 @@ local daskNodes = [
   // A not yet fully established policy is being developed about using a single
   // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
   //
-<% for hub in hubs %>
+<% for hub in dask_hubs %>
   {
     namePrefix: 'dask-<< hub >>',
     labels+: { '2i2c/hub-name': '<< hub >>' },


### PR DESCRIPTION
Ref: https://github.com/2i2c-org/infrastructure/issues/6221

### Motivation
In order to make rollouts easier to eksctl clusters, there is now a command that just re-renders the template again. This way we must only update the template and re-redender for each cluster.

### Implementation details
The command only needs the cluster name and the hub/s that have gpu.
This ⬆️ is the only caveat, as getting the hubs with gpu requires lots of parsing and was considered out of scope. But all the other info that the template needs is just deducted from configs.

In order to support this, the template was updated to support gpu hubs as well and the new aws cluster generator was also updated to request the hub names that will have a gpu.
