### PR TITLE
[catalystproject-latam, labi] Restore labi hub

### DIFF
--- a/config/clusters/catalystproject-latam/labi.values.yaml
+++ b/config/clusters/catalystproject-latam/labi.values.yaml
@@ -4,6 +4,7 @@ jupyterhub:
     tls:
     - hosts: [labi.latam.catalystproject.2i2c.cloud]
       secretName: https-auto-tls
+    enabled: true
   custom:
     homepage:
       templateVars:


### PR DESCRIPTION
This re-enables the ingress for labi. I've manually deployed this.