### PR TITLE
fix: set 2GB as default for openscapes

### DIFF
--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -82,6 +82,7 @@ basehub:
             display_name: Resource Allocation
             choices:
               mem_2_gb:
+                default: true
                 display_name: ~2 GB RAM, ~0.2 CPUs
                 description: Up to ~4 CPUs when available
                 kubespawner_override:


### PR DESCRIPTION
I'm not sure why this is needed *now*, but I'm wondering if the workshop users are intentionally selecting `mem_29_gb`, or it if is just defaulting there.

They're consuming an entire node at a time.