### PR TITLE
Support redirects with nginx-ingress

### DIFF
--- a/helm-charts/support/templates/redirects.yaml
+++ b/helm-charts/support/templates/redirects.yaml
@@ -8,6 +8,25 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: nginx-ingress-redirect-{{ .from }}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.org/server-snippets: |
+      rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};
+spec:
+  # for nginx-ingress controller
+  ingressClassName: nginx-ingress
+  tls:
+    - hosts:
+        - {{ .from }}
+      secretName: redirect-{{ .from }}-tls
+  rules:
+    - host: {{ .from }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  # for ingress-nginx controller
   name: ingress-redirect-{{ .from }}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -25,6 +25,9 @@ nginx-ingress:
     appprotectdos:
       enable: false
 
+    # Enable custom config snippets, which we use for rewriting
+    enableSnippets: true
+
     # Get this ingressClass a different name, so we can co-exist with ingress-nginx
     ingressClass:
       name: nginx-ingress


### PR DESCRIPTION
Requires enabling custom snippet support.

Ref https://github.com/2i2c-org/infrastructure/issues/7106