### PR TITLE
Update name of NextGen enabled hub image to avoid name conflict

### DIFF
--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -107,7 +107,7 @@ basehub:
                   image: quay.io/awiciroh/devcon25:jmframe_d25
                   image_pull_policy: Always
               devcon7:
-                display_name: NextGen National Water Model(NWM)
+                display_name: CIROH Community NextGen Hub
                 slug: devcon7
                 kubespawner_override:
                   image: quay.io/fbaig25/ngiab-2i2c:v1.1.0


### PR DESCRIPTION
There was a minor but possibly important name conflict to avoid here. Please see discussion here for more background:
https://github.com/CIROH-UA/awi-ciroh-image/issues/89

