### PR TITLE
Configure for Project Pythia Cookoff 2025

### DIFF
--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -87,6 +87,18 @@ jupyterhub:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+    - name: volume-mount-ownership-fix
+      image: busybox:1.36.1
+      command:
+      - sh
+      - -c
+      - id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: home
+        mountPath: /home/jovyan
+        subPath: '{escaped_username}'
     extraFiles:
       project_pythia_cookoff:
         mountPath: /mnt/project_pythia_cookoff/cookbook_prep


### PR DESCRIPTION
This PR reverts some of the changes made in #6479

1.  Removes injection of file content from infrastructure in favour of using git-init instead to pull content
2. Ensure the the security patch ghsa-w3vc-fx9p-wp4v/check-patch-run is still used
3. uses conda instead of pip for injecting jupyterlab-git and gh-scoped-creds