### PR TITLE
Put contents of repo image is built from into /srv/repo

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -56,6 +56,12 @@ binderhub-service:
     BinderHub:
       base_url: /services/binder
       use_registry: true
+    BuildExecutor:
+      # Put the contents of the repo under `/srv/repo`
+      # By default they go under `/home/jovyan`, which gets overwritten
+      # by the home directory
+      repo2docker_extra_args:
+      - --target-repo-dir=/srv/repo
     KubernetesBuildExecutor:
       build_image: quay.io/jupyterhub/repo2docker:2024.07.0-159.gd0ddd2e
       node_selector:


### PR DESCRIPTION
# BIG TODO

This should really only apply for *dynamic imagebuilding hubs* and *not* binderhubs we run. Update the config appropriately.


By default repo2docker puts the contents of the repo the image is built from in /home/jovyan. This is overwritten by persistent home directory storage when using a persistent hub, so users can not access it.

The solution in repo2docker is to put the contents in a different place. We have been putting it `/srv/repo` as part of our user image template with repo2docker-action
(https://github.com/2i2c-org/hub-user-image-template/blob/e0a2578e66825134accccbd34b36ca2802e29079/.github/workflows/build.yaml#L44).

This PR puts out the same behavior for all our dynamic imagebuilding hubs.


Ref https://github.com/2i2c-org/infrastructure/issues/5499