### PR TITLE
feat: update staging image on utoronto

### DIFF
--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -1,4 +1,8 @@
 jupyterhub:
+  singleuser:
+    image:
+      name: quay.io/2i2c/utoronto-image
+      tag: update-latest
   ingress:
     hosts: [staging.utoronto.2i2c.cloud]
     tls:


### PR DESCRIPTION
This PR updates the utoronto staging configuration to use a specific image tag. This will be used to permit the community to try out an upgraded version of their image, as per https://github.com/2i2c-org/infrastructure/issues/6374.
