### PR TITLE
[projectpythia-binder] Add temporary fix for node purpose

### DIFF
--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -120,11 +120,14 @@ binderhub-service:
       - binder.projectpythia.org
   dockerApi:
     nodeSelector:
-      hub.jupyter.org/node-purpose:
       capi.stackhpc.com/node-group: user-m3-large
     storage:
       emptyDir:
         sizeLimit: 15Gi
+  extraConfig:
+    00-temp-fix-selector.py: |
+      if isinstance(c.KubernetesBuildExecutor.node_selector, dict):
+        c.KubernetesBuildExecutor.node_selector.pop("hub.jupyter.org/node-purpose", None)
   config:
     GitHubRepoProvider:
       allowed_specs:


### PR DESCRIPTION
For some reason, the `node-purpose` selector is being added to the builder pods as `''`, which appears distinct from `null`. We set this to `null` in our config, but it appears that the BinderHub service does not filter out null values.

I'm not sure _why_ this is suddenly failing now, but this workaround simply deletes the selector. I haven't tested what happens if we remove the line altogether -- I was short for time and made an assumption that we're overriding the base configuration.