### PR TITLE
chore: update Nix flake to fix venvs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "dev-python": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "python",
+        "lastModified": 1772196754,
+        "narHash": "sha256-DNlnNdQkydAZl0UWFxsX3burQjp83kOxQEAs5+9fKnw=",
+        "owner": "agoose77",
+        "repo": "dev-flakes",
+        "rev": "e0b0b96e09968d3ba1ccf8ec82865a35e2cba7b8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "python",
+        "owner": "agoose77",
+        "ref": "e0b0b96",
+        "repo": "dev-flakes",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767767207,
@@ -34,6 +57,7 @@
     },
     "root": {
       "inputs": {
+        "dev-python": "dev-python",
         "nixpkgs": "nixpkgs",
         "nixpkgs-helm": "nixpkgs-helm"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,16 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-helm.url = "github:NixOS/nixpkgs/9b100cfb67ccb2ff6e723b78d4ae2f9c88654a1c";
+    dev-python = {
+      url = "github:agoose77/dev-flakes/e0b0b96?dir=python";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs = {
     self,
     nixpkgs,
     nixpkgs-helm,
+    dev-python,
   }: let
     forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
   in {
@@ -20,8 +25,6 @@
         inherit system;
         config.allowUnfree = true;
       };
-      inherit (pkgs) lib;
-
       # Additional nixpkgs for a particular package (helm)
       pkgs-helm = import nixpkgs-helm {
         inherit system;
@@ -29,11 +32,9 @@
 
       # Define our interpreter
       python = pkgs.python313;
-      manyLinux = pkgs.pythonManylinuxPackages.manylinux2014;
       gdk = pkgs.google-cloud-sdk.withExtraComponents (with pkgs.google-cloud-sdk.components; [
         gke-gcloud-auth-plugin
       ]);
-
       # Configure packages that need additional deps
       openstack = python.pkgs.toPythonApplication (
         python.pkgs.python-openstackclient.overridePythonAttrs (oldAttrs: {
@@ -42,12 +43,17 @@
             ++ [python.pkgs.python-magnumclient];
         })
       );
-
+      # Configure the hook for enabling venvs
+      # I think there's a way to auto-detect this, but
+      # let's worry about that another time
+      venvHook =
+        dev-python.packages.${system}.nix-ld-venv-hook.override
+        {python = python;};
       # Define our env packages (including the above)
       packages =
         [
           python
-          python.pkgs.venvShellHook
+          venvHook
         ]
         ++ (with pkgs; [
           cmake
@@ -79,7 +85,6 @@
       default = pkgs.mkShell {
         inherit packages;
         # Define additional input for patching interpreter
-        nativeBuildInputs = [pkgs.makeWrapper];
 
         venvDir = ".venv";
 
@@ -88,18 +93,10 @@
 
         # Setup venv by patching interpreter with LD_LIBRARY_PATH
         # This is required because ld does not exist on Nix systems
-        postVenvCreation = let
-          # Find the interpreter of the venv
-          interpreterSubPath = lib.path.subpath.join ["bin" (baseNameOf python.interpreter)];
-        in
-          unwantedEnvPreamble
-          # Patch the venv to find the dynamic libs
-          + ''
-            wrapProgram "$VIRTUAL_ENV/${interpreterSubPath}" --prefix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath manyLinux}"
-          ''
-          +
+        postVenvCreation =
           # Install package
           ''
+            ${unwantedEnvPreamble}
             pip install -e ".[dev]"
           '';
       };


### PR DESCRIPTION
Ugh, Python.

I ran into a problem with Python venvs on my machine that led to me spinning up a blog just so that I can ~rant~ write down my experience: https://agoose77.github.io/blog/nix-python-envs/ (wip)

The TL;DR is that Python makes assumptions (manylinux) about the environment, and there are not many ways to virtualise that setup without going full FHS chroot stuff. I really want to avoid chroot for all manner of reasons, so this flake update pulls in my personal venv hook that spins up a venv using nix-ld under the hood.

The basic idea is that setting LD_LIBRARY_PATH breaks any new subshells (where glibc isn't compatible), and we use subshells to invoke things like Git. Whilst I could just update the flake lock to match my host, that's not a fix. Instead, this new venv hook patches the Python interpreter after the fact to change the default linker to a shim that updates LD_LIBRARY_PATH. This sounds like the same thing, but crucially the change is scoped only to the linker, rather than the entire application!