### PR TITLE
[nasa-cryo, prod]: Grow the NFS hard quota for home storage

### DIFF
--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -37,4 +37,4 @@ basehub:
     eks:
       volumeId: vol-00b9cf4a258bce8ef
     quotaEnforcer:
-      hardQuota: '350' # in GB
+      hardQuota: '400' # in GB


### PR DESCRIPTION
They need more space in shared-public. Addresses https://2i2c.freshdesk.com/a/tickets/3703