### PR TITLE
Fix max amt of RAM for g4dn.2xlarge instances

### DIFF
--- a/config/clusters/neurohackademy/common.values.yaml
+++ b/config/clusters/neurohackademy/common.values.yaml
@@ -143,8 +143,8 @@ jupyterhub:
               slug: gpu
               description: Start a container on a dedicated node with a GPU
               kubespawner_override:
-                mem_limit: 30G
-                mem_guarantee: 30G
+                mem_limit: 29G
+                mem_guarantee: 29G
                 environment:
                   NVIDIA_DRIVER_CAPABILITIES: compute,utility
                 node_selector:


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/6537