### PR TITLE
update image tags

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -90,7 +90,7 @@ jupyterhub:
               display_name: R - Positron - latest
               slug: positron
               kubespawner_override:
-                image: ghcr.io/nmfs-opensci/container-images/psaw-workshop:latest                
+                image: ghcr.io/nmfs-opensci/container-images/psaw-workshop:latest
             python:
               display_name: Py - NASA Openscapes, Dask Gateway + GCS 65d6916
               slug: python


### PR DESCRIPTION
* move py-rocket-geospatial-2 so it appears at top
* move upcoming workshops to be 2nd and 3rd
* update the ML images to 2025.12.30