### PR TITLE
Setup nginx-ingress in addition to ingress-nginx

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -30,6 +30,14 @@ dependencies:
     version: 4.14.3
     repository: https://kubernetes.github.io/ingress-nginx
 
+  # This is the ingress maintained by nginx, rather than the one maintained by the
+  # kubernetes community. We switch to this to have least potential disruption
+  # possible, until we eventually perhaps move to the Gateway API someday
+  - name: nginx-ingress
+    version: 2.4.4
+    repository: oci://ghcr.io/nginx/charts
+    condition: nginx-ingress.enabled
+
   # cluster-autoscaler for k8s clusters where it doesn't come out of the box (EKS)
   # https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler
   - name: cluster-autoscaler

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -23,6 +23,9 @@ properties:
   ingress-nginx:
     type: object
     additionalProperties: true
+  nginx-ingress:
+    type: object
+    additionalProperties: true
   prometheus:
     type: object
     additionalProperties: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -14,6 +14,21 @@
 cluster-autoscaler:
   enabled: false
 
+nginx-ingress:
+  # Disable this by default
+  enabled: false
+  controller:
+    # Don't enable any custom resource definitions, as that just makes our lives hard for no reason
+    enableCustomResources: false
+    appprotect:
+      enable: false
+    appprotectdos:
+      enable: false
+
+    # Get this ingressClass a different name, so we can co-exist with ingress-nginx
+    ingressClass:
+      name: nginx-ingress
+
 # ingress-nginx is responsible for proxying traffic based on k8s Ingress
 # resources defined in the k8s cluster.
 #


### PR DESCRIPTION
Such is life, one supposes. Thank you for everything, ingress-nginx.

This doesn't turn it on anywhere, only allows it to be.

Ref https://github.com/2i2c-org/infrastructure/issues/7106