### PR TITLE
Modify Staging S3 ARNs in maap.tfvars

### DIFF
--- a/terraform/aws/projects/maap.tfvars
+++ b/terraform/aws/projects/maap.tfvars
@@ -95,8 +95,8 @@ hub_cloud_permissions = {
               "s3:AbortMultipartUpload"
             ],
             "Resource": [
-              "arn:aws:s3:::maap-ops-workspace",
-              "arn:aws:s3:::maap-ops-workspace/*"
+              "arn:aws:s3:::maap-uat-workspace",
+              "arn:aws:s3:::maap-uat-workspace/*"
             ]
           },
           {


### PR DESCRIPTION
Updated Staging S3 resource ARNs to use `maap-uat-workspace`. This will allow the 2i2c Staging Hub to use the correct MAAP UAT s3 bucket.