### PR TITLE
chore: bump flake versions & hash Python

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,10 @@
         # Unset leaky PYTHONPATH
         unset PYTHONPATH
 
+        local __hash=$(command -v python | sha256sum)
+
         # Setup if not defined ####
-        if [[ ! ( -d ".venv" && -f ".venv/marker" ) ]]; then
+        if [[ ! -f ".venv/$__hash" ]]; then
             __setup_env() {
                 # Remove existing venv
                 if [[ -d .venv ]]; then
@@ -62,7 +64,7 @@
                 ".venv/bin/python" -m pip install -e ".[dev]"
 
                 # Add a marker that marks this venv as "ready"
-                touch .venv/marker
+                touch ".venv/$__hash"
             }
 
             __setup_env


### PR DESCRIPTION
Update package versions.

Also, safeguard against the time when the Python version doesn't match the venv that we generated.
