### PR TITLE
fix: change server restart alerts to non-resolving delta-fns

### DIFF
--- a/helm-charts/support/enc-support.secret.values.yaml
+++ b/helm-charts/support/enc-support.secret.values.yaml
@@ -17,6 +17,7 @@ prometheus:
         - name: ENC[AES256_GCM,data:lNppPrxGAL3JPZkhaQRsM+gd,iv:jB5EymgGnsGAW97jtCf/n7tlJI0M7pqB+k5qA01cHi4=,tag:Hk17ZdO3W6HNDjM/xOdL/Q==,type:str]
           pagerduty_configs:
             - routing_key: ENC[AES256_GCM,data:9bFt0hSoJFUkY3S5rDTMNSR73dEAxN8m+GB+QtriIuc=,iv:Hqq+6AKckW0WCIPAeEBVId9HEheuxRB3pm4u/fZHhKY=,tag:0jBt9CO9HU3FWk4MMDPI3w==,type:str]
+              send_resolved: ENC[AES256_GCM,data:ZpteoqQ=,iv:0TrJjEF7tB2BrhbN2QAoHY3JssCr2NksfycYI6I9zyM=,tag:3zjKfmsMaycpnRrpwTKbLg==,type:bool]
         - name: ENC[AES256_GCM,data:msVs5EpwE6ymVYxx7fnp90FcVIE=,iv:QWvD3gDeHxjZmIOktRGdxYzHgItoxh7AcfTssTg5kGg=,tag:ysN8T/GIiplwUzv+f2MHlw==,type:str]
           pagerduty_configs:
             - routing_key: ENC[AES256_GCM,data:yWaHcQBV+4jlKBMHb0xTtwgFpLLVEN9pEj8e0sH1IeE=,iv:LFDdmMN99eqmkscE8LdZ5J1+i5wVGz4huZYovIfQyiQ=,tag:lYyBtLFCgMZG7FUfwTAMjw==,type:str]
@@ -26,7 +27,7 @@ sops:
     - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
       created_at: "2024-12-18T10:09:21Z"
       enc: CiUA4OM7eOThrN3NqDXYd4belMxUdYfF8XpeUSYfiefKkYutN2KoEkkAnGhyNqzzrXyUXTvtS4xl4IjlJpo6hwm9FVbQAyh2Vw9dcXH6h1+NNUHGPYj6KQJvvWZzgXHFLiWdqOfUgTJME0YDx/DYgXgm
-  lastmodified: "2025-09-03T10:23:32Z"
-  mac: ENC[AES256_GCM,data:27VTOtP+0dDhqDYAqsMXdw/hQlJQQWscLxs/oOKhw+pB4im3d5Op9oo63vGo1mJ12dOUhBKPMntU6m3f3MgUiyJxxjyaEHqGrOcdWX3dNBe7vMb+YZ8wWkKUIZgSC2wsLEMaSqIU9+Nags7TrA6G15mdVlwd5xGF7BRzabqqjiQ=,iv:0EbD1jDglA9rzgGwvilRE3CoJx2FSTfo2XGLhMVA3BI=,tag:X9Z+KhlQsZfgc/7gAGO/ow==,type:str]
+  lastmodified: "2025-09-09T18:53:04Z"
+  mac: ENC[AES256_GCM,data:0O0krdj8krVKq0uwlLJhfvRG/phcQRyh/hYkpVV90t0QCvEa+zH2sfRYZrFL3ZvB20Qf9eqQiZloCiOzLP06hcoJGqjPnq+gR4aKvRIaPkmbopg3l6frxaUxiFg+fAvQ53AUtumDnCnN0XHlu95UOKiOfMTRCgIrWfxquZ7gR/Y=,iv:G++9Q+w7o5z1uiCCclg9W+W2rxTrkVTBV8Cp/ZrCbhM=,tag:Xm/d3VnX4u5k6pHeM4nH7w==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -104,7 +104,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
         (
               sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~".*%s.*"})
             -
-              (sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~".*%s.*"} offset 10m))
+              sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~".*%s.*"} offset 10m)
         ) >= 1    
     ||| % [pod_name_substring, pod_name_substring],
     'for': '5m',

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -47,9 +47,11 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
     expr: |||
       # We trigger any time there is a server startup failure, for any reason.
       # The 'min' is to reduce the labels being passed to only the necessary ones
-      min(
-        jupyterhub_server_spawn_duration_seconds_count{status="failure"} > 0
-      ) by (namespace)
+      min by (namespace) (
+          (jupyterhub_server_spawn_duration_seconds_count{status="failure"} > 0)
+        -
+          ((jupyterhub_server_spawn_duration_seconds_count{status="failure"} offset 2m) > 0)
+      )
     |||,
     'for': '1m',
     labels: {


### PR DESCRIPTION
Following https://github.com/2i2c-org/infrastructure/pull/6738, this PR changes server restart alerts to delta functions, and turns off the auto-resolution in PD.

This means that we'll trigger and then resolve the alert in Prometheus, but PD will keep the alert open. This reflects the point made in https://github.com/2i2c-org/infrastructure/pull/6738 — restart alerts and failed server starts are events, not system state, so we can't automatically resolve them.