### PR TITLE
Add docs about using bitwarden send for sharing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,8 @@ cython_debug/
 
 # osx
 .DS_Store
+
+cloudbank_hub_setup_guide.md
+
+# A documentation file with 'secrets' is hard
+!send-secrets.md

--- a/docs/howto/send-secrets.md
+++ b/docs/howto/send-secrets.md
@@ -1,0 +1,12 @@
+# Sending Secrets to communities
+
+Sometimes we may want to send secret keys or other sensitive information to our
+communities. The easiest way to do this is to use [bitwarden send](https://bitwarden.com/products/send/).
+It lets you create a secret link you can send to the community with an expiry date.
+Set it to expire no later than 7 days, and let the community know they need to access it
+before then.
+
+You can access Bitwarden Send [here](https://vault.bitwarden.com/#/sends) after logging in.
+
+An alternative is to ask the community to setup [age](https://github.com/FiloSottile/age),
+and give us their public key. This is a bit more secure, but harder than using Bitwarden Send.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ howto/manage-alerts/index.md
 howto/grafana-github-auth.md
 howto/regenerate-smce-creds.md
 howto/troubleshoot/index.md
+howto/send-secrets.md
 ```
 
 ## Topic guides


### PR DESCRIPTION
I learnt from https://github.com/2i2c-org/infrastructure/issues/7392 that they were waiting for `age` setup on their side, to wrap up https://github.com/2i2c-org/infrastructure/issues/7304.

Document that we can use bitwarden send too for things like that, as that may be easier.