### PR TITLE
fix: URL for 2i2c-owned hub

### DIFF
--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -1,6 +1,7 @@
 name: 2i2c-aws-us
 provider: aws
-provider_url: https://2i2c.awsapps.com/start#/ under the two-eye-two-see account
+# two-eye-two-see
+provider_url: https://2i2c.awsapps.com/start
 aws:
   account: 790657130469
   key: enc-deployer-credentials.secret.json


### PR DESCRIPTION
This fixes some URL metadata.