### PR TITLE
fix: set header snippets for websocket upgrade on nginx-ingress

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -431,6 +431,10 @@ jupyterhub:
     ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
+      # Handle websocket upgrades in nginx-ingress
+      nginx.org/location-snippets: |
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
       cert-manager.io/cluster-issuer: letsencrypt-prod
   scheduling:
     # We declare matchNodePurpose=require to get a nodeAffinity like a

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -13,6 +13,8 @@ binderhub-service:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
       cert-manager.io/cluster-issuer: letsencrypt-prod
+      nginx.org/server-snippets: |
+        resolver_timeout 30s;
   nodeSelector:
     hub.jupyter.org/node-purpose: core
   service:
@@ -435,6 +437,8 @@ jupyterhub:
       nginx.org/location-snippets: |
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
+      nginx.org/server-snippets: |
+        resolver_timeout 30s;
       cert-manager.io/cluster-issuer: letsencrypt-prod
   scheduling:
     # We declare matchNodePurpose=require to get a nodeAffinity like a


### PR DESCRIPTION
@ktyle reported that kernels and terminals weren't working properly on the Pythia BinderHub. He also saw 502 errors. Both of these, I reproduced.

We recently upgraded that hub to use nginx-ingress, and it turns out that our current configuration does not support websocket upgrades.

This PR sets the location snippet required to support that. There may be other configuration we need to tweak here (like buffering, timeouts, etc).

It also sets a TTL on DNS replies to match the old ingress defaults. 