### PR TITLE
fix: change alert query to delta function for restarts

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -101,8 +101,12 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
       # Count total container restarts with pod name containing 'pod_name_substring'.
       # We sum by pod name (which resets after restart) and namespace, so we don't get all
       # the other labels of the metric in our alert.
-      sum(kube_pod_container_status_restarts_total{pod=~'.*%s.*'}) by (pod, namespace) >= 1
-    ||| % [pod_name_substring],
+        (
+              sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~".*%s.*"})
+            -
+              (sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~".*%s.*"} offset 10m))
+        ) >= 1    
+    ||| % [pod_name_substring, pod_name_substring],
     'for': '5m',
     labels: {
       cluster: cluster_name,


### PR DESCRIPTION
I noticed that we were receiving repeated alerts for pod restarts on the `nasa-ghg-hub` despite the value remaining constant. We were testing whether any restarts had happened in the pod lifetime, not whether it had increased (pods that have restarted are typically perfectly allowed).

I'm not enough of a Prometheus expert to know about whether there is a better way to do this, but here's the logic:

- Compute $N_R$ at $t_{-10m}$ and $t$. 
- Subtract the older value from the newer value  $N_R(t) - N_R(t_{-10m})$ 
- If the difference is positive and greater/equal to one, then we had a new restart in the last 10m.
- If this alert signal remains high for 5m, we trigger.

I don't think we can use `delta` because the container ID changes between container restart.

This means that we wouldn't get this alert if a pod restart happens, and then the pod is destroyed and recreated within 5m. I don't feel so worried about that for now.

I tested this by killing a container inside the NFS pod on showcase, and ensuring that the alert triggered and _did not auto resolve_ in PD. After clearing the PD alert, it never resurfaced.