### PR TITLE
Update Helm chart for NFS server updates

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 1.0.2-0.dev.git.1.hc7ff343
+    version: 1.1.0
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -68,6 +68,9 @@ local jupyterhubHomeNFSConfig = {
       QuotaManager: {
         paths: ['/export/%s' % hub_name],
         hard_quota: 0,
+        projects_file: '/export/%s/.projects' % hub_name,
+        projid_file: '/export/%s/.projid' % hub_name,
+        log_level: 'INFO',
       },
     },
   },


### PR DESCRIPTION
Recently, we made a few updates to `jupyterhub-home-nfs` in the interest of reducing the verbosity of logging and increasing hardness against desync between the file system quota attributes and the quota generator internal state.

This PR updates our helm charts to deploy this new release.