### PR TITLE
[temple] Upgrade node pools to set `singleProcessOOMKill`

### DIFF
--- a/eksctl/temple.jsonnet
+++ b/eksctl/temple.jsonnet
@@ -18,7 +18,7 @@ local c = cluster.withNodeGroupConfigOverride(
         instanceType: 'g4dn.xlarge',
       },
     ],
-    nodeGroupGenerations=['a']
+    nodeGroupGenerations=['a', 'b']
   ),
   kind='core',
   overrides={ maxSize: 2 }


### PR DESCRIPTION
Part of #7568

I've left generation b in play whilst we have non-empty user pools. See the parent initiative for cleaning this up.
