### PR TITLE
[Grafana] Remove raise exception for deploy dashboards CI/CD

### DIFF
--- a/deployer/commands/deploy_dashboards.py
+++ b/deployer/commands/deploy_dashboards.py
@@ -58,9 +58,9 @@ def deploy_dashboards(
             f"Only values {', '.join([str(v) for v in allowed_types])} are allowed."
         )
 
-    if dashboard_type == None or dashboard_type == "cost":
+    if dashboard_type == "cost":
         if cluster_provider != "aws":
-            raise Exception(
+            print_colour(
                 f"Cost dashboards are currently available on AWS only. {cluster_name.capitalize()} is deployed on {cluster_provider.upper()}."
             )
 


### PR DESCRIPTION
CI/CD was broken because I was too aggressive with raising an exception in CI/CD, where we have clusters with no cost dashboards:

https://github.com/2i2c-org/infrastructure/actions/runs/18813264017