### PR TITLE
feat: add fperez as admin

### DIFF
--- a/config/clusters/aimatx-2i2c-hub/common.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/common.values.yaml
@@ -199,6 +199,7 @@ jupyterhub:
         Authenticator:
           admin_users:
           - philrodoni
+          - fperez
 
   scheduling:
     userScheduler:


### PR DESCRIPTION
This PR adds @fperez as an admin of the aimatx-2i2c-hub hubs.