### PR TITLE
fix: turn leader election off for nginx-ingress

### DIFF
--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -4,10 +4,6 @@ prometheusIngressAuthSecret:
 nginx-ingress:
   enabled: true
   controller:
-    reportIngressStatus:
-      # This fixes Helm deploy _for this cluster_.
-      # The fact that we have to do this only for 2i2c-aws-us is ... worrying.
-      enableLeaderElection: false
     ingressClass:
       # Claim the `nginx` ingress class
       create: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -22,6 +22,10 @@ nginx-ingress:
   # Disable this by default
   enabled: false
   controller:
+    reportIngressStatus:
+      # Disable leader election — we only have one replica.
+      # This was motivated by an apparent race condition on 2i2c-aws-us
+      enableLeaderElection: false
     # Don't enable any custom resource definitions, as that just makes our lives hard for no reason
     enableCustomResources: false
     appprotect:


### PR DESCRIPTION
I don't know why this is needed, but here we are.

See #7994 for context.