### PR TITLE
feat: better handle install interruption

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,8 @@
       gdk = pkgs.google-cloud-sdk.withExtraComponents (with pkgs.google-cloud-sdk.components; [
         gke-gcloud-auth-plugin
       ]);
+      python = pkgs.python313;
+      pythonPackages = pkgs.python313Packages;
       envWithScript = script:
         (pkgs.buildFHSUserEnv {
           name = "2i2c-env";
@@ -44,16 +46,42 @@
             terraform
             eksctl
           ]);
+          targetPkgs = pkgs:
+            [
+              python
+              pkgs.pythonManylinuxPackages.manylinux2014Package
+            ]
+            ++ (with pythonPackages; [pip virtualenv])
+            ++ (with pkgs; [
+              cmake
+              ninja
+              gcc
+              pre-commit
+              # Infra packages
+              go-jsonnet
+              kubernetes-helm
+              kubectl
+              sops
+              gdk
+              awscli2
+              azure-cli
+              terraform
+              eksctl
+            ]);
+          # If there is a higher power, why does it allow such horrible autoformatting below
           runScript = "${pkgs.writeShellScriptBin "runScript" (''
-              set -e
-              if [[ ! -d .venv ]]; then
-                ${pkgs.python3.interpreter} -m venv .venv
-                source .venv/bin/activate
-                python -m pip install -e .[dev]
-              else
-                source .venv/bin/activate
-              fi
-              set +e
+                               set -e
+                               if [[ ! -d .venv ]]; then
+                          __setup_env() {
+                     tmp_path="$(mktemp -d)"
+                    	  ${python.interpreter} -m venv "$tmp_path"
+                                   "''${tmp_path}/bin/python" -m pip install -e .[dev]
+              mv "$tmp_path" "''${PWD}/.venv"
+                   }
+                   __setup_env
+                               fi
+                               source .venv/bin/activate
+                               set +e
             ''
             + script)}/bin/runScript";
         })


### PR DESCRIPTION
When at SciPy, I switched to my laptop. In addition to running into a Python version pinning requirement, I also noticed that the virtualenv setup is not safe against interruption.

In the long run, the proper way to handle Python packages is to package them with Nix. I am thoroughly disinterested in doing this -- it will require me to keep the derivation up to date with the source package. Given the purpose of this is to bootstrap a development environment, I'm entirely happy using Python's packaging system with virtual environments.

This change implements a setup-then-move pattern that is naturally safe against interruption.