### PR TITLE
[Terraform] Update File to Handle REGULAR Channel Not Existing

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -14,9 +14,12 @@ data "google_container_engine_versions" "k8s_version_prefixes" {
   for_each       = var.k8s_version_prefixes
   version_prefix = each.value
 }
+
 output "regular_channel_latest_k8s_versions" {
   value = {
-    for k, v in data.google_container_engine_versions.k8s_version_prefixes : k => v.release_channel_latest_version["REGULAR"]
+    for k, v in data.google_container_engine_versions.k8s_version_prefixes :
+    k => try(v.release_channel_latest_version["REGULAR"], null)
+    if contains(keys(v.release_channel_latest_version), "REGULAR")
   }
 }
 


### PR DESCRIPTION
@yuvipanda I needed to added this condition to handle channels that did not the REGULAR key.

The error I was getting was this:
```
  on cluster.tf line 19, in output "regular_channel_latest_k8s_versions":
  19:     for k, v in data.google_container_engine_versions.k8s_version_prefixes : k => v.release_channel_latest_version["REGULAR"]
    ├────────────────
    │ v.release_channel_latest_version is map of string with 1 element
```

Here is sample output where you can see "REGULAR" is missing from the keys on version 1.31
```
+ debug_k8s_versions                  = {
      + "1."    = {
          + EXTENDED = "1.34.1-gke.3971001"
          + RAPID    = "1.35.0-gke.1795000"
          + REGULAR  = "1.34.1-gke.3971001"
          + STABLE   = "1.33.5-gke.2072000"
        }
      + "1.31." = {
          + EXTENDED = "1.31.14-gke.1243000"
        }
      + "1.32." = {
          + EXTENDED = "1.32.9-gke.1734000"
          + RAPID    = "1.32.11-gke.1075000"
          + REGULAR  = "1.32.9-gke.1734000"
          + STABLE   = "1.32.9-gke.1711000"
        }
    }
  ~ persistent_disk_id_map              = {
      + hub-nfs-homedirs-mmc          = (known after apply)
        # (58 unchanged attributes hidden)
    }
  ~ regular_channel_latest_k8s_versions = {
      ~ "1."    = "1.34.1-gke.3947000" -> "1.34.1-gke.3971001"
      - "1.31." = "1.31.14-gke.1166000"
      ~ "1.32." = "1.32.9-gke.1728000" -> "1.32.9-gke.1734000"
    }
```