### PR TITLE
Improve resource allocation choice generator

### DIFF
--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -23,7 +23,7 @@ basehub:
     custom:
       homepage:
         gitRepoBranch: staging
-        gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
+        gitRepoUrl: https://github.com/US-GHG-Center/ghgc-hub-homepage
     hub:
       config:
         GitHubOAuthenticator:

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -1,5 +1,4 @@
 import json
-import math
 import sys
 from enum import Enum
 from pathlib import Path

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -49,9 +49,10 @@ def proportional_memory_strategy(
     # as well as daemonsets we run on every node. This represents the resources that are available
     # for user pods.
 
-    # FIXME: Add some more more wiggle room here
-    available_node_mem = nodeinfo["available"]["memory"]
-    available_node_cpu = nodeinfo["available"]["cpu"]
+    WIGGLE_ROOM = 0.02
+
+    available_node_mem = nodeinfo["available"]["memory"] * (1 - WIGGLE_ROOM)
+    available_node_cpu = nodeinfo["available"]["cpu"] * (1 - WIGGLE_ROOM)
 
     # Only show one digit after . for CPU, but round *down* not up so we never
     # say they are getting more CPU than our limit is set to. We multiply & divide

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -51,10 +51,11 @@ def proportional_memory_strategy(
     # In addition, we provide some wiggle room to account for additional daemonset requests or other
     # issues that may pop up due to changes outside our control (like k8s upgrades). This is either
     # 2% of the available capacity, or 2GB / 1 CPU (whichever is smaller)
+    WIGGLE_PERCENTAGE = 0.02
     mem_overhead_wiggle = min(
-        nodeinfo["available"]["memory"] * 0.02, 2 * 1024 * 1024 * 1024
+        nodeinfo["available"]["memory"] * WIGGLE_PERCENTAGE, 2 * 1024 * 1024 * 1024
     )
-    cpu_overhead_wiggle = min(nodeinfo["available"]["cpu"] * 0.02, 1)
+    cpu_overhead_wiggle = min(nodeinfo["available"]["cpu"] * WIGGLE_PERCENTAGE, 1)
 
     available_node_mem = nodeinfo["available"]["memory"] - mem_overhead_wiggle
     available_node_cpu = nodeinfo["available"]["cpu"] - cpu_overhead_wiggle

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -80,9 +80,9 @@ def proportional_memory_strategy(
         else:
             cpu_guarantee_display = f"~{cpu_guarantee:0.0f}"
 
-        display_name = f"{mem_display} RAM, {cpu_guarantee_display} CPUs"
+        display_name = f"~{mem_display} RAM, {cpu_guarantee_display} CPUs"
         if cpu_guarantee != available_node_cpu:
-            description = f"Upto ~{available_node_cpu:.0f} CPUs when available"
+            description = f"Up to ~{available_node_cpu:.0f} CPUs when available"
         else:
             description = f"~{available_node_cpu:.0f} CPUs always available"
 

--- a/deployer/commands/generate/resource_allocation/generate_choices.py
+++ b/deployer/commands/generate/resource_allocation/generate_choices.py
@@ -52,7 +52,9 @@ def proportional_memory_strategy(
     # In addition, we provide some wiggle room to account for additional daemonset requests or other
     # issues that may pop up due to changes outside our control (like k8s upgrades). This is either
     # 2% of the available capacity, or 2GB / 1 CPU (whichever is smaller)
-    mem_overhead_wiggle = min(nodeinfo["available"]["memory"] * 0.02, 2 * 1024 * 1024 * 1024)
+    mem_overhead_wiggle = min(
+        nodeinfo["available"]["memory"] * 0.02, 2 * 1024 * 1024 * 1024
+    )
     cpu_overhead_wiggle = min(nodeinfo["available"]["cpu"] * 0.02, 1)
 
     available_node_mem = nodeinfo["available"]["memory"] - mem_overhead_wiggle
@@ -120,7 +122,8 @@ def proportional_memory_strategy(
 @resource_allocation_app.command()
 def choices(
     instance_specification: List[str] = typer.Argument(
-        ..., help="Instance type and number of choices to generate Resource Allocation options for. Specify as instance_type:count."
+        ...,
+        help="Instance type and number of choices to generate Resource Allocation options for. Specify as instance_type:count.",
     ),
     strategy: ResourceAllocationStrategies = typer.Option(
         ResourceAllocationStrategies.PROPORTIONAL_MEMORY_STRATEGY,
@@ -139,16 +142,19 @@ def choices(
 
         if instance_type not in nodeinfo:
             print(
-                f"Capacity information about {instance_type} not available", file=sys.stderr
+                f"Capacity information about {instance_type} not available",
+                file=sys.stderr,
             )
             print("TODO: Provide information on how to update it", file=sys.stderr)
             sys.exit(1)
 
         # Call appropriate function based on what strategy we want to use
         if strategy == ResourceAllocationStrategies.PROPORTIONAL_MEMORY_STRATEGY:
-            choices.update(proportional_memory_strategy(
-                instance_type, nodeinfo[instance_type], int(num_allocations)
-            ))
+            choices.update(
+                proportional_memory_strategy(
+                    instance_type, nodeinfo[instance_type], int(num_allocations)
+                )
+            )
         else:
             raise ValueError(f"Strategy {strategy} is not currently supported")
     yaml.dump(choices, sys.stdout)


### PR DESCRIPTION
- In https://github.com/2i2c-org/infrastructure/pull/6309, we discovered that some of our resource allocations were now outdated, causing some servers to not spawn. We add a 2% wiggle room (clamped at 2GB / 1CPU) to work around this.
- Based on feedback from earthscope's @sarahwilson523 in https://github.com/2i2c-org/infrastructure/pull/6351#issuecomment-3071223299, we've updated the choice descriptions to be clearer to end users. No more fractions, better messaging around CPU guarantees and limits.
- Allow generating allocations for multiple instance types in one go, to reduce copy pasting