### PR TITLE
Update default python image for openscapes

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -88,7 +88,7 @@ basehub:
                 display_name: Python
                 description: Python datascience environment
                 kubespawner_override:
-                  image: openscapes/python:7f529cb
+                  image: openscapes/python:7093bd3
               02-R:
                 display_name: R + Python Geospatial
                 description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest


### PR DESCRIPTION
Apologies for submitting another PR so soon after #6749. We removed `jupyterlab-collaboration` and upgraded Jupyterlab (https://github.com/NASA-Openscapes/corn/pull/55).