### PR TITLE
Update PyHC image tag

### DIFF
--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -74,7 +74,7 @@ jupyterhub:
               description: Environment containing every published Python in Heliophysics Community (PyHC) package
               kubespawner_override:
                 default_url: /lab/tree/pyhc/Welcome.ipynb
-                image: spolson/pyhc-environment:v2025.09.18-2
+                image: spolson/pyhc-environment:v2025.09.16
             heliophysics-core-survey:
               display_name: Heliophysics "Core" Survey Environment
               description: Environment containing "core" heliophysics packages identified from our survey


### PR DESCRIPTION
Quick PR to update the PyHC image tag again. I found and fixed a small bug in one of the notebooks. 

Ignore the fact that the date went from 09.18 to 09.16; 09.16 is newer, I just hacked in an older date to avoid overwriting anything in Docker Hub.