### PR TITLE
[earthscope, staging] Add test quota policy config

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -80,6 +80,9 @@ basehub:
           - geolab
           - geolab:dev
           - geolab:power
+          - cpu-1
+          - cpu-2
+          - cpu-3
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.dev.earthscope.org

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -41,6 +41,15 @@ basehub:
                 unit: GiB-hours
               window: 7
             intersection: max
+          policy:
+          - resource: memory
+            limit:
+              value: 250
+              unit: GiB-hours
+            window: 7
+            scope:
+              group:
+              - cpu-1
       extraConfig:
         11-enforce-usage-quotas: |
           from jupyterhub_usage_quotas.manager import SpawnException, UsageQuotaManager


### PR DESCRIPTION
### Context

This is a sample PR to demonstrate how to apply a quota policy of *"250 GiB-hours[^1] of memory requests over 7 days to user group `cpu-1`"*. The user group is derived from the scopes requested from OIDC.

See [docs](https://jupyterhub-usage-quotas.readthedocs.io/en/latest/explanation/technical/#policy-configuration) on how to configure quota policies in general.

Ref https://github.com/2i2c-org/infrastructure/issues/7909

[^1]: I chose this example value because I can see one user on the staging hub with a current memory request usage of 236 GiB-hours in the last 7 days (as of writing on Friday 13th March).

