### PR TITLE
[openscapes] Refactor for LP-DAAC

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -13,7 +13,6 @@ basehub:
       - soft   # We pick soft over hard, so NFS lockups don't lead to hung processes
       - retrans=2
       - noresvport
-      serverIP: fs-b25253b5.efs.us-west-2.amazonaws.com
       baseShareName: /
   dask-gateway:
     enabled: true
@@ -103,68 +102,74 @@ basehub:
           resource_allocation:
             display_name: Resource Allocation
             choices:
-              mem_1_9:
-                display_name: 1.9 GB RAM, upto 3.7 CPUs
+              mem_2_gb:
+                display_name: ~2 GB RAM, ~0.2 CPUs
+                description: Up to ~4 CPUs when available
                 kubespawner_override:
-                  mem_guarantee: 1991244775
-                  mem_limit: 1991244775
-                  cpu_guarantee: 0.2328125
-                  cpu_limit: 3.725
+                  mem_guarantee: 1951419879
+                  mem_limit: 1951419879
+                  cpu_guarantee: 0.22815625
+                  cpu_limit: 3.6505
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-                default: true
-              mem_3_7:
-                display_name: 3.7 GB RAM, upto 3.7 CPUs
+              mem_4_gb:
+                display_name: ~4 GB RAM, ~0.5 CPUs
+                description: Up to ~4 CPUs when available
                 kubespawner_override:
-                  mem_guarantee: 3982489550
-                  mem_limit: 3982489550
-                  cpu_guarantee: 0.465625
-                  cpu_limit: 3.725
+                  mem_guarantee: 3902839759
+                  mem_limit: 3902839759
+                  cpu_guarantee: 0.4563125
+                  cpu_limit: 3.6505
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-              mem_7_4:
-                display_name: 7.4 GB RAM, upto 3.7 CPUs
+              mem_7_gb:
+                display_name: ~7 GB RAM, ~0.9 CPUs
+                description: Up to ~4 CPUs when available
                 kubespawner_override:
-                  mem_guarantee: 7964979101
-                  mem_limit: 7964979101
-                  cpu_guarantee: 0.93125
-                  cpu_limit: 3.725
+                  mem_guarantee: 7805679519
+                  mem_limit: 7805679519
+                  cpu_guarantee: 0.912625
+                  cpu_limit: 3.6505
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-              mem_14_8:
-                display_name: 14.8 GB RAM, upto 3.7 CPUs
+              mem_15_gb:
+                display_name: ~15 GB RAM, ~1.8 CPUs
+                description: Up to ~4 CPUs when available
                 kubespawner_override:
-                  mem_guarantee: 15929958203
-                  mem_limit: 15929958203
-                  cpu_guarantee: 1.8625
-                  cpu_limit: 3.725
+                  mem_guarantee: 15611359038
+                  mem_limit: 15611359038
+                  cpu_guarantee: 1.82525
+                  cpu_limit: 3.6505
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-              mem_29_7:
-                display_name: 29.7 GB RAM, upto 3.7 CPUs
+              mem_29_gb:
+                display_name: ~29 GB RAM, ~4 CPUs
+                description: ~4 CPUs always available
                 kubespawner_override:
-                  mem_guarantee: 31859916406
-                  mem_limit: 31859916406
-                  cpu_guarantee: 3.725
-                  cpu_limit: 3.725
+                  mem_guarantee: 31222718077
+                  mem_limit: 31222718077
+                  cpu_guarantee: 3.6505
+                  cpu_limit: 3.6505
                   node_selector:
                     node.kubernetes.io/instance-type: r5.xlarge
-              mem_60_6:
-                display_name: 60.6 GB RAM, upto 15.6 CPUs
+              mem_60_gb:
+                display_name: ~60 GB RAM, ~8 CPUs
+                description: Up to ~15 CPUs when available
                 kubespawner_override:
-                  mem_guarantee: 65094448840
-                  mem_limit: 65094448840
-                  cpu_guarantee: 7.8475
-                  cpu_limit: 15.695
+                  mem_guarantee: 64020707016
+                  mem_limit: 64020707016
+                  cpu_guarantee: 7.69055
+                  cpu_limit: 15.3811
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
-              mem_121_2:
-                display_name: 121.2 GB RAM, upto 15.6 CPUs
+              mem_119_gb:
+                display_name: ~119 GB RAM, ~15 CPUs
+                description: ~15 CPUs always available
                 kubespawner_override:
-                  mem_guarantee: 130188897681
-                  mem_limit: 130188897681
-                  cpu_guarantee: 15.695
-                  cpu_limit: 15.695
+                  mem_guarantee: 128041414033
+                  mem_limit: 128041414033
+                  cpu_guarantee: 15.3811
+                  cpu_limit: 15.3811
                   node_selector:
                     node.kubernetes.io/instance-type: r5.4xlarge
     scheduling:

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -3,18 +3,13 @@ basehub:
     hub:
       config:
         DummyAuthenticator:
-          password: ENC[AES256_GCM,data:OoFm55AFDVZ5Xo95Gb3R,iv:I1RB0W6jcHLu0xMd8PaHCmEIytzly3SQ5S6ImDdSEqA=,tag:tKc++MJZD9tn7ic6fPitZA==,type:str]
+          password: ENC[AES256_GCM,data:9en8qGYYEZA=,iv:stNVXPw8xwRTULkbUEUuUKGzcm+6SjW6uswyVPmHGzM=,tag:ieB+YB3mcsd9oXz/NCdeUg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2025-08-07T13:17:08Z'
     enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2025-08-20T22:05:45Z'
-  mac: ENC[AES256_GCM,data:tVUJhzERcoe8vylcX1jLpl1qhekr9f10hWnS7JC5Lp1hTIBLyn6/vDTZqIiKeCMgsFyAFtVGtoInxnt/iUo4igIP0c+8sM0Y0Vnc68Nv06vIEiCNbc44/gQhm7VQsIaTIYRSwy8OnmNgH1jDVSeHNgftuzSCpbcCzAb8d+Ezy14=,iv:CpTpZmT9KqrgttmblsMUKdhqN2Gl12kWFqUXbej/cP0=,tag:wfSFJmQZ3mp3PfTKbPTfmA==,type:str]
-  pgp: []
+  lastmodified: '2025-09-11T12:41:30Z'
+  mac: ENC[AES256_GCM,data:BNT3xswv5mdKlrOnNrkmeKjGcoEVR7rmT6d7yWIxbk7HG2BdptNdNXFIDwm88KNKUgpGNL5hSOcFoaIP5d0ySdp3AiKB2L4lb4S2eYJdzKL7jR2LsRlM+ptB3KtnVBUIwblVuOcHLRzod1Xgq7Qg/DqnJxl2cu0f3mdh70XzEBo=,iv:SGnQDC4qmTjLdLD5tBuLRgxCAOnjqxnMUXliCKe+gz8=,tag:bhNifxtFqehKvsUyWivwLQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.10.1
+  version: 3.10.2

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -6,10 +6,10 @@ basehub:
           password: ENC[AES256_GCM,data:FqhuDuW9Q5FigB0nYwk/,iv:kWG5hdcAdPKnRc3Ftv9qpKEph/wmFJwc1rqiYIE/2OM=,tag:p3PDCd6bw5BjhaDvBVo2FA==,type:str]
 sops:
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-08-07T13:17:08Z"
-      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
-  lastmodified: "2025-09-12T13:35:10Z"
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-08-07T13:17:08Z'
+    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+  lastmodified: '2025-09-12T13:35:10Z'
   mac: ENC[AES256_GCM,data:V2hCeBi8n3bf1cBxHBLDERegLAhCiSmLqQ0sqd2WRwxlAu3HBpstWEmHdRQULHFVLBmPMnROr43k3Cr5M3P42okWCv4Q8x3i8ZD0UqXh9y74lQ4oGV43Y2JAYPGSQG3RrIcK7fXvBNxja8vToB+ZpVbp/elwGNBNq0B+t0O7Iyo=,iv:KDfNIDeLu3cNgV0Ak8DKgNWpXj3aL6eIHbWobhX40Xc=,tag:1quEzIfwYMClqssggMQkpQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -3,13 +3,13 @@ basehub:
     hub:
       config:
         DummyAuthenticator:
-          password: ENC[AES256_GCM,data:9en8qGYYEZA=,iv:stNVXPw8xwRTULkbUEUuUKGzcm+6SjW6uswyVPmHGzM=,tag:ieB+YB3mcsd9oXz/NCdeUg==,type:str]
+          password: ENC[AES256_GCM,data:FqhuDuW9Q5FigB0nYwk/,iv:kWG5hdcAdPKnRc3Ftv9qpKEph/wmFJwc1rqiYIE/2OM=,tag:p3PDCd6bw5BjhaDvBVo2FA==,type:str]
 sops:
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-08-07T13:17:08Z'
-    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
-  lastmodified: '2025-09-11T12:41:30Z'
-  mac: ENC[AES256_GCM,data:BNT3xswv5mdKlrOnNrkmeKjGcoEVR7rmT6d7yWIxbk7HG2BdptNdNXFIDwm88KNKUgpGNL5hSOcFoaIP5d0ySdp3AiKB2L4lb4S2eYJdzKL7jR2LsRlM+ptB3KtnVBUIwblVuOcHLRzod1Xgq7Qg/DqnJxl2cu0f3mdh70XzEBo=,iv:SGnQDC4qmTjLdLD5tBuLRgxCAOnjqxnMUXliCKe+gz8=,tag:bhNifxtFqehKvsUyWivwLQ==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-08-07T13:17:08Z"
+      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+  lastmodified: "2025-09-12T13:35:10Z"
+  mac: ENC[AES256_GCM,data:V2hCeBi8n3bf1cBxHBLDERegLAhCiSmLqQ0sqd2WRwxlAu3HBpstWEmHdRQULHFVLBmPMnROr43k3Cr5M3P42okWCv4Q8x3i8ZD0UqXh9y74lQ4oGV43Y2JAYPGSQG3RrIcK7fXvBNxja8vToB+ZpVbp/elwGNBNq0B+t0O7Iyo=,iv:KDfNIDeLu3cNgV0Ak8DKgNWpXj3aL6eIHbWobhX40Xc=,tag:1quEzIfwYMClqssggMQkpQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -1,7 +1,7 @@
 basehub:
   nfs:
     pv:
-      serverIP: 10.100.50.169
+      serverIP: 10.100.130.27
   jupyterhub:
     custom:
       2i2c:
@@ -52,96 +52,11 @@ basehub:
           mountPath: /home/jovyan/shared-public
           subPath: _shared-public
           readOnly: false
-      defaultUrl: /lab
       nodeSelector:
         2i2c/hub-name: workshop
       extraEnv:
         SCRATCH_BUCKET: s3://openscapeshub-scratch-workshop/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: s3://openscapeshub-persistent-workshop/$(JUPYTERHUB_USER)
-      profileList:
-      - display_name: Choose your environment and resources
-        default: true
-        profile_options:
-          image:
-            display_name: Environment
-            unlisted_choice:
-              enabled: true
-              display_name: Custom image
-              description: Specify your own docker image (must have python and jupyterhub installed in it)
-              validation_regex: ^.+:.+$
-              validation_message: Must be a publicly available docker image, of form <image-name>:<tag>
-              kubespawner_override:
-                image: '{value}'
-            choices:
-              01-python:
-                display_name: Python
-                description: Python datascience environment
-                kubespawner_override:
-                  image: openscapes/python:8d3d96f
-              02-R:
-                display_name: R + Python Geospatial
-                description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest
-                kubespawner_override:
-                  image: ghcr.io/nmfs-opensci/container-images/py-rocket-geospatial-2:latest
-              03-Matlab:
-                display_name: Matlab
-                description: Matlab environment
-                kubespawner_override:
-                  image: openscapes/matlab:2023-11-28
-          resource_allocation:
-            display_name: Resource Allocation
-            choices:
-              mem_2_gb:
-                display_name: ~2 GB RAM, ~0.2 CPUs
-                description: Up to ~4 CPUs when available
-                kubespawner_override:
-                  mem_guarantee: 1951419879
-                  mem_limit: 1951419879
-                  cpu_guarantee: 0.22815625
-                  cpu_limit: 3.6505
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
-              mem_4_gb:
-                display_name: ~4 GB RAM, ~0.5 CPUs
-                description: Up to ~4 CPUs when available
-                kubespawner_override:
-                  mem_guarantee: 3902839759
-                  mem_limit: 3902839759
-                  cpu_guarantee: 0.4563125
-                  cpu_limit: 3.6505
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
-              mem_7_gb:
-                display_name: ~7 GB RAM, ~0.9 CPUs
-                description: Up to ~4 CPUs when available
-                kubespawner_override:
-                  mem_guarantee: 7805679519
-                  mem_limit: 7805679519
-                  cpu_guarantee: 0.912625
-                  cpu_limit: 3.6505
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
-              mem_15_gb:
-                display_name: ~15 GB RAM, ~1.8 CPUs
-                description: Up to ~4 CPUs when available
-                default: true
-                kubespawner_override:
-                  mem_guarantee: 15611359038
-                  mem_limit: 15611359038
-                  cpu_guarantee: 1.82525
-                  cpu_limit: 3.6505
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
-              mem_29_gb:
-                display_name: ~29 GB RAM, ~4 CPUs
-                description: ~4 CPUs always available
-                kubespawner_override:
-                  mem_guarantee: 31222718077
-                  mem_limit: 31222718077
-                  cpu_guarantee: 3.6505
-                  cpu_limit: 3.6505
-                  node_selector:
-                    node.kubernetes.io/instance-type: r5.xlarge
 
   dask-gateway:
     gateway:
@@ -158,6 +73,6 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 100
+          hard_quota: 10
     eks:
       volumeId: vol-0ab191452f5c85c6b

--- a/terraform/aws/projects/openscapeshub.tfvars
+++ b/terraform/aws/projects/openscapeshub.tfvars
@@ -21,7 +21,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "workshop" = {
-    size        = 150
+    size        = 500
     type        = "gp3"
     name_suffix = "workshop"
     tags        = { "2i2c:hub-name" : "workshop" }


### PR DESCRIPTION
- Deduplicate profiles, move into common
- Correct NFS limit to 10GiB
- Sets LP-DAAC pre-agreed password

> [!Note]
> This needs a disk resize to make 10GiB/user scale to 500 users.

> [!Warning]
> Do not deploy during core hours -- I moved the NFS config around in `common` and we should be cautious when deploying.