### PR TITLE
fix: bump jupyterhub-home-nfs version (utf8 escape)

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 1.2.0
+    version: 1.2.1-0.dev.git.1.h701b21b
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter


### PR DESCRIPTION
This PR updates our jupyterhub-home-nfs version, which pulls in a fix for non-UTF8 output streams. This was a necessary fix for an incident.