### PR TITLE
[ohw] Update images & image config

### DIFF
--- a/config/clusters/oceanhackweek/common.values.yaml
+++ b/config/clusters/oceanhackweek/common.values.yaml
@@ -67,7 +67,7 @@ jupyterhub:
 
     profileList:
     - display_name: Escoge Entorno R o Python
-      # slug: only-choice
+      slug: only-choice
       profile_options:
         image:
           display_name: Entorno ("imagen")


### PR DESCRIPTION
Update to image profile selections in preparation for next event.
- For existing Python and R images, change tag to latest
- Add py-rocket-geospatial-2 image as one of the choices (for testing)
- Enable unlisted_choice

Commented out `profileList` `slug`, *guessing* it no longer applies ...

See PR https://github.com/oceanhackweek/jupyter-image/pull/152