### PR TITLE
[cloudbank, bcc & chabot] Bump home storage for cloudbank

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -16,7 +16,7 @@ persistent_disks = {
     name_suffix = "authoring"
   }
   "bcc" = {
-    size        = 1
+    size        = 2
     name_suffix = "bcc"
   }
   "ccsf" = {
@@ -24,7 +24,7 @@ persistent_disks = {
     name_suffix = "ccsf"
   }
   "chabot" = {
-    size        = 1
+    size        = 2
     name_suffix = "chabot"
   }
   "chaffey" = {


### PR DESCRIPTION
Doubles rather than 10% increase, because 1GB is objectively not much space for modern workloads.