### PR TITLE
[disasters] Enable custom GPU plugin

### DIFF
--- a/config/clusters/disasters/support.values.yaml
+++ b/config/clusters/disasters/support.values.yaml
@@ -35,3 +35,8 @@ cluster-autoscaler:
 
 calico:
   enabled: true
+
+# FIXME: remove this once eksctl is fixed
+nvidiaDevicePlugin:
+  aws:
+    enabled: true


### PR DESCRIPTION
Follow up to #7228, because I forgot to deploy our own GPU daemonset.