### PR TITLE
[climatematch]: bump support limits

### DIFF
--- a/config/clusters/climatematch/support.values.yaml
+++ b/config/clusters/climatematch/support.values.yaml
@@ -17,6 +17,11 @@ prometheus:
       - secretName: prometheus-tls
         hosts:
         - prometheus.climatematch.2i2c.cloud
+    resources:
+      requests:
+        memory: 6Gi
+      limits:
+        memory: 6Gi
 
 grafana:
   grafana.ini:

--- a/docs/sre-guide/common-problems-solutions.md
+++ b/docs/sre-guide/common-problems-solutions.md
@@ -64,7 +64,7 @@ prometheus:
         memory: {{RAM_LIMIT}}
 ```
 
-The [default for this value is 2GB](https://github.com/2i2c-org/infrastructure/tree/HEAD/helm-charts/support/values.yaml#L38).
+The [default for this value is 4GB](https://github.com/2i2c-org/infrastructure/tree/HEAD/helm-charts/support/values.yaml#L38).
 Try increasing this value in small increments and deploying using `deployer deploy-support {{CLUSTER_NAME}}` until the server successfully starts up.
 Then make a Pull Request with your updated config.
 


### PR DESCRIPTION
This PR bumps the memory limit for prometheus from 4→6GiB. This should fix the OOM error (assuming that 150% capacity is sufficient).