### PR TITLE
fix: move gitconfig for r hubs

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -60,13 +60,6 @@ jupyterhub:
         # to meet the chart schema validation requirements without the need to
         # use secret values during the validation.
         stringData: dummy
-      gitconfig:
-        mountPath: /etc/gitconfig
-        # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner
-        stringData: |
-          [credential "https://github.com"]
-          helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
-          useHttpPath = true
   hub:
     db:
       pvc:

--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -3,6 +3,14 @@ jupyterhub:
     image:
       name: quay.io/2i2c/utoronto-image
       tag: 34b2777825b1
+    extraFiles:
+      gitconfig:
+        mountPath: /etc/gitconfig
+        # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner
+        stringData: |
+          [credential "https://github.com"]
+          helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
+          useHttpPath = true
   hub:
     config:
       Authenticator:

--- a/config/clusters/utoronto/r-common.values.yaml
+++ b/config/clusters/utoronto/r-common.values.yaml
@@ -21,3 +21,11 @@ jupyterhub:
     image:
       name: quay.io/2i2c/utoronto-r-image
       tag: 217c910c5072
+    extraFiles:
+      gitconfig:
+        mountPath: /opt/conda/etc/gitconfig
+        # app-id comes from https://github.com/organizations/utoronto-2i2c/settings/apps/utoronto-jupyterhub-private-cloner
+        stringData: |
+          [credential "https://github.com"]
+          helper = !git-credential-github-app --app-key-file /etc/github/github-app-private-key.pem --app-id 93515
+          useHttpPath = true


### PR DESCRIPTION
Having upgraded the R hub to a new rocker/binder image, a lot of the foundations of the image are different, including things like where `git` comes from. In the new image, `git` is provisioned from `conda` rather than the system, so the prefix has changed.

Right now I'm concerned with patching this, but in the medium term I don't feel super happy with this -- it feels a bit fragile.

This patch moves the common config into two separate config sections, one for each hub kind.