### PR TITLE
[deployer] Fix cmd defaults

### DIFF
--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -62,7 +62,7 @@ def deploy_support(
     Deploy support components to a cluster
     """
     validate_cluster_config(cluster_name)
-    validate_support_config(cluster_name)
+    validate_support_config(cluster_name, False, False)
 
     cluster = Cluster.from_name(cluster_name)
 

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -236,9 +236,10 @@ def validate_authenticator_config(
 @validate_app.command()
 def support_config(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
-    debug: bool = typer.Option(False, "--debug", help="Enable verbose output"),
+    debug: bool = typer.Option(False, help="Enable verbose output"),
     skip_refresh: bool = typer.Option(
-        False, "--skip-refresh", help="Skip the helm dep update"
+        False,
+        help="Skip the helm dep update",
     ),
 ):
     """
@@ -315,10 +316,8 @@ def cluster_config(
 def all_hub_config(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(None, help="Name of hub to operate on"),
-    skip_refresh: bool = typer.Option(
-        False, "--skip-refresh", help="Skip the helm dep update"
-    ),
-    debug: bool = typer.Option(False, "--debug", help="Enable verbose output"),
+    skip_refresh: bool = typer.Option(False, help="Skip the helm dep update"),
+    debug: bool = typer.Option(False, help="Enable verbose output"),
 ):
     """
     Validates the provided non-encrypted helm chart values files and the


### PR DESCRIPTION
The defaults were not being picked up correctly when running the validate cmds from the cli.

Also, even if they're correctly set for the cli, when called from the deploy function they're still not there, so we're setting them explicitly to False in the deploy-support cmd.

Ref https://github.com/2i2c-org/infrastructure/actions/runs/20915802401