### PR TITLE
[ghg] Remove temp iops bump

### DIFF
--- a/terraform/aws/projects/nasa-ghg.tfvars
+++ b/terraform/aws/projects/nasa-ghg.tfvars
@@ -210,7 +210,6 @@ ebs_volumes = {
     # ref https://github.com/2i2c-org/infrastructure/issues/6308
     size = 1750 # 1.75 TB
     # ref https://github.com/2i2c-org/infrastructure/issues/6293
-    iops        = 10000 # Temporarily have 10k iops for the summer workshop
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/6323

Based on the graphics fom 8-18 July, I don't think 10k iops were needed and the default 3k looks like it's more than enough.

Not sure how different will the workshop starting today will be in terms of needs, so I'll wait for your feedback on this one @yuvipanda  before changing anything.

*The terraform changes in this PR were not applied.