### PR TITLE
Bump core nodepool size

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -216,6 +216,7 @@ k8s_versions = {
 }
 
 core_node_machine_type = "n2-highmem-2"
+core_node_max_count    = 6
 enable_network_policy  = true
 
 notebook_nodes = {


### PR DESCRIPTION
Not enough core nodes to acomodate all the jupyterhuib-home-nfs deployments of all the hubs. Let's see if this fixes it