### PR TITLE
OHW common.values.yaml: translations, GH teams and options

### DIFF
--- a/config/clusters/oceanhackweek/common.values.yaml
+++ b/config/clusters/oceanhackweek/common.values.yaml
@@ -38,6 +38,8 @@ jupyterhub:
       GitHubOAuthenticator:
         allowed_organizations:
         - Intercoonecta:ohwes25-organizers
+        - Intercoonecta:ohwes25-participants-tallerintermed
+        - Intercoonecta:ohwes25-participants-hackaton
       Authenticator:
         admin_users:
         - ocefpaf
@@ -64,13 +66,13 @@ jupyterhub:
           protocol: TCP
 
     profileList:
-    - display_name: Choose your environment and resources
+    - display_name: Escoge Entorno y Capacidad
       slug: only-choice
       profile_options:
         image:
-          display_name: Image
+          display_name: Entorno ("imagen")
           unlisted_choice:
-            enabled: true
+            enabled: false
             display_name: Custom image
             validation_regex: ^.+:.+$
             validation_message: Must be a publicly available docker image, of form <image-name>:<tag>
@@ -93,11 +95,11 @@ jupyterhub:
                 default_url: /rstudio
                 image: ghcr.io/oceanhackweek/r:d690195
         resource_allocation:
-          display_name: Resource Allocation
+          display_name: Asignación de Capacidad
           choices:
             mem_4_gb:
               display_name: ~4 GB RAM, ~0.5 CPUs
-              description: Up to ~4 CPUs when available
+              description: Hasta ~4 CPUs si están disponibles
               default: true
               kubespawner_override:
                 mem_guarantee: 3902839759
@@ -106,16 +108,16 @@ jupyterhub:
                 cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_7_gb:
-              display_name: ~7 GB RAM, ~0.9 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 7805679519
-                mem_limit: 7805679519
-                cpu_guarantee: 0.912625
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
+            # mem_7_gb:
+            #   display_name: ~7 GB RAM, ~0.9 CPUs
+            #   description: Up to ~4 CPUs when available
+            #   kubespawner_override:
+            #     mem_guarantee: 7805679519
+            #     mem_limit: 7805679519
+            #     cpu_guarantee: 0.912625
+            #     cpu_limit: 3.6505
+            #     node_selector:
+            #       node.kubernetes.io/instance-type: r5.xlarge
 
 jupyterhub-home-nfs:
   enabled: true


### PR DESCRIPTION
- Translate user-facing names and descriptions to Spanish
- Add 2 GitHub teams to the authorized teams (organizations)
- Trim image and resource allocation options to ones that will actually be used / provided to users
  - For image `unlisted_choice`, instead of deleting or commenting out the block, I set `enabled: false`, as it seemed cleaner. @yuvipanda  If the result is that the option to provide your own image is hidden, that's what I want; but if it's still visible but unselectable, could you comment it out altogether for me, please?
  - In resource allocation, I chose to comment out the second option rather than deleting it, mainly so the code is still visible to me in the future

It'd be nice to also be able to translate the page title ("Server Options") and button text ("Start"), but that text doesn't seem to be driven by the `common.values.yaml` file.

cc @yuvipanda 