### PR TITLE
Turn off ingress-nginx on 2i2c-aws cluster

### DIFF
--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -6,6 +6,8 @@ nginx-ingress:
 
 ingress-nginx:
   controller:
+    # Turn off the controller, as it's all served by nginx-ingress now
+    replicaCount: 0
     service:
       selectorLabelsOverride:
         app.kubernetes.io/instance: support


### PR DESCRIPTION
This completes migration to nginx-ingress on one cluster, in a way that should translate across all our hubs.

Ref https://github.com/2i2c-org/infrastructure/issues/7106