### PR TITLE
Bump prometheus disk to be lower

### DIFF
--- a/config/clusters/berkeley-geojupyter/support.values.yaml
+++ b/config/clusters/berkeley-geojupyter/support.values.yaml
@@ -5,6 +5,8 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    persistentVolume:
+      size: 100Gi
     ingress:
       enabled: true
       hosts:

--- a/config/clusters/templates/common/support.values.yaml
+++ b/config/clusters/templates/common/support.values.yaml
@@ -9,6 +9,8 @@ prometheusStorageClass:
 
 prometheus:
   server:
+    persistentVolume:
+      size: 100Gi
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
This is expensive cloud cost that doesn't buy us anything - the thing it was trying to mitigate (an explosion in disk space) has been mitigated in other ways since.

Change the berkeley-geojupyter one because it has no real data yet. But others will need to be actively migrated.