### PR TITLE
[2i2c-uk, staging] Fix `custom.2i2c.add_staff_user_ids_of_type`

### DIFF
--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -25,7 +25,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
-      add_staff_user_ids_of_type: github
+      add_staff_user_ids_of_type: google
     homepage:
       templateVars:
         org:


### PR DESCRIPTION
There was a mismatch between `add_staff_user_ids_of_type: github` and the CILogonOAuthenticator