### PR TITLE
NASA VEDA: Enable auth for fancy-profile binderhub

### DIFF
--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -32,7 +32,9 @@ basehub:
           subPath: _shared-public
     hub:
       image:
-        tag: 0.0.1-0.dev.git.13134.hb8ed00131
+        # custom image built to install jupyterhub-fancy-profiles version from
+        # https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/122 for testing
+        tag: 0.0.1-0.dev.git.14111.h9010443c8
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.hub.openveda.cloud/hub/oauth_callback


### PR DESCRIPTION
Make the necessary config changes to test https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/122 on VEDA staging hub. cc @batpad

@GeorgianaElena, @agoose77 -- I'm not 100% sure that I've made the config changes in the right place and in the right format. I would appreciate it if you could take a quick look before we test this on staging 🙏🏽  