### PR TITLE
Update recurrent-get-billing-data.yaml

### DIFF
--- a/.github/workflows/recurrent-get-billing-data.yaml
+++ b/.github/workflows/recurrent-get-billing-data.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run on every 28th of the month at midnight
-  - cron: 0 0 28 * *
+  - cron: 0 0 15 * *
 
 jobs:
   create_issue:


### PR DESCRIPTION
Update creation date so that this shows up before a sprint planning session