### PR TITLE
[2i2c-aws-us, showcase] Fix GPU plugin

### DIFF
--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -42,3 +42,8 @@ redirects:
 
 calico:
   enabled: true
+
+# FIXME: remove this once eksctl is fixed
+nvidiaDevicePlugin:
+  aws:
+    enabled: true


### PR DESCRIPTION
This enables the GPU plugin on showcase, an AWS deployment. I noticed that we didn't have this enabled despite having made the EKS upgrades.