### PR TITLE
maint: automate cluster list for deploying grafana dashboards

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -7,48 +7,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  identify_clusters:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v5
+    - name: Build matrix
+      id: matrix
+      run: |
+        # Find names of clusters from `cluster.yaml` entries
+        matrix=$(yq '[.[].name]' config/clusters/*/cluster.yaml -s -r -c)
+        echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
   deploy_grafana_dashboards:
     runs-on: ubuntu-22.04
+    needs: identify_clusters
     strategy:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
-        include:
-        - cluster_name: 2i2c
-        - cluster_name: 2i2c-aws-us
-        - cluster_name: 2i2c-jetstream2
-        - cluster_name: 2i2c-uk
-        - cluster_name: aimatx-2i2c-hub
-        - cluster_name: awi-ciroh
-        - cluster_name: berkeley-geojupyter
-        - cluster_name: bnext-bio
-        - cluster_name: catalystproject-africa
-        - cluster_name: catalystproject-latam
-        - cluster_name: cloudbank
-        - cluster_name: dubois
-        - cluster_name: disasters
-        - cluster_name: earthscope
-        - cluster_name: hhmi
-        - cluster_name: jupyter-health
-        - cluster_name: leap
-        - cluster_name: maap
-        - cluster_name: nasa-cryo
-        - cluster_name: nasa-ghg-hub
-        - cluster_name: nasa-veda
-        - cluster_name: neurohackademy
-        - cluster_name: nmfs-openscapes
-        - cluster_name: openscapeshub
-        - cluster_name: opensci
-        - cluster_name: projectpythia
-        - cluster_name: projectpythia-binder
-        - cluster_name: reflective
-        - cluster_name: smithsonian
-        - cluster_name: strudel
-        - cluster_name: temple
-        - cluster_name: ubc-eoas
-        - cluster_name: utoronto
-        - cluster_name: victor
-        - cluster_name: oceanhackweek
+        include: ${{fromJson(needs.identify_clusters.outputs.matrix)}}
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
This PR means we have one fewer (tiny) steps to do when setting up or tearing down a cluster.