### PR TITLE
Enable EBS metrics collection for a few more clusters

### DIFF
--- a/eksctl/nasa-veda.jsonnet
+++ b/eksctl/nasa-veda.jsonnet
@@ -25,6 +25,7 @@ local nodeAz = 'us-west-2a';
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+  // staging
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-staging',
@@ -43,6 +44,7 @@ local notebookNodes = [
     labels+: { '2i2c/hub-name': 'staging' },
     tags+: { '2i2c:hub-name': 'staging' },
   },
+  // prod
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-prod',
@@ -62,6 +64,7 @@ local notebookNodes = [
     labels+: { '2i2c/hub-name': 'prod' },
     tags+: { '2i2c:hub-name': 'prod' },
   },
+  // binder
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-binder',
@@ -71,6 +74,7 @@ local notebookNodes = [
   {
     instanceType: 'g4dn.xlarge',
     namePrefix: 'gpu-staging',
+    minSize: 0,
     labels+: {
       '2i2c/hub-name': 'staging',
       '2i2c/has-gpu': 'true',
@@ -91,6 +95,7 @@ local notebookNodes = [
   {
     instanceType: 'g4dn.xlarge',
     namePrefix: 'gpu-prod',
+    minSize: 0,
     labels+: {
       '2i2c/hub-name': 'prod',
       '2i2c/has-gpu': 'true',
@@ -172,9 +177,6 @@ local daskNodes = [
           //
           name: 'vpc-cni',
           attachPolicyARNs: ['arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'],
-          // FIXME: enabling network policy enforcement didn't work as of
-          //        August 2024, what's wrong isn't clear.
-          //
           // configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
           configurationValues: |||
             enableNetworkPolicy: "false"
@@ -192,10 +194,16 @@ local daskNodes = [
           wellKnownPolicies: {
             ebsCSIController: true,
           },
+          // We enable detailed metrics collection to watch for issues with
+          // jupyterhub-home-nfs
           // configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
           configurationValues: |||
             defaultStorageClass:
                 enabled: true
+            controller:
+                enableMetrics: true
+            node:
+                enableMetrics: true
           |||,
         },
       ]
@@ -231,12 +239,12 @@ local daskNodes = [
             'hub.jupyter.org/node-purpose': 'user',
             'k8s.dask.org/node-purpose': 'scheduler',
           },
-          tags+: {
-            '2i2c:node-purpose': 'user',
-          },
           taints+: {
             'hub.jupyter.org_dedicated': 'user:NoSchedule',
             'hub.jupyter.org/dedicated': 'user:NoSchedule',
+          },
+          tags+: {
+            '2i2c:node-purpose': 'user',
           },
         } + n
         for n in notebookNodes
@@ -251,12 +259,12 @@ local daskNodes = [
               labels+: {
                 'k8s.dask.org/node-purpose': 'worker',
               },
-              tags+: {
-                '2i2c:node-purpose': 'worker',
-              },
               taints+: {
                 'k8s.dask.org_dedicated': 'worker:NoSchedule',
                 'k8s.dask.org/dedicated': 'worker:NoSchedule',
+              },
+              tags+: {
+                '2i2c:node-purpose': 'worker',
               },
               instancesDistribution+: {
                 onDemandBaseCapacity: 0,

--- a/eksctl/nmfs-openscapes.jsonnet
+++ b/eksctl/nmfs-openscapes.jsonnet
@@ -1,3 +1,18 @@
+/*
+    This file is a jsonnet template of a eksctl's cluster configuration file,
+    that is used with the eksctl CLI to both update and initialize an AWS EKS
+    based cluster.
+
+    This file has in turn been generated from eksctl/template.jsonnet which is
+    relevant to compare with for changes over time.
+
+    To use jsonnet to generate an eksctl configuration file from this, do:
+
+        jsonnet nmfs-openscapes.jsonnet > nmfs-openscapes.eksctl.yaml
+
+    References:
+    - https://eksctl.io/usage/schema/
+*/
 local ng = import './libsonnet/nodegroup.jsonnet';
 
 // place all cluster nodes here
@@ -10,6 +25,7 @@ local nodeAz = 'us-west-2b';
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+  // staging
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-staging',
@@ -17,18 +33,56 @@ local notebookNodes = [
     tags+: { '2i2c:hub-name': 'staging' },
   },
   {
+    instanceType: 'r5.4xlarge',
+    namePrefix: 'nb-staging',
+    labels+: { '2i2c/hub-name': 'staging' },
+    tags+: { '2i2c:hub-name': 'staging' },
+  },
+  {
+    instanceType: 'r5.16xlarge',
+    namePrefix: 'nb-staging',
+    labels+: { '2i2c/hub-name': 'staging' },
+    tags+: { '2i2c:hub-name': 'staging' },
+  },
+  // prod
+  {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-prod',
-    nameSuffix: 'b',
     labels+: { '2i2c/hub-name': 'prod' },
     tags+: { '2i2c:hub-name': 'prod' },
   },
+  {
+    instanceType: 'r5.4xlarge',
+    namePrefix: 'nb-prod',
+    labels+: { '2i2c/hub-name': 'prod' },
+    tags+: { '2i2c:hub-name': 'prod' },
+  },
+  {
+    instanceType: 'r5.16xlarge',
+    namePrefix: 'nb-prod',
+    labels+: { '2i2c/hub-name': 'prod' },
+    tags+: { '2i2c:hub-name': 'prod' },
+  },
+  // workshop
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-workshop',
     labels+: { '2i2c/hub-name': 'workshop' },
     tags+: { '2i2c:hub-name': 'workshop' },
   },
+  {
+    instanceType: 'r5.4xlarge',
+    namePrefix: 'nb-workshop',
+    labels+: { '2i2c/hub-name': 'workshop' },
+    tags+: { '2i2c:hub-name': 'workshop' },
+  },
+  {
+    instanceType: 'r5.16xlarge',
+    namePrefix: 'nb-workshop',
+    labels+: { '2i2c/hub-name': 'workshop' },
+    tags+: { '2i2c:hub-name': 'workshop' },
+  },
+  // noaa-only
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-noaa-only',
@@ -37,45 +91,9 @@ local notebookNodes = [
   },
   {
     instanceType: 'r5.4xlarge',
-    namePrefix: 'nb-staging',
-    labels+: { '2i2c/hub-name': 'staging' },
-    tags+: { '2i2c:hub-name': 'staging' },
-  },
-  {
-    instanceType: 'r5.4xlarge',
-    namePrefix: 'nb-prod',
-    labels+: { '2i2c/hub-name': 'prod' },
-    tags+: { '2i2c:hub-name': 'prod' },
-  },
-  {
-    instanceType: 'r5.4xlarge',
-    namePrefix: 'nb-workshop',
-    labels+: { '2i2c/hub-name': 'workshop' },
-    tags+: { '2i2c:hub-name': 'workshop' },
-  },
-  {
-    instanceType: 'r5.4xlarge',
     namePrefix: 'nb-noaa-only',
     labels+: { '2i2c/hub-name': 'noaa-only' },
     tags+: { '2i2c:hub-name': 'noaa-only' },
-  },
-  {
-    instanceType: 'r5.16xlarge',
-    namePrefix: 'nb-staging',
-    labels+: { '2i2c/hub-name': 'staging' },
-    tags+: { '2i2c:hub-name': 'staging' },
-  },
-  {
-    instanceType: 'r5.16xlarge',
-    namePrefix: 'nb-prod',
-    labels+: { '2i2c/hub-name': 'prod' },
-    tags+: { '2i2c:hub-name': 'prod' },
-  },
-  {
-    instanceType: 'r5.16xlarge',
-    namePrefix: 'nb-workshop',
-    labels+: { '2i2c/hub-name': 'workshop' },
-    tags+: { '2i2c:hub-name': 'workshop' },
   },
   {
     instanceType: 'r5.16xlarge',
@@ -86,6 +104,7 @@ local notebookNodes = [
   {
     instanceType: 'g4dn.xlarge',
     namePrefix: 'gpu-staging',
+    minSize: 0,
     labels+: {
       '2i2c/hub-name': 'staging',
       '2i2c/has-gpu': 'true',
@@ -106,6 +125,7 @@ local notebookNodes = [
   {
     instanceType: 'g4dn.xlarge',
     namePrefix: 'gpu-prod',
+    minSize: 0,
     labels+: {
       '2i2c/hub-name': 'prod',
       '2i2c/has-gpu': 'true',
@@ -126,6 +146,7 @@ local notebookNodes = [
   {
     instanceType: 'g4dn.xlarge',
     namePrefix: 'gpu-noaa-only',
+    minSize: 0,
     labels+: {
       '2i2c/hub-name': 'noaa-only',
       '2i2c/has-gpu': 'true',
@@ -146,6 +167,16 @@ local notebookNodes = [
 ];
 
 local daskNodes = [
+  // Node definitions for dask worker nodes. Config here is merged
+  // with our dask worker node definition, which uses spot instances.
+  // A `node.kubernetes.io/instance-type label is set to the name of the
+  // *first* item in instanceDistribution.instanceTypes, to match
+  // what we do with notebook nodes. Pods can request a particular
+  // kind of node with a nodeSelector
+  //
+  // A not yet fully established policy is being developed about using a single
+  // node pool, see https://github.com/2i2c-org/infrastructure/issues/2687.
+  //
   {
     namePrefix: 'dask-staging',
     labels+: { '2i2c/hub-name': 'staging' },
@@ -209,9 +240,6 @@ local daskNodes = [
           //
           name: 'vpc-cni',
           attachPolicyARNs: ['arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'],
-          // FIXME: enabling network policy enforcement didn't work as of
-          //        August 2024, what's wrong isn't clear.
-          //
           // configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
           configurationValues: |||
             enableNetworkPolicy: "false"
@@ -229,10 +257,16 @@ local daskNodes = [
           wellKnownPolicies: {
             ebsCSIController: true,
           },
+          // We enable detailed metrics collection to watch for issues with
+          // jupyterhub-home-nfs
           // configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
           configurationValues: |||
             defaultStorageClass:
                 enabled: true
+            controller:
+                enableMetrics: true
+            node:
+                enableMetrics: true
           |||,
         },
       ]
@@ -253,7 +287,9 @@ local daskNodes = [
             'hub.jupyter.org/node-purpose': 'core',
             'k8s.dask.org/node-purpose': 'core',
           },
-          tags+: { '2i2c:node-purpose': 'core' },
+          tags+: {
+            '2i2c:node-purpose': 'core',
+          },
         },
       ] + [
         ng {
@@ -266,10 +302,12 @@ local daskNodes = [
             'hub.jupyter.org/node-purpose': 'user',
             'k8s.dask.org/node-purpose': 'scheduler',
           },
-          tags+: { '2i2c:node-purpose': 'user' },
           taints+: {
             'hub.jupyter.org_dedicated': 'user:NoSchedule',
             'hub.jupyter.org/dedicated': 'user:NoSchedule',
+          },
+          tags+: {
+            '2i2c:node-purpose': 'user',
           },
         } + n
         for n in notebookNodes
@@ -287,6 +325,9 @@ local daskNodes = [
               taints+: {
                 'k8s.dask.org_dedicated': 'worker:NoSchedule',
                 'k8s.dask.org/dedicated': 'worker:NoSchedule',
+              },
+              tags+: {
+                '2i2c:node-purpose': 'worker',
               },
               instancesDistribution+: {
                 onDemandBaseCapacity: 0,

--- a/eksctl/openscapes.jsonnet
+++ b/eksctl/openscapes.jsonnet
@@ -25,6 +25,7 @@ local nodeAz = 'us-west-2b';
 // A `node.kubernetes.io/instance-type label is added, so pods
 // can request a particular kind of node with a nodeSelector
 local notebookNodes = [
+  // staging
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-staging',
@@ -43,6 +44,7 @@ local notebookNodes = [
     labels+: { '2i2c/hub-name': 'staging' },
     tags+: { '2i2c:hub-name': 'staging' },
   },
+  // prod
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-prod',
@@ -61,6 +63,7 @@ local notebookNodes = [
     labels+: { '2i2c/hub-name': 'prod' },
     tags+: { '2i2c:hub-name': 'prod' },
   },
+  // workshop
   {
     instanceType: 'r5.xlarge',
     namePrefix: 'nb-workshop',
@@ -80,11 +83,12 @@ local notebookNodes = [
     tags+: { '2i2c:hub-name': 'workshop' },
   },
 ];
+
 local daskNodes = [
   // Node definitions for dask worker nodes. Config here is merged
   // with our dask worker node definition, which uses spot instances.
   // A `node.kubernetes.io/instance-type label is set to the name of the
-  // *first* item in instancesDistribution.instanceTypes, to match
+  // *first* item in instanceDistribution.instanceTypes, to match
   // what we do with notebook nodes. Pods can request a particular
   // kind of node with a nodeSelector
   //
@@ -148,9 +152,6 @@ local daskNodes = [
           //
           name: 'vpc-cni',
           attachPolicyARNs: ['arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'],
-          // FIXME: enabling network policy enforcement didn't work as of
-          //        August 2024, what's wrong isn't clear.
-          //
           // configurationValues ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/HEAD/charts/aws-vpc-cni/values.yaml
           configurationValues: |||
             enableNetworkPolicy: "false"
@@ -168,10 +169,16 @@ local daskNodes = [
           wellKnownPolicies: {
             ebsCSIController: true,
           },
+          // We enable detailed metrics collection to watch for issues with
+          // jupyterhub-home-nfs
           // configurationValues ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/HEAD/charts/aws-ebs-csi-driver/values.yaml
           configurationValues: |||
             defaultStorageClass:
                 enabled: true
+            controller:
+                enableMetrics: true
+            node:
+                enableMetrics: true
           |||,
         },
       ]
@@ -207,38 +214,41 @@ local daskNodes = [
             'hub.jupyter.org/node-purpose': 'user',
             'k8s.dask.org/node-purpose': 'scheduler',
           },
-          tags+: {
-            '2i2c:node-purpose': 'user',
-          },
           taints+: {
             'hub.jupyter.org_dedicated': 'user:NoSchedule',
             'hub.jupyter.org/dedicated': 'user:NoSchedule',
           },
+          tags+: {
+            '2i2c:node-purpose': 'user',
+          },
         } + n
         for n in notebookNodes
-      ] + [
-        ng {
-          namePrefix: 'dask',
-          availabilityZones: [nodeAz],
-          minSize: 0,
-          maxSize: 500,
-          labels+: {
-            'k8s.dask.org/node-purpose': 'worker',
-          },
-          tags+: {
-            '2i2c:node-purpose': 'worker',
-          },
-          taints+: {
-            'k8s.dask.org_dedicated': 'worker:NoSchedule',
-            'k8s.dask.org/dedicated': 'worker:NoSchedule',
-          },
-          instancesDistribution+: {
-            onDemandBaseCapacity: 0,
-            onDemandPercentageAboveBaseCapacity: 0,
-            spotAllocationStrategy: 'capacity-optimized',
-          },
-        } + n
-        for n in daskNodes
-      ]
+      ] + (
+        if daskNodes != null then
+          [
+            ng {
+              namePrefix: 'dask',
+              availabilityZones: [nodeAz],
+              minSize: 0,
+              maxSize: 500,
+              labels+: {
+                'k8s.dask.org/node-purpose': 'worker',
+              },
+              taints+: {
+                'k8s.dask.org_dedicated': 'worker:NoSchedule',
+                'k8s.dask.org/dedicated': 'worker:NoSchedule',
+              },
+              tags+: {
+                '2i2c:node-purpose': 'worker',
+              },
+              instancesDistribution+: {
+                onDemandBaseCapacity: 0,
+                onDemandPercentageAboveBaseCapacity: 0,
+                spotAllocationStrategy: 'capacity-optimized',
+              },
+            } + n
+            for n in daskNodes
+          ] else []
+      )
   ],
 }

--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -55,10 +55,12 @@ local notebookNodes = [
     labels+: {
       '2i2c/hub-name': '<< hub >>',
       '2i2c/has-gpu': 'true',
+      'k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
     },
     tags+: {
-      'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
       '2i2c:hub-name': '<< hub >>',
+      'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      'k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
     },
     taints+: {
       'nvidia.com/gpu': 'present:NoSchedule',


### PR DESCRIPTION
While doing https://github.com/2i2c-org/infrastructure/issues/6184, while I'm authenticating I'm also updating the addons and some of the nodegroups that are missing labels/etc.

Ref #6221 

- [x] openscapes
- [x] nmfs-openscapes
- [x] nasa-veda