### PR TITLE
Remove subPath for volume mounts in MAAP's common.values.yaml

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -139,22 +139,18 @@ jupyterhub:
         readOnly: true
       - name: s3fs-volume
         mountPath: /home/jovyan/my-private-bucket
-        subPath: my-private-bucket
         mountPropagation: HostToContainer
         readOnly: false
       - name: s3fs-volume
         mountPath: /home/jovyan/my-public-bucket
-        subPath: my-public-bucket
         mountPropagation: HostToContainer
         readOnly: false
       - name: s3fs-volume
         mountPath: /home/jovyan/shared-buckets
-        subPath: shared-buckets
         mountPropagation: HostToContainer
         readOnly: true
       - name: s3fs-volume
         mountPath: /home/jovyan/triaged-jobs
-        subPath: triaged-jobs
         mountPropagation: HostToContainer
         readOnly: true
     extraContainers:
@@ -163,20 +159,6 @@ jupyterhub:
       image_pull_policy: Always
       securityContext:
         privileged: true
-      livenessProbe:
-        # This automatically restarts just this container every 45 minutes
-        # This is a *temporary* workaround, with a present expiry date of Feb 23, 2026
-        # The date must be extended, or a different workaround must be found, or something
-        # else must be agreed to by that date.
-        # See https://github.com/2i2c-org/infrastructure/pull/7601 for more information
-        exec:
-          command:
-          - sh
-          - -c
-          - '[ -f /tmp/active ]'
-        initialDelaySeconds: 60
-        periodSeconds: 5
-        failureThreshold: 1
       resources:
         limits:
           memory: 512Mi
@@ -189,19 +171,15 @@ jupyterhub:
       volumeMounts:
       - name: s3fs-volume
         mountPath: /my-public-bucket
-        subPath: my-public-bucket
         mountPropagation: Bidirectional
       - name: s3fs-volume
         mountPath: /my-private-bucket
-        subPath: my-private-bucket
         mountPropagation: Bidirectional
       - name: s3fs-volume
         mountPath: /shared-buckets
-        subPath: shared-buckets
         mountPropagation: Bidirectional
       - name: s3fs-volume
         mountPath: /triaged-jobs
-        subPath: triaged-jobs
         mountPropagation: Bidirectional
     profileList:
     - display_name: Choose your environment and resources


### PR DESCRIPTION
Removed subPath entries for several volume mounts in the MAAP common.values.yaml file.

This change removes subPath usage for s3fs FUSE mounts, which caused nested directory artifacts in JupyterLab.

Mounting directly to the volume root resolves the duplication while preserving mount propagation and path layout.