### PR TITLE
docs: add a last-updated cue to footer

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
         python-version: '3.13'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: '3.13'
+  jobs:
+    post_checkout:
+    - git fetch --unshallow || true
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinxcontrib.mermaid",
     "sphinxcontrib.jquery",
     "sphinx_togglebutton",
+    "sphinx_last_updated_by_git",
 ]
 
 intersphinx_mapping = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ sphinx-design
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinxcontrib-mermaid
 sphinxcontrib-jquery
+sphinx-last-updated-by-git


### PR DESCRIPTION
Following the work in our team-compass, this adds a `last-updated` span to our footer. This should help us keep track of which docs are most up to date.