### PR TITLE
[disasters, prod] Change volume to prod volume

### DIFF
--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -46,6 +46,6 @@ binderhub-service:
 
 jupyterhub-home-nfs:
   eks:
-    volumeId: vol-08f3d124fcfd518b0
+    volumeId: vol-00174260142d50e1b
   quotaEnforcer:
     hardQuota: '200' # in GB


### PR DESCRIPTION
@jnywong noticed that a storage volume was not marked `in-use`. This PR adjusts the config to split prod and staging.