### PR TITLE
fix: bump helm-chart version of jupyterhub-home-nfs (logging)

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 1.2.1-0.dev.git.1.h701b21b
+    version: 1.2.1-0.dev.git.1.h9ad3a21
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter


### PR DESCRIPTION
This PR follows #6973 to pull in a revised logging strategy. This should address the cash associated with OOM.