### PR TITLE
[neurohackademy, prod] Grow home directory disk space

### DIFF
--- a/terraform/aws/projects/neurohackademy.tfvars
+++ b/terraform/aws/projects/neurohackademy.tfvars
@@ -16,7 +16,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   }
   "prod" = {
-    size        = 5000 # in GB
+    size        = 5200 # in GB
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }


### PR DESCRIPTION
This is only a 4% bump, which buys us time — they have a user consuming >50% of the disk, which is not nominal usage. I've reached out to ask them to reclaim space. In the meantime, we'll need to keep an eye on this.