### PR TITLE
Fix ubc-eoas nodegroup tag

### DIFF
--- a/eksctl/ubc-eoas.jsonnet
+++ b/eksctl/ubc-eoas.jsonnet
@@ -37,8 +37,8 @@ local notebookNodes = [
     instanceType: 'r5.2xlarge',
     nameSuffix: 'b',
     namePrefix: 'nb-staging',
-    labels+: { '2i2c/hub-name': 'prod' },
-    tags+: { '2i2c:hub-name': 'prod' },
+    labels+: { '2i2c/hub-name': 'staging' },
+    tags+: { '2i2c:hub-name': 'staging' },
   },
   {
     instanceType: 'r5.4xlarge',


### PR DESCRIPTION
Without it, pods on staging weren't spawning up. Follow-up to https://github.com/2i2c-org/infrastructure/pull/6631