### PR TITLE
Increase our concurent spawn limit

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -890,6 +890,9 @@ jupyterhub:
                   - 172.16.0.0/12
                   - 192.168.0.0/16
   hub:
+    # Lift from default 64, as that seems to be a bit
+    # too low for our communities
+    concurrentSpawnLimit: 100
     config:
       JupyterHub:
         # Allow unauthenticated prometheus requests


### PR DESCRIPTION
We're fine given the jupyterhub-simulator testing I did for the openscapes workshop from a while back.

Ref https://2i2c.freshdesk.com/a/tickets/3825