### PR TITLE
maint: use non-FHS flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
       python = pkgs.python313;
       packages =
         [
-          (python.withPackages (pypkgs: with pypkgs; [virtualenv]))
+          python
         ]
         ++ (with pkgs; [
           cmake
@@ -45,6 +45,9 @@
           eksctl
         ]);
       shellHook = ''
+        # Unset leaky PYTHONPATH
+        unset PYTHONPATH
+
         # Setup if not defined ####
         if [[ ! ( -d ".venv" && -f ".venv/marker" ) ]]; then
             __setup_env() {
@@ -56,9 +59,6 @@
                 # Stand up new venv
                 ${python.interpreter} -m venv .venv
 
-                # Unset leaky PYTHONPATH
-                unset PYTHONPATH
-
                 ".venv/bin/python" -m pip install -e ".[dev]"
 
                 # Add a marker that marks this venv as "ready"
@@ -66,9 +66,6 @@
             }
 
             __setup_env
-        else
-            # Unset leaky PYTHONPATH
-            unset PYTHONPATH
         fi
         ###########################
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,67 +18,73 @@
         inherit system;
         config.allowUnfree = true;
       };
+      inherit (pkgs) lib;
+
       gdk = pkgs.google-cloud-sdk.withExtraComponents (with pkgs.google-cloud-sdk.components; [
         gke-gcloud-auth-plugin
       ]);
       python = pkgs.python313;
       pythonPackages = pkgs.python313Packages;
-      envWithScript = script:
-        (pkgs.buildFHSEnv {
-          name = "2i2c-env";
-          targetPkgs = pkgs:
-            [
-              python
-              pkgs.pythonManylinuxPackages.manylinux2014Package
-            ]
-            ++ (with pythonPackages; [pip virtualenv])
-            ++ (with pkgs; [
-              cmake
-              ninja
-              gcc
-              pre-commit
-              # Infra packages
-              go-jsonnet
-              kubernetes-helm
-              kubectl
-              sops
-              gdk
-              awscli2
-              azure-cli
-              terraform
-              eksctl
-            ]);
-          # If there is a higher power, why does it allow such horrible autoformatting below
-          runScript = "${pkgs.writeShellScriptBin "runScript" (''
-              set -e
+      packages =
+        [
+          python
+        ]
+        ++ (with pythonPackages; [virtualenv])
+        ++ (with pkgs; [
+          cmake
+          ninja
+          gcc
+          pre-commit
+          # Infra packages
+          go-jsonnet
+          kubernetes-helm
+          kubectl
+          sops
+          gdk
+          awscli2
+          azure-cli
+          terraform
+          eksctl
+        ]);
+      shellHook = ''
+        # Setup if not defined ####
+        if [[ ! ( -d ".venv" && -f ".venv/marker" ) ]]; then
+            __setup_env() {
+                # Remove existing venv
+                if [[ -d .venv ]]; then
+                    rm -r .venv
+                fi
 
-              # Setup if not defined ####
-              if [[ ! ( -d ".venv" && -f ".venv/marker" ) ]]; then
-                  __setup_env() {
-                      # Remove existing venv
-                      if [[ -d .venv ]]; then
-                          rm -r .venv
-                      fi
+                # Stand up new venv
+                ${python.interpreter} -m venv .venv
 
-                      # Stand up new venv
-                      ${python.interpreter} -m venv .venv
-                      ".venv/bin/python" -m pip install -e .[dev]
+                # Unset leaky PYTHONPATH
+                unset PYTHONPATH
 
-                      # Add a marker that marks this venv as "ready"
-                      touch .venv/marker
-                  }
+                ".venv/bin/python" -m pip install -e ".[dev]"
 
-                  __setup_env
-              fi
-              ###########################
+                # Add a marker that marks this venv as "ready"
+                touch .venv/marker
+            }
 
-              source .venv/bin/activate
-              set +e
-            ''
-            + script)}/bin/runScript";
-        })
-        .env;
+            __setup_env
+        else
+            # Unset leaky PYTHONPATH
+            unset PYTHONPATH
+        fi
+        ###########################
+
+        # Activate venv
+        source .venv/bin/activate
+      '';
+      env = lib.optionalAttrs pkgs.stdenv.isLinux {
+        # Python uses dynamic loading for certain libraries.
+        # We'll set the linker path instead of patching RPATH
+        LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux2014;
+      };
     in {
-      devShell = envWithScript "bash";
+      devShell = pkgs.mkShell {
+        inherit env packages shellHook;
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,10 @@
         gke-gcloud-auth-plugin
       ]);
       python = pkgs.python313;
-      pythonPackages = pkgs.python313Packages;
       packages =
         [
-          python
+          (python.withPackages (pypkgs: with pypkgs; [virtualenv]))
         ]
-        ++ (with pythonPackages; [virtualenv])
         ++ (with pkgs; [
           cmake
           ninja


### PR DESCRIPTION
The Nix package manager's most disruptive design choice is the deliberate neglect of the [FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html). This means that applications packaged for Nix cannot rely on `/usr/lib` etc, and instead need to use `rpath` and other mechanisms to ensure that they link properly. 

The Python ecosystem has a subtle concept of a "runtime environment" that most users don't see. On Linux, that's `manylinux`. In the existing version of this Flake, Nix builds a FHS environment using namespaces and chroot, so that the assumptions about where to find the `manylinux` dependencies holds true. 

This PR replaces the heavier FHS with a simple `mkShell`, and defines `LD_LIBRARY_PATH` to ensure that Python finds the proper dependencies for `manylinux`. 