### PR TITLE
Update to pangeo-notebook-veda-image:2025.08.14-v1

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -148,7 +148,7 @@ jupyterhub:
               display_name: Modified Pangeo Notebook
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.06.02-v1
+                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v1
                 init_containers:
                     # Need to explicitly fix ownership here, as otherwise these directories will be owned
                     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -131,7 +131,7 @@ jupyterhub:
               display_name: Modified Pangeo Notebook
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.06.02-v1
+                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v1
                 init_containers:
                     # Need to explicitly fix ownership here, as otherwise these directories will be owned
                     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -65,7 +65,7 @@ jupyterhub:
               display_name: Modified Pangeo Notebook
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.06.02-v1
+                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v1
                 init_containers:
                     # Need to explicitly fix ownership here, as otherwise these directories will be owned
                     # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid

--- a/config/clusters/nasa-ghg-hub/common.values.yaml
+++ b/config/clusters/nasa-ghg-hub/common.values.yaml
@@ -126,7 +126,7 @@ basehub:
                 display_name: Modified Pangeo Notebook
                 description: Pangeo based notebook with a Python environment
                 kubespawner_override:
-                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.06.02-v1
+                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v1
                   init_containers:
                   - *volume_ownership_fix_initcontainer
                       # this container uses nbgitpuller to mount https://github.com/US-GHG-Center/ghgc-docs/ for user pods

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -159,7 +159,7 @@ basehub:
                 display_name: Modified Pangeo Notebook
                 description: Pangeo based notebook with a Python environment
                 kubespawner_override:
-                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.06.02-v1
+                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v1
                   init_containers:
                       # Need to explicitly fix ownership here, as otherwise these directories will be owned
                       # by root on most NFS filesystems - neither EFS nor Google Filestore support anonuid


### PR DESCRIPTION
This PR updates all hubs to contain pangeo notebook images based off of 2025.08.14 with virtualizarr>=2 and icechunk>=1 on top (https://github.com/NASA-IMPACT/pangeo-notebook-veda-image/pull/45) as requested in https://github.com/NASA-IMPACT/veda-analytics/issues/172