### PR TITLE
Add disasters-docs path for Disasters-Hub

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -131,9 +131,9 @@ jupyterhub:
                   image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
                   env:
                   - name: TARGET_PATH
-                    value: veda-docs
+                    value: disasters-docs
                   - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
+                    value: https://github.com/Disasters-Learning-Portal/disasters-docs
                   volumeMounts:
                   - name: home
                     mountPath: /home/jovyan


### PR DESCRIPTION
## Summary

Rather than using the `veda-docs` repo within Disasters, this PR updates to using the `disasters-docs` repo instead. 