### PR TITLE
[ubc-eoas, *] Set reasonable quotas

### DIFF
--- a/config/clusters/ubc-eoas/enc-prod.secret.values.yaml
+++ b/config/clusters/ubc-eoas/enc-prod.secret.values.yaml
@@ -1,3 +1,7 @@
+jupyterhub-home-nfs:
+  quotaEnforcer:
+    extraConfig:
+      secret-quota-overrides: ENC[AES256_GCM,data:Lk7DPEfTt7ohVn6KsZJed+rAygWujewuJHYDJ9/Q+g6CQPPtFsgsWpGq0lJzm9lfrYgHGQ==,iv:11FvfBf8bH1e2SgEZDYOZ95nOpHMqRwJvGW7Y28774w=,tag:ZJ8f1RXX/pl/A6IRuHq+Zg==,type:str]
 jupyterhub:
   hub:
     config:
@@ -5,16 +9,11 @@ jupyterhub:
         client_id: ENC[AES256_GCM,data:rjHalDF7ELAIK3Z8WH6iqTV91fFUhFshSS/UXpmNR+h4sYtp8M/4djC20gKzd7azyx9F,iv:WXGPRkbrmQo1EJvsDiwLtjN4SryAsZ/cWLfXV5h/nwM=,tag:KredArQjdYNBlVOYcRADBw==,type:str]
         client_secret: ENC[AES256_GCM,data:RwJUhf1MgKcTzoiZIl0iVQ+BEdKehx40Ydcr6jXDIVAV8miinSIswrLRvDx0X6YSTjG/sZZW1NR5bkNsqi6IDh3MYpk7H3zGQQ1GZh8h5Wi1Mg+A2bE=,iv:IIl4EdBr5rjWTSgX7i0zMkxP7WY8LloUlhlPzKdrrN0=,tag:eB0QFx+/aU20esW9go0K4w==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2023-01-11T19:07:32Z'
     enc: CiUA4OM7eIe5PxqVN4mXDwCewulzkQ77D6n99WmTIHUkakNHz3eAEkkA+0T9hYGIMZgKygouCk8oaCnpqatYuy7UkdMpgdSKbtX87soo1t4cV/Hv2invIU5ORgg99Fl8Iu+i1GNla3RCBP1YRMd4YI8s
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-01-11T19:07:33Z'
-  mac: ENC[AES256_GCM,data:92xKAu2o4he22xq+4AgcNDYR1REni9rsclxKNZyaypioOdod/0oZPUWjLQqsGO88Ph/g/hWPr6iIzlfVFvfQ0zMLF3SXlcjd/vsv3MkigHbDqd4VHq61dNxbca/p/DMOwYLVzFrCpFdPai1QFrQMY9PBUHe1rR2DA3wgnqO69Zo=,iv:wLdNZqn8sm3cCisPzr8fCmpzqqlGe8cV+ADOTZzNZTM=,tag:lGSNhlqGn2oDU7/9jSlWFw==,type:str]
-  pgp: []
+  lastmodified: '2025-10-17T11:17:11Z'
+  mac: ENC[AES256_GCM,data:WXBnEteT85qiKgOXouWa6ZRxvirRPgKm8dY58pghCJTyNv/m5vjvcsIMmpbjjjqh/jlFRMLDOONoEyOxYFp9cY2YSQKD7wOFbcUZ+9NGLWVJJZe/ogwBVP3f1G1z27Lkvr1EawrY5JpaWGCGXGEM5kR03CFP5CvPIvSbe43D3Jc=,iv:4CnjHF3oI1qwo6smA3DJZSfoljGuheEXs4kcQ2U7v8Y=,tag:nZ+dtfGVkw1cG1QOtGsOFQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.7.2
+  version: 3.10.2

--- a/config/clusters/ubc-eoas/prod.values.yaml
+++ b/config/clusters/ubc-eoas/prod.values.yaml
@@ -14,6 +14,10 @@ jupyterhub:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-084a510095d5b3b9b
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 10 # in GiB
 nfs:
   pv:
     serverIP: 10.100.213.235

--- a/config/clusters/ubc-eoas/staging.values.yaml
+++ b/config/clusters/ubc-eoas/staging.values.yaml
@@ -14,6 +14,10 @@ jupyterhub:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-09051a9e20963690a
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 1 # in GiB
 nfs:
   pv:
     serverIP: 10.100.188.202


### PR DESCRIPTION
Follows on from #6969.

> [!Note]
> As in the previous PR, this PR also sets `_shared` to 0. This is a policy -- shared on prod is always exempt, whilst we don't bother on staging.