### PR TITLE
fix: bump binderhub chart

### DIFF
--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     version: 4.3.3-0.dev.git.7272.h2ff70453
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.318.h477a6fa
+    version: 0.1.0-0.dev.git.321.h6d1ccf4
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled
     # If bumping the version of dask-gateway, please also bump the default version set


### PR DESCRIPTION
This PR deploys a version of the binderhub chart that includes https://github.com/2i2c-org/binderhub-service/pull/165, which fixes #7884.