### PR TITLE
[temple, prod]: Migrate from GCP

### DIFF
--- a/config/clusters/temple/cluster.yaml
+++ b/config/clusters/temple/cluster.yaml
@@ -23,6 +23,15 @@ hubs:
   - enc-common.secret.values.yaml
   - staging.values.yaml
   - enc-staging.secret.values.yaml
+- name: prod
+  display_name: Temple University
+  domain: temple.2i2c.cloud
+  helm_chart: basehub
+  helm_chart_values_files:
+  - common.values.yaml
+  - enc-common.secret.values.yaml
+  - prod.values.yaml
+  - enc-prod.secret.values.yaml
 - name: advanced
   display_name: Temple University (Advanced)
   domain: advanced.temple.2i2c.cloud

--- a/config/clusters/temple/enc-prod.secret.values.yaml
+++ b/config/clusters/temple/enc-prod.secret.values.yaml
@@ -1,0 +1,19 @@
+jupyterhub-home-nfs:
+  quotaEnforcer:
+    extraConfig:
+      secret-quota-overrides: ENC[AES256_GCM,data:P8MqJtfj+2ypIK1l1p7Jj8UKXqRb6bsWHl2t6+WOyKtx9qqtBmtDCq86KjnrPhQX8vsNmxU0,iv:YJhWip7g4ejPwSuOeBUZrZKiBpwQfqEvwJqQMLlxZZA=,tag:AhXdPtkxt5NRRzGKkkGHdQ==,type:str]
+jupyterhub:
+  hub:
+    config:
+      CILogonOAuthenticator:
+        client_id: ENC[AES256_GCM,data:kovFvnwRbd17wXJ/LziS+X6FpyxgjvutTVvWPVXgqPgENJoH0vvdFws5shR1ZBpQboOc,iv:ioVLOPb5fnRnfQlgu4419n7+AKk+JcFFejlk+CISy/8=,tag:wWnjvCx7QIcYkXyGFqqQXg==,type:str]
+        client_secret: ENC[AES256_GCM,data:xsgNrDIF+/eD4TvAlzTpIn9GnLHnyA7QnkMs1U5ANq1CLrnLBJchnJWlECVXdkIhiZfD9vKdIeiNqDyz0iRCaWru/f754zDKaUDQkRpdqw9QpKwA8pY=,iv:3Vw6byls5/vN3FiZKimwq8ubCdWDDzUTYU7CnxfKEQM=,tag:hjcmZVWz4XU86gg3wpOmxQ==,type:str]
+sops:
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2022-08-31T01:06:20Z'
+    enc: CiQA4OM7eNxG+aMy3zghXJxeOS5WhtKv4+j9QlRn36BIgkIWRMESSQDuy/p8Unhzj8xdhnf1aA7xj8X3s5nxo8NK4Zc0N89qll2FZmlvtclp6NQAxslwh+ojM+Kxn3+3mkmbi7r0HSaK7nazA4qeQbE=
+  lastmodified: '2025-10-17T17:30:20Z'
+  mac: ENC[AES256_GCM,data:oyUMg8BeXECyu0pAQRXYryhU5BOLYwJGZRG1qhLG4HeNx8lxBnDHPPKJx6RNFOp1gBAcHyebbtUan+42QPx0wkUZ3CIWQeK5l/pWo/6aYW9ui6S6JuAUioJC8ZJ5vuIncb6j/cFC6ANazEV4iJoRSUVW7itgV5EL6wdRoI0fKek=,iv:1UkQKxlh2HXx7gi0oum7i5kk10qI9BK8lPxJjLTWBNA=,tag:e2neTsfL5kO8ad/MkazK4Q==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.10.2

--- a/config/clusters/temple/prod.values.yaml
+++ b/config/clusters/temple/prod.values.yaml
@@ -1,0 +1,21 @@
+nfs:
+  pv:
+    serverIP: storage-quota-home-nfs.temple.svc.cluster.local
+jupyterhub-home-nfs:
+  gke:
+    volumeId: projects/two-eye-two-see/zones/us-central1-b/disks/hub-nfs-homedirs-temple
+jupyterhub:
+  hub:
+    config:
+      CILogonOAuthenticator:
+        oauth_callback_url: https://temple.2i2c.cloud/hub/oauth_callback
+  ingress:
+    hosts:
+    - temple.2i2c.cloud
+    tls:
+    - secretName: https-auto-tls
+      hosts:
+      - temple.2i2c.cloud
+  singleuser:
+    nodeSelector:
+      2i2c/hub-name: advanced


### PR DESCRIPTION
This PR tracks the work to migrate temple from GCP to AWS as a dedicated hub.

## Initial work
- [x] Copy CILogon credentials
- [ ] Create / modify GitHub login application
- [ ] Initial clone of user-storage to AWS

## Switchover
- [ ] Secondary clone of user-storage to AWS before commissioning
- [ ] Change domain of `2i2c/temple` to `temple-shared`, add `temple.2i2c.cloud` to `prod`