### PR TITLE
GCP: Switch to 'total' node limits, than zonal limits

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -237,8 +237,10 @@ resource "google_container_node_pool" "notebook" {
 
   initial_node_count = each.value.min
   autoscaling {
-    min_node_count = each.value.min
-    max_node_count = each.value.max
+    # Use total_ rather than min_ as we want total max across zones,
+    # rather than just in one zone
+    total_min_node_count = each.value.min
+    total_max_node_count = each.value.max
     # Put nodes wherever we can, don't try to balance across zones
     location_policy = "ANY"
   }


### PR DESCRIPTION
The intention of our min and max counts have always been about total number of nodes, rather than per-zone limits. Let's explicitly set that.

This may cause some churn in `terraform apply` but should be harmless.

Ref https://github.com/2i2c-org/infrastructure/issues/7794 Ref https://github.com/2i2c-org/infrastructure/issues/7758