### PR TITLE
[2i2c, temple] Delete temple legacy disk

### DIFF
--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -36,10 +36,6 @@ persistent_disks = {
     size        = 75 # in GB
     name_suffix = "mtu"
   },
-  "temple" = {
-    size        = 2100 # in GB
-    name_suffix = "temple"
-  },
   "ucmerced-staging" = {
     size        = 10 # in GB
     name_suffix = "ucmerced-staging"


### PR DESCRIPTION
It's been several weeks since the migration now, and we've had no reports of missing data. The disk has been deleted. Closes #7175 