### PR TITLE
[cryocloud, bcc] Bump home storage again

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -16,7 +16,7 @@ persistent_disks = {
     name_suffix = "authoring"
   }
   "bcc" = {
-    size        = 3
+    size        = 5
     name_suffix = "bcc"
   }
   "ccsf" = {


### PR DESCRIPTION
As they take on more users, we're seeing a linear increasing the storage requirements. I'm bumping this nonlinearly, to save us having to do this for every N users