### PR TITLE
[strudel, workshop] Add user:email scope to GitHubOAuthenticator

### DIFF
--- a/config/clusters/strudel/workshop.values.yaml
+++ b/config/clusters/strudel/workshop.values.yaml
@@ -34,6 +34,8 @@ jupyterhub:
         - strudel-workshops
         scope:
         - read:org
+        # So that we can pre-populate Git commits
+        - user:email
       JupyterHub:
         authenticator_class: github
     extraConfig:


### PR DESCRIPTION
This should allow for users that have hidden emails to correctly annotate commits.