### PR TITLE
Allow setting up monthly / quarterly threshold budgets on AWS

### DIFF
--- a/terraform/aws/projects/heliophysics.tfvars
+++ b/terraform/aws/projects/heliophysics.tfvars
@@ -28,9 +28,23 @@ ebs_volumes = {
 }
 enable_nfs_backup = true
 
-budget_alert_threshold_emails = [
-  "shawn.polson@lasp.colorado.edu"
-]
+budget_alerts = {
+  # Per https://github.com/2i2c-org/meta/issues/2523,
+  # they have two major events, between Sep 22-26 and
+  # Oct 19-24. We don't have custom time'd budgets yet, so let's
+  # use monthly budgets of $1000 for now.
+  "monthly": {
+    time_period = "MONTHLY",
+    emails = [
+      # "yuvipanda@2i2c.org",
+      "shawn.polson@lasp.colorado.edu"
+    ],
+    max_cost = 1000
+  },
+}
+monthly_budget_alerts = {
+
+}
 # "scratch-staging" : {
 #   "delete_after" : 7,
 #   "tags" : { "2i2c:hub-name" : "staging" },
@@ -56,8 +70,5 @@ default_budget_alert = {
   enabled : false
 }
 
-budget_alert_thresholds = [
-  500, 1000, 1500, 2000
-]
 # Uncomment to enable cost monitoring
 enable_jupyterhub_cost_monitoring = true

--- a/terraform/aws/projects/heliophysics.tfvars
+++ b/terraform/aws/projects/heliophysics.tfvars
@@ -33,7 +33,7 @@ budget_alerts = {
   # they have two major events, between Sep 22-26 and
   # Oct 19-24. We don't have custom time'd budgets yet, so let's
   # use monthly budgets of $1000 for now.
-  "monthly": {
+  "monthly" : {
     time_period = "MONTHLY",
     emails = [
       # "yuvipanda@2i2c.org",

--- a/terraform/aws/projects/oceanhackweek.tfvars
+++ b/terraform/aws/projects/oceanhackweek.tfvars
@@ -20,7 +20,7 @@ ebs_volumes = {
 enable_nfs_backup = true
 
 budget_alerts = {
-  "monthly": {
+  "monthly" : {
     time_period = "MONTHLY",
     emails = [
       "emiliomayorga@gmail.com"

--- a/terraform/aws/projects/oceanhackweek.tfvars
+++ b/terraform/aws/projects/oceanhackweek.tfvars
@@ -19,6 +19,17 @@ ebs_volumes = {
 
 enable_nfs_backup = true
 
+budget_alerts = {
+  "monthly": {
+    time_period = "MONTHLY",
+    emails = [
+      "emiliomayorga@gmail.com"
+    ],
+    # They have a total of $1000, and two events (one in Oct, one in Nov) to spend it on
+    max_cost = 500
+  },
+}
+
 # Setup IAM creds but no buckets
 hub_cloud_permissions = {
   "staging" : {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -199,13 +199,23 @@ variable "default_budget_alert" {
   EOT
 }
 
-variable "budget_alert_thresholds" {
-  type        = list(number)
-  default     = []
+variable "budget_alerts" {
+  type        = map(object({
+    time_period: string,
+    emails : list(string),
+    max_cost: number
+  }))
+  default     = {}
   description = <<-EOT
-  List of currency units to set up budget alerts for
+  Budget Alerts to set up
+
+  Each value of the map can contain:
+  1. `time_period` - One of "MONTHLY", "YEARLY", "QUARTERLY" or "DAILY"
+  2. `emails` - List of emails to send the alert to
+  3. `max_cost` - Max
   EOT
 }
+
 
 variable "budget_alert_threshold_emails" {
   type        = list(string)

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -200,10 +200,10 @@ variable "default_budget_alert" {
 }
 
 variable "budget_alerts" {
-  type        = map(object({
-    time_period: string,
+  type = map(object({
+    time_period : string,
     emails : list(string),
-    max_cost: number
+    max_cost : number
   }))
   default     = {}
   description = <<-EOT

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -216,17 +216,6 @@ variable "budget_alerts" {
   EOT
 }
 
-
-variable "budget_alert_threshold_emails" {
-  type        = list(string)
-  default     = []
-  description = <<-EOT
-  List of emails to notify for budget alerts
-
-  The default 2i2c support email is always included.
-  EOT
-}
-
 variable "disable_cluster_wide_filestore" {
   default     = true
   type        = bool


### PR DESCRIPTION
- And set them up for helio & oceanhackweek