### PR TITLE
ghg: Add "sdap-dev-zarr"

### DIFF
--- a/terraform/aws/projects/nasa-ghg-hub.tfvars
+++ b/terraform/aws/projects/nasa-ghg-hub.tfvars
@@ -69,7 +69,9 @@ hub_cloud_permissions = {
               "arn:aws:s3:::ghg-ssim",
               "arn:aws:s3:::ghg-ssim/*",
               "arn:aws:s3:::ghg-retrieval-algorithm",
-              "arn:aws:s3:::ghg-retrieval-algorithm/*"
+              "arn:aws:s3:::ghg-retrieval-algorithm/*",
+              "arn:aws:s3:::sdap-dev-zarr",
+              "arn:aws:s3:::sdap-dev-zarr/*"
             ]
           },
           {
@@ -125,6 +127,8 @@ hub_cloud_permissions = {
               "arn:aws:s3:::ghg-ssim/*",
               "arn:aws:s3:::ghg-retrieval-algorithm",
               "arn:aws:s3:::ghg-retrieval-algorithm/*"
+              "arn:aws:s3:::sdap-dev-zarr",
+              "arn:aws:s3:::sdap-dev-zarr/*"              
             ]
           },
           {


### PR DESCRIPTION
Request for adding the following bucket in the 'nasa-ghg-hub-prod-extra-user-policy'  policy

1."arn:aws:s3:::sdap-dev-zarr",
2."arn:aws:s3:::sdap-dev-zarr/*"