### PR TITLE
[utoronto, r]: bump tag to tentative new image and set GITCONFIG path

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -53,6 +53,9 @@ jupyterhub:
     memory:
       limit: 2G
       guarantee: 1G
+    extraEnv:
+      # In case the Git binary is not under the typical prefix
+      GIT_CONFIG: /etc/gitconfig
     extraFiles:
       github-app-private-key.pem:
         mountPath: /etc/github/github-app-private-key.pem

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-r-image
-      tag: 217c910c5072
+      tag: 56d60b40210a
 
   ingress:
     hosts: [r-staging.datatools.utoronto.ca]


### PR DESCRIPTION
This enables us to have the UToronto community test on this hub. I'm setting `GIT_CONFIG` rather than placing the gitconfig file in different places.