### PR TITLE
fix: patch ingresses on all clusters

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -14,6 +14,10 @@ binderhub-service:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
       nginx.org/client-max-body-size: 256m
       cert-manager.io/cluster-issuer: letsencrypt-prod
+      # Allow cert-manager to edit this ingress
+      # as nginx-ingress considers duplicate hosts "host collisions"
+      # causing problems when cert-manager creates the temporary ACME ingress
+      acme.cert-manager.io/http01-edit-in-place: "true"
   nodeSelector:
     hub.jupyter.org/node-purpose: core
   service:
@@ -408,6 +412,10 @@ jupyterhub:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
       nginx.org/client-max-body-size: 256m
+      # Allow cert-manager to edit this ingress
+      # as nginx-ingress considers duplicate hosts "host collisions"
+      # causing problems when cert-manager creates the temporary ACME ingress
+      acme.cert-manager.io/http01-edit-in-place: "true"
       # Handle websocket upgrades in nginx-ingress
       nginx.org/location-snippets: |
         proxy_set_header Upgrade $http_upgrade;

--- a/helm-charts/support/templates/redirects.yaml
+++ b/helm-charts/support/templates/redirects.yaml
@@ -14,6 +14,10 @@ metadata:
     # for nginx-ingress controller
     nginx.org/server-snippets: |
       rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};
+    # Allow cert-manager to edit this ingress
+    # as nginx-ingress considers duplicate hosts "host collisions"
+    # causing problems when cert-manager creates the temporary ACME ingress
+    acme.cert-manager.io/http01-edit-in-place: "true"
     # for ingress-nginx controller
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite "^\/(?!\.well-known\/acme-challenge)(.*)$" "$scheme://{{ .to }}/$1" {{ .type | default "redirect" }};

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -191,6 +191,10 @@ prometheus:
         # increase the timeout here as well.
         nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
         nginx.org/proxy-read-timeout: "120s"
+        # Allow cert-manager to edit this ingress
+        # as nginx-ingress considers duplicate hosts "host collisions"
+        # causing problems when cert-manager creates the temporary ACME ingress
+        acme.cert-manager.io/http01-edit-in-place: "true"
     strategy:
       # type is set to Recreate as we have a persistent disk attached. The
       # default of RollingUpdate would fail by getting stuck waiting for a new
@@ -331,6 +335,10 @@ grafana:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
       nginx.org/proxy-read-timeout: 120s
       cert-manager.io/cluster-issuer: letsencrypt-prod
+      # Allow cert-manager to edit this ingress
+      # as nginx-ingress considers duplicate hosts "host collisions"
+      # causing problems when cert-manager creates the temporary ACME ingress
+      acme.cert-manager.io/http01-edit-in-place: "true"
 
   # grafana is partially configured for GitHub authentication here, but the
   # following values need to be set as well, where client_secret should be kept


### PR DESCRIPTION
Closes #8016 by adding an annotation to all "primary" ingresses that allows cert-manager to patch them temporarily.