### PR TITLE
feat: add dashboard shortcut 💻

### DIFF
--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -1,5 +1,6 @@
 name: 2i2c-aws-us
-provider: aws # https://2i2c.awsapps.com/start#/ under the two-eye-two-see account
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/ under the two-eye-two-see account
 aws:
   account: 790657130469
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/2i2c-uk/cluster.yaml
+++ b/config/clusters/2i2c-uk/cluster.yaml
@@ -1,5 +1,6 @@
 name: 2i2c-uk
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?project=two-eye-two-see-uk
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?project=two-eye-two-see-uk
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see-uk

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -1,5 +1,6 @@
 name: 2i2c
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pilot-hubs-cluster/details?project=two-eye-two-see
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pilot-hubs-cluster/details?project=two-eye-two-see
 tenancy: shared
 gcp:
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/awi-ciroh/cluster.yaml
+++ b/config/clusters/awi-ciroh/cluster.yaml
@@ -1,5 +1,6 @@
 name: awi-ciroh
-provider: gcp # https://console.cloud.google.com/home/dashboard?&project=ciroh-jupyterhub-423218
+provider: gcp
+provider_url: https://console.cloud.google.com/home/dashboard?&project=ciroh-jupyterhub-423218
 gcp:
   key: enc-deployer-credentials.secret.json
   project: ciroh-jupyterhub-423218

--- a/config/clusters/berkeley-geojupyter/cluster.yaml
+++ b/config/clusters/berkeley-geojupyter/cluster.yaml
@@ -1,5 +1,6 @@
 name: berkeley-geojupyter
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 622703418259
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/catalystproject-africa/cluster.yaml
+++ b/config/clusters/catalystproject-africa/cluster.yaml
@@ -1,5 +1,6 @@
 name: catalystproject-africa
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 495928966746
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/catalystproject-latam/cluster.yaml
+++ b/config/clusters/catalystproject-latam/cluster.yaml
@@ -1,5 +1,6 @@
 name: catalystproject-latam
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/southamerica-east1/catalystproject-latam-cluster/details?project=catalystproject-392106
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/southamerica-east1/catalystproject-latam-cluster/details?project=catalystproject-392106
 gcp:
   key: enc-deployer-credentials.secret.json
   project: catalystproject-392106

--- a/config/clusters/climatematch/cluster.yaml
+++ b/config/clusters/climatematch/cluster.yaml
@@ -1,5 +1,6 @@
 name: climatematch
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/climatematch-cluster/observability?project=climatematch
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/climatematch-cluster/observability?project=climatematch
 gcp:
   key: enc-deployer-credentials.secret.json
   project: climatematch

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -1,5 +1,6 @@
 name: cloudbank
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/cb-cluster/nodes?project=cb-1003-1696
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/cb-cluster/nodes?project=cb-1003-1696
 gcp:
   key: enc-deployer-credentials.secret.json
   project: cb-1003-1696

--- a/config/clusters/disasters/cluster.yaml
+++ b/config/clusters/disasters/cluster.yaml
@@ -1,5 +1,6 @@
 name: disasters
-provider: aws # https://smce-aws-disasters.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://smce-aws-disasters.signin.aws.amazon.com/console
 aws:
   account: 515966502221
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/dubois/cluster.yaml
+++ b/config/clusters/dubois/cluster.yaml
@@ -1,5 +1,6 @@
 name: dubois
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/dubois-cluster/observability?project=dubois-436615
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/dubois-cluster/observability?project=dubois-436615
 gcp:
   key: enc-deployer-credentials.secret.json
   project: dubois-436615

--- a/config/clusters/earthscope/cluster.yaml
+++ b/config/clusters/earthscope/cluster.yaml
@@ -1,5 +1,6 @@
 name: earthscope
-provider: aws # https://762698921361.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://762698921361.signin.aws.amazon.com/console
 aws:
   account: 762698921361
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/hhmi/cluster.yaml
+++ b/config/clusters/hhmi/cluster.yaml
@@ -1,5 +1,6 @@
 name: hhmi
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-west2/hhmi-cluster/details?project=hhmi-398911
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-west2/hhmi-cluster/details?project=hhmi-398911
 gcp:
   key: enc-deployer-credentials.secret.json
   project: hhmi-398911

--- a/config/clusters/jupyter-health/cluster.yaml
+++ b/config/clusters/jupyter-health/cluster.yaml
@@ -1,5 +1,6 @@
 name: jupyter-health
-provider: aws # https://2i2c.awsapps.com/start/#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start/#/
 aws:
   account: 211125465508
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/leap/cluster.yaml
+++ b/config/clusters/leap/cluster.yaml
@@ -1,5 +1,6 @@
 name: leap
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/leap-cluster/nodes?project=leap-pangeo
+provider: gcp
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/leap-cluster/nodes?project=leap-pangeo
 gcp:
   key: enc-deployer-credentials.secret.json
   project: leap-pangeo

--- a/config/clusters/maap/cluster.yaml
+++ b/config/clusters/maap/cluster.yaml
@@ -1,5 +1,6 @@
 name: maap
-provider: aws # https://916098889494.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://916098889494.signin.aws.amazon.com/console
 aws:
   account: 916098889494
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-cryo/cluster.yaml
+++ b/config/clusters/nasa-cryo/cluster.yaml
@@ -1,5 +1,6 @@
 name: nasa-cryo
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 574251165169
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-ghg-hub/cluster.yaml
+++ b/config/clusters/nasa-ghg-hub/cluster.yaml
@@ -1,5 +1,6 @@
 name: nasa-ghg-hub
-provider: aws # https://smce-ghg-center.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://smce-ghg-center.signin.aws.amazon.com/console
 aws:
   account: 597746869805
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -1,5 +1,6 @@
 name: nasa-veda
-provider: aws # https://smce-veda.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://smce-veda.signin.aws.amazon.com/console
 aws:
   account: 444055461661
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/neurohackademy/cluster.yaml
+++ b/config/clusters/neurohackademy/cluster.yaml
@@ -1,5 +1,6 @@
 name: neurohackademy
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 181398284065
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nmfs-openscapes/cluster.yaml
+++ b/config/clusters/nmfs-openscapes/cluster.yaml
@@ -1,5 +1,6 @@
 name: nmfs-openscapes
-provider: aws # https://891612562472.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://891612562472.signin.aws.amazon.com/console
 aws:
   account: 891612562472
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/openscapeshub/cluster.yaml
+++ b/config/clusters/openscapeshub/cluster.yaml
@@ -1,5 +1,6 @@
 name: openscapeshub
-provider: aws # https://783616723547.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://783616723547.signin.aws.amazon.com/console
 aws:
   account: 783616723547
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/opensci/cluster.yaml
+++ b/config/clusters/opensci/cluster.yaml
@@ -1,5 +1,6 @@
 name: opensci
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 211125293633
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/projectpythia/cluster.yaml
+++ b/config/clusters/projectpythia/cluster.yaml
@@ -1,5 +1,6 @@
 name: projectpythia
-provider: aws # https://590183926898.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://590183926898.signin.aws.amazon.com/console
 aws:
   account: 590183926898
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/reflective/cluster.yaml
+++ b/config/clusters/reflective/cluster.yaml
@@ -1,5 +1,6 @@
 name: reflective
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 916143380841
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/smithsonian/cluster.yaml
+++ b/config/clusters/smithsonian/cluster.yaml
@@ -1,5 +1,6 @@
 name: smithsonian
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 969396938818
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/strudel/cluster.yaml
+++ b/config/clusters/strudel/cluster.yaml
@@ -1,5 +1,6 @@
 name: strudel
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 207567775686
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/templates/aws/cluster.yaml
+++ b/config/clusters/templates/aws/cluster.yaml
@@ -1,5 +1,6 @@
 name: {{ cluster_name }}
-provider: aws # {{ sign_in_url }}
+provider: aws
+provider_url: {{ sign_in_url }}
 aws:
   account: {{ cluster_account_id }}
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/templates/gcp/cluster.yaml
+++ b/config/clusters/templates/gcp/cluster.yaml
@@ -1,5 +1,6 @@
 name: {{ cluster_name }}
-provider: gcp # https://console.cloud.google.com/kubernetes/clusters/details/{{ cluster_region }}/{{ cluster_name }}-cluster/observability?project={{ project_id }}
+provider: gcp 
+provider_url: https://console.cloud.google.com/kubernetes/clusters/details/{{ cluster_region }}/{{ cluster_name }}-cluster/observability?project={{ project_id }}
 gcp:
   key: enc-deployer-credentials.secret.json
   project: {{ project_id }}

--- a/config/clusters/temple/cluster.yaml
+++ b/config/clusters/temple/cluster.yaml
@@ -1,5 +1,6 @@
 name: temple
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 324830304144
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/ubc-eoas/cluster.yaml
+++ b/config/clusters/ubc-eoas/cluster.yaml
@@ -1,5 +1,6 @@
 name: ubc-eoas
-provider: aws # https://2i2c.awsapps.com/start#/
+provider: aws
+provider_url: https://2i2c.awsapps.com/start#/
 aws:
   account: 259060176665
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/victor/cluster.yaml
+++ b/config/clusters/victor/cluster.yaml
@@ -1,5 +1,6 @@
 name: victor
-provider: aws # https://129856558350.signin.aws.amazon.com/console
+provider: aws
+provider_url: https://129856558350.signin.aws.amazon.com/console
 aws:
   account: 129856558350
   key: enc-deployer-credentials.secret.json

--- a/deployer/commands/debug.py
+++ b/deployer/commands/debug.py
@@ -4,6 +4,7 @@ Helper commands for debugging active issues in a hub
 
 import string
 import subprocess
+import webbrowser
 from enum import Enum
 
 import escapism
@@ -121,7 +122,7 @@ def user_logs(
 def start_docker_proxy(
     docker_daemon_cluster: str = typer.Argument(
         "2i2c", help="Name of cluster where the docker daemon lives"
-    )
+    ),
 ):
     """
     Proxy a docker daemon from a remote cluster to local port 23760.
@@ -141,3 +142,20 @@ def start_docker_proxy(
         ]
 
         subprocess.check_call(cmd)
+
+
+@debug_app.command()
+def dashboard(
+    cluster_name: str = typer.Argument(
+        "2i2c", help="Name of cluster for which to load dashboard"
+    ),
+):
+    """
+    Open the provider dashboard for a cluster in the webbrowser
+    """
+    cluster = Cluster.from_name(cluster_name)
+    try:
+        url = cluster.spec["provider_url"]
+    except KeyError:
+        raise KeyError("Cluster {cluster_name!r} does not have a valid provider URL")
+    webbrowser.open(url)

--- a/deployer/commands/validate/cluster.schema.yaml
+++ b/deployer/commands/validate/cluster.schema.yaml
@@ -35,6 +35,11 @@ properties:
     - kubeconfig
     - aws
     - azure
+  provider_url:
+    type: string
+    format: uri
+    description: |
+      URL to cloud provider dashboard for this cluster.
   tenancy:
     type: string
     description: |


### PR DESCRIPTION
I find myself often looking at the AWS/GCP console to investigate logs or other resources. Given that most of our providers have dashboard URLs, I thought it would be useful to enshrine this in the structured data about each cluster, and add a shortcut to launch it.

This is something you can already do with
```shell
xdg-open $(rg 'provider.*(https.*)' config/clusters/$CLUSTER_NAME/cluster.yaml -r '$1')
```

But I think we should optimise things we do often.