### PR TITLE
feat: split out GPU profile entry for `projectpythia`

### DIFF
--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -99,16 +99,6 @@ jupyterhub:
               slug: scipy
               kubespawner_override:
                 image: quay.io/jupyter/scipy-notebook:2024-04-15
-            tensorflow:
-              display_name: Pangeo Tensorflow ML Notebook
-              slug: tensorflow
-              kubespawner_override:
-                image: pangeo/ml-notebook:2024.05.21
-            pytorch:
-              display_name: Pangeo PyTorch ML Notebook
-              slug: pytorch
-              kubespawner_override:
-                image: pangeo/pytorch-notebook:2024.05.21
         resources:
           display_name: Resource Allocation
           choices:


### PR DESCRIPTION
I asked a question on Slack about whether we should split out the GPU entry for the `projectpythia` cluster, to reflect the approach taken by the majority of our other clusters.

There was mixed response -- some of this is just UI preference, but given that we have other clusters that split them, I am splitting them out. 