### PR TITLE
coredumps: Don't set requests on the pause container

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -495,13 +495,8 @@ disableCoredumps:
       requests:
         cpu: 1m
         memory: 16Mi
-    pauseContainer:
-      limits:
-        cpu: 5m
-        memory: 16Mi
-      requests:
-        cpu: 1m
-        memory: 8Mi
+    # Don't set any requests or limits here, as it's ok for it to be best effort qos
+    pauseContainer: {}
 
 # Setup a separate storageClass specifically for prometheus data
 prometheusStorageClass:


### PR DESCRIPTION
It's ok for this to be killed. We don't need to reserve any requests for this.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/7588