### PR TITLE
fix: bump nmfs-openscapes workshop quota

### DIFF
--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -222,7 +222,7 @@ jupyterhub-home-nfs:
   eks:
     volumeId: vol-07154b7def3b80b96
   quotaEnforcer:
-    hardQuota: '4' # in GB
+    hardQuota: '10' # in GB
 
 binderhub-service:
   enabled: false


### PR DESCRIPTION
This reflects what I have done, but we need to follow up here -- something is awry.