### PR TITLE
[maap] Use proper schema for imagePullPolicy

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -157,7 +157,7 @@ jupyterhub:
     extraContainers:
     - name: s3fs
       image: mas.dit.maap-project.org/root/che-sidecar-s3fs:2i2c
-      image_pull_policy: Always
+      imagePullPolicy: Always
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
I noticed an invalid pod spec key in the image pull policy.