### PR TITLE
feat: enable dynamic image building for `projectpythia`

### DIFF
--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -74,6 +74,9 @@ jupyterhub:
       profile_options:
         image:
           display_name: Image
+          # Enables dynamic image building for this profile
+          dynamic_image_building:
+            enabled: true
           unlisted_choice:
             enabled: true
             display_name: Custom image


### PR DESCRIPTION
Adds dynamic image building to the profile list in `projectpythia`, following https://infrastructure.2i2c.org/howto/features/imagebuilding/#connect-with-jupyterhub-fancy-profiles.


I only needed to add the configuration for the UI entry -- this hub already has a registry set up for its BinderHub.