### PR TITLE
[earthscope]: define more instancetypes for Dask

### DIFF
--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -158,7 +158,7 @@ local daskNodes = [
       'earthscope:application:name': 'geolab',
       'earthscope:application:owner': 'research-onramp-to-the-cloud',
     },
-    instancesDistribution+: { instanceTypes: ['r5.4xlarge'] },
+    instancesDistribution+: { instanceTypes: ['r5.4xlarge', 'r6i.4xlarge', 'r7i.4xlarge'] },
   },
   {
     namePrefix: 'dask-prod',
@@ -168,7 +168,7 @@ local daskNodes = [
       'earthscope:application:name': 'geolab',
       'earthscope:application:owner': 'research-onramp-to-the-cloud',
     },
-    instancesDistribution+: { instanceTypes: ['r5.4xlarge'] },
+    instancesDistribution+: { instanceTypes: ['r5.4xlarge', 'r6i.4xlarge', 'r7i.4xlarge'] },
   },
 ];
 


### PR DESCRIPTION
This closes https://github.com/2i2c-org/infrastructure/issues/6522 by adding additional spot instance types for Dask.

I haven't been able to observe these instances being provisioned in practice yet, but the config and generated pod specs look correct.