### PR TITLE
Remove github authenticator for maap staging

### DIFF
--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -194,8 +194,6 @@ jupyterhub:
         authenticator_class: generic-oauth
       Authenticator:
         admin_users: []
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.hub.maap.2i2c.cloud/hub/oauth_callback
       GenericOAuthenticator:
         oauth_callback_url: https://staging.hub.maap.2i2c.cloud/hub/oauth_callback
         token_url: https://keycloak.delta-backend.xyz/realms/veda/protocol/openid-connect/token


### PR DESCRIPTION
Set MAAP staging to use the Keycloak authenticator, remove the Github authenticator.

We used to have MAAP staging configured with Keycloak - seems like the Github authenticator was added back (likely to test something)

This removes the Github authenticator to (hopefully) set it back to using Keycloak for authentication.

cc @GeorgianaElena @sunu @wildintellect 