### PR TITLE
Add back r5.2xlarge to ubc-eoas

### DIFF
--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -34,6 +34,13 @@ local notebookNodes = [
     tags+: { '2i2c:hub-name': 'staging' },
   },
   {
+    instanceType: 'r5.2xlarge',
+    nameSuffix: 'b',
+    namePrefix: 'nb-staging',
+    labels+: { '2i2c/hub-name': 'prod' },
+    tags+: { '2i2c:hub-name': 'prod' },
+  },
+  {
     instanceType: 'r5.4xlarge',
     namePrefix: 'nb-staging',
     nameSuffix: 'b',
@@ -50,6 +57,13 @@ local notebookNodes = [
   // prod
   {
     instanceType: 'r5.xlarge',
+    nameSuffix: 'b',
+    namePrefix: 'nb-prod',
+    labels+: { '2i2c/hub-name': 'prod' },
+    tags+: { '2i2c:hub-name': 'prod' },
+  },
+  {
+    instanceType: 'r5.2xlarge',
     nameSuffix: 'b',
     namePrefix: 'nb-prod',
     labels+: { '2i2c/hub-name': 'prod' },


### PR DESCRIPTION
Their nodeSelector asked for r5.2xlarge but that wasn't part of the eksctl config, causing no new nodes to be spun up.