### PR TITLE
[nasa-cryo] Upgrade node pools to set `singleProcessOOMKill`

### DIFF
--- a/eksctl/nasa-cryo.jsonnet
+++ b/eksctl/nasa-cryo.jsonnet
@@ -23,6 +23,7 @@ local c = cluster.makeCluster(
       instanceType: 'g4dn.xlarge',
     },
   ],
-  nodeGroupGenerations=['f']
+  // TODO: remove `f` once user nodes are empty
+  nodeGroupGenerations=['f', 'g']
 );
 c


### PR DESCRIPTION
Part of #7568 

I've left generation `f` in play whilst we have non-empty user pools. See the parent initiative for cleaning this up.