### PR TITLE
Bump version of jupyterhub-home-nfs

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 1.0.1
+    version: 1.0.2-0.dev.git.1.hc7ff343
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/6683

A bunch of pod restarts were because `xfs_quota` was failing and crashing the whole pod.