### PR TITLE
Bump version of prometheus-dirsize-exporter

### DIFF
--- a/helm-charts/basehub/templates/home-dirsize-reporter.yaml
+++ b/helm-charts/basehub/templates/home-dirsize-reporter.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
         - name: dirsize-exporter
           # From https://github.com/yuvipanda/prometheus-dirsize-exporter
-          image: quay.io/yuvipanda/prometheus-dirsize-exporter:v3.1
+          image: quay.io/yuvipanda/prometheus-dirsize-exporter:v3.3
           resources:
             # Provide limited resources for this collector, as it can
             # balloon up (especially in CPU) quite easily. We are quite ok with


### PR DESCRIPTION
Brings in newer version that can co-exist with
https://github.com/2i2c-org/jupyterhub-home-nfs/pull/76

Ref https://github.com/2i2c-org/infrastructure/issues/7166