### PR TITLE
Revert "[LIS] Update to lis.values.yaml to update docker image tag"

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -57,7 +57,7 @@ jupyterhub:
     image:
       # https://hub.docker.com/r/lisacuk/lishub-base
       name: lisacuk/lishub-base
-      tag: 059efdb
+      tag: 5addc51
     defaultUrl: /lab
     profileList:
       # Setup as requested in https://2i2c.freshdesk.com/a/tickets/1348


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#7212 under suspicion that it caused https://2i2c.freshdesk.com/a/tickets/4503