### PR TITLE
[utoronto] Update Python hub image

### DIFF
--- a/config/clusters/utoronto/default-common.values.yaml
+++ b/config/clusters/utoronto/default-common.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   singleuser:
     image:
       name: quay.io/2i2c/utoronto-image
-      tag: 063892275af8
+      tag: c2d316fa18d9
   hub:
     config:
       Authenticator:

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -1,8 +1,4 @@
 jupyterhub:
-  singleuser:
-    image:
-      name: quay.io/2i2c/utoronto-image
-      tag: fbad32f53fb4
   ingress:
     hosts: [staging.utoronto.2i2c.cloud]
     tls:


### PR DESCRIPTION
Pulls in new image built from https://github.com/2i2c-org/utoronto-image/pull/78 as per https://2i2c.freshdesk.com/a/tickets/5068