### PR TITLE
fix: set a bogus username to silence Terraform error

### DIFF
--- a/terraform/aws/db.tf
+++ b/terraform/aws/db.tf
@@ -106,7 +106,7 @@ provider "mysql" {
   # not an empty string, so we set it to "does-not-exist"
   endpoint = var.db_enabled ? aws_db_instance.db[0].endpoint : "does-not-exist"
 
-  username = var.db_enabled ? aws_db_instance.db[0].username : ""
+  username = var.db_enabled ? aws_db_instance.db[0].username : "not-a-real-user"
   password = var.db_enabled ? random_password.db_root_password[0].result : ""
 }
 


### PR DESCRIPTION
I run into this when running plans on AWS IAAC. @GeorgianaElena I feel like you have added similar fixes for TF errors recently, can you review please? :pray: 
