### PR TITLE
docs: add note about region

### DIFF
--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -250,7 +250,7 @@ you at least one core node running.
 ````{tab-item} Google Cloud
 :sync: gcp-key
 ```{caution}
-We have encountered resource-exhaustion incidents due to limitations of certain GCP regions. Prefer us-central1 unless _there's a very good reason_, as this decision is hard to change later on.
+We have encountered resource-exhaustion incidents due to limitations of certain GCP regions. Prefer us-central1 for US-based communities unless _there's a very good reason_, as this decision is hard to change later on.
 ```
 ```bash
 export CLUSTER_NAME=<cluster-name>


### PR DESCRIPTION
We ran into resource exhaustion for HMMI on us-west2. We should generally prefer to use a large region, even if it's farther away from our communities, particularly as the compute and other infrastructure needs of the community may evolve over time.