### PR TITLE
Revert "[CloudBank] Update CCSF Image"

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -12,7 +12,7 @@ jupyterhub:
       limit: 1.5G
     image:
       name: quay.io/ccsf/jupyterhub
-      tag: sp26
+      tag: fa25
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#7421.

Preventing user servers to start. See https://2i2c.slack.com/archives/C0A9ZE8L472.
cc @sean-morris 