### PR TITLE
GHG: tune the CPU request for SSIM workshop

### DIFF
--- a/config/clusters/nasa-ghg/common.values.yaml
+++ b/config/clusters/nasa-ghg/common.values.yaml
@@ -217,7 +217,7 @@ basehub:
                 kubespawner_override:
                   mem_guarantee: 65094448840
                   mem_limit: 65094448840
-                  cpu_guarantee: 7.8475
+                  cpu_guarantee: 7.0000
                   cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
@@ -273,7 +273,7 @@ basehub:
                 kubespawner_override:
                   mem_guarantee: 65094448840
                   mem_limit: 65094448840
-                  cpu_guarantee: 7.8475
+                  cpu_guarantee: 7.0000
                   cpu_limit: 15.695
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge


### PR DESCRIPTION
We tested spinning up multiple pods for the SSIM workshop. It always created a node per pod because the CPU availability was insufficient.

I'm decreasing the CPU request here a bit to test if that helps put 2 user pods in a single node for the workshop.

Changing the option for the non-workshop environment too just to help us test without being part of the workshop group.

refs https://github.com/2i2c-org/infrastructure/issues/6308