### PR TITLE
feat: grow nasa-cryo storage

### DIFF
--- a/terraform/aws/db.tf
+++ b/terraform/aws/db.tf
@@ -106,7 +106,7 @@ provider "mysql" {
   # not an empty string, so we set it to "does-not-exist"
   endpoint = var.db_enabled ? aws_db_instance.db[0].endpoint : "does-not-exist"
 
-  username = var.db_enabled ? aws_db_instance.db[0].username : ""
+  username = var.db_enabled ? aws_db_instance.db[0].username : "not-a-real-user"
   password = var.db_enabled ? random_password.db_root_password[0].result : ""
 }
 

--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -12,7 +12,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 4750
+    size        = 5300
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }


### PR DESCRIPTION
We had a PagerDuty incident regarding the nasa-cryo storage: 
https://2i2c-org.pagerduty.com/incidents/Q2FM1L4RX1AP8J?utm_campaign=channel&utm_source=slack

I grew the disk to ensure that we trigger neither alert. I should have grown to leave us at ~87%, but I mistakenly treated GiB as GB.