### PR TITLE
Update funded_by from SMCE to HDRL

### DIFF
--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -29,8 +29,8 @@ jupyterhub:
           name: 2i2c
           url: https://2i2c.org
         funded_by:
-          name: NASA's Science Managed Cloud Environment (SMCE)
-          url: https://smce.nasa.gov/overview/
+          name: NASA's Heliophysics Digital Resource Library (HDRL)
+          url: https://hdrl.gsfc.nasa.gov
   hub:
     allowNamedServers: true
     config:


### PR DESCRIPTION
This short PR changes the `name` and `url` values under `funded_by:` to "NASA's Heliophysics Digital Resource Library (HDRL)" and "https://hdrl.gsfc.nasa.gov", respectively.

My NASA contact suggested we change it to this.