### PR TITLE
Update NMFS Openscapes core python

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -79,10 +79,10 @@ jupyterhub:
             enabled: true
           choices:
             python:
-              display_name: Py - NASA Openscapes Python, Dask Gateway 07980b9
+              display_name: Py - NASA Openscapes Python, Dask Gateway 65d6916
               slug: python
               kubespawner_override:
-                image: openscapes/python:07980b9
+                image: openscapes/python:65d6916
             pyrbase:
               display_name: Py-R - py-rocket-base image 4.4-3.10
               slug: pyrbase

--- a/config/clusters/nmfs-openscapes/noaa-only.values.yaml
+++ b/config/clusters/nmfs-openscapes/noaa-only.values.yaml
@@ -79,10 +79,10 @@ jupyterhub:
             enabled: true
           choices:
             python:
-              display_name: Py - NASA Openscapes Python, Dask Gateway 07980b9
+              display_name: Py - NASA Openscapes Python, Dask Gateway 65d6916
               slug: python
               kubespawner_override:
-                image: openscapes/python:07980b9
+                image: openscapes/python:65d6916
             pyrbase:
               display_name: Py-R - py-rocket-base image 4.4-3.10
               slug: pyrbase


### PR DESCRIPTION
This updates the core Python image used in NMFS-Openscapes hubs to the same as in NASA-openscapes (openscapeshub). The main change is adding `openssh` and `jupyter-sshd-proxy` to the image to allow SSH into the hubs.

cc @eeholmes