### PR TITLE
Add liveness probe configuration to common.values.yaml

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -164,6 +164,11 @@ jupyterhub:
       securityContext:
         privileged: true
       livenessProbe:
+        # This automatically restarts just this container every 45 minutes
+        # This is a *temporary* workaround, with a present expiry date of Feb 23, 2026
+        # The date must be extended, or a different workaround must be found, or something
+        # else must be agreed to by that date.
+        # See https://github.com/2i2c-org/infrastructure/pull/7601 for more information
         exec:
           command:
           - sh


### PR DESCRIPTION
## Add Liveness Probe to S3FS Sidecar Container for Automatic Credential Refresh

### Problem
The MAAP s3fs sidecar container loses access to S3 buckets after approximately 1 hour due to AWS session credential expiration in EKS environments using IRSA (IAM Roles for Service Accounts).

###  Root Cause
- **IRSA Token vs Session Credentials**: While the IRSA web identity token is valid for ~24 hours, the STS session credentials derived from it expire after 1 hour by default
- **s3fs-fuse Limitation**: s3fs-fuse does not support automatic credential refresh with IRSA - it uses the credentials provided at mount time and has no mechanism to refresh them
- **Mount Propagation Issue**: Attempting to unmount and remount S3 buckets within the running container breaks Kubernetes mount propagation, causing the mounts to disappear from the JupyterHub container

### Solution
Add a liveness probe that monitors a sentinel file (/tmp/active) which the container removes after 45 minutes, triggering an automatic restart with fresh credentials.

### Alternative Approaches Considered
- In-place credential refresh: Not supported by s3fs-fuse with IRSA
- Remounting without restart: Breaks Kubernetes mount propagation
- mount-s3 (AWS Mountpoint): Doesn't support file rename/move operations required by JupyterHub
- Direct container termination: Protected PID 1 prevents internal kill 1 command