### PR TITLE
Bump cost-monitoring chart

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
   # jupyterhub-cost-monitoring, cost reporting for Grafana
   # https://github.com/2i2c-org/jupyterhub-cost-monitoring
   - name: jupyterhub-cost-monitoring
-    version: "1.1.1-0.dev.git.145.h06814b4"
+    version: "1.1.1"
     repository: https://2i2c.org/jupyterhub-cost-monitoring/
     condition: jupyterhub-cost-monitoring.enabled
 


### PR DESCRIPTION
Ref https://github.com/2i2c-org/jupyterhub-cost-monitoring/releases/tag/v1.1.1