### PR TITLE
Use GPUs from all possible zones

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -325,6 +325,14 @@ notebook_nodes = {
       type : "nvidia-tesla-t4",
       count : 1,
     },
+    zones : [
+      # Get GPUs wherever they are available, as sometimes a single
+      # zone might be out of GPUs.
+      "us-central1-a",
+      "us-central1-b",
+      "us-central1-c",
+      "us-central1-f"
+    ]
   },
   "n2-highmem-16" : {
     min : 0,


### PR DESCRIPTION
A single zone can exhaust GPUs often

Ref https://github.com/2i2c-org/infrastructure/issues/7758