### PR TITLE
[victor] Upgrade node pools to set `singleProcessOOMKill`

### DIFF
--- a/eksctl/victor.jsonnet
+++ b/eksctl/victor.jsonnet
@@ -26,6 +26,6 @@ local c = cluster.makeCluster(
       instanceType: 'g4dn.xlarge',
     },
   ],
-  nodeGroupGenerations=['b']
+  nodeGroupGenerations=['b', 'c']
 );
 c


### PR DESCRIPTION
Part of #7568

I've left generation b in play whilst we have non-empty user pools. See the parent initiative for cleaning this up.
