### PR TITLE
fix: GPU resource indentation

### DIFF
--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -164,8 +164,8 @@ jupyterhub:
                 mem_guarantee: 14G
                 node_selector:
                   node.kubernetes.io/instance-type: g4dn.xlarge
-              extra_resource_limits:
-                nvidia.com/gpu: '1'
+                extra_resource_limits:
+                  nvidia.com/gpu: '1'
 
 binderhub-service:
   enabled: true


### PR DESCRIPTION
Project Pythia's GPU profile does not successfully spawn pods. This is because of an indentation issue in our config.