### PR TITLE
Revert "Updates the NeuroHackademy user images"

### DIFF
--- a/config/clusters/neurohackademy/common.values.yaml
+++ b/config/clusters/neurohackademy/common.values.yaml
@@ -73,7 +73,7 @@ jupyterhub:
               display_name: nh2025
               slug: regular-profile
               kubespawner_override:
-                image: quay.io/arokem/nh2025:bf7189a87a09
+                image: quay.io/arokem/nh2025:11f1cd342757
                 init_containers: &init_containers
                 - name: volume-mount-ownership-fix
                   image: busybox:1.36.1
@@ -114,7 +114,7 @@ jupyterhub:
               display_name: nh2025-gpu
               slug: gpu-profile
               kubespawner_override:
-                image: quay.io/arokem/nh2025-gpu:eb1bbe6322b8
+                image: quay.io/arokem/nh2025-gpu:726a3d89f074
                 init_containers: *init_containers
             unlisted_choice:
               enabled: true


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#6456 because there's a problem with the user image that has prevented the user server to start. Has been observed on staging.

Because this failed on staging, the changes weren't deployed to prod anyway. This just removes any confusion.