### PR TITLE
Fix temple hub's logo URL

### DIFF
--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -15,7 +15,7 @@ jupyterhub:
         org:
           name: Temple University JupyterHub
           url: https://www.temple.edu/
-          logo_url: https://www.temple.edu/sites/all/modules/custom/tu_global/images/svg/temple-logo-t-box.svg
+          logo_url: https://www.temple.edu/modules/custom/tu_layout/images/brand/t-cherry.svg
         designed_by:
           name: 2i2c
           url: https://2i2c.org


### PR DESCRIPTION
The existing one seems broken