### PR TITLE
fix path error for hubs

### DIFF
--- a/deployer/commands/config/get_clusters.py
+++ b/deployer/commands/config/get_clusters.py
@@ -24,7 +24,7 @@ def get_clusters(
     cluster_names = []
     for config_file_path in get_all_cluster_yaml_files():
         with open(config_file_path) as f:
-            cluster = Cluster(yaml.load(f), config_file_path.parent)
+            cluster = Cluster(yaml.load(f), config_file_path)
         if provider and cluster.spec["provider"] != provider:
             continue
         cluster_names.append(os.path.basename(config_file_path.parent))

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -51,7 +51,7 @@ class Hub:
         # Go through the values files and check for other characteristics
         for values_file in self.spec["helm_chart_values_files"]:
             if "secret" not in values_file:
-                config_filename = self.cluster.config_path / values_file
+                config_filename = self.cluster.config_dir / values_file
                 with open(config_filename) as f:
                     config = yaml.load(f)
                     # If its a legacy daskhub, the config will be nested under the "basehub" key

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -51,7 +51,7 @@ class Hub:
         # Go through the values files and check for other characteristics
         for values_file in self.spec["helm_chart_values_files"]:
             if "secret" not in values_file:
-                config_filename = self.cluster.config_dir / values_file
+                config_filename = self.cluster.config_path / values_file
                 with open(config_filename) as f:
                     config = yaml.load(f)
                     # If its a legacy daskhub, the config will be nested under the "basehub" key


### PR DESCRIPTION
The `deployer` subcommand

`$ deployer config get-clusters` 

fails with errors of the type

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/jmunroe/2i2c-org/infrastructure/config/clusters/binderhub.values.yaml'
```

This PR makes a fix that corrects this error.  

