### PR TITLE
fix: set `pullPolicy` to Always for `staging` (Python)

### DIFF
--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -2,7 +2,9 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
+      # TODO: unset Always once latest tag is used
       tag: update-latest
+      pullPolicy: Always
   ingress:
     hosts: [staging.utoronto.2i2c.cloud]
     tls:


### PR DESCRIPTION
See https://github.com/2i2c-org/infrastructure/pull/6516/ for the same PR against the R staging environment.