### PR TITLE
[ohw] Change back two images to specific tags

### DIFF
--- a/config/clusters/oceanhackweek/common.values.yaml
+++ b/config/clusters/oceanhackweek/common.values.yaml
@@ -92,13 +92,13 @@ jupyterhub:
               slug: python
               description: Python en JupyterLab
               kubespawner_override:
-                image: ghcr.io/oceanhackweek/python:latest
+                image: ghcr.io/oceanhackweek/python:c881ad5
             r:
               display_name: R (*Viejo*)
               description: R en RStudio
               kubespawner_override:
                 default_url: /rstudio
-                image: ghcr.io/oceanhackweek/r:latest
+                image: ghcr.io/oceanhackweek/r:293f282
         resource_allocation:
           display_name: Capacidad Asignada
           choices:


### PR DESCRIPTION
Correcting mistake made in my recent PR #7061. Sorry!

Stepping back from using `latest` tag for the two images that we plan to decommission (unless the new py-rocket image ends up being unworkable). Use of `latest` for the Python image was a mistake.

If all goes well with our new py-rocket image, there'll be just one more change to `common.values.yaml` before the event: removing the old Python and R images and the option to enter a docker image path.

ref https://github.com/oceanhackweek/Hub-Management/issues/7