### PR TITLE
[leap, *] Enable L4 and A100 GPUs

### DIFF
--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -403,6 +403,19 @@ basehub:
                   extra_resource_limits:
                     nvidia.com/gpu: '1'
 
+              nvidia_a100:
+                display_name: NVIDIA A100 [40GB VRAM], ~85GB RAM, 12 CPUs
+                kubespawner_override:
+                  node_selector:
+                    node.kubernetes.io/instance-type: a2-highgpu-1g
+                    cloud.google.com/gke-accelerator: nvidia-tesla-a100
+                  environment:
+                    NVIDIA_DRIVER_CAPABILITIES: compute,utility
+                  mem_guarantee: 70G
+                  mem_limit: 82G
+                  extra_resource_limits:
+                    nvidia.com/gpu: '1'
+
           image:
             display_name: Image
             unlisted_choice: *profile_list_unlisted_choice

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -159,6 +159,24 @@ notebook_nodes = {
       "us-central1-c",
     ]
   },
+  "gpu-a100-a" : {
+    min : 0,
+    max : 100,
+    machine_type : "a2-highgpu-1g",
+    gpu : {
+      enabled : true,
+      type : "nvidia-tesla-a100",
+      count : 1
+    },
+    zones : [
+      # Get GPUs wherever they are available, as sometimes a single
+      # zone might be out of GPUs.
+      "us-central1-a",
+      "us-central1-b",
+      "us-central1-c",
+      "us-central1-f",
+    ]
+  },
 }
 
 # Setup a single node pool for dask workers.


### PR DESCRIPTION
This PR theoretically exposes L4 GPU and A100 GPU configurations (with more VRAM) to the hub. 

L4 GPUs are much cheaper than A100s, but unfortunately, over the last couple of days, I've not been able to provision L4 GPUs at all, which suggests that they might be scarce.

There's context for this change in the linked issue.