### PR TITLE
[maap] Update bucket write permissions

### DIFF
--- a/terraform/aws/projects/maap.tfvars
+++ b/terraform/aws/projects/maap.tfvars
@@ -29,6 +29,7 @@ hub_cloud_permissions = {
             "Effect": "Allow",
             "Action": [
               "s3:PutObject",
+              "s3:PutObjectAcl",
               "s3:GetObject",
               "s3:ListBucketMultipartUploads",
               "s3:AbortMultipartUpload",
@@ -153,7 +154,8 @@ hub_cloud_permissions = {
           {
             "Effect": "Allow",
             "Action": [
-              "s3:PutObject"
+              "s3:PutObject",
+              "s3:PutObjectAcl"
             ],
             "Resource": [
               "arn:aws:s3:::maap-ops-workspace",


### PR DESCRIPTION
## Description
Objects can be put into the maap-ops-workspace bucket in MCP but are then owned by the SMCE account. This change will allow us to set the owner of the objects and make the objects visible in both the MAAP Hub and ADE during this transition period.

## Changes
- Adds the PutObjectAcl permission