### PR TITLE
cloudbank: Switch gpu-demo to its own scheduler

### DIFF
--- a/config/clusters/cloudbank/gpu-demo.values.yaml
+++ b/config/clusters/cloudbank/gpu-demo.values.yaml
@@ -4,7 +4,7 @@ jupyterhub:
       # I was noticing sometimes upto a minute between when
       # a new node is up and the scheduler notices with the
       # default optimizing scheduler. Let's run our own scheduler
-      # which is much faster. This is anectodal information
+      # which is much faster. This is anecdotal information
       enabled: true
   ingress:
     hosts: [gpu-demo.cloudbank.2i2c.cloud]


### PR DESCRIPTION
I was noticing sometimes upto a minute between when a new node is up and the scheduler notices with the default optimizing scheduler. Let's run our own scheduler which is much faster. This is anectodal information.

Ref https://github.com/2i2c-org/infrastructure/issues/7758