### PR TITLE
Experiment with adding CODEOWNERS for specific instances

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/config/clusters/disasters/common.values.yaml @freitagb
+/config/clusters/maap/common.values.yaml @wildintellect @batpad
+/config/clusters/nasa-veda/common.values.yaml @wildintellect @batpad
+/config/clusters/nasa-ghg-hub/common.values.yaml @smk0033


### PR DESCRIPTION
We were discussing who needs to be pinged for a each VEDA hub and it occurred to me that it might be possible to automate this a bit. Anyways this is a little experiment.