### PR TITLE
Add liveness probe to container configuration

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -173,7 +173,7 @@ jupyterhub:
           command:
           - sh
           - -c
-          - "[ -f /tmp/active ]"
+          - '[ -f /tmp/active ]'
         initialDelaySeconds: 60
         periodSeconds: 5
         failureThreshold: 1


### PR DESCRIPTION
This resolves the CI error from the previous PR: https://github.com/2i2c-org/infrastructure/pull/7601