### PR TITLE
feat: update r staging image on utoronto

### DIFF
--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -1,4 +1,8 @@
 jupyterhub:
+  singleuser:
+    image:
+      name: quay.io/2i2c/utoronto-r-image
+      tag: update-latest
   ingress:
     hosts: [r-staging.datatools.utoronto.ca]
     tls:


### PR DESCRIPTION
This PR updates the utoronto staging configuration to use a specific image tag for their R image. This will be used to permit the community to try out an upgraded version of their image, as per https://github.com/2i2c-org/infrastructure/issues/6375.
