### PR TITLE
cloudbank: Increase size of GPU node disks

### DIFF
--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -320,6 +320,7 @@ notebook_nodes = {
     },
     # Let's try a faster disk to see if that speeds up image pulls
     disk_type : "pd-ssd",
+    disk_size : 150, # 100G default too small for big images
     zones : [
       # Get GPUs wherever they are available, as sometimes a single
       # zone might be out of GPUs.


### PR DESCRIPTION
Otherwise there was disk pressure with pre-pulling the large images

Ref https://github.com/2i2c-org/infrastructure/issues/7758