### PR TITLE
maint: drop highmem-8 nodepool

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -56,11 +56,6 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  "n2-highmem-8" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-8",
-  },
   "n2-highmem-8-ucmerced" : {
     min : 0,
     max : 100,


### PR DESCRIPTION
We don't need this pool. Although we have other costlier node pools in this infra, they're not in use. I am not certain, but I think the autoscaler prefers cheaper / smaller nodes, so I'm less worried about the other pools.

In fact, I'm not worried hugely about _this_ pool — I think it was in use for so long only because it never scaled to zero, rather than because it was sometimes scaled up -- the same node was running for the entire time.

Nevertheless, this PR reverts us to the old config.