### PR TITLE
Update to pangeo-notebook-veda-image:2025.12.30-v1

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -115,7 +115,7 @@ jupyterhub:
               display_name: Modified Pangeo Notebook
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v2
+                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.12.30-v1
                 init_containers:
                 # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
                 # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -209,7 +209,7 @@ jupyterhub:
               display_name: Modified Pangeo Notebook
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v2
+                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.12.30-v1
                 init_containers:
                 # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
                 # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init

--- a/config/clusters/nasa-ghg-hub/common.values.yaml
+++ b/config/clusters/nasa-ghg-hub/common.values.yaml
@@ -94,7 +94,7 @@ basehub:
                 display_name: Modified Pangeo Notebook
                 description: Pangeo based notebook with a Python environment
                 kubespawner_override:
-                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v2
+                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.12.30-v1
                   init_containers:
                   - name: jupyterhub-gitpuller-init
                     image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -132,7 +132,7 @@ basehub:
                 display_name: Modified Pangeo Notebook
                 description: Pangeo based notebook with a Python environment
                 kubespawner_override:
-                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.08.14-v2
+                  image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.12.30-v1
                   init_containers:
                   # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
                   # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init


### PR DESCRIPTION
This PR updates all NASA-IMPACT hubs to contain pangeo notebook images based off of 2025.12.30 as requested in https://github.com/NASA-IMPACT/veda-analytics/issues/192

I think it's still @wildintellect, @smk0033, and @freitagb who represent the various hubs and will be able to say whether this is a good time for an update or whether we want to hold off for a workshop or something.

Note that I am pretty sure MAAP doesn't actually use most of what's in common-values. They have overrides for everything in https://github.com/2i2c-org/infrastructure/blob/e5e2c988ecfb52aeb1abcb06880afee633a23a4e/config/clusters/maap/prod.values.yaml#L42-L46