### PR TITLE
[cloudbank] remove filestore 

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -6,9 +6,7 @@ region           = "us-central1"
 regional_cluster = false
 
 enable_filestore_backups = true
-filestores = {
-  "filestore" : { "capacity_gb" : 1792 }
-}
+filestores               = {}
 
 persistent_disks = {
   "authoring" = {


### PR DESCRIPTION
Now that we're using persistent disks, and @sean-morris has confirmed that we can remove the disk on Slack: https://2i2c.slack.com/archives/C01J397UX24/p1757710786151509

This PR removes the disk from our Terraform, after separately deleting it from GCP.