### PR TITLE
[projectpythia, prod] Set to 2GB per user

### DIFF
--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -6,7 +6,7 @@ jupyterhub-home-nfs:
   eks:
     volumeId: vol-0cdc25a68ca0303ce
   quotaEnforcer:
-    hardQuota: '10' # in GB
+    hardQuota: '2' # in GB
 jupyterhub:
   ingress:
     hosts: [projectpythia.2i2c.cloud]


### PR DESCRIPTION
The total disk size for home directories is 100GB. There are currently around 35 participants signed up, so reducing quota per person from 10GB to 2GB.