### PR TITLE
Revert "cryo: Update disk quota for one user"

### DIFF
--- a/config/clusters/nasa-cryo/enc-prod.secret.values.yaml
+++ b/config/clusters/nasa-cryo/enc-prod.secret.values.yaml
@@ -2,7 +2,7 @@ basehub:
   jupyterhub-home-nfs:
     quotaEnforcer:
       extraConfig:
-        secret-quota-overrides: ENC[AES256_GCM,data:hn8NqIJ10X0kYJFolh0b1ItzXVfFztjvflPHClHuuFzsJTZkGR0gCtsaRfvYnfsVk/yiEzci54FmciHCt1tQ2eDlbM+iqmYuOjiUKjgLJYzOBx67cR/mGnzBCSiYhgLhkZayTCVcDckSB/nkiLMtPIVA7mr10MW0Pco+1MUjPdJV37nCCpsq3mb7OV4wtkJeW2GQUDbUKX3bUV6XH2isH0XpmlCnTAJq3cOQWhocZPHAs/2wik5F3xLKYYXW1+bsOzOp+k3c22oPvljh4FqWL7eJdzzOXn32WNjqpPa+F/4w6nCqQn9zbsxN5Pegzyt035fnyzgsU/izPWsdx74olxHlyeVjs7GWoPSUf8wwB4kwg/Sq1ckeT1qjbWL2d/8xRyZfHDBbemzwHjhzMgsC9abggYoz5XMdvLcHJOPl9Ti0IdTzzaOR+3FylU5WoDc0Xqvz0hKXQxfknGMIxSIcl3pnYkaIHRZX79SXqRaIA7pjy/dBhUH6ojj1Mxz6E4ja+z38O06TowJj3MaKPh041NklSqurWzE55BmILikAjjrCwPPq6cNvWezMyBr4cdNzbcg3K+jMlBX4A0IKWQ2IKOGwqO0pdB8r7HhdDZA22WMEgAnshC8WzBYYF4H7If+gwOt4U9rIxOJp0CA+BF6SveSTqRi0k/UsFtmfJAxNKdi0pIkvlNVcws8gvaHn9Q+EF99mn8cdlEZmdAaQoTtHKop+RNq54fiOYaCIjWH8AeyXLvI9X9p5AXjI6FcbwJ/bFq97PARjYuFwvsxw4cxzmudPHKC5WSOezHFNbCZt2YprIefXs3PMFz7EPXcIfym7Uy2Us/c+QhYmJ1E2BExwNOXEwMhecdcQZASFpjj42XEWmkUNK0iVo59pGVRyQLVBpZSGB6WtBH5lzJ0aGcq60LCv7EXmSFXccyUcIX78dpDkOwFeM7I194eFOXSZnw2Ypucusv6MUJL2KUJ2QglMYgHXGhZXxzzYKojwtdEk6SGY,iv:EQmn8xrhETpaN8hZqCWJ/GJ+fT5V3he84YxF+KWAp8U=,tag:Ev+nYkU/DbYlpmfh8Q/cGw==,type:str]
+        secret-quota-overrides: ENC[AES256_GCM,data:ver7q/fDElBhXvEqLDqyC/g9kmQXsOjA3Mlspz6k2tL4KG/ot12AZ2cCWKQ9X2uW6yZ+23yQhB4blhK2dDg3UQpNSJ+z/4KGmwapsZ6+LCvo7sB8/KM6m5942U+SVA//h6mnPjaNyE7MYKWxbfsX70L3XX0pIBqHyc4aHtqX0479JCn/1+vTiPSe4MoArTps2rEsdEFMranv/tNGuIONI8lLqKMHM3nJwtSU5zInGCNlzInxovruxHCURyNUwbN7mHOVQ/X/Pzo2vhvGFJrhUEpUJ8LXNqQU/WtE6YxMERYyiaoEDcCozMwENljW4dO5IqsCCDzjNgJ70vlvHNScLCgpT9K151DvuHAbzorVrDRL/nir9PnCZCBUSMSVFgiojtmqfpNNUnvWUiG0wr2BAb9cYvjG85eIXapyI4iMgsHPtADsiOW631MKWxzhG5mBq/aMVUIDOMVd2IHq14dET9zzLPjjAJITSQA5+czcvzfIQ/uC1kZqG8A95oWLg+FNUa8K9+r/UttgtHGEwKOIaGbauKjCum6OE00iOvoKaRjkKQLpqRba3OLMvhFz24LGO0Cwf859TNSURw+/v5ITYkfF0MKKzYZoPr6zEFv8gT9gGp+/jgP9OPF8v/+Aotwn0eg9JgW56hZ5KLgLtSrifHuraT215Y/4vs6CDRD8KMR1qkyFs255phz2ft5x67ZgSyb/fiovQWvK6SUOt1pPMQvadVjqCZQ/mNq4oVlBunk7/6sVgXijx6QkEdyMqU57cuUvX1GpXAyANoGYKgvgZD35PxEUh0HECIyTl2y1cs+1M4I71jwIk3UVQxPG/iyEIExSOhasXkl47AW5eo5zacFI5dvXetp6ffx8V5u/trTR9ctFvit7NGsD4orFOoy8w9HOGkjw77ljMSN7fuajH9Xqksfk98x45b9q+oXvoLxD3mqrvIoVuIzIiVnXoyXzS7Me4SB96rDrS2F6NsvHlhdMmbRGSOSEXbId1/L42Js=,iv:Y+XrIn4EwEuli7SclvINWV4UOLqHrJOaIuWGlCcomNc=,tag:0XQfbQhael8Qdqi7hKaoZQ==,type:str]
   jupyterhub:
     hub:
       config:
@@ -18,8 +18,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2026-02-23T19:22:04Z'
-  mac: ENC[AES256_GCM,data:P6naS9sDh52jiiHhgM3KFxXK5suD1e+LPoaVTyeMQMwl/0P28a68tDa0pq0y5Zu4EZXIAI1DTeGd5p27M0qh+/NrDYAy0Ux1XJ1+LCUi/Pyuf1gcvoIBNv7N6TbxTRgck1q7fZsyV7fYlKQYSZQj1Qpb5rx93dt94b5TTnlC/ZE=,iv:/n+FWHOH1yJ6cX+ZJ4GRfvOTluGhnt/DovkvTkdZb8o=,tag:uIQQ7b+qoqQpZU9c4UxA1A==,type:str]
+  lastmodified: '2026-02-06T22:55:59Z'
+  mac: ENC[AES256_GCM,data:YoSfJmkm07K+DBnneEDgAbjTUWM2npoho9t3aJnueoN27lp5eFgstQp8lhYvn2WaNc/RV+WMsXH30grwsVzkKBGw195hieRwMD+2wVbOSyUb3/iIsY3LUfhVewxXj6Z7z1mc9eFkn72uDhZnNTUuK9x0VJQebmx2qCojrMv7fW0=,iv:WGJ6bdyD90NHC7HbZ2872LXG4DtxAr9/wJxYanFyC/o=,tag:zV2HAQR8vW1j3jb5TB67SA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#7735 as per https://2i2c.freshdesk.com/a/tickets/5073

I have checked that the user's quota usage is below the previous limit, and that the changes in the PR being reverted have not since been overwritten.