### PR TITLE
fix: disable fabric for NVIDIA T4 instances

### DIFF
--- a/eksctl/libsonnet/cluster.jsonnet
+++ b/eksctl/libsonnet/cluster.jsonnet
@@ -188,6 +188,14 @@
         effect: 'NoSchedule',
       },
     ]
+  ) + (
+    // Turn off fabric on GPU nodes, as they are not nvswitch devices
+    if gpuType == 'nvidia-tesla-t4' then {
+      preBootstrapCommands: [
+        'systemctl disable --now nvidia-fabricmanager.service || true',
+        'systemctl mask nvidia-fabricmanager.service || true',
+      ],
+    } else {}
   ),
   makeDaskNodeGroup(
     clusterName,


### PR DESCRIPTION
This PR disables the fabric service for GPU nodes. For non nvswitch GPUs, like the NVIDIA T4, the service fails to start on AL2023 AMIs, which 

Thanks @GeorgianaElena for the idea!
