### PR TITLE
Update nasa-openscapes core python image

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -85,7 +85,7 @@ basehub:
                 display_name: Python
                 description: Python datascience environment
                 kubespawner_override:
-                  image: openscapes/python:7093bd3
+                  image: openscapes/python:65d6916
               02-R:
                 display_name: R + Python Geospatial
                 description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest


### PR DESCRIPTION
Includes `openssh` and `jupyter-sshd-proxy` to enable remote SSH access in default image