### PR TITLE
VEDA: Enable 'allusers' directory for VEDA hubs

### DIFF
--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -25,6 +25,25 @@ basehub:
       2i2c:
         add_staff_user_ids_to_admin_users: true
         add_staff_user_ids_of_type: github
+      singleuserAdmin:
+        extraVolumeMounts:
+          # /allusers is an extra mount point for admins to access to all users'
+          # home dirs
+        - name: home
+          mountPath: /home/jovyan/allusers
+          readOnly: false
+        - name: home
+          mountPath: /home/rstudio/allusers
+          readOnly: false
+          # mounts below are copied from basehub's values that we override by
+          # specifying extraVolumeMounts (lists get overridden when helm values
+          # are combined)
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
+        - name: home
+          mountPath: /home/rstudio/shared-readwrite
+          subPath: _shared
       jupyterhubConfigurator:
         enabled: false
       homepage:


### PR DESCRIPTION
refs https://github.com/NASA-IMPACT/veda-analytics/issues/177

We want to delete some old home directories of inactive users on VEDA hubs.