### PR TITLE
[awi-ciroh, workshop] Tear down infrastructure & k8s for workshop

### DIFF
--- a/config/clusters/awi-ciroh/cluster.yaml
+++ b/config/clusters/awi-ciroh/cluster.yaml
@@ -9,30 +9,30 @@ gcp:
     paid_by_us: false
 support:
   helm_chart_values_files:
-  - support.values.yaml
-  - enc-support.secret.values.yaml
+    - support.values.yaml
+    - enc-support.secret.values.yaml
 hubs:
-- name: staging
-  display_name: 'Alabama Water Institute: CIROH (staging)'
-  domain: staging.ciroh.awi.2i2c.cloud
-  helm_chart: daskhub
-  helm_chart_values_files:
-  - common.values.yaml
-  - staging.values.yaml
-  - enc-staging.secret.values.yaml
-- name: prod
-  display_name: 'Alabama Water Institute: CIROH (prod)'
-  domain: ciroh.awi.2i2c.cloud
-  helm_chart: daskhub
-  helm_chart_values_files:
-  - common.values.yaml
-  - prod.values.yaml
-  - enc-prod.secret.values.yaml
-- name: workshop
-  display_name: 'Alabama Water Institute: CIROH (workshop)'
-  domain: workshop.ciroh.awi.2i2c.cloud
-  helm_chart: daskhub
-  helm_chart_values_files:
-  - common.values.yaml
-  - workshop.values.yaml
-  - enc-workshop.secret.values.yaml
+  - name: staging
+    display_name: "Alabama Water Institute: CIROH (staging)"
+    domain: staging.ciroh.awi.2i2c.cloud
+    helm_chart: daskhub
+    helm_chart_values_files:
+      - common.values.yaml
+      - staging.values.yaml
+      - enc-staging.secret.values.yaml
+  - name: prod
+    display_name: "Alabama Water Institute: CIROH (prod)"
+    domain: ciroh.awi.2i2c.cloud
+    helm_chart: daskhub
+    helm_chart_values_files:
+      - common.values.yaml
+      - prod.values.yaml
+      - enc-prod.secret.values.yaml
+# - name: workshop
+#   display_name: 'Alabama Water Institute: CIROH (workshop)'
+#   domain: workshop.ciroh.awi.2i2c.cloud
+#   helm_chart: daskhub
+#   helm_chart_values_files:
+#   - common.values.yaml
+#   - workshop.values.yaml
+#   - enc-workshop.secret.values.yaml

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -18,10 +18,10 @@ persistent_disks = {
     size        = 2800 # in GiB
     name_suffix = "prod"
   }
-  "workshop" = {
-    size        = 1000 # in GiB
-    name_suffix = "workshop"
-  }
+#  "workshop" = {
+#    size        = 1000 # in GiB
+#    name_suffix = "workshop"
+#  }
 }
 
 # Cloud costs for this project are not passed through by 2i2c
@@ -52,10 +52,10 @@ user_buckets = {
     "delete_after" : null,
     "uniform_bucket_level_access_only" : true
   }
-  "scratch-workshop" : {
-    "delete_after" : 7,
-    "uniform_bucket_level_access_only" : true
-  },
+#  "scratch-workshop" : {
+#    "delete_after" : 7,
+#    "uniform_bucket_level_access_only" : true
+#  },
 }
 
 # Setup notebook node pools
@@ -111,10 +111,10 @@ hub_cloud_permissions = {
     bucket_admin_access : ["scratch", "persistent"],
     hub_namespace : "prod"
   }
-  "workshop" : {
-    bucket_admin_access : ["scratch-workshop"],
-    hub_namespace : "workshop"
-  }
+#  "workshop" : {
+#    bucket_admin_access : ["scratch-workshop"],
+#    hub_namespace : "workshop"
+#  }
 }
 
 container_repos = []


### PR DESCRIPTION
Fixes #6489 by:

- Deleting the workshop persistent disk
- Tearing down the k8s `workshop` namespace and Helm release
- Removing the workshop hub from `awi-ciroh.tfvars` & `cluster.yaml`