### PR TITLE
[openscapes, workshop]: Set 1 GiB limit for home storage

### DIFF
--- a/config/clusters/openscapes/workshop.values.yaml
+++ b/config/clusters/openscapes/workshop.values.yaml
@@ -115,7 +115,7 @@ basehub:
             nodeSelector:
               2i2c/hub-name: workshop
   jupyterhub-home-nfs:
-    # quotaEnforcer:
-    #   hardQuota: '2' # in GB
+    quotaEnforcer:
+      hardQuota: '1' # in GB
     eks:
       volumeId: vol-0ab191452f5c85c6b


### PR DESCRIPTION
We should change this, but waiting on openscapes. In the meantime, this ensures ~20 users can safely fit on the storage.