### PR TITLE
Add alert for server failing to start

### DIFF
--- a/docs/topic/monitoring-alerting/alerting.md
+++ b/docs/topic/monitoring-alerting/alerting.md
@@ -24,7 +24,7 @@ At the time of writing, we have the following classes of alerts:
 
 1. when a persistent volume claim (PVC) is approaching full capacity
 2. when a pod has restarted
-3. when a user pod has had an unschedulable status for more than 5 minutes
+3. when a user server has failed to start
 4. when a disk is approaching IO saturation
 
 When an alert threshold is crossed, an automatic notification is sent to PagerDuty and the `#pagerduty-notifications` channel on the 2i2c Slack.

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -43,6 +43,33 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
     ],
   };
 
+  local makeServerStartupFailureAlert = function(
+    name,
+    summary,
+    severity,
+    labels={},
+                                      ) {
+    // Structure is documented in https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+    name: name,
+    rules: [
+      {
+        alert: name,
+        expr: |||
+          # We trigger any time there is a server startup failure, for any reason.
+          jupyterhub_server_spawn_duration_seconds_count{status="failure"} > 0
+        |||,
+        'for': '1m',
+        labels: {
+          cluster: cluster_name,
+          severity: severity,
+        } + labels,
+        annotations: {
+          summary: summary,
+        },
+      },
+    ],
+  };
+
   local diskIOApproachingSaturation = function(
     name,
     severity,
@@ -205,6 +232,12 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               0.1,
               'same day action needed',
             ),
+
+            makeServerStartupFailureAlert(
+              'Server Startup Failed',
+              'Outage alert: Server Startup failed: cluster %s hub:{{ $labels.namespace }}' % [cluster_name],
+              'take immediate action'
+            ),
             makePVCApproachingFullAlert(
               'Home directory has 0% space left!',
               'Take action! Home Directory Disk very close to full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
@@ -232,11 +265,6 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               'jupyterhub-groups-exporter pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
               'groups-exporter',
               'action needed this week'
-            ),
-            makeUserPodUnschedulableAlert(
-              'A user pod was unschedulable',
-              'The user pod {{ $labels.pod }} is unschedulable on cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
-              'same day action needed',
             ),
             diskIOApproachingSaturation(
               'Disk IO approaching saturation',


### PR DESCRIPTION
This replaces the unschedulable pod alert, as this is more accurate (hopefully). We had an UBC EOAS outage today that was not caught by the unschedulable pod alert until much later.

I removed the unschedulable pod alert as it was added for the same reason this one is. And I don't want us to have alert fatigue