### PR TITLE
utoronto: Restore initcontainer for chowning user dirs

### DIFF
--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -43,6 +43,20 @@ jupyterhub:
           name: University of Toronto
           url: https://www.utoronto.ca/
   singleuser:
+    initContainers:
+      # We still need it here in utoronto, because they are on Azure and not using home-nfs
+      - name: volume-mount-ownership-fix
+        image: busybox:1.36.1
+        command:
+        - sh
+        - -c
+        - id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: '{escaped_username}'
     cpu:
       # Each node has about 8 CPUs total, and if we limit users to no more than
       # 4, no single user can take down a full node by themselves. We have to

--- a/config/clusters/utoronto/common.values.yaml
+++ b/config/clusters/utoronto/common.values.yaml
@@ -45,18 +45,18 @@ jupyterhub:
   singleuser:
     initContainers:
       # We still need it here in utoronto, because they are on Azure and not using home-nfs
-      - name: volume-mount-ownership-fix
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -c
-        - id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: '{escaped_username}'
+    - name: volume-mount-ownership-fix
+      image: busybox:1.36.1
+      command:
+      - sh
+      - -c
+      - id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: home
+        mountPath: /home/jovyan
+        subPath: '{escaped_username}'
     cpu:
       # Each node has about 8 CPUs total, and if we limit users to no more than
       # 4, no single user can take down a full node by themselves. We have to


### PR DESCRIPTION
This was causing issues with server startups for users who have never started up before. Utoronto is on Azure and still on Azure managed filestore.

Ref https://2i2c.freshdesk.com/a/tickets/4038