### PR TITLE
Bump to helm v4

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -69,54 +69,19 @@ runs:
       go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
     shell: bash
 
-    # This action use the github official cache mechanism internally
   - uses: azure/setup-helm@v4
     with:
-        # Manually update a pinning of helm to a minor version based on:
-        #
-        # - it seems to work
-        # - to avoid falling behind
-        #
-        # Related:
-        #
-        # - helm versions: https://github.com/helm/helm/releases
-        #
-      version: v3.14.4
+      version: v4.1.1
 
-    # Manually update a pinning of kubectl to a minor version based on:
-    #
-    # - the current range of k8s version in our k8s clusters, as of 2024-04-17,
-    #   this is k8s 1.27 - 1.29
-    # - the next expected change in this range, as of 2024-04-17, is to expand
-    #   to include 1.30
-    # - the kubectl <-> k8s api-server skew policy of +/- one minor version
-    # - the policy of attempting to update our kubectl version here to be +/-
-    #   one minor versions of future k8s clusters additions or upgrades, so that
-    #   additions or upgrades of k8s clusters aren't unexpectedly held back
-    #
-    # As an example, we upgraded to kubectl to version 1.24 before we
-    # added/upgraded a k8s cluster to version 1.25.
-    #
-    # Related:
-    #
-    # - k8s versions: https://kubernetes.io/releases/
-    # - Kubectl version skew policy: https://kubernetes.io/releases/version-skew-policy/#kubectl
-    # - 2i2c, k8s upgrades tracked: https://github.com/2i2c-org/infrastructure/issues/2293
-    # - 2i2c, historical issue: https://github.com/2i2c-org/infrastructure/issues/1271
-    #
   - uses: azure/setup-kubectl@v4
     with:
-      version: v1.28.8
+      version: v1.34
 
-    # This action use the github official cache mechanism internally
   - name: Install sops
     uses: mdgreenwald/mozilla-sops-action@v1.6.0
 
     # Install pre-requisite for "gcloud container clusters get-credentials"
-    # command with a modern k8s client.
-    #
-    # A manual install step has been needed as they opted to not provide it in
-    # the github-runner image. See
+    # command with a modern k8s client. See
     # https://github.com/actions/runner-images/issues/5925#issuecomment-1216417721.
     #
   - name: Install gke-gcloud-auth-plugin

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import json
 import os
 import subprocess
@@ -72,6 +73,12 @@ class Cluster:
             raise ValueError(f"Provider {self.spec['provider']} not supported")
 
     def deploy_support(self, cert_manager_version, debug, skip_crds, dry_run):
+        helm_version = subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        if not helm_version.startswith("v4."):
+            print(f"Minimum required version of helm is v4. Found version {helm_version}", file=sys.stderr)
+            print(f"Upgrade your version of helm and try again")
+            sys.exit(1)
+
         if not skip_crds:
             cert_manager_url = "https://charts.jetstack.io"
 

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import sys
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -73,9 +73,14 @@ class Cluster:
             raise ValueError(f"Provider {self.spec['provider']} not supported")
 
     def deploy_support(self, cert_manager_version, debug, skip_crds, dry_run):
-        helm_version = subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        helm_version = (
+            subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        )
         if not helm_version.startswith("v4."):
-            print(f"Minimum required version of helm is v4. Found version {helm_version}", file=sys.stderr)
+            print(
+                f"Minimum required version of helm is v4. Found version {helm_version}",
+                file=sys.stderr,
+            )
             print("Upgrade your version of helm and try again")
             sys.exit(1)
 

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -76,7 +76,7 @@ class Cluster:
         helm_version = subprocess.check_output(["helm", "version", "--short"]).decode().strip()
         if not helm_version.startswith("v4."):
             print(f"Minimum required version of helm is v4. Found version {helm_version}", file=sys.stderr)
-            print(f"Upgrade your version of helm and try again")
+            print("Upgrade your version of helm and try again")
             sys.exit(1)
 
         if not skip_crds:

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -105,7 +105,7 @@ class Hub:
                 f"Minimum required version of helm is v4. Found version {helm_version}",
                 file=sys.stderr,
             )
-            print(f"Upgrade your version of helm and try again")
+            print("Upgrade your version of helm and try again")
             sys.exit(1)
         # Support overriding domain configuration in the loaded cluster.yaml via
         # a cluster.yaml specified enc-<something>.secret.yaml file that only

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from contextlib import ExitStack
 from pathlib import Path
-import sys
 from typing import TYPE_CHECKING
 
 from ruamel.yaml import YAML
@@ -97,9 +97,14 @@ class Hub:
         Deploy this hub
         """
         # Make sure we're on helm v4
-        helm_version = subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        helm_version = (
+            subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        )
         if not helm_version.startswith("v4."):
-            print(f"Minimum required version of helm is v4. Found version {helm_version}", file=sys.stderr)
+            print(
+                f"Minimum required version of helm is v4. Found version {helm_version}",
+                file=sys.stderr,
+            )
             print(f"Upgrade your version of helm and try again")
             sys.exit(1)
         # Support overriding domain configuration in the loaded cluster.yaml via

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 from contextlib import ExitStack
 from pathlib import Path
+import sys
 from typing import TYPE_CHECKING
 
 from ruamel.yaml import YAML
@@ -95,6 +96,12 @@ class Hub:
         """
         Deploy this hub
         """
+        # Make sure we're on helm v4
+        helm_version = subprocess.check_output(["helm", "version", "--short"]).decode().strip()
+        if not helm_version.startswith("v4."):
+            print(f"Minimum required version of helm is v4. Found version {helm_version}", file=sys.stderr)
+            print(f"Upgrade your version of helm and try again")
+            sys.exit(1)
         # Support overriding domain configuration in the loaded cluster.yaml via
         # a cluster.yaml specified enc-<something>.secret.yaml file that only
         # includes the domain configuration of a typical cluster.yaml file.


### PR DESCRIPTION
Tested it locally, and seems fine. Also bumps kubectl version.

Remove a lot of superfluous and drifted-to-no-longer-be-accurate comments.

Once this is merged, we would need to make sure everyone upgrades their local install of helm to v4 as well

Ref https://github.com/2i2c-org/infrastructure/issues/7470