### PR TITLE
[hhmi, *] Set reasonable quotas

### DIFF
--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -15,6 +15,12 @@ jupyterhub-home-nfs:
   gke:
     enabled: true
     volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-spyglass
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        # Explicitly disabling quotas, we only have _staging
+        # which is always exempt
+        hard_quota: 0 # in GiB
 
 jupyterhub:
   ingress:


### PR DESCRIPTION
Follow on from #6970

> [!Note]
> HHMI only uses jupyterhub-home-nfs on spyglass, and that's just to mount shared. 
> So this hub is an exception in that we don't define quota overrides for shared.
> We just turn off quotas.