### PR TITLE
[cost-monitoring] Downsize pod memory limits

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -430,7 +430,7 @@ jupyterhub-cost-monitoring:
   resources:
   limits:
     cpu: 800m
-    memory: 500Gi
+    memory: 500Mi
   requests:
     cpu: 5m
     memory: 100Mi


### PR DESCRIPTION
I think memory pressure from a spike in the cost-monitoring backend could kick out the grafana server pod.

Ref https://2i2c-org.pagerduty.com/incidents/Q264D5BX38XV7K