### PR TITLE
cloudbank: Make gpu-demo node disk be pd-ssd

### DIFF
--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -134,7 +134,7 @@ notebook_nodes = {
       count : 1
     },
     # Let's try a faster disk to see if that speeds up image pulls
-    disk_type: "pd-ssd",
+    disk_type : "pd-ssd",
     zones : [
       # Get GPUs wherever they are available, as sometimes a single
       # zone might be out of GPUs.


### PR DESCRIPTION
Let's see if this leads to faster image pull times

Ref https://github.com/2i2c-org/infrastructure/issues/7758