### PR TITLE
maap: Set max session timeout to 12hr

### DIFF
--- a/terraform/aws/projects/maap.tfvars
+++ b/terraform/aws/projects/maap.tfvars
@@ -21,6 +21,7 @@ user_buckets = {
 hub_cloud_permissions = {
   "staging" : {
     bucket_admin_access : ["scratch-staging"],
+    max_session_duration : 12 * 60 * 60, # 12 hr max
     extra_iam_policy : <<-EOT
       {
         "Version": "2012-10-17",
@@ -96,6 +97,7 @@ hub_cloud_permissions = {
   },
   "prod" : {
     bucket_admin_access : ["scratch-prod"],
+    max_session_duration : 12 * 60 * 60, # 12 hr max
     extra_iam_policy : <<-EOT
       {
         "Version": "2012-10-17",

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -72,6 +72,8 @@ variable "hub_cloud_permissions" {
      permissions to.
   3. extra_iam_policy: An AWS IAM Policy document that grants additional rights
      to this Kubernetes Service Account.
+  4. max_session_duration: Duration (in seconds) after which AWS session tokens expire.
+     Maximum of 12 hours.
 
   EOT
 }


### PR DESCRIPTION
Requested for their S3 mounts to work. This is a temporary bandaid while a longer term solution is worked out.