### PR TITLE
maap: Staging now points to uat api

### DIFF
--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -14,7 +14,7 @@ jupyterhub:
   singleuser:
     extraEnv:
       SCRATCH_BUCKET: s3://maap-scratch-staging/$(JUPYTERHUB_USER)
-      MAAP_API_HOST: api.dit.maap-project.org
+      MAAP_API_HOST: api.uat.maap-project.org
       WORKSPACE_BUCKET: maap-staging-workspace
       DOCKERIMAGE_PATH_DEFAULT: mas.dit.maap-project.org/root/maap-workspaces/custom_images/maap_base:develop
       DOCKERIMAGE_PATH_BASE_IMAGE: $(JUPYTER_IMAGE)


### PR DESCRIPTION
We agreed this makes the most sense in a meeting for users who want to start working with OGC
DIT API is not stable enough for staging to have users 