### PR TITLE
fix: tighten up deployment checks

### DIFF
--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -21,6 +21,7 @@ on:
     - '!config/clusters/templates/**'
        ########### Additional includes ##########
     - .github/actions/setup-deploy/**
+    - .github/workflows/comment-test-link-merged-pr.yaml
       #####################################################################
 
 jobs:

--- a/.github/workflows/comment-test-link-merged-pr.yaml
+++ b/.github/workflows/comment-test-link-merged-pr.yaml
@@ -8,19 +8,19 @@ on:
       #################### Copied from deploy-hubs workflow ###############
       # Include changes to the deployer script's folder
     - deployer/**
+    - pyproject.toml
+    - requirements.txt
+    - helm-charts/**
+    - config/clusters/**
     - '!deployer/README.md'
+      # Checking that a hub is online should not trigger a deployment
     - '!deployer/health_check_tests/**'
       # We can ignore dev commands
     - '!deployer/dev_commands/**'
-    - requirements.txt
-    - .github/actions/setup-deploy/**
-    - helm-charts/**
-    - config/clusters/**
-        # Exclude the template configuration files
+       # Exclude the template configuration files
     - '!config/clusters/templates/**'
-    - '!terraform/aws/projects/template.tfvars'
-    - '!terraform/gcp/projects/cluster.tfvars.template'
-    - '!eksctl/template.jsonnet'
+       ########### Additional includes ##########
+    - .github/actions/setup-deploy/**
       #####################################################################
 
 jobs:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -20,6 +20,7 @@ on:
     - '!config/clusters/templates/**'
        ########### Additional includes ##########
     - .github/actions/setup-deploy/**
+    - .github/workflows/deploy-hubs.yaml
   pull_request:
     branches:
     - main

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -7,39 +7,38 @@ on:
     paths:
       # Include changes to the deployer script's folder
     - deployer/**
+    - pyproject.toml
+    - requirements.txt
+    - helm-charts/**
+    - config/clusters/**
     - '!deployer/README.md'
+      # Checking that a hub is online should not trigger a deployment
     - '!deployer/health_check_tests/**'
       # We can ignore dev commands
     - '!deployer/dev_commands/**'
-    - requirements.txt
-    - .github/actions/setup-deploy/**
-    - helm-charts/**
-    - config/clusters/**
-        # Exclude the template configuration files
+       # Exclude the template configuration files
     - '!config/clusters/templates/**'
-    - '!terraform/aws/projects/template.tfvars'
-    - '!terraform/gcp/projects/cluster.tfvars.template'
-    - '!eksctl/template.jsonnet'
-
+       ########### Additional includes ##########
+    - .github/actions/setup-deploy/**
   pull_request:
     branches:
     - main
     paths:
       # Include changes to the deployer script's folder
     - deployer/**
+    - pyproject.toml
+    - requirements.txt
+    - helm-charts/**
+    - config/clusters/**
     - '!deployer/README.md'
+      # Checking that a hub is online should not trigger a deployment
     - '!deployer/health_check_tests/**'
       # We can ignore dev commands
     - '!deployer/dev_commands/**'
-    - requirements.txt
-    - .github/actions/setup-deploy/**
-    - helm-charts/**
-    - config/clusters/**
-        # Exclude the template configuration files
+       # Exclude the template configuration files
     - '!config/clusters/templates/**'
-    - '!terraform/aws/projects/template.tfvars'
-    - '!terraform/gcp/projects/cluster.tfvars.template'
-    - '!eksctl/template.jsonnet'
+       ########### Additional includes ##########
+    - .github/actions/setup-deploy/**
 
 # ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -40,6 +40,7 @@ on:
     - '!config/clusters/templates/**'
        ########### Additional includes ##########
     - .github/actions/setup-deploy/**
+    # - .github/workflows/deploy-hubs.yaml — this workflow is not pull_request_target
 
 # ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -18,7 +18,8 @@ on:
       # triggering this workflow
     - '!config/clusters/templates/**'
     - helm-charts/**
-    - .github/workflows/validate-clusters.yaml
+    # - .github/workflows/validate-clusters.yaml — this workflow is not pull_request_target
+
       ############ Deployer-related config modified from deploy-hubs.yaml ####
       # Include changes to the deployer script's folder
     - deployer/**

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -18,21 +18,37 @@ on:
       # triggering this workflow
     - '!config/clusters/templates/**'
     - helm-charts/**
-    - deployer/**
-    - requirements.txt
     - .github/workflows/validate-clusters.yaml
+      ############ Deployer-related config modified from deploy-hubs.yaml ####
+      # Include changes to the deployer script's folder
+    - deployer/**
+    - pyproject.toml
+    - requirements.txt
+    - '!deployer/README.md'
+      # Checking that a hub is online should not trigger a deployment
+    - '!deployer/health_check_tests/**'
+      # We can ignore dev commands
+    - '!deployer/dev_commands/**'
   push:
     branches:
     - main
     paths:
     - config/clusters/**
-      # Exclude changes the templates directory from
+      # Exclude changes to the templates directory from
       # triggering this workflow
     - '!config/clusters/templates/**'
     - helm-charts/**
-    - deployer/**
-    - requirements.txt
     - .github/workflows/validate-clusters.yaml
+      ############ Deployer-related config modified from deploy-hubs.yaml ####
+      # Include changes to the deployer script's folder
+    - deployer/**
+    - pyproject.toml
+    - requirements.txt
+    - '!deployer/README.md'
+      # Checking that a hub is online should not trigger a deployment
+    - '!deployer/health_check_tests/**'
+      # We can ignore dev commands
+    - '!deployer/dev_commands/**'
     tags:
     - '**'
   workflow_dispatch:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
   - id: disallow-dev-commands
     name: disallow dev commands in commands
     language: pygrep
-    entry: dev_commands
+    entry: \b(from|import)\b.*dev_commands
     files: ^deployer/commands/.*$
 
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration

--- a/deployer/commands/plan_upgrade/decision.py
+++ b/deployer/commands/plan_upgrade/decision.py
@@ -35,7 +35,7 @@ def discover_modified_common_files(modified_paths):
 
     # If any of the following filepaths have changed, we should upgrade all hubs on all
     # clusters
-    # Patterns taken from CI deploy-hubs
+    # Patterns taken from CI deploy-hubs, and MODIFIED TO REMOVE CI/CD specific changes
     # Files of interest must be in `includes`, but not in `excludes`
     includes = [
         # Include changes to the deployer script's folder


### PR DESCRIPTION
Now that we can scope deployment checks more tightly, this PR actually uses those checks:

- `deploy-hubs.yaml` — this should only trigger if something affecting _deployment_ is changed, such as most of `deployer`, the install scripts for deployer, auxiliary workflow files. We don't include terraform files in the `files` list, so I've removed the exclusions.
- `comment-test-link-merged-pr.yaml` — identical to `deploy-hubs`. Really we could probably couple these to drop the need for the duplication.
- `validate-clusters.yaml` — changes to deployer, the install scripts for deployer, auxiliary workflow files.
- `deployer plan-upgrade` — the same changes as `deploy-hubs`, but separating support changes from non-support changes, and ignoring CI/CD files.