### PR TITLE
Allow user servers to start even with disks full

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -743,6 +743,12 @@ jupyterhub:
           BaseFileIdManager: *server_config_base_file_id_manager
     startTimeout: 600 # 10 mins, node startup + image pulling sometimes takes more than the default 5min
     defaultUrl: /tree
+    # Putting the .jupyter config dir in a tmp location, rather than the home dir will
+    # permit the user server to start even if the user hits its home storage quota.
+    # Same goes for the npm logs stored in ~/.npm
+    extraEnv:
+      JUPYTER_CONFIG_DIR: /tmp/.jupyter
+      NPM_CONFIG_CACHE: /tmp/.npm
     image:
       name: quay.io/jupyter/scipy-notebook
       tag: "2024-03-18"


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/6639

Running `fatrace` showed that the following files were written at startup:

```
root@storage-quota-home-nfs-57f6f75bd5-gfl64:/export# fatrace -f W -c
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.jupyter/migrated
unknown(0): W   /export/staging/georgianaelena-402i2c-2eorg/.npm/_logs/2025-11-10T13_07_33_076Z-debug-0.log
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.npm/_logs/2025-11-10T13_07_33_076Z-debug-0.log
unknown(0): W   /export/staging/georgianaelena-402i2c-2eorg/.jupyter/lab/workspaces/default-37a8.jupyterlab-workspace
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.jupyter/lab/workspaces/default-37a8.jupyterlab-workspace
unknown(0): W   /export/staging/georgianaelena-402i2c-2eorg/.jupyter/lab/workspaces/default-37a8.jupyterlab-workspace
unknown(0): W   /export/staging/georgianaelena-402i2c-2eorg/.jupyter/lab/workspaces/default-37a8.jupyterlab-workspace
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.jupyter/lab/workspaces/default-37a8.jupyterlab-workspace
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.jupyter/migrated
unknown(0): W   /export/staging/georgianaelena-402i2c-2eorg/.npm/_logs/2025-11-10T13_10_02_551Z-debug-0.log
unknown(0): CW  /export/staging/georgianaelena-402i2c-2eorg/.npm/_logs/2025-11-10T13_10_02_551Z-debug-0.log
```

Unfortunaly, the `migrated` dirname is [hardcoded](https://github.com/jupyter/jupyter_core/blob/2e63fd3928a979844fa0c2a247ee1937bbae9a99/jupyter_core/migrate.py#L246-L247), so we have to put the entire `.jupyter` config in `/tmp`.

Is that acceptable? I am thinking specifically if the workspaces are to be persisted, that this new setup will make it impossible.