### PR TITLE
[ohw] Final image selection options and messages

### DIFF
--- a/config/clusters/oceanhackweek/common.values.yaml
+++ b/config/clusters/oceanhackweek/common.values.yaml
@@ -66,7 +66,7 @@ jupyterhub:
           protocol: TCP
 
     profileList:
-    - display_name: Escoge Entorno
+    - display_name: Entorno y Capacidad Asignados
       slug: only-choice
       profile_options:
         image:
@@ -76,29 +76,18 @@ jupyterhub:
             display_name: Custom image
             validation_regex: ^.+:.+$
             validation_message: Must be a publicly available docker image, of form <image-name>:<tag>
-            display_name_in_choices: Specify an existing docker image
-            description_in_choices: Use a pre-existing docker image from a public docker registry (dockerhub, quay, etc)
+            display_name_in_choices: Especifica una imagen docker existente
+            description_in_choices: Imagen docker pre-existente de un registro de docker público (dockerhub, quay, etc)
             kubespawner_override:
               image: '{value}'
           choices:
             pyrgeo2:
-              display_name: Python + R, OHW en Español. JupyterLab, RStudio, y Desktop
+              display_name: Python y R - OHW en Español
+              description: Contiene JupyterLab, RStudio, y Desktop
               slug: pyrgeo2
               kubespawner_override:
                 image: ghcr.io/nmfs-opensci/container-images/py-rocket-oceanhw-esp:latest
               default: true
-            python:
-              display_name: Python (*Viejo*)
-              slug: python
-              description: Python en JupyterLab
-              kubespawner_override:
-                image: ghcr.io/oceanhackweek/python:c881ad5
-            r:
-              display_name: R (*Viejo*)
-              description: R en RStudio
-              kubespawner_override:
-                default_url: /rstudio
-                image: ghcr.io/oceanhackweek/r:293f282
         resource_allocation:
           display_name: Capacidad Asignada
           choices:


### PR DESCRIPTION
Final settings before start of event on 11/24. Just one image (based on py-rocket), set as the default, plus the "bring your own image" option -- which hopefully we won't need to resort to.

This should be the last change to `common.values.yaml` before the event :crossed_fingers: 

ref https://github.com/oceanhackweek/Hub-Management/issues/7