### PR TITLE
feat: first round of ingress upgrades

### DIFF
--- a/config/clusters/2i2c-uk/support.values.yaml
+++ b/config/clusters/2i2c-uk/support.values.yaml
@@ -26,3 +26,21 @@ grafana:
     - secretName: grafana-tls
       hosts:
       - grafana.uk.2i2c.cloud
+
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress

--- a/config/clusters/awi-ciroh/support.values.yaml
+++ b/config/clusters/awi-ciroh/support.values.yaml
@@ -16,6 +16,24 @@ grafana:
       hosts:
       - grafana.ciroh.awi.2i2c.cloud
 
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
+
 prometheus:
   server:
     ingress:

--- a/config/clusters/bnext-bio/support.values.yaml
+++ b/config/clusters/bnext-bio/support.values.yaml
@@ -32,6 +32,25 @@ grafana:
       hosts:
       - grafana.bnext-bio.2i2c.cloud
 
+
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
+
 cluster-autoscaler:
   enabled: true
   autoDiscovery:

--- a/config/clusters/nasa-ghg-hub/support.values.yaml
+++ b/config/clusters/nasa-ghg-hub/support.values.yaml
@@ -33,5 +33,23 @@ prometheus:
         hosts:
         - prometheus.nasa-ghg.2i2c.cloud
 
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
+
 calico:
   enabled: true

--- a/config/clusters/reflective/support.values.yaml
+++ b/config/clusters/reflective/support.values.yaml
@@ -26,6 +26,24 @@ grafana:
       hosts:
       - grafana.reflective.2i2c.cloud
 
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
+
 cluster-autoscaler:
   enabled: true
   autoDiscovery:

--- a/config/clusters/temple/support.values.yaml
+++ b/config/clusters/temple/support.values.yaml
@@ -1,8 +1,6 @@
 prometheusIngressAuthSecret:
   enabled: true
 
-
-
 prometheus:
   server:
     persistentVolume:
@@ -30,6 +28,24 @@ grafana:
     - secretName: grafana-tls
       hosts:
       - grafana.temple.2i2c.cloud
+
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
 
 cluster-autoscaler:
   enabled: true

--- a/config/clusters/ucmerced/support.values.yaml
+++ b/config/clusters/ucmerced/support.values.yaml
@@ -34,6 +34,23 @@ grafana:
       hosts:
       - grafana.ucmerced.2i2c.cloud
 
+nginx-ingress:
+  enabled: true
+  controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
+
+ingress-nginx:
+  controller:
+    # Turn off this controller
+    replicaCount: 0
+    # Let go of the `nginx` ingress class
+    ingressClassResource:
+      enabled: false
+
+clusterEntrypoint:
+  targetController: nginx-ingress
 
 cluster-autoscaler:
   enabled: true


### PR DESCRIPTION
Perform ingress upgrades for these clusters.

Closes #7773 

> [!Important]
> To be able to do this, we have to delete the ingress class first:
> ```bash
> kubectl delete ingressclass nginx && deployer deploy-support $CLUSTER_NAME --skip-crds
> ```

I ran into some problems whilst testing this out on 2i2c-aws-us, which I think is isolated to that cluster — some Helm state seems borked.