### PR TITLE
fix: pin tag of image for utoronto staging hubs.

### DIFF
--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -2,9 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      # TODO: unset Always once latest tag is used
-      tag: update-latest
-      pullPolicy: Always
+      tag: 34b2777825b1
   ingress:
     hosts: [staging.utoronto.2i2c.cloud]
     tls:

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -2,9 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-r-image
-      # TODO: unset Always once latest tag is used
-      tag: update-latest
-      pullPolicy: Always
+      tag: 217c910c5072
 
   ingress:
     hosts: [r-staging.datatools.utoronto.ca]


### PR DESCRIPTION
I had not realised that the image-building workflows push tags. This simplifies how we define the singleuser images, and means we can drop the pull policy.