### PR TITLE
Switch showcase hub without downtime to nginx-ingress

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -17,6 +17,7 @@ basehub:
           hard_quota: 20 # in GiB
   jupyterhub:
     ingress:
+      ingressClassName: nginx-ingress
       hosts: [showcase.2i2c.cloud]
       tls:
       - hosts: [showcase.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -4,6 +4,13 @@ prometheusIngressAuthSecret:
 nginx-ingress:
   enabled: true
 
+ingress-nginx:
+  controller:
+    service:
+      selectorLabelsOverride:
+        app.kubernetes.io/instance: support
+        app.kubernetes.io/name: nginx-ingress
+
 grafana:
   grafana.ini:
     server:

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   # that references this controller.
   # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
   - name: ingress-nginx
-    version: 4.14.3
+    version: 4.14.3-1
     repository: file://../ingress-nginx/charts/ingress-nginx/
 
   # This is the ingress maintained by nginx, rather than the one maintained by the


### PR DESCRIPTION
Requires https://github.com/2i2c-org/kubernetes-ingress-nginx/pull/1

Ref https://github.com/2i2c-org/infrastructure/issues/7106