### PR TITLE
[cost monitoring] Chart versions and config values for test deploy of cost-monitoring with groups

### DIFF
--- a/config/clusters/2i2c-aws-us/basehub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/basehub-common.values.yaml
@@ -31,3 +31,11 @@ jupyterhub-home-nfs:
   prometheusExporter:
     enabled: true
 
+jupyterhub-groups-exporter:
+  config:
+    groupsExporter:
+      update_info_interval: 3600
+      update_metrics_interval: 300
+      update_dirsize_interval: 3600
+      prometheus_host: support-prometheus-server.support.svc.cluster.local
+      prometheus_port: 80

--- a/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
+++ b/config/clusters/2i2c-aws-us/daskhub-common.values.yaml
@@ -39,3 +39,11 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: github
+  jupyterhub-groups-exporter:
+    config:
+      groupsExporter:
+        update_info_interval: 3600
+        update_metrics_interval: 300
+        update_dirsize_interval: 3600
+        prometheus_host: support-prometheus-server.support.svc.cluster.local
+        prometheus_port: 80

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -347,6 +347,11 @@ basehub:
         - geolab
         - geolab:dev
         - geolab:power
+        update_info_interval: 3600
+        update_metrics_interval: 300
+        update_dirsize_interval: 3600
+        prometheus_host: support-prometheus-server.support.svc.cluster.local
+        prometheus_port: 80
   binderhub-service:
     enabled: true
     networkPolicy:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -281,3 +281,11 @@ basehub:
     prometheusExporter:
       enabled: true
 
+  jupyterhub-groups-exporter:
+    config:
+      groupsExporter:
+        update_info_interval: 3600
+        update_metrics_interval: 300
+        update_dirsize_interval: 3600
+        prometheus_host: support-prometheus-server.support.svc.cluster.local
+        prometheus_port: 80

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -308,3 +308,12 @@ basehub:
       enabled: true
     prometheusExporter:
       enabled: true
+
+  jupyterhub-groups-exporter:
+    config:
+      groupsExporter:
+        update_info_interval: 3600
+        update_metrics_interval: 300
+        update_dirsize_interval: 3600
+        prometheus_host: support-prometheus-server.support.svc.cluster.local
+        prometheus_port: 80

--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -207,3 +207,11 @@ basehub:
     enabled: true
     eks:
       enabled: true
+  jupyterhub-groups-exporter:
+    config:
+      groupsExporter:
+        update_info_interval: 3600
+        update_metrics_interval: 300
+        update_dirsize_interval: 3600
+        prometheus_host: support-prometheus-server.support.svc.cluster.local
+        prometheus_port: 80

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -30,6 +30,6 @@ dependencies:
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter
-    version: 0.0.1-0.dev.git.110.h7b374a1
+    version: 1.0.1-0.dev.git.131.h2f6c770
     repository: https://2i2c.org/jupyterhub-groups-exporter
     condition: jupyterhub-groups-exporter.enabled

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # jupyterhub-cost-monitoring, cost reporting for Grafana
   # https://github.com/2i2c-org/jupyterhub-cost-monitoring
   - name: jupyterhub-cost-monitoring
-    version: "0.0.1-0.dev.git.119.h8ed359a"
+    version: "1.0.1-0.dev.git.141.h4733559"
     repository: https://2i2c.org/jupyterhub-cost-monitoring/
     condition: jupyterhub-cost-monitoring.enabled
 


### PR DESCRIPTION
> [!warning]
> Do not merge, for information only.

These are the config changes in reference to https://github.com/2i2c-org/infrastructure/issues/7016 for rolling out the group cost prototype to a subset of our clusters for initial testing.

