### PR TITLE
Switch to nginx-ingress for 2i2c-aws support

### DIFF
--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -1,6 +1,9 @@
 prometheusIngressAuthSecret:
   enabled: true
 
+nginx-ingress:
+  enabled: true
+
 grafana:
   grafana.ini:
     server:
@@ -9,6 +12,7 @@ grafana:
       enabled: true
       allowed_organizations: 2i2c-org
   ingress:
+    ingressClassName: nginx-ingress
     hosts:
     - grafana.aws.2i2c.cloud
     tls:
@@ -20,6 +24,7 @@ prometheus:
   server:
     ingress:
       enabled: true
+      ingressClassName: nginx-ingress
       hosts:
       - prometheus.aws.2i2c.cloud
       tls:

--- a/helm-charts/support/templates/issuer.yaml
+++ b/helm-charts/support/templates/issuer.yaml
@@ -15,4 +15,9 @@ spec:
     solvers:
     - http01:
         ingress:
-          class:  nginx
+          # for the ingress-nginx controller
+          class: nginx
+    - http01:
+        ingress:
+          # for the nginx-ingress controller
+          class: nginx-ingress

--- a/helm-charts/support/templates/prometheus-ingres-auth/secret.yaml
+++ b/helm-charts/support/templates/prometheus-ingres-auth/secret.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.prometheusIngressAuthSecret.enabled -}}
 {{- /*
 Build the auth list first with htpasswd because helm renders templates before parsing yaml
-*/ -}} 
+*/ -}}
 {{- $lines := list -}}
 {{- range .Values.prometheusIngressAuthSecret.users -}}
 {{- $lines = append $lines (htpasswd .username .password) -}}
 {{- end -}}
 
+{{/* Used with ingress-nginx for providing basic auth */}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,5 +15,15 @@ metadata:
 type: Opaque
 stringData:
   auth: |
+    {{- $lines | join "\n" | nindent 4 }}
+---
+{{/* Used with nginx-ingress for providing basic auth */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-nginx-ingress-auth-basic
+type: nginx.org/htpasswd
+stringData:
+  htpasswd: |
     {{- $lines | join "\n" | nindent 4 }}
 {{- end }}

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -159,11 +159,13 @@ prometheus:
         # into prometheus server from the outside world. This secret is
         # created via templates/prometheus-ingress-auth/secret.yaml file in the support chart,
         # and the contents are controlled by config under prometheusIngressAuthSecret.
-        # Ingress is not enabled by default, so whichever clusters we want
-        # this we should enable it explicitly.
+        # These annotations set it up for ingress-nginx ingress controller
         nginx.ingress.kubernetes.io/auth-type: basic
         nginx.ingress.kubernetes.io/auth-secret: prometheus-ingress-auth-basic
         nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+        # These annotations set it up for the nginx-ingress controller
+        nginx.org/basic-auth-secret: prometheus-nginx-ingress-auth-basic
+        nginx.org/auth-realm: "Authentication Required"
         # If we enable external ingress into prometheus, we must secure it with HTTPS
         cert-manager.io/cluster-issuer: letsencrypt-prod
         # Increase timeout for each query made by the grafana frontend to the


### PR DESCRIPTION
- Add separate issuer for let's encrypt. Still needs to be tested, as both nginx-ingress and ingress-nginx are able to use the same existing secrets for TLS! So no mass re-issue of certificates needed!
- Swap out ingressClass for prometheus and grafana, plus change the DNS. This *did* cause a 404 for the duration of the DNS change propagating though - roughly 30min by default. We would want to find ways to avoid that.
- Add another secret type for HTTPS basic auth, and unconditionally deploy this everywhere. This isn't used but that's ok.
- Add annotations for nginx.org basic auth to all prometheus ingresses. Again, nop unless the nginx-ingress is deployed there

Ref https://github.com/2i2c-org/infrastructure/issues/7106