### PR TITLE
[nmfs-openscapes] Upgrade node pools to set `singleProcessOOMKill`

### DIFF
--- a/eksctl/nmfs-openscapes.jsonnet
+++ b/eksctl/nmfs-openscapes.jsonnet
@@ -24,7 +24,7 @@ local c = cluster.withNodeGroupConfigOverride(
         instanceType: 'g4dn.xlarge',
       },
     ],
-    nodeGroupGenerations=['a', 'b'],
+    nodeGroupGenerations=['b', 'c'],
   ),
   kind='core',
   overrides={ maxSize: 2 }


### PR DESCRIPTION
Part of #7568

I've left generation b in play whilst we have non-empty user pools. See the parent initiative for cleaning this up.
