### PR TITLE
earthscope: Don't add 2i2c emails as admins to earthscope

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -21,8 +21,9 @@ basehub:
       daskhubSetup:
         enabled: true
       2i2c:
-        add_staff_user_ids_to_admin_users: true
-        add_staff_user_ids_of_type: google
+        # This uses custom ids from auth0, so we can't use our default
+        # emails as access
+        add_staff_user_ids_to_admin_users: false
     hub:
       extraConfig:
         001-username-claim: |


### PR DESCRIPTION
This uses custom user ids, and so won't work. Attempts to start these users from the admin panel will result in failures.