### PR TITLE
profile options for SSIM GHG Workshop 2025

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -99,6 +99,14 @@ basehub:
       profileList:
       - display_name: Choose environment and resources
         default: true
+        allowed_groups:
+          - US-GHG-Center:ghgc-hub-access
+          - US-GHG-Center:ghg-use-case-1
+          - US-GHG-Center:ghg-use-case-2
+          - US-GHG-Center:ghg-use-case-3
+          - US-GHG-Center:ghg-external-collaborators
+          - US-GHG-Center:ghg-workshop-access
+          - US-GHG-Center:ghg-trial-access        
         profile_options:
           image:
             display_name: Environment
@@ -221,6 +229,54 @@ basehub:
                   cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
+      - display_name: SSIM GHG Workshop 2025
+        default: true
+        allowed_groups:
+          - US-GHG-Center:ssim-ghg-2025      
+        profile_options:
+          image:
+            display_name: Environment
+            dynamic_image_building:
+              enabled: false
+            unlisted_choice:
+              enabled: false
+            choices:
+              01-workshop-image:
+                display_name: SSIM-GHG Workshop 2025 Image
+                description: Workshop image with Python and R environments
+                kubespawner_override:
+                  image: public.ecr.aws/nasa-veda/ssim-ghg-workshop-2025-image:dbe5860
+                  init_containers:
+                  - *volume_ownership_fix_initcontainer
+                      # this container uses nbgitpuller to mount https://github.com/US-GHG-Center/ghgc-docs/ for user pods
+                      # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init
+                  - name: jupyterhub-gitpuller-init
+                    image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
+                    env:
+                    - name: TARGET_PATH
+                      value: ghgc-docs
+                    - name: SOURCE_REPO
+                      value: https://github.com/US-GHG-Center/ghgc-docs
+                    volumeMounts:
+                    - name: home
+                      mountPath: /home/jovyan
+                      subPath: '{escaped_username}'
+                    securityContext:
+                      runAsUser: 1000
+                      runAsGroup: 1000
+          resource_allocation:
+            display_name: Resource Allocation
+            choices:
+              mem_60_6:
+                display_name: 60.6 GB RAM, upto 15.6 CPUs
+                kubespawner_override:
+                  mem_guarantee: 65094448840
+                  mem_limit: 65094448840
+                  cpu_guarantee: 7.8475
+                  cpu_limit: 15.695
+                  node_selector:
+                    node.kubernetes.io/instance-type: r5.4xlarge
+
 
     scheduling:
       userScheduler:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -230,7 +230,6 @@ basehub:
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
       - display_name: SSIM GHG Workshop 2025
-        default: true
         allowed_groups:
         - US-GHG-Center:ssim-ghg-2025
         profile_options:

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -107,6 +107,7 @@ basehub:
         - US-GHG-Center:ghg-external-collaborators
         - US-GHG-Center:ghg-workshop-access
         - US-GHG-Center:ghg-trial-access
+        - 2i2c-org:hub-access-for-2i2c-staff
         profile_options:
           image:
             display_name: Environment

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -233,6 +233,7 @@ basehub:
       - display_name: SSIM GHG Workshop 2025
         allowed_groups:
         - US-GHG-Center:ssim-ghg-2025
+        - 2i2c-org:hub-access-for-2i2c-staff
         profile_options:
           image:
             display_name: Environment

--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -100,13 +100,13 @@ basehub:
       - display_name: Choose environment and resources
         default: true
         allowed_groups:
-          - US-GHG-Center:ghgc-hub-access
-          - US-GHG-Center:ghg-use-case-1
-          - US-GHG-Center:ghg-use-case-2
-          - US-GHG-Center:ghg-use-case-3
-          - US-GHG-Center:ghg-external-collaborators
-          - US-GHG-Center:ghg-workshop-access
-          - US-GHG-Center:ghg-trial-access        
+        - US-GHG-Center:ghgc-hub-access
+        - US-GHG-Center:ghg-use-case-1
+        - US-GHG-Center:ghg-use-case-2
+        - US-GHG-Center:ghg-use-case-3
+        - US-GHG-Center:ghg-external-collaborators
+        - US-GHG-Center:ghg-workshop-access
+        - US-GHG-Center:ghg-trial-access
         profile_options:
           image:
             display_name: Environment
@@ -232,7 +232,7 @@ basehub:
       - display_name: SSIM GHG Workshop 2025
         default: true
         allowed_groups:
-          - US-GHG-Center:ssim-ghg-2025      
+        - US-GHG-Center:ssim-ghg-2025
         profile_options:
           image:
             display_name: Environment
@@ -276,8 +276,6 @@ basehub:
                   cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
-
-
     scheduling:
       userScheduler:
         enabled: true


### PR DESCRIPTION
Makes a separate Profile Option restricted to the SSIM GHG 2025 Workshop participants' group.

**Desired Outcome**: Existing groups / users see the existing profile options. Members of the `ssim-ghg-2025` group see only the profile option specific for the workshop: with the custom workshop image and resource allocations set at a fixed ~60GB RAM.

**Questions**: Currently, I have disabled dynamic image building and the unlisted image choice for the workshop group - they will only be able to use the defined image.

 - Should users be allowed dynamic image building and / or specifying an arbitrary image with the `unlisted_choice` option?
 - Should we continue to give options for the existing images like Pangeo, Rocker, QGIS?
 - Currently, we are also pulling in the ghgc-docs folder for the Workshop users as part of the init scripts - do we want to skip doing that for workshop participants?

All the above things are just configuration, so happy to implement things either way if you let us know what's best @wildintellect @AgilentGCMS 

cc @sunu 