### PR TITLE
Deploy ingress-nginx as a submodule

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -70,6 +70,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - uses: actions/setup-python@v6
       with:
@@ -249,6 +251,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Setup deploy for ${{ matrix.jobs.cluster_name }}
       uses: ./.github/actions/setup-deploy
@@ -482,6 +486,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
       uses: ./.github/actions/setup-deploy
@@ -620,6 +626,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
       uses: ./.github/actions/setup-deploy

--- a/.github/workflows/validate-clusters.yaml
+++ b/.github/workflows/validate-clusters.yaml
@@ -97,6 +97,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
@@ -228,6 +230,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: true
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "helm-charts/ingress-nginx"]
+	path = helm-charts/ingress-nginx
+	url = https://github.com/kubernetes/ingress-nginx

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
   - name: ingress-nginx
     version: 4.14.3
-    repository: https://kubernetes.github.io/ingress-nginx
+    repository: file://../ingress-nginx/charts/ingress-nginx/
 
   # This is the ingress maintained by nginx, rather than the one maintained by the
   # kubernetes community. We switch to this to have least potential disruption


### PR DESCRIPTION
This lets us:

1. Modify the template to pass on different label selectors to the service (https://github.com/2i2c-org/infrastructure/issues/7106#issuecomment-3929540075)
2. Point the submodule to a fork we maintain temporarily (with just the modified template)
3. Still bring in any final security fixes or similar we will have for ingress-nginx for the duration of its lifetime

Ref https://github.com/2i2c-org/infrastructure/issues/7106