### PR TITLE
[lis] Use older image

### DIFF
--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -76,7 +76,7 @@ jupyterhub:
               description: Image maintained by LIS
               default: true
               kubespawner_override:
-                image: lisacuk/lishub-base:5addc51
+                image: lisacuk/lishub-base:a57e973
         resource_allocation:
           display_name: Resource Allocation
           choices:


### PR DESCRIPTION
LIS are still running into problems related to `jupyter-collaboration`. I suspect this is related to the versions of these packages, but at this stage the focus is on restoring something that works rather than building a new image.

https://2i2c.freshdesk.com/a/tickets/4503?note=80656945585