### PR TITLE
fix: pin Python in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,9 +25,9 @@
         (pkgs.buildFHSUserEnv {
           name = "2i2c-env";
           targetPkgs = pkgs: (with pkgs; [
-            python3
-            python3Packages.pip
-            python3Packages.virtualenv
+            python313
+            python313Packages.pip
+            python313Packages.virtualenv
             pythonManylinuxPackages.manylinux2014Package
             cmake
             ninja


### PR DESCRIPTION
When attempting to lend Yuvi my laptop, I discovered that I could not install the `deployer` package because of the minimum Python version. Unpinned, the existing flake pulls in Python 3.12 as of writing.

I didn't notice this at home (I work on a desktop) because I had already installed the package before this change was made, so the failing version check was never encountered.

This PR sets the minimum Python version to 3.13.