### PR TITLE
[openscapes] Offer just one allocation option for the workshop on a bigger machine:

### DIFF
--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -64,7 +64,7 @@ basehub:
         default: true
         kubespawner_override:
           image: openscapes/python:3ad4036
-        profile_options: &profile_options
+        profile_options:
           requests: &profile_options_resource_allocation
             display_name: Resource Allocation
             choices:
@@ -78,11 +78,6 @@ basehub:
                   cpu_limit: 15.3811
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
-      - display_name: R + Python Geospatial
-        description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest
-        kubespawner_override:
-          image: ghcr.io/nmfs-opensci/container-images/py-rocket-geospatial-2:latest
-        profile_options: *profile_options
       - display_name: Bring your own image
         description: Specify your own docker image (must have python and jupyterhub installed in it)
         slug: custom


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/6370

### Changes

- This PR uses #6313 to re-generates 5 choices on a r5.4xlarge.
- The option that was closest to the community's `14.8 GB RAM / up to 3.7 CPU` is chosen, i.e. `~15 GB RAM, ~1.9 CPUs, up to 15 cpu`
- It removes all other resource options that are not used and all other image options that are not used in the workshop

It's important to note that this choice is now on a r5.4xlarge instead of a r5.xlarge, which means that it will pack 8 users on a node instead of two, allowing for smaller startup time.
At ~200 users, there will be around 25 scale up events on a r5.4xlarge, whereas on a r5.xlarge there would have been 100 events.

### *This change should be reverted after the workshop