### PR TITLE
[nasa-veda, prod] Increase home-directory disk size

### DIFF
--- a/docs/howto/filesystem-management/increase-disk-size.md
+++ b/docs/howto/filesystem-management/increase-disk-size.md
@@ -61,7 +61,7 @@ Please let the community know that we've performed an emergency resize using an 
 
 > Dear all,
 > 
-> The home directory disk capacity for the <$CLUSTER_NAME> <$HUB_NAME> was close to its maximum limit.
+> The home directory disk capacity for the <$CLUSTER_NAME> <$HUB_NAME> hub was close to its maximum limit.
 > We have increased the disk so that now there is between 10% to 15% free space remaining.
 > Recommended actions:
 > 

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -241,7 +241,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 2500 # 2.5TB
+    size        = 2815 # 2.815TB
     type        = "gp3"
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }


### PR DESCRIPTION
I sent an alert on Thursday last week, which gave some opportunity (not much) to avoid this. We've now switched to a more defensive policy of resizing _at_ 90% rather than alerting, so giving warning was a bespoke action.

This PR increases the EBS size to leave 15% free.