### PR TITLE
Bump heliocloud node disk size from 80 to 160GB

### DIFF
--- a/eksctl/heliophysics.jsonnet
+++ b/eksctl/heliophysics.jsonnet
@@ -16,7 +16,15 @@ local c = cluster.makeCluster(
   ],
   hubs=['staging', 'prod'],
   notebookGPUNodeGroups=[],
-  nodeGroupGenerations=['a']
+  nodeGroupGenerations=['b']
 );
 
-c
+# Give all notebook nodes 160G disk space rather than the default 80,
+# because there are 4 images in use with this hub and they all big!
+cluster.withNodeGroupConfigOverride(
+  c,
+  kind="notebook",
+  overrides={
+    volumeSize: 160
+  }
+)

--- a/eksctl/heliophysics.jsonnet
+++ b/eksctl/heliophysics.jsonnet
@@ -19,12 +19,12 @@ local c = cluster.makeCluster(
   nodeGroupGenerations=['b']
 );
 
-# Give all notebook nodes 160G disk space rather than the default 80,
-# because there are 4 images in use with this hub and they all big!
+// Give all notebook nodes 160G disk space rather than the default 80,
+// because there are 4 images in use with this hub and they all big!
 cluster.withNodeGroupConfigOverride(
   c,
-  kind="notebook",
+  kind='notebook',
   overrides={
-    volumeSize: 160
+    volumeSize: 160,
   }
 )


### PR DESCRIPTION
The images being pulled are large enough that they were exhausting the 80GB disk. I considered enabling the continuous prepuller, but decided against it as such a last minute change. Let's turn it on next time.

Ref https://2i2c.freshdesk.com/a/tickets/3903