### PR TITLE
[*] Bump `jupyterhub-home-nfs` version

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "https://helm.dask.org/"
     condition: dask-gateway.enabled
   - name: jupyterhub-home-nfs
-    version: 1.2.1-0.dev.git.1.h9ad3a21
+    version: 1.2.1-0.dev.git.1.h23a4744
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
     condition: jupyterhub-home-nfs.enabled
   - name: jupyterhub-groups-exporter


### PR DESCRIPTION
This PR bumps the `jupyterhub-home-nfs` version so that we can define `extraContainers`, as is required by #6550 