### PR TITLE
Add homedir archive bucket to NMFS-openscapes

### DIFF
--- a/terraform/aws/projects/nmfs-openscapes.tfvars
+++ b/terraform/aws/projects/nmfs-openscapes.tfvars
@@ -7,6 +7,7 @@ default_budget_alert = {
 }
 
 enable_jupyterhub_cost_monitoring = true
+enable_jupyterhub_cost_tags       = true
 
 disable_cluster_wide_filestore = true
 ebs_volumes = {

--- a/terraform/aws/projects/nmfs-openscapes.tfvars
+++ b/terraform/aws/projects/nmfs-openscapes.tfvars
@@ -59,8 +59,8 @@ user_buckets = {
     "tags" : { "2i2c:hub-name" : "noaa-only" },
   },
   "prod-homedirs-archive" : {
-  "archival_storageclass_after" : 3,
-  "delete_after" : 185,
+    "archival_storageclass_after" : 3,
+    "delete_after" : 185,
   }
 }
 

--- a/terraform/aws/projects/nmfs-openscapes.tfvars
+++ b/terraform/aws/projects/nmfs-openscapes.tfvars
@@ -58,6 +58,10 @@ user_buckets = {
     "delete_after" : 7,
     "tags" : { "2i2c:hub-name" : "noaa-only" },
   },
+  "prod-homedirs-archive" : {
+  "archival_storageclass_after" : 3,
+  "delete_after" : 185,
+  }
 }
 
 hub_cloud_permissions = {


### PR DESCRIPTION
This adds a home directory archive bucket to the NMFS prod environment, based on the model for NASA-Openscapes (https://github.com/2i2c-org/infrastructure/blob/4efe1457efd49a3f2d9196a738c0873c110d4e40/terraform/aws/projects/openscapeshub.tfvars#L53-L56). Please let me know if there is a more formal process I should go through to request this.

Thanks!