### PR TITLE
feat: add GPU support to earthscope

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -311,6 +311,11 @@ basehub:
               kubespawner_override:
                 image: '{value}'
             choices:
+              tensorflow:
+                display_name: Pangeo Tensorflow ML Notebook
+                slug: tensorflow
+                kubespawner_override:
+                  image: quay.io/pangeo/ml-notebook:2025.07.09
               pytorch:
                 display_name: Pangeo PyTorch ML Notebook
                 default: true

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -303,6 +303,8 @@ basehub:
         profile_options:
           image:
             display_name: Image
+            dynamic_image_building:
+              enabled: true
             unlisted_choice:
               enabled: true
               display_name: Custom image

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -293,6 +293,40 @@ basehub:
                   cpu_limit: 63.575
                   node_selector:
                     node.kubernetes.io/instance-type: r5.16xlarge
+      - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
+        description: Start a container on a dedicated node with a GPU
+        slug: gpu
+        allowed_groups:
+        - geolab
+        - geolab:dev
+        - geolab:power
+        profile_options:
+          image:
+            display_name: Image
+            unlisted_choice:
+              enabled: true
+              display_name: Custom image
+              validation_regex: ^.+:.+$
+              validation_message: Must be a publicly available docker image of form <image-name>:<tag>
+              kubespawner_override:
+                image: '{value}'
+            choices:
+              pytorch:
+                display_name: Pangeo PyTorch ML Notebook
+                default: true
+                slug: pytorch
+                kubespawner_override:
+                  image: quay.io/pangeo/pytorch-notebook:2025.05.22
+        kubespawner_override:
+          environment:
+            NVIDIA_DRIVER_CAPABILITIES: compute,utility
+          mem_limit:
+          mem_guarantee: 14G
+          node_selector:
+            node.kubernetes.io/instance-type: g4dn.xlarge
+          extra_resource_limits:
+            nvidia.com/gpu: '1'
+
     scheduling:
       userScheduler:
         enabled: true

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -96,6 +96,48 @@ local notebookNodes = [
       'earthscope:application:owner': 'research-onramp-to-the-cloud',
     },
   },
+  {
+    instanceType: 'g4dn.xlarge',
+    namePrefix: 'gpu-staging',
+    minSize: 0,
+    labels+: {
+      'k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
+      '2i2c/hub-name': 'staging',
+      '2i2c/has-gpu': 'true',
+    },
+    tags+: {
+      'k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
+      'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      '2i2c:hub-name': 'staging',
+    },
+    taints+: {
+      'nvidia.com/gpu': 'present:NoSchedule',
+    },
+    // Allow provisioning GPUs across all AZs, to prevent situation where all
+    // GPUs in a single AZ are in use and no new nodes can be spawned
+    availabilityZones: masterAzs,
+  },
+  {
+    instanceType: 'g4dn.xlarge',
+    namePrefix: 'gpu-prod',
+    minSize: 0,
+    labels+: {
+      'k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
+      '2i2c/hub-name': 'prod',
+      '2i2c/has-gpu': 'true',
+    },
+    tags+: {
+      'k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator': 'nvidia-tesla-t4',
+      'k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu': '1',
+      '2i2c:hub-name': 'prod',
+    },
+    taints+: {
+      'nvidia.com/gpu': 'present:NoSchedule',
+    },
+    // Allow provisioning GPUs across all AZs, to prevent situation where all
+    // GPUs in a single AZ are in use and no new nodes can be spawned
+    availabilityZones: masterAzs,
+  },
 ];
 local daskNodes = [
   // Node definitions for dask worker nodes. Config here is merged


### PR DESCRIPTION
This PR enables GPUs for the earthscope cluster as per https://2i2c.freshdesk.com/a/tickets/3591, following our [infrastructure guide](https://infrastructure.2i2c.org/howto/features/gpu/#aws).

I had to make some decisions:

1. I omitted requesting a new limit ­— the default is 64 vCPU, which is sufficient for 16 concurrent users. We need to actually ask the community how many GPU instances they need.
2. I set the permissions to _all_ users. My expectation is that we'll want to restrict this to power users, for example. My read of [the notes about 2i2c access](https://github.com/2i2c-org/infrastructure/blob/0f09bb3e65e17927cec6d3ceb7d2fe92beee8436/config/clusters/earthscope/common.values.yaml#L123-L126) in the cluster config file is that 2i2c won't have the power user scopes that we'd need for me to be able to test a stricter configuration.
3. I enabled dynamic image building for the GPU. I took prior art from the NASA VEDA cluster.