### PR TITLE
Remove custom image, update paths and tags

### DIFF
--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -61,7 +61,7 @@ jupyterhub:
               description: Minimal base image
               kubespawner_override:
                 default_url: /lab/tree/heliocloud-base/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-2025-update:1685267f64eb
+                image: quay.io/sapols/heliocloud-base-2025-update:6cf475762c4a
               default: true
             pyhc:
               display_name: PyHC Environment
@@ -74,13 +74,13 @@ jupyterhub:
               description: Environment containing "core" heliophysics packages identified from our survey
               kubespawner_override:
                 default_url: /lab/tree/survey-core/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-w-survey-core:ef41e36afa4c
+                image: quay.io/sapols/heliocloud-base-w-survey-core:72039f4c459e
             heliophysics-extended-survey:
               display_name: Heliophysics "Extended" Survey Environment
               description: Environment extending the "core" packages with all remaining from our survey
               kubespawner_override:
                 default_url: /lab/tree/survey-extended/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-w-survey-extended:852d200e21d9
+                image: quay.io/sapols/heliocloud-base-w-survey-extended:238352acb5d1
         resource_allocation:
           display_name: Resource Allocation
           choices:

--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -53,21 +53,15 @@ jupyterhub:
         image:
           display_name: Image
           unlisted_choice:
-            # Temporarily enabled so images can be tested
-            enabled: true
-            display_name: Custom image
-            description: Specify your own docker image (must have python and jupyterhub installed in it)
-            validation_regex: ^.+:.+$
-            validation_message: Must be a publicly available docker image, of form <image-name>:<tag>
-            kubespawner_override:
-              image: '{value}'
+            # We want to only support 4 environments
+            enabled: false
           choices:
             heliocloud-base:
               display_name: HelioCloud Base Image
               description: Minimal base image
               kubespawner_override:
-                default_url: /lab/tree/heliocloud-base-2025-update/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-2025-update:835960da281d
+                default_url: /lab/tree/heliocloud-base/Welcome.ipynb
+                image: quay.io/sapols/heliocloud-base-2025-update:1685267f64eb
               default: true
             pyhc:
               display_name: PyHC Environment
@@ -79,14 +73,14 @@ jupyterhub:
               display_name: Heliophysics "Core" Survey Environment
               description: Environment containing "core" heliophysics packages identified from our survey
               kubespawner_override:
-                default_url: /lab/tree/heliocloud-base-w-survey-core/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-w-survey-core:e643c94f1dec
+                default_url: /lab/tree/survey-core/Welcome.ipynb
+                image: quay.io/sapols/heliocloud-base-w-survey-core:ef41e36afa4c
             heliophysics-extended-survey:
               display_name: Heliophysics "Extended" Survey Environment
               description: Environment extending the "core" packages with all remaining from our survey
               kubespawner_override:
-                default_url: /lab/tree/heliocloud-base-w-survey-extended/Welcome.ipynb
-                image: quay.io/sapols/heliocloud-base-w-survey-extended:379ca14ad88c
+                default_url: /lab/tree/survey-extended/Welcome.ipynb
+                image: quay.io/sapols/heliocloud-base-w-survey-extended:852d200e21d9
         resource_allocation:
           display_name: Resource Allocation
           choices:


### PR DESCRIPTION
This PR:
1. Removes the custom image option so we're back to only showing our 4
2. Simplifies the names of the folders used for `default_url` so they look nicer in the hub
3. Updates image tags to versions that expect the new simplified folder names

I tested the new folder paths using the custom image option and my files appeared at the new locations (e.g. `home/jovyan/survey-core/Welcome.ipynb`) so this should work.

I referenced an old PR to see how to remove the custom image option; please confirm I got that right. 
And please confirm if there's no other config files/fields that need to be updated in response to the new paths.

I found no remaining problems in the hub after my testing last night, so assuming all goes well removing the custom image and updating these paths, this should be my last PR here!

Thanks for everything.
