### PR TITLE
[catalystproject-*] Disable ingress

### DIFF
--- a/config/clusters/catalystproject-africa/common.values.yaml
+++ b/config/clusters/catalystproject-africa/common.values.yaml
@@ -30,6 +30,8 @@ jupyterhub:
         org:
           url: https://catalystproject.cloud/
           logo_url: https://catalystproject.cloud/_images/catalyst-icon-dark.png
+  ingress:
+    enabled: false
   singleuser:
     profileList:
     - display_name: Jupyter SciPy Notebook

--- a/config/clusters/catalystproject-latam/common.values.yaml
+++ b/config/clusters/catalystproject-latam/common.values.yaml
@@ -27,6 +27,8 @@ jupyterhub:
           logo_url: https://catalystproject.cloud/_static/catalyst-logo-dark-bg-white.png
   hub:
     allowNamedServers: true
+  ingress:
+    enabled: false
   singleuser:
     profileList:
     - display_name: Jupyter SciPy Notebook


### PR DESCRIPTION
Closes #7565 by disabling the hub ingresses, and setting up NGINX to redirect:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
    nginx.ingress.kubernetes.io/temporal-redirect: https://2i2c.org/catalyst-project-placeholder/
  name: ingress-redirect-wildcard
  namespace: temporary-redirect
spec:
  ingressClassName: nginx
  rules:
  - host: '*.af.catalystproject.2i2c.cloud'
  tls:
  - hosts:
    - staging.af.catalystproject.2i2c.cloud
    - nm-aist.af.catalystproject.2i2c.cloud
    - must.af.catalystproject.2i2c.cloud
    - uvri.af.catalystproject.2i2c.cloud
    - wits.af.catalystproject.2i2c.cloud
    - kush.af.catalystproject.2i2c.cloud
    - molerhealth.af.catalystproject.2i2c.cloud
    - aibst.af.catalystproject.2i2c.cloud
    - bhki.af.catalystproject.2i2c.cloud
    - bon.af.catalystproject.2i2c.cloud
    secretName: tls-secret-wildcard

```