### PR TITLE
Update the Reflective image tag

### DIFF
--- a/config/clusters/reflective/common.values.yaml
+++ b/config/clusters/reflective/common.values.yaml
@@ -89,7 +89,7 @@ jupyterhub:
               default: true
               slug: reflective
               kubespawner_override:
-                image: quay.io/2i2c/reflective-image:31aa6abf39c9
+                image: quay.io/2i2c/reflective-image:5cb60c85bbb0
             01-scipy:
               display_name: Jupyter SciPy Notebook
               description: Scientific Python image


### PR DESCRIPTION
This PR updates the Reflective image tag. We added some additional tools and fixed a Python package versioning issue we found. We have tested that everything is working as expected in binder.