### PR TITLE
[cloudbank] Upgrade GKE version to 1.34

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -286,6 +286,7 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
+  # TODO: remove this if it's empty in future.
   "n2-highmem-4-b" : {
     min : 0,
     max : 100,


### PR DESCRIPTION
This PR is part of #7397

> [!Note]
> I've left the old nodepool with a `NO_SCHEDULE` taint, so we'll clean that up down the road.