### PR TITLE
Apply ghg styleguide to staging hub login page

### DIFF
--- a/config/clusters/nasa-ghg/staging.values.yaml
+++ b/config/clusters/nasa-ghg/staging.values.yaml
@@ -22,9 +22,8 @@ basehub:
         secretName: https-auto-tls
     custom:
       homepage:
-        gitRepoBranch: bootstrap5-nasa-ghg-staging
-        # FIXME: use this repository again once the changes in the bootstrap5-nasa-ghg-staging branch of 2i2c-org/default-hub-homepage have been ported to it
-        # gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
+        gitRepoBranch: staging
+        gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
     hub:
       config:
         GitHubOAuthenticator:


### PR DESCRIPTION
# Description
Update styling of the staging GHG hub login page based on new style guide.

> FIXME: use this repository again once the changes in the bootstrap5-nasa-ghg-staging branch of 2i2c-org/default-hub-homepage have been ported to it

https://github.com/US-GHG-Center/ghgc-hub-homepage/pull/21 has been merged already.

