### PR TITLE
[lis] Enable unlisted-choice

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -59,23 +59,44 @@ jupyterhub:
       name: lisacuk/lishub-base
       tag: 5addc51
     defaultUrl: /lab
+
     profileList:
-      # Setup as requested in https://2i2c.freshdesk.com/a/tickets/1348
-    - display_name: Regular Instance
-      description: Provides 512M - 2G of RAM
+    - display_name: Choose your environment and resources
       default: true
-      kubespawner_override:
-        mem_limit: 2G
-        mem_guarantee: 512M
-    - display_name: Large Instance
-        # Requested in https://2i2c.freshdesk.com/a/tickets/1348
-        # FIXME: The </p><p> is a hack for kubespawner to render a new line, maybe there are better ways to do this?
-      description: |
-        Provides 1G - 4G of RAM.
-        ⚠️ Please use this instance only if you know you need it, otherwise use the Regular Instance!
-      kubespawner_override:
-        mem_limit: 4G
-        mem_guarantee: 1G
+      profile_options:
+        image:
+          display_name: Environment
+          unlisted_choice:
+            enabled: true
+            display_name: Custom image
+            description: Specify your own docker image (must have Python and JupyterHub installed).
+            validation_regex: ^.+:.+$
+            validation_message: Must be a publicly available Docker image, of form <image-name>:<tag>
+            kubespawner_override:
+              image: '{value}'
+          choices:
+            01-default:
+              display_name: Default Image
+              description: Image maintained by LIS
+              default: true
+              kubespawner_override:
+                image: lisacuk/lishub-base:5addc51
+        resource_allocation:
+          display_name: Resource Allocation
+          choices:
+            mem_2_gb:
+              default: true
+              display_name: Regular Instance
+              description: Provides 512M - 2G of RAM.
+              kubespawner_override:
+                mem_limit: 2G
+                mem_guarantee: 512M
+            mem_4_gb:
+              display_name: Large Instance
+              description: Provides 1G - 4G of RAM.
+              kubespawner_override:
+                mem_limit: 4G
+                mem_guarantee: 1G
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
This PR does the smallest amount of work to add an `unlisted-choice`. It intentionally doesn't update the profile limits as we normally would, because LIS is on a shared cluster and have been running this config for a while. I think we _should_ change their resource allocations, but talk to them about it when we next think about things like migrations.