### PR TITLE
cloudbank: Switch GPU demo to shared-password auth

### DIFF
--- a/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
@@ -9,13 +9,13 @@ jupyterhub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2026-03-06T17:29:37Z"
-      enc: CiUA4OM7eDhFaujgbGtD9cPg1K1dM11BQgHbH4Dc65ZBAyalg9JxEkkAPHlbmbI86OKSPF6G0+yC1hu3kH+79JBEbNvUukoLYfVRHZHnpz6Yv2fO7awE90fw4gmP+zREl7kIDAvXrWM7Z8vGxk5Mp9AK
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-03-06T17:29:37Z'
+    enc: CiUA4OM7eDhFaujgbGtD9cPg1K1dM11BQgHbH4Dc65ZBAyalg9JxEkkAPHlbmbI86OKSPF6G0+yC1hu3kH+79JBEbNvUukoLYfVRHZHnpz6Yv2fO7awE90fw4gmP+zREl7kIDAvXrWM7Z8vGxk5Mp9AK
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-03-06T22:15:43Z"
+  lastmodified: '2026-03-06T22:15:43Z'
   mac: ENC[AES256_GCM,data:POrGJZjfPyc2GxeX+4qZzEoaf7Vfnsvq3DM8JjTK/MYDPUvL/KnmyHMZ4njoUqD6WrWuzEs8Zncst8LV2tYq8ac/nzVAGrSW1I8hAj5Y3Yxh/EJqP5fMTtBM9yzjlG6QWD8UOAJ0VkXnYscFl+0CJSwwvCeCBpIxILVvBFyt/ts=,iv:wIzsWjWBzSGNBSn0THKShUrYqz5XAM+g5+5ES2rkp0E=,tag:yIrr7pRvpS9kie/sF+kznw==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/cloudbank/gpu-demo.values.yaml
+++ b/config/clusters/cloudbank/gpu-demo.values.yaml
@@ -121,7 +121,7 @@ jupyterhub:
       Authenticator:
         manage_groups: false
         # Allow everyone with the right password to log in
-        allow_all: True
+        allow_all: true
         admin_users:
         - yuvipanda@2i2c.org
 jupyterhub-home-nfs:


### PR DESCRIPTION
The major limitation with using dummyauth for workshop hubs was that we were not able to use admin access. I contributed https://github.com/jupyterhub/jupyterhub/pull/5037 upstream to make the situation better, and sinze we're on the latest JupyterHub now, we can use it!

This PR changes gpu-demo to use SharedPasswordAuthenticator, using the existing password for regular users and a different one for admins. Admin users will need to be specifically listed in config here as well.

Ref https://github.com/2i2c-org/infrastructure/issues/7758