### PR TITLE
[nmfs-openscapes] Add 2025 Champions GitHub team to NMFS-Openscapes hub

### DIFF
--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -52,6 +52,7 @@ jupyterhub:
         - nmfs-openscapes:2024-science-teams
         - nmfs-openscapes:2024-CoastWatch
         - nmfs-openscapes:2024-nmfs-champions-cohort
+        - nmfs-openscapes:2025-nmfs-champions-cohort
 
 jupyterhub-home-nfs:
   eks:

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -52,6 +52,7 @@ jupyterhub:
         - nmfs-openscapes:2024-science-teams
         - nmfs-openscapes:2024-CoastWatch
         - nmfs-openscapes:2024-nmfs-champions-cohort
+        - nmfs-openscapes:2025-nmfs-champions-cohort
 
 jupyterhub-home-nfs:
   eks:


### PR DESCRIPTION
This adds access for our nmfs-openscapes 2025 Champions cohort to the NMFS-Openscapes hub. Thanks!