### PR TITLE
Disable NAT gateway for new eksctl clusters

### DIFF
--- a/eksctl/template.jsonnet
+++ b/eksctl/template.jsonnet
@@ -115,6 +115,11 @@ local daskNodes = [];
       '2i2c.org/cluster-name': $.metadata.name,
     },
   },
+  vpc: {
+    nat: {
+      gateway: "Disable"
+    }
+  },
   availabilityZones: masterAzs,
   iam: {
     withOIDC: true,


### PR DESCRIPTION
eksctl creates a NAT gateway by default (https://eksctl.io/usage/vpc-configuration/#nat-gateway) that we can't then delete.

This changes our eksctl template to disable NAT creation for new clusters.