### PR TITLE
Update nasa-openscapes image

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -89,7 +89,7 @@ basehub:
                 display_name: Python
                 description: Python datascience environment
                 kubespawner_override:
-                  image: openscapes/python:8d3d96f
+                  image: openscapes/python:7f529cb
               02-R:
                 display_name: R + Python Geospatial
                 description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -77,7 +77,7 @@ basehub:
                 display_name: Python
                 description: Python datascience environment
                 kubespawner_override:
-                  image: openscapes/python:8d3d96f
+                  image: openscapes/python:7f529cb
               02-R:
                 display_name: R + Python Geospatial
                 description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest


### PR DESCRIPTION
This image works around issues with `jupyterlab-collaboration` and jupyterlab > 4.2 by pinning (downgrading) jupyterlab to v4.2. See https://github.com/NASA-Openscapes/corn/pull/54