### PR TITLE
[earthscope, *] Refactor authenticator configuration

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -61,8 +61,9 @@ basehub:
 
           c.Spawner.auth_state_hook = populate_token
 
-          c.JupyterHub.authenticator_class = GenericOAuthenticator
       config:
+        JupyterHub:
+          authenticator_class: generic-oauth
         GenericOAuthenticator:
           allowed_scopes:
             # This allows EarthScope to control who can login to the hub


### PR DESCRIPTION
The Earthscope hub has some bespoke configuration logic that we've since upstreamed in 
- https://github.com/jupyterhub/oauthenticator/pull/719/changes
- https://github.com/jupyterhub/oauthenticator/pull/735/changes

In order to simplify the administration of this hub, we should remove it.