### PR TITLE
[heliophysics, *] Set reasonable quotas

### DIFF
--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -157,7 +157,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10
+        hard_quota: 10 # in GB
   eks:
     enabled: true
   prometheusExporter:

--- a/config/clusters/heliophysics/prod.values.yaml
+++ b/config/clusters/heliophysics/prod.values.yaml
@@ -6,7 +6,6 @@ userServiceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::965872589083:role/heliophysics-prod
 
-
 jupyterhub:
   singleuser:
     nodeSelector:
@@ -20,3 +19,7 @@ jupyterhub:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-08b5d4964b0347330
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 10 # in GB

--- a/config/clusters/heliophysics/staging.values.yaml
+++ b/config/clusters/heliophysics/staging.values.yaml
@@ -20,3 +20,7 @@ jupyterhub:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0d056ca6fe7d4b930
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 1 # in GB


### PR DESCRIPTION
Follow on from #6960.

This PR just lifts the quota limits into the leaf values.yaml, and sets comments.

The intention is that every hub has its own quota, and in time we lift the default config into the base configuration.