### PR TITLE
Allow sending budget alerts to community members

### DIFF
--- a/terraform/aws/budget-alerts.tf
+++ b/terraform/aws/budget-alerts.tf
@@ -40,9 +40,8 @@ resource "aws_budgets_budget" "threshold_budgets" {
     threshold           = each.value
     threshold_type      = "ABSOLUTE_VALUE"
     notification_type   = "ACTUAL"
-    subscriber_email_addresses = [
-      for email in var.default_budget_alert.subscriber_email_addresses :
-      replace(email, "{var_cluster_name}", var.cluster_name)
-    ]
+    subscriber_email_addresses = concat([
+      "support+${var.cluster_name}@2i2c.org"
+    ], var.budget_alert_threshold_emails)
   }
 }

--- a/terraform/aws/projects/heliophysics.tfvars
+++ b/terraform/aws/projects/heliophysics.tfvars
@@ -21,14 +21,16 @@ ebs_volumes = {
   "prod" = {
     name_suffix = "prod",
     type        = "gp3",
-    size        = 100,
+    size        = 400,
     tags        = { "2i2c:hub-name" : "prod" },
   },
 
 }
 enable_nfs_backup = true
 
-
+budget_alert_threshold_emails = [
+  "shawn.polson@lasp.colorado.edu"
+]
 # "scratch-staging" : {
 #   "delete_after" : 7,
 #   "tags" : { "2i2c:hub-name" : "staging" },

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -207,6 +207,16 @@ variable budget_alert_thresholds {
   EOT
 }
 
+variable budget_alert_threshold_emails {
+  type = list(string)
+  default = []
+  description = <<-EOT
+  List of emails to notify for budget alerts
+
+  The default 2i2c support email is always included.
+  EOT
+}
+
 variable "disable_cluster_wide_filestore" {
   default     = true
   type        = bool


### PR DESCRIPTION
So they can have it *directly* instead of having to come from us.

Ref https://github.com/2i2c-org/infrastructure/issues/6698