### PR TITLE
fix: update flake to latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
       },
       "locked": {
         "dir": "python",
-        "lastModified": 1772196754,
-        "narHash": "sha256-DNlnNdQkydAZl0UWFxsX3burQjp83kOxQEAs5+9fKnw=",
+        "lastModified": 1772621537,
+        "narHash": "sha256-/jBAYzRIRkXwykuNrIUqvh6HzWEiMwc+WBswuO5MB94=",
         "owner": "agoose77",
         "repo": "dev-flakes",
-        "rev": "e0b0b96e09968d3ba1ccf8ec82865a35e2cba7b8",
+        "rev": "45e941722640b75cb55af326151c8a9af52f598b",
         "type": "github"
       },
       "original": {
         "dir": "python",
         "owner": "agoose77",
-        "ref": "e0b0b96",
+        "ref": "v10",
         "repo": "dev-flakes",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-helm.url = "github:NixOS/nixpkgs/9b100cfb67ccb2ff6e723b78d4ae2f9c88654a1c";
     dev-python = {
-      url = "github:agoose77/dev-flakes/e0b0b96?dir=python";
+      url = "github:agoose77/dev-flakes/v10?dir=python";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -90,6 +90,11 @@
 
         # Drop bad env vars on activation
         postShellHook = unwantedEnvPreamble;
+
+        env = {
+          # Disable nested kubeconfigs! This is nearly always a footgun
+          DEPLOYER_NO_NESTED_KUBECONFIG = "1";
+        };
 
         # Setup venv by patching interpreter with LD_LIBRARY_PATH
         # This is required because ld does not exist on Nix systems


### PR DESCRIPTION
I've been playing around a lot with the Nix configuration. I've been converging on the proper way to handle the runtime environment expected by naive Python installs.

This flake update just fixes a mistake in the patching logic that introduced execution-relative paths into the Python shim.