### PR TITLE
Remove GitHubOAuthenticator

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -47,7 +47,7 @@ jupyterhub:
     allowNamedServers: true
     config:
       JupyterHub:
-        authenticator_class: github
+        authenticator_class: generic-oauth
       Authenticator:
         admin_users:
         - freitagb


### PR DESCRIPTION
Removed GitHubOAuthenticator configuration since it appears to be overriding our Keycloak login service.