### PR TITLE
Add defined-term-access-2i2c to allowed organizations

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -169,6 +169,7 @@ basehub:
           - NASA-Openscapes:workshopaccess-2i2c
           - NASA-Openscapes:longtermaccess-2i2c
           - NASA-Openscapes:championsaccess-2i2c
+          - NASA-Openscapes:defined-term-access-2i2c
             # Requested in: https://2i2c.freshdesk.com/a/tickets/1284
           - nasa-openscapes-workshops:AdminTeam
           - nasa-openscapes-workshops:nasa-champions-2024


### PR DESCRIPTION
This team is a parent team in NASA-Openscapes, where subteams will be created to allow access to the hub for a defined term. I'm hoping this workflow will allow us to manage short-medium term team-level access by creating new teams under `defined-term-access-2i2c` and removing them from the parent team when their access period is over, and not having to do PR's on this config every time.