### PR TITLE
Raise temple quota to 10G

### DIFF
--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -64,7 +64,7 @@ jupyterhub-home-nfs:
     config:
       QuotaManager:
         paths: [/export/temple]
-        hard_quota: 5 # in GB
+        hard_quota: 10 # in GB
     resources:
       requests:
         cpu: 0.2


### PR DESCRIPTION
Instructurs find 5G too small, and we don't have a clear way to do overrides yet.

Ref https://2i2c.freshdesk.com/a/tickets/3850