### PR TITLE
[utoronto] Upgrade node pools to 1.34

### DIFF
--- a/terraform/azure/cluster.tf
+++ b/terraform/azure/cluster.tf
@@ -110,6 +110,7 @@ resource "azurerm_kubernetes_cluster" "jupyterhub" {
 
     vnet_subnet_id = azurerm_subnet.node_subnet.id
 
+    temporary_name_for_rotation = "coretemppool"
     upgrade_settings {
       # If this is unset, it will force a new resource to be created
       # This is set to the current value on utoronto

--- a/terraform/azure/projects/utoronto.tfvars
+++ b/terraform/azure/projects/utoronto.tfvars
@@ -46,11 +46,11 @@ node_pools = {
 
       min : 1,
       max : 10,
-      kubernetes_version = "1.33.2"
     },
   ],
 
   user : [
+    # FIXME: tainted, to be deleted when empty, replaced by equivalent during k8s upgrade
     {
       name : "usere8sv5c",
       vm_size : "Standard_E8s_v5",
@@ -59,6 +59,14 @@ node_pools = {
       min : 1,
       max : 20,
       kubernetes_version = "1.33.2"
+    },
+    {
+      name : "usere8sv5d",
+      vm_size : "Standard_E8s_v5",
+      os_disk_size_gb : 200,
+      kubelet_disk_type : "OS",
+      min : 1,
+      max : 20,
     },
   ],
 


### PR DESCRIPTION
This PR upgrades the core and user node pools to 1.34. It also sets `temporary_name_for_rotation` so that future tweaks that require a recreation of the core pool are less problematic.

We need to follow up and destroy the tainted nodepool.

Closes https://github.com/2i2c-org/infrastructure/issues/7306