### PR TITLE
Add a separate cluster-entrypoint service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "helm-charts/ingress-nginx"]
-	path = helm-charts/ingress-nginx
-	url = https://github.com/kubernetes/ingress-nginx

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -17,7 +17,7 @@ basehub:
           hard_quota: 20 # in GiB
   jupyterhub:
     ingress:
-      ingressClassName: nginx-ingress
+      ingressClassName: nginx
       hosts: [showcase.2i2c.cloud]
       tls:
       - hosts: [showcase.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -17,7 +17,6 @@ basehub:
           hard_quota: 20 # in GiB
   jupyterhub:
     ingress:
-      ingressClassName: nginx
       hosts: [showcase.2i2c.cloud]
       tls:
       - hosts: [showcase.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -15,7 +15,7 @@ jupyterhub-home-nfs:
         hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
-    ingressClassName: nginx-ingress
+    ingressClassName: nginx
     hosts: [staging.aws.2i2c.cloud]
     tls:
     - hosts: [staging.aws.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -15,7 +15,6 @@ jupyterhub-home-nfs:
         hard_quota: 10 # in GiB
 jupyterhub:
   ingress:
-    ingressClassName: nginx
     hosts: [staging.aws.2i2c.cloud]
     tls:
     - hosts: [staging.aws.2i2c.cloud]

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -3,10 +3,21 @@ prometheusIngressAuthSecret:
 
 nginx-ingress:
   enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
 
 trafficEntrypoint:
   targetController: ingress-nginx
-
 
 grafana:
   grafana.ini:
@@ -16,7 +27,6 @@ grafana:
       enabled: true
       allowed_organizations: 2i2c-org
   ingress:
-    ingressClassName: nginx
     hosts:
     - grafana.aws.2i2c.cloud
     tls:

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -16,7 +16,7 @@ ingress-nginx:
     ingressClassResource:
       enabled: false
 
-trafficEntrypoint:
+clusterEntrypoint:
   targetController: nginx-ingress
 
 grafana:

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -4,14 +4,9 @@ prometheusIngressAuthSecret:
 nginx-ingress:
   enabled: true
 
-ingress-nginx:
-  controller:
-    # Turn off the controller, as it's all served by nginx-ingress now
-    replicaCount: 0
-    service:
-      selectorLabelsOverride:
-        app.kubernetes.io/instance: support
-        app.kubernetes.io/name: nginx-ingress
+trafficEntrypoint:
+  targetController: ingress-nginx
+
 
 grafana:
   grafana.ini:
@@ -21,7 +16,7 @@ grafana:
       enabled: true
       allowed_organizations: 2i2c-org
   ingress:
-    ingressClassName: nginx-ingress
+    ingressClassName: nginx
     hosts:
     - grafana.aws.2i2c.cloud
     tls:
@@ -33,7 +28,7 @@ prometheus:
   server:
     ingress:
       enabled: true
-      ingressClassName: nginx-ingress
+      ingressClassName: nginx
       hosts:
       - prometheus.aws.2i2c.cloud
       tls:

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -38,7 +38,6 @@ prometheus:
   server:
     ingress:
       enabled: true
-      ingressClassName: nginx
       hosts:
       - prometheus.aws.2i2c.cloud
       tls:

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -17,7 +17,7 @@ ingress-nginx:
       enabled: false
 
 trafficEntrypoint:
-  targetController: ingress-nginx
+  targetController: nginx-ingress
 
 grafana:
   grafana.ini:

--- a/docs/howto/migrate-ingress.md
+++ b/docs/howto/migrate-ingress.md
@@ -1,0 +1,68 @@
+
+# Migrate from one ingress controller to another
+
+## Why migrate ingress controllers?
+
+In 2026, the policy of best-effort maintenance of the Ingress NGINX Controller ended. Following the announcement of this plan, a considerable amount of discussion has taken place amongst Kubernetes users around the topic of a replacement.
+
+In the near term, 2i2c has decided to migrate to the [official NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/install/helm/open-source/). This is likely not a "permanent" solution — alongside the Ingress NGINX Controller deprecation, the Kubernetes Ingress API _itself_ is also frozen, with the Kubernetes project recommending the Gateway API instead. Although there has not been an announcement that the Ingress API will become deprecated in future, we may need/want to migrate to the Gateway API down the road.
+
+```{note} Concerns with ingress migration
+
+Naively using the provided LoadBalancer (LB) from each ingress controller requires the update of DNS records to migrate domains from one LB to another. During this time, the cluster infrastructure will be unavailable to some of external users.
+
+When migrating between controllers, we also want to avoid re-issuing TLS certificates, which are a "costly" resource.
+```
+
+## How to migrate from Ingress NGINX Controller
+
+To facilitate zero downtime migration between controllers, we have introduced a new LoadBalancer ingress service. The purpose of this service is to provide a static external IP address that lives independently of the ingress controller. Consequently, we no longer need ingress controllers to create their own LBs — we can use simple clusterIP services.
+
+For clusters that are still running Ingress NGINX Controller, the existing DNS records point to the controller-managed LoadBalancer service external IP. To migrate between two ingress controllers `ingress-nginx` and `nginx-ingress`, we must perform two separate migrations:
+
+(migrate-ingress:migrate-dns)=
+### Migrate DNS records to dedicated LoadBalancer service
+
+We recently updated the support chart to enable the LoadBalancer service on all hubs. In this phase, we must migrate the DNS records for the cluster to the `traffic-entrypoint` LoadBalancer external IP. We can easily lookup the LB hostname with:
+
+```bash
+kubectl --namespace=support get service/traffic-entrypoint  --template="{{(index .status.loadBalancer.ingress 0).hostname}}"
+```
+
+We must migrate the DNS records for the domain to point to this external IP. During the migration, both the "new" LB and existing ingress-nginx owned LB must be available.
+
+
+(migrate-ingress:switch-controller)=
+### Switch to official `nginx-ingress` controller
+
+Once the DNS records have been updated to point to the `traffic-entrypoint` LB, we can safely transition to the official `ingress-nginx` service:
+
+1. Enable the `nginx-ingress` service in the support chart with
+   ```{code-block} yaml
+   nginx-ingress:
+     # Enable controller
+     enabled: true
+     controller:
+       ingressClass:
+         # Claim the `nginx` ingress class
+         create: true
+   ```
+1. Disable the `ingress-nginx` controller:
+   ```{code-block} yaml
+   ingress-nginx:
+     controller:
+       # Turn off controller
+       replicaCount: 0
+       # Let go of the `nginx` ingress class
+       ingressClassResource:
+         enabled: false
+   ```
+1. Point the `traffic-entrypoint` LB to the new `nginx-ingress` service:
+   ```{code-block} yaml
+   trafficEntrypoint:
+     targetController: nginx-ingress
+   ```
+
+## How to handle future migrations 
+Once all clusters are using the `traffic-entrypoint` LB for their DNS records, it should be trivial to migrate to a new ingress controller or Gateway that establishes a clusterIP service. Once a new controller/gateway is introduced, simply point the `traffic-entrypoint` LB at the new service pods.
+

--- a/docs/howto/migrate-ingress.md
+++ b/docs/howto/migrate-ingress.md
@@ -59,10 +59,10 @@ Once the DNS records have been updated to point to the `traffic-entrypoint` LB, 
    ```
 1. Point the `traffic-entrypoint` LB to the new `nginx-ingress` service:
    ```{code-block} yaml
-   trafficEntrypoint:
+   clusterEntrypoint:
      targetController: nginx-ingress
    ```
 
-## How to handle future migrations 
+## How to handle future migrations
 Once all clusters are using the `traffic-entrypoint` LB for their DNS records, it should be trivial to migrate to a new ingress controller or Gateway that establishes a clusterIP service. Once a new controller/gateway is introduced, simply point the `traffic-entrypoint` LB at the new service pods.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ howto/grafana-github-auth.md
 howto/regenerate-smce-creds.md
 howto/troubleshoot/index.md
 howto/send-secrets.md
+howo/migrate-ingress.md
 ```
 
 ## Topic guides

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ howto/grafana-github-auth.md
 howto/regenerate-smce-creds.md
 howto/troubleshoot/index.md
 howto/send-secrets.md
-howo/migrate-ingress.md
+howto/migrate-ingress.md
 ```
 
 ## Topic guides

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -27,8 +27,8 @@ dependencies:
   # that references this controller.
   # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
   - name: ingress-nginx
-    version: 4.14.3-1
-    repository: file://../ingress-nginx/charts/ingress-nginx/
+    version: 4.14.3
+    repository: https://kubernetes.github.io/ingress-nginx
 
   # This is the ingress maintained by nginx, rather than the one maintained by the
   # kubernetes community. We switch to this to have least potential disruption

--- a/helm-charts/support/templates/issuer.yaml
+++ b/helm-charts/support/templates/issuer.yaml
@@ -15,9 +15,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          # for the ingress-nginx controller
           class: nginx
-    - http01:
-        ingress:
-          # for the nginx-ingress controller
-          class: nginx-ingress

--- a/helm-charts/support/templates/redirects.yaml
+++ b/helm-charts/support/templates/redirects.yaml
@@ -8,28 +8,13 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: nginx-ingress-redirect-{{ .from }}
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.org/server-snippets: |
-      rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};
-spec:
-  # for nginx-ingress controller
-  ingressClassName: nginx-ingress
-  tls:
-    - hosts:
-        - {{ .from }}
-      secretName: redirect-{{ .from }}-tls
-  rules:
-    - host: {{ .from }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  # for ingress-nginx controller
   name: ingress-redirect-{{ .from }}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    # for nginx-ingress controller
+    nginx.org/server-snippets: |
+      rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};
+    # for ingress-nginx controller
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};
 spec:

--- a/helm-charts/support/templates/traffic-entrypoint.yaml
+++ b/helm-charts/support/templates/traffic-entrypoint.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.trafficEntrypoint.enabled }}
+{{ if .Values.clusterEntrypoint.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: traffic-entrypoint
+  name: cluster-entrypoint
   labels:
-    app: traffic-entrypoint
+    app: cluster-entrypoint
 spec:
   type: LoadBalancer
   ports:
@@ -15,7 +15,7 @@ spec:
       port: 443
       targetPort: 443
   selector:
-    {{ if eq .Values.trafficEntrypoint.targetController "nginx-ingress" }}
+    {{ if eq .Values.clusterEntrypoint.targetController "nginx-ingress" }}
     app.kubernetes.io/instance: support
     app.kubernetes.io/name: nginx-ingress
     {{ else }}

--- a/helm-charts/support/templates/traffic-entrypoint.yaml
+++ b/helm-charts/support/templates/traffic-entrypoint.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.trafficEntrypoint.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: traffic-entrypoint
+  labels:
+    app: traffic-entrypoint
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+  selector:
+    {{ if eq .Values.trafficEntrypoint.targetController "nginx-ingress" }}
+    app.kubernetes.io/instance: support
+    app.kubernetes.io/name: nginx-ingress
+    {{ else }}
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: support
+    app.kubernetes.io/name: ingress-nginx
+    {{ end }}
+{{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -74,6 +74,20 @@ properties:
                 Relates to the HTTP Status code to use for the redirect.
 
                 Specify "redirect" for 302 (default), or "permanent" for 301.
+  trafficEntrypoint:
+    type: object
+    additionalProperties: false
+    required:
+    - enabled
+    - targetController
+    properties:
+      enabled:
+        type: boolean
+      targetController:
+        type: string
+        enum:
+        - ingress-nginx
+        - nginx-ingress
   nvidiaDevicePlugin:
     type: object
     additionalProperties: false

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -74,7 +74,7 @@ properties:
                 Relates to the HTTP Status code to use for the redirect.
 
                 Specify "redirect" for 302 (default), or "permanent" for 301.
-  trafficEntrypoint:
+  clusterEntrypoint:
     type: object
     additionalProperties: false
     required:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -14,6 +14,10 @@
 cluster-autoscaler:
   enabled: false
 
+trafficEntrypoint:
+  enabled: true
+  targetController: ingress-nginx
+
 nginx-ingress:
   # Disable this by default
   enabled: false
@@ -31,6 +35,9 @@ nginx-ingress:
     # Get this ingressClass a different name, so we can co-exist with ingress-nginx
     ingressClass:
       name: nginx-ingress
+
+    service:
+      type: ClusterIP
 
 # ingress-nginx is responsible for proxying traffic based on k8s Ingress
 # resources defined in the k8s cluster.

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -32,9 +32,8 @@ nginx-ingress:
     # Enable custom config snippets, which we use for rewriting
     enableSnippets: true
 
-    # Get this ingressClass a different name, so we can co-exist with ingress-nginx
     ingressClass:
-      name: nginx-ingress
+      create: false
 
     service:
       type: ClusterIP

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -14,7 +14,7 @@
 cluster-autoscaler:
   enabled: false
 
-trafficEntrypoint:
+clusterEntrypoint:
   enabled: true
   targetController: ingress-nginx
 


### PR DESCRIPTION
- Create our own LoadBalancer service, so we can migrate to other implementations in the future *without* having to futz around with DNS at all.
- Switch things in 2i2c-aws-us back to ingress-nginx, so we can test to see if this mechanism works for seamless transfer between ingress controllers. That's a simpler way to move things over compared to maintaining a temporary fork of ingress-nginx.
- Switch things *back* to nginx-ingress from ingress-nginx, to test that this idea works. It does!
- Don't use nginx-ingress as a new `IngressClass`. Instead, keep the class name as `nginx`, and as part of switching over, we switch which controller creates this `IngressClass`. This lets us switch entire clusters at once, and lets us switch them easily.

Thanks to @minrk for the idea

Ref https://github.com/2i2c-org/infrastructure/issues/7106