### PR TITLE
Change severity of server startup failures from P1 to P2 until we figure out how to distinghuish an outage

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -241,7 +241,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
             makeServerStartupFailureAlert(
               'Server Startup Failed',
               'Outage alert: Server Startup failed: cluster %s hub:{{ $labels.namespace }}' % [cluster_name],
-              'take immediate action'
+              'same day action needed'
             ),
             makePVCApproachingFullAlert(
               'Home directory has 0% space left!',


### PR DESCRIPTION


We will manually elevate the priority if confirmed an actual outage
