### PR TITLE
fix: apply GPU pre-labelling to victor config

### DIFF
--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -68,6 +68,7 @@ local notebookNodes = [
     tags+: {
       '2i2c:hub-name': 'staging',
       'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      'k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
     },
     taints+: {
       'nvidia.com/gpu': 'present:NoSchedule',
@@ -83,6 +84,7 @@ local notebookNodes = [
     tags+: {
       '2i2c:hub-name': 'prod',
       'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      'k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
     },
     taints+: {
       'nvidia.com/gpu': 'present:NoSchedule',


### PR DESCRIPTION
A successor to #6215 for `victor`. 


## Deployments updated
- [ ] `victor`