### PR TITLE
VEDA: include rstudio home directory mounts

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -100,7 +100,7 @@ basehub:
         extraVolumeMounts:
         - name: home
           mountPath: /home/rstudio
-          subPath: "{escaped_username}"
+          subPath: '{escaped_username}'
         - name: home
           mountPath: /home/jovyan/shared-public
           subPath: _shared-public

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -99,6 +99,9 @@ basehub:
       storage:
         extraVolumeMounts:
         - name: home
+          mountPath: /home/rstudio
+          subPath: "{escaped_username}"
+        - name: home
           mountPath: /home/jovyan/shared-public
           subPath: _shared-public
           readOnly: false
@@ -108,6 +111,10 @@ basehub:
           readOnly: false
         - name: home
           mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
+        - name: home
+          mountPath: /home/rstudio/shared
           subPath: _shared
           readOnly: true
         - name: dev-shm


### PR DESCRIPTION
Lists in Helm values get overwritten in their entirety. We need to ensure that the home directory mount for rstudio is included in the values for individual hubs where we overwrite `singleuser.storage.extraVolumeMounts`.

refs #6342 