### PR TITLE
cloudbank: Bump ccsf quota to 10G

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -89,6 +89,11 @@ jupyterhub:
 jupyterhub-home-nfs:
   gke:
     volumeId: projects/cb-1003-1696/zones/us-central1-b/disks/hub-nfs-homedirs-ccsf
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 10 # in GB
+
 nfs:
   pv:
     serverIP: storage-quota-home-nfs.ccsf.svc.cluster.local


### PR DESCRIPTION
There are a few users here over 5G, causing server startups to fail with https://2i2c-org.pagerduty.com/incidents/Q2D966AA7LTNVW