### PR TITLE
Update list of teams corresponding to a shared folder

### DIFF
--- a/config/clusters/bnext-bio/common.values.yaml
+++ b/config/clusters/bnext-bio/common.values.yaml
@@ -52,6 +52,8 @@ jupyterhub:
         - nucleus-eng:devcells-all-nodes
         - nucleus-eng:devcells-chicago-node
         - nucleus-eng:devcells-london-node
+        - nucleus-eng:bnext
+        - nucleus-eng:metapure
       Authenticator:
         admin_users:
         - antonjs


### PR DESCRIPTION
This PR requests that a shared folder on the bnext hub (Nucleus Hub) be created for the following two teams in the nucleus-eng org:

- metapure (https://github.com/orgs/nucleus-eng/teams/metapure)
- bnext (https://github.com/orgs/nucleus-eng/teams/bnext)