### PR TITLE
feat: use jupyterhub-gitpuller-init to pre-populate climaterisk

### DIFF
--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -39,7 +39,7 @@ jupyterhub:
       jupyterHub:
         authenticator_class: dummy
   singleuser:
-    defaultUrl: /git-pull?repo=https%3A%2F%2Fgithub.com%2FScienceCore%2Fclimaterisk&urlpath=lab%2Ftree%2Fclimaterisk%2Fbook%2FStartup.ipynb&branch=notebooks
+    defaultUrl: /lab/tree/climaterisk/book/Startup.ipynb
     image:
       name: quay.io/2i2c/sciencecore-climaterisk-image
       tag: 09c3a11f1698
@@ -68,6 +68,24 @@ jupyterhub:
       - name: home
         mountPath: /home/jovyan
         subPath: '{escaped_username}'
+          # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
+          # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init
+      - name: jupyterhub-gitpuller-init
+        image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
+        env:
+        - name: TARGET_PATH
+          value: climaterisk
+        - name: SOURCE_REPO
+          value: https://github.com/ScienceCore/climaterisk
+        - name: SOURCE_BRANCH
+          value: notebooks
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: '{escaped_username}'
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
     storage:
       extraVolumeMounts: []
 dask-gateway:


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/6292 by adding an `initcontainer` to the `climaterisk` pod.

I URL decoded the Git repo, and start-up `urlPath` to derive the `SOURCE_REPO` and `defaultUrl` parameters. I copied the base configuration from our `veda` hub (using the same tag, for ease of future maintainance).

I've tested this on staging and it matches my expectations. Good to go!