### PR TITLE
Regenerate resource options for disasters

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -157,82 +157,89 @@ jupyterhub:
         resource_allocation:
           display_name: Resource Allocation
           choices:
-            mem_1_9:
-              display_name: 1.9 GB RAM, upto 3.7 CPUs
+            mem_2_gb:
+              display_name: ~2 GB RAM, ~0.2 CPUs
+              description: Up to ~4 CPUs when available
               allowed_groups:
               - CPU:XS
+              default: true
               kubespawner_override:
-                mem_guarantee: 1991244775
-                mem_limit: 1991244775
-                cpu_guarantee: 0.2328125
-                cpu_limit: 3.725
+                mem_guarantee: 1951419879
+                mem_limit: 1951419879
+                cpu_guarantee: 0.22815625
+                cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-              default: true
-            mem_3_7:
-              display_name: 3.7 GB RAM, upto 3.7 CPUs
+            mem_4_gb:
+              display_name: ~4 GB RAM, ~0.5 CPUs
+              description: Up to ~4 CPUs when available
               allowed_groups:
               - CPU:S
               kubespawner_override:
-                mem_guarantee: 3982489550
-                mem_limit: 3982489550
-                cpu_guarantee: 0.465625
-                cpu_limit: 3.725
+                mem_guarantee: 3902839759
+                mem_limit: 3902839759
+                cpu_guarantee: 0.4563125
+                cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_7_4:
-              display_name: 7.4 GB RAM, upto 3.7 CPUs
+            mem_7_gb:
+              display_name: ~7 GB RAM, ~0.9 CPUs
+              description: Up to ~4 CPUs when available
               allowed_groups:
               - CPU:M
               kubespawner_override:
-                mem_guarantee: 7964979101
-                mem_limit: 7964979101
-                cpu_guarantee: 0.93125
-                cpu_limit: 3.725
+                mem_guarantee: 7805679519
+                mem_limit: 7805679519
+                cpu_guarantee: 0.912625
+                cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_14_8:
-              display_name: 14.8 GB RAM, upto 3.7 CPUs
+            mem_15_gb:
+              display_name: ~15 GB RAM, ~1.8 CPUs
+              description: Up to ~4 CPUs when available
               allowed_groups:
               - CPU:L
               kubespawner_override:
-                mem_guarantee: 15929958203
-                mem_limit: 15929958203
-                cpu_guarantee: 1.8625
-                cpu_limit: 3.725
+                mem_guarantee: 15611359038
+                mem_limit: 15611359038
+                cpu_guarantee: 1.82525
+                cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_29_7:
-              display_name: 29.7 GB RAM, upto 3.7 CPUs
+            mem_29_gb:
+              display_name: ~29 GB RAM, ~4 CPUs
+              description: ~4 CPUs always available
               allowed_groups:
               - CPU:XL
               kubespawner_override:
-                mem_guarantee: 31859916406
-                mem_limit: 31859916406
-                cpu_guarantee: 3.725
-                cpu_limit: 3.725
+                mem_guarantee: 31222718077
+                mem_limit: 31222718077
+                cpu_guarantee: 3.6505
+                cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
-            mem_60_6:
-              display_name: 60.6 GB RAM, upto 15.6 CPUs
+            mem_60_gb:
+              display_name: ~60 GB RAM, ~8 CPUs
+              description: Up to ~15 CPUs when available
               allowed_groups:
               - CPU:XXL
               kubespawner_override:
-                mem_guarantee: 65094448840
-                mem_limit: 65094448840
-                cpu_guarantee: 7.8475
-                cpu_limit: 15.695
+                mem_guarantee: 64020707016
+                mem_limit: 64020707016
+                cpu_guarantee: 7.69055
+                cpu_limit: 15.3811
                 node_selector:
                   node.kubernetes.io/instance-type: r5.4xlarge
-            mem_121_2:
-              display_name: 121.2 GB RAM, upto 15.6 CPUs
+            mem_119_gb:
+              display_name: ~119 GB RAM, ~15 CPUs
+              description: ~15 CPUs always available
               allowed_groups:
               - CPU:XXXL
               kubespawner_override:
-                mem_guarantee: 130188897681
-                mem_limit: 130188897681
-                cpu_guarantee: 15.695
-                cpu_limit: 15.695
+                mem_guarantee: 128041414033
+                mem_limit: 128041414033
+                cpu_guarantee: 15.3811
+                cpu_limit: 15.3811
                 node_selector:
                   node.kubernetes.io/instance-type: r5.4xlarge
     - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs


### PR DESCRIPTION
Regenerated with `deployer generate resource-allocation choices r5.xlarge:5 r5.4xlarge:2`

Without this, the server sizes that account for an entire node ask for more memory / cpu than is available on those nodes, causing spawn failures.