### PR TITLE
Don't disable grafana alerting

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -326,10 +326,6 @@ grafana:
       # Because our grafana is behind an nginx ingress, this should match the
       # read timeout set above under `ingress.annotations`.
       timeout: 120
-    unified_alerting:
-      # Disable alerting for now as its not something our community users can
-      # setup. See https://github.com/2i2c-org/infrastructure/issues/4919.
-      enabled: false
     server:
       root_url: ""
       enable_gzip: true


### PR DESCRIPTION
I lost a bunch of time today trying to figure out why this default feature was not enabled.

Ref https://github.com/2i2c-org/infrastructure/issues/7166