### PR TITLE
[nasa-ghg-hub, *] Set reasonable quotas

### DIFF
--- a/config/clusters/nasa-ghg-hub/enc-prod.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-prod.secret.values.yaml
@@ -1,4 +1,8 @@
 basehub:
+  jupyterhub-home-nfs:
+    quotaEnforcer:
+      extraConfig:
+        secret-quota-overrides: ENC[AES256_GCM,data:xiAwIdoM1a+y00w17i7IANyJwC+d2bxMdWvpHxROj117qPBRcAa59BCOwHdLOf0189NQqThW,iv:R1ari4f7i8cIN3x2adqFbMvoNw6gLGCA8YyhyYMgkQM=,tag:o0cVAXU6aUPrgRp2dlWSJQ==,type:str]
   jupyterhub:
     hub:
       config:
@@ -6,16 +10,11 @@ basehub:
           client_id: ENC[AES256_GCM,data:IpzKolS3LxPsZrDdw0aHC9wXLbY=,iv:QP4HSlEmZBWBOi/2IrfkmKKgVjJ3lv2HB6JvsTZKjrQ=,tag:Fvcld54b9qTP3x3GQgPe8Q==,type:str]
           client_secret: ENC[AES256_GCM,data:jU3KKDPQOuT/p7aK/CkXVOefiY3rmX7xsJetBNtTGiJg1uZn5bO/pA==,iv:hXZ/fMPlnM0IERSymkbK5xCf4LTmm/T7y++dRE2UQc4=,tag:hna5KtWsnDyVS9vCxAMvhQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2023-08-01T03:55:31Z'
     enc: CiUA4OM7eDcPMsiqsadTNMJZHVg/0plUSzopoWj5kW2RzFzsUCiMEkkAyiwFHPIIQOt0KkMpSWxtm9U0zgoEl8WTdwAeG9Sw40VIDr5s7VJ2o+zjjQIXhjkavGGs2NTXnnr5v4qZ/qXvL69l2JSzlE/4
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-08-01T03:55:32Z'
-  mac: ENC[AES256_GCM,data:9Mm/cMouxibxBQqUe8Xs/P37OFePTx5tr/APWCd0QT2f8MYJlCTms6i6oBxbJLUFzmx/7xbRQB6KkUeY31R9txvplfUKKSQy504wq4IqGv2wrNH853dteFp+Spl/FQS098Ep0UG3iKmiTi6tms1NlYHBihgVNpIcJKMC7GIdkis=,iv:HFOidEywVRpNaEaTvnzTNPO6IwEmXGXHu54HdtpL1rg=,tag:gGrDWqmKiO6LPS+g9tsxgg==,type:str]
-  pgp: []
+  lastmodified: '2025-10-17T16:20:38Z'
+  mac: ENC[AES256_GCM,data:aXjCd6XnPvKR0bIE0UUhYBbWYGxwgb1Fvqv80n+J6CeHFwnZTtFn86UykZdTEpgQ7zktQiO9xwAFFQr8dxN3NL5rRZrGMPMHdlsC1MfXqAI7rDHVU5nt5dmvh7ELO8Ci2e/aZcuBGzYf8d3iVdb5crpil57OS/c7ZkFo7yoaNU4=,iv:KzIQm5pW749nCMlf2gQXQOESyN5b+ZJgoFcEgRqP9OI=,tag:WH6E3FmGFcOAkugElGwJpA==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.10.2

--- a/config/clusters/nasa-ghg-hub/prod.values.yaml
+++ b/config/clusters/nasa-ghg-hub/prod.values.yaml
@@ -49,7 +49,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 50
+          hard_quota: 50 # in GiB
   nfs:
     pv:
       serverIP: 10.100.172.188

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -49,7 +49,7 @@ basehub:
     quotaEnforcer:
       config:
         QuotaManager:
-          hard_quota: 1
+          hard_quota: 1 # in GiB
   nfs:
     pv:
       serverIP: 10.100.52.143


### PR DESCRIPTION
Follows on from #6972.

> [!Note]
> We changed the `_shared` policy again to use 100GiB as default.