### PR TITLE
[leap, *] Update hub logo

### DIFF
--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -44,7 +44,7 @@ basehub:
           org:
             name: LEAP
             url: https://leap-stc.github.io
-            logo_url: https://leap-stc.github.io/_static/LEAP_logo.png
+            logo_url: https://raw.githubusercontent.com/leap-stc/leap-stc.github.io/refs/heads/main/docs/assets/NSF_LEAP_joint_logo.svg
           designed_by:
             name: 2i2c
             url: https://2i2c.org


### PR DESCRIPTION
I noticed it was broken, and took the logo from https://leap-stc.github.io/