### PR TITLE
fix: rename GB to GiB

### DIFF
--- a/config/clusters/2i2c/temple.values.yaml
+++ b/config/clusters/2i2c/temple.values.yaml
@@ -68,7 +68,7 @@ jupyterhub-home-nfs:
     config:
       QuotaManager:
         paths: [/export/temple]
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
     resources:
       requests:
         cpu: 0.2

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -11,7 +11,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 20 # in GB
+          hard_quota: 20 # in GiB
   jupyterhub:
     ingress:
       hosts: [staging.ciroh.awi.2i2c.cloud]

--- a/config/clusters/catalystproject-africa/aibst.values.yaml
+++ b/config/clusters/catalystproject-africa/aibst.values.yaml
@@ -27,7 +27,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-05810452a41759168
 nfs:

--- a/config/clusters/catalystproject-africa/bhki.values.yaml
+++ b/config/clusters/catalystproject-africa/bhki.values.yaml
@@ -32,7 +32,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-010d4c82c22dd5e69
 nfs:

--- a/config/clusters/catalystproject-africa/bon.values.yaml
+++ b/config/clusters/catalystproject-africa/bon.values.yaml
@@ -28,7 +28,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-09dc8201c516e2e70
 nfs:

--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -110,4 +110,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/catalystproject-africa/kush.values.yaml
+++ b/config/clusters/catalystproject-africa/kush.values.yaml
@@ -27,7 +27,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-0de5b955b6bd6dfc6
 nfs:

--- a/config/clusters/catalystproject-africa/molerhealth.values.yaml
+++ b/config/clusters/catalystproject-africa/molerhealth.values.yaml
@@ -27,7 +27,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-0818b363dec5d022f
 nfs:

--- a/config/clusters/catalystproject-africa/must.values.yaml
+++ b/config/clusters/catalystproject-africa/must.values.yaml
@@ -37,7 +37,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-0e86b4abbf3083190
 

--- a/config/clusters/catalystproject-africa/nm-aist.values.yaml
+++ b/config/clusters/catalystproject-africa/nm-aist.values.yaml
@@ -37,7 +37,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-0335f8d2d1795a035
 nfs:

--- a/config/clusters/catalystproject-africa/staging.values.yaml
+++ b/config/clusters/catalystproject-africa/staging.values.yaml
@@ -27,7 +27,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-0b6a28a6eec8fdb3f
 nfs:

--- a/config/clusters/catalystproject-africa/uvri.values.yaml
+++ b/config/clusters/catalystproject-africa/uvri.values.yaml
@@ -29,7 +29,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-048173ffd8e87f1d3
 nfs:

--- a/config/clusters/catalystproject-africa/wits.values.yaml
+++ b/config/clusters/catalystproject-africa/wits.values.yaml
@@ -27,7 +27,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-0c891ce78c5d76b2b
 nfs:

--- a/config/clusters/climatematch/prod.values.yaml
+++ b/config/clusters/climatematch/prod.values.yaml
@@ -8,7 +8,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
     hosts:

--- a/config/clusters/climatematch/staging.values.yaml
+++ b/config/clusters/climatematch/staging.values.yaml
@@ -8,7 +8,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
 
 jupyterhub:
   ingress:

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -92,7 +92,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 15 # in GB
+        hard_quota: 15 # in GiB
 
 nfs:
   pv:

--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -30,4 +30,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 5 # in GB
+        hard_quota: 5 # in GiB

--- a/config/clusters/cloudbank/foothill.values.yaml
+++ b/config/clusters/cloudbank/foothill.values.yaml
@@ -54,7 +54,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 nfs:
   pv:
     serverIP: storage-quota-home-nfs.foothill.svc.cluster.local

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -69,7 +69,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 nfs:
   pv:
     serverIP: storage-quota-home-nfs.humboldt.svc.cluster.local

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -50,4 +50,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -49,4 +49,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -42,7 +42,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 100 # in GB
+          hard_quota: 100 # in GiB
     eks:
       volumeId: vol-06f3c3dc2ded0cd06
   nfs:

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -47,7 +47,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 1 # in GB
+          hard_quota: 1 # in GiB
   nfs:
     pv:
       serverIP: 10.100.240.119

--- a/config/clusters/heliophysics/common.values.yaml
+++ b/config/clusters/heliophysics/common.values.yaml
@@ -157,7 +157,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     enabled: true
   prometheusExporter:

--- a/config/clusters/heliophysics/prod.values.yaml
+++ b/config/clusters/heliophysics/prod.values.yaml
@@ -22,4 +22,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/heliophysics/staging.values.yaml
+++ b/config/clusters/heliophysics/staging.values.yaml
@@ -23,4 +23,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -52,7 +52,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 100 # in GB
+          hard_quota: 100 # in GiB
     resources:
       requests:
         cpu: 0.2

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -27,4 +27,4 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 1 # in GB
+          hard_quota: 1 # in GiB

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -50,4 +50,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -305,4 +305,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -39,7 +39,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 35 # in GB
+          hard_quota: 35 # in GiB
   binderhub-service:
     dockerApi:
       nodeSelector:

--- a/config/clusters/nasa-cryo/staging.values.yaml
+++ b/config/clusters/nasa-cryo/staging.values.yaml
@@ -39,7 +39,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 1 # in GB
+          hard_quota: 1 # in GiB
   binderhub-service:
     dockerApi:
       nodeSelector:

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -52,4 +52,4 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 200 # in GB
+          hard_quota: 200 # in GiB

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -55,4 +55,4 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 10 # in GB
+          hard_quota: 10 # in GiB

--- a/config/clusters/neurohackademy/prod.values.yaml
+++ b/config/clusters/neurohackademy/prod.values.yaml
@@ -31,4 +31,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 50 # in GB
+        hard_quota: 50 # in GiB

--- a/config/clusters/neurohackademy/staging.values.yaml
+++ b/config/clusters/neurohackademy/staging.values.yaml
@@ -31,4 +31,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -60,6 +60,6 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 binderhub-service:
   enabled: false

--- a/config/clusters/oceanhackweek/prod.values.yaml
+++ b/config/clusters/oceanhackweek/prod.values.yaml
@@ -28,4 +28,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/oceanhackweek/staging.values.yaml
+++ b/config/clusters/oceanhackweek/staging.values.yaml
@@ -28,4 +28,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB

--- a/config/clusters/openscapeshub/prod.values.yaml
+++ b/config/clusters/openscapeshub/prod.values.yaml
@@ -36,7 +36,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 30 # in GB
+          hard_quota: 30 # in GiB
     eks:
       volumeId: vol-0cddd71981a7ff6ba
   nfs:

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -55,6 +55,6 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 10 # in GB
+          hard_quota: 10 # in GiB
     eks:
       volumeId: vol-0ab191452f5c85c6b

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -7,7 +7,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
     hosts: [climaterisk.opensci.2i2c.cloud]

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -12,7 +12,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
     hosts:

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -7,7 +7,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
 
 jupyterhub:
   ingress:

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -7,7 +7,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
 
 jupyterhub:
   ingress:

--- a/config/clusters/reflective/prod.values.yaml
+++ b/config/clusters/reflective/prod.values.yaml
@@ -39,4 +39,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 20 # in GB
+        hard_quota: 20 # in GiB

--- a/config/clusters/reflective/staging.values.yaml
+++ b/config/clusters/reflective/staging.values.yaml
@@ -38,4 +38,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB

--- a/config/clusters/reflective/workshop.values.yaml
+++ b/config/clusters/reflective/workshop.values.yaml
@@ -56,4 +56,4 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -8,7 +8,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 10 # in GB
+          hard_quota: 10 # in GiB
   jupyterhub:
     ingress:
       hosts: [smithsonian.2i2c.cloud]

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -8,7 +8,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 1 # in GB
+          hard_quota: 1 # in GiB
   jupyterhub:
     ingress:
       hosts: [staging.smithsonian.2i2c.cloud]

--- a/config/clusters/temple/prod.values.yaml
+++ b/config/clusters/temple/prod.values.yaml
@@ -5,7 +5,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-0b5fc915293bd5bec
 jupyterhub:

--- a/config/clusters/temple/research.values.yaml
+++ b/config/clusters/temple/research.values.yaml
@@ -5,7 +5,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
   eks:
     volumeId: vol-0b5fc915293bd5bec
 jupyterhub:

--- a/config/clusters/temple/staging.values.yaml
+++ b/config/clusters/temple/staging.values.yaml
@@ -5,7 +5,7 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 1 # in GB
+        hard_quota: 1 # in GiB
   eks:
     volumeId: vol-09652a5540fdbd50f
 jupyterhub:

--- a/docs/howto/features/storage-quota.md
+++ b/docs/howto/features/storage-quota.md
@@ -20,7 +20,7 @@ For infrastructure running on AWS, we can create a disk through Terraform by add
 ```
 ebs_volumes = {
   "staging" = {
-    size        = 100  # in GB
+    size        = 100  # in GiB
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name": "staging" }
@@ -33,7 +33,7 @@ ebs_volumes = {
 ```
 persistent_disks = {
   "staging" = {
-    size        = 100  # in GB
+    size        = 100  # in GiB
     name_suffix = "staging"
   }
 }
@@ -44,7 +44,7 @@ persistent_disks = {
 ```
 persistent_disks = {
   "staging" = {
-    size        = 100  # in GB
+    size        = 100  # in GiB
     name_suffix = "staging"
     tags        = { "2i2c:hub-name": "staging" }
   }
@@ -53,7 +53,7 @@ persistent_disks = {
 ````
 `````
 
-This will create a disk with a size of 100GB for the `staging` hub that we can reference when configuring the NFS server.
+This will create a disk with a size of 100GiB for the `staging` hub that we can reference when configuring the NFS server.
 
 Apply these changes with:
 
@@ -154,20 +154,20 @@ Now we can set quotas for each user and configure the path to monitor for storag
 
 ```{tip} Deciding upon a reasonable quota
 
-We should set _reasonable_ quota limits. As of writing, that means a small limit for most users. If you're not sure, choose 10GB per user. For research hubs, this figure is likely much higher (e.g. 100GB/user). Specific users *may* have exceptions made with custom quotas.
+We should set _reasonable_ quota limits. As of writing, that means a small limit for most users. If you're not sure, choose 10GiB per user. For research hubs, this figure is likely much higher (e.g. 100GiB/user). Specific users *may* have exceptions made with custom quotas.
 ```
 
-This can be done by updating `basehub.jupyterhub-home-nfs.quotaEnforcer` in the hub's values file. For example, to set a quota of 10GB for all users on the `staging` hub, we would add the following to the hub's values file:
+This can be done by updating `basehub.jupyterhub-home-nfs.quotaEnforcer` in the hub's values file. For example, to set a quota of 10GiB for all users on the `staging` hub, we would add the following to the hub's values file:
 
 ```yaml
 jupyterhub-home-nfs:
   quotaEnforcer:
     config:
       QuotaManager:
-        hard_quota: 10 # in GB
+        hard_quota: 10 # in GiB
 ```
 
-The `path` field is the path to the parent directory of the user's home directory in the NFS server. The `hard_quota` field is the maximum allowed size of the user's home directory in GB.
+The `path` field is the path to the parent directory of the user's home directory in the NFS server. The `hard_quota` field is the maximum allowed size of the user's home directory in GiB.
 
 To deploy the changes, we need to run the following command:
 
@@ -192,7 +192,7 @@ jupyterhub-home-nfs:
     config:
       QuotaManager:
         quota_overrides:
-          "foo-bar": 100 # in GB
+          "foo-bar": 100 # in GiB
 ```
 
 The keys under ``basehub.jupyterhub-home-nfs.quotaEnforcer.config.QuotaManager.quota_overrides` must be the names of directories under the top-level path(s) managed by `jupyterhub-home-nfs`. This configuration may be deployed using the strategy outlined in [](#global-storage-quotas)


### PR DESCRIPTION
Right now we use GB in our docs, but GB isn't entirely standardised. It would be nice for us to move towards a standard definition:

- GB — $1000^3$ bytes
- GiB — $1024^3$ bytes

For now, this PR _only_ changes our docs and config comments to make that component more explicit. It does mean we might infer the distinction to have more meaning, but that's not intentional at this stage.