### PR TITLE
[CloudBank] Staging Submit/Collect Shares

### DIFF
--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -16,22 +16,22 @@ jupyterhub:
       tag: sp26.4
     storage:
       extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/submit
-          subPath: _shared-private/{escaped_username}
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
-          readOnly: true
-        - name: dev-shm
-          mountPath: /dev/shm
-        - name: home
-          mountPath: /home/rstudio
-          subPath: "{escaped_username}"
-        - name: home
-          mountPath: /home/rstudio/shared
-          subPath: _shared
-          readOnly: true
+      - name: home
+        mountPath: /home/jovyan/submit
+        subPath: _shared-private/{escaped_username}
+      - name: home
+        mountPath: /home/jovyan/shared
+        subPath: _shared
+        readOnly: true
+      - name: dev-shm
+        mountPath: /dev/shm
+      - name: home
+        mountPath: /home/rstudio
+        subPath: '{escaped_username}'
+      - name: home
+        mountPath: /home/rstudio/shared
+        subPath: _shared
+        readOnly: true
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
@@ -53,15 +53,15 @@ jupyterhub:
           url: https://2i2c.org
     singleuserAdmin:
       extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/collect
-          subPath: _shared-private
-        - name: home
-          mountPath: /home/jovyan/shared-readwrite
-          subPath: _shared
-        - name: home
-          mountPath: /home/rstudio/shared-readwrite
-          subPath: _shared
+      - name: home
+        mountPath: /home/jovyan/collect
+        subPath: _shared-private
+      - name: home
+        mountPath: /home/jovyan/shared-readwrite
+        subPath: _shared
+      - name: home
+        mountPath: /home/rstudio/shared-readwrite
+        subPath: _shared
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
I'm setting up a "submit/collect" workflow for the East Tennessee hub.

**The Setup:**
- Students: Can drop files into a "submit" folder but have zero visibility into other files in the underlying _shared-private mount.
- Instructors: Have a "collect" folder with full access to everyone's subfolders.

**Issues**
- All instructors see all student folders; ETSU only has one instructor so this is not a problem yet.
- Folder names are the full CILogon email addresses. (I’m not sure yet if I can strip the domain to keep the folder names cleaner).

I'm going to deploy this for ETSU to give it a try - do you see problems with how I handled all this?