### PR TITLE
gcp: Set locationpolicy to ANY

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -239,6 +239,8 @@ resource "google_container_node_pool" "notebook" {
   autoscaling {
     min_node_count = each.value.min
     max_node_count = each.value.max
+    # Put nodes wherever we can, don't try to balance across zones
+    location_policy = "ANY"
   }
 
   lifecycle {


### PR DESCRIPTION
Without this, we were trying to 'balance' where the nodes were coming up. However, we aren't spreading out the nodes for resiliency - just for resource availability reasons. So let's just get them wherever we can!

Ref https://github.com/2i2c-org/infrastructure/issues/7758