### PR TITLE
[ucmerced] Scale down node pool

### DIFF
--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -6,6 +6,20 @@ jupyterhub:
     - secretName: https-auto-tls
       hosts:
       - ucmerced.2i2c.cloud
+  scheduling:
+    userPlaceholder:
+      # Keep at least one spare node around
+      replicas: 2
+      resources:
+        requests:
+          # Each node on the shared cluster has 60045228Ki of RAM
+          # You can find this out by looking at the output of `kubectl get node <node-name> -o yaml`
+          # Look under `allocatable`, not `capacity`. Unfortunately then you have to fiddle with it to
+          # find the right number that's big enough that no user pods will schedule here, but small enough
+          # that pods in `kube-system` will still schedule.
+          # So even though this is under `userPlaceholder`, it really is operating as a `nodePlaceholder`
+          # This value was arrived at by assuming that this works for utoronto, and taking the delta between `jupyterhub.scheduling.userPlaceholder.resources.memory` and the `capacity` above (2E6Ki)
+          memory: 58045228Ki
   singleuser:
     nodeSelector:
       # Schedule on dedicated n2-highmem-8

--- a/config/clusters/2i2c/ucmerced.values.yaml
+++ b/config/clusters/2i2c/ucmerced.values.yaml
@@ -6,10 +6,13 @@ jupyterhub:
     - secretName: https-auto-tls
       hosts:
       - ucmerced.2i2c.cloud
+  prePuller:
+    continuous:
+      enabled: true
   scheduling:
     userPlaceholder:
       # Keep at least one spare node around
-      replicas: 2
+      replicas: 1
       resources:
         requests:
           # Each node on the shared cluster has 60045228Ki of RAM
@@ -37,7 +40,7 @@ jupyterhub:
       kubespawner_override:
           # From https://github.com/SaiUCM/example-inherit-from-community-image
         image: quay.io/cirt_ucm/jupyter-scipy-xarray:1e26b42ad87b
-          # Launch into JupyterLab after the user logs in
+            # Launch into JupyterLab after the user logs in
         default_url: /lab
       profile_options: &profile_options
         requests:
@@ -60,8 +63,8 @@ jupyterhub:
           # From https://github.com/2i2c-org/rocker-with-nbgitpuller
         image: quay.io/2i2c/rocker-with-nbgitpuller:3edc87d73e3d
         default_url: /lab
-          # Ensures container working dir is homedir
-          # https://github.com/2i2c-org/infrastructure/issues/2559
+            # Ensures container working dir is homedir
+            # https://github.com/2i2c-org/infrastructure/issues/2559
         working_dir: /home/rstudio
       profile_options: *profile_options
   hub:

--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -9,7 +9,7 @@ jupyterhub:
       enabled: true
   scheduling:
     userPlaceholder:
-      # Keep at least one spare node around
+      # Keep at least two spare nodes around
       replicas: 2
       resources:
         requests:

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -62,7 +62,7 @@ notebook_nodes = {
     machine_type : "n2-highmem-8",
   },
   "n2-highmem-8-ucmerced" : {
-    min : 5,
+    min : 1,
     max : 100,
     machine_type : "n2-highmem-8",
     labels : {


### PR DESCRIPTION
This PR addresses the consumption of cloud resources for ucmerced by:

1. Scaling the dedicated node pool down to 1 node
2. Enabling a single node placeholder
3. Enabling the continuous image puller, so that scale-up driving by placeholder eviction immediately starts pulling the image.