### PR TITLE
[cloudbank] Increase Prometheus pv disk

### DIFF
--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -3,6 +3,8 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    persistentVolume:
+      size: 500Gi
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
This increases the cloudbank hub's prometheus-server disk size, so that it doesn't run out of space!