### PR TITLE
Switch 2i2c-aws-us staging over to nginx-ingress

### DIFF
--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -15,6 +15,7 @@ jupyterhub-home-nfs:
         hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
+    ingressClassName: nginx-ingress
     hosts: [staging.aws.2i2c.cloud]
     tls:
     - hosts: [staging.aws.2i2c.cloud]


### PR DESCRIPTION
Since I changed the DNS for *.aws.2i2c.cloud, this needs to swap over too.

Ref https://github.com/2i2c-org/infrastructure/issues/7106