### PR TITLE
Changed MAAP default workspace size to 7.4GB

### DIFF
--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -93,18 +93,17 @@ jupyterhub:
                 cpu_limit: 3.725
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_8:
-              display_name: 8 GB RAM, upto 3.7 CPUs
+            mem_7_4:
+              display_name: 7.4 GB RAM, upto 3.7 CPUs
               allowed_groups:
               - CPU:M
               kubespawner_override:
-                mem_guarantee: 8589934592
-                mem_limit: 8589934592
-                cpu_guarantee: 1.007
+                mem_guarantee: 7964979101
+                mem_limit: 7964979101
+                cpu_guarantee: 0.93125
                 cpu_limit: 3.725
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-              default: true
             mem_14_8:
               display_name: 14.8 GB RAM, upto 3.7 CPUs
               allowed_groups:
@@ -116,6 +115,7 @@ jupyterhub:
                 cpu_limit: 3.725
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
+              default: true
             mem_29_7:
               display_name: 29.7 GB RAM, upto 3.7 CPUs
               allowed_groups:


### PR DESCRIPTION
8GB is the best/min for running conda which most of our users do