### PR TITLE
[utoronto, default*] Add louvain package

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: 34b2777825b1
+      tag: 063892275af8
   hub:
     config:
       Authenticator:


### PR DESCRIPTION
This PR updates the utoronto-image tag to pull in 2i2c-org/utoronto-image#75 in order to close https://github.com/2i2c-org/infrastructure/issues/6835.