### PR TITLE
Drastically simplify core-dumps daemonset

### DIFF
--- a/helm-charts/support/templates/disable-coredumps.yaml
+++ b/helm-charts/support/templates/disable-coredumps.yaml
@@ -20,9 +20,7 @@ spec:
     spec:
       hostPID: true # Access the host's PID namespace for sysctl commands
       tolerations:
-      # This, along with the priorityClassName below marks this pod as a critical add-on.
-      - key: CriticalAddonsOnly
-        operator: Exists
+      # Run on GPU nodes too
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
@@ -35,14 +33,9 @@ spec:
         key: hub.jupyter.org_dedicated
         operator: Equal
         value: user
-      # Mark this pod as a critical add-on; when enabled, the critical add-on
-      # scheduler reserves resources for critical add-on pods so that they can
-      # be rescheduled after a failure.
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      priorityClassName: "system-node-critical"
       initContainers:
       - name: disable-coredumps
-        image: {{ .Values.disableCoredumps.image }}
+        image: {{ .Values.disableCoredumps.initContainer.image }}
         command:
         - /bin/sh
         - -c
@@ -55,30 +48,8 @@ spec:
           privileged: true
           runAsUser: 0
         resources:
-          {{- toYaml .Values.disableCoredumps.resources.initContainer | nindent 10 }}
+          {{- toYaml .Values.disableCoredumps.initContainer.resources | nindent 10 }}
       containers:
       - name: pause
-        image: {{ .Values.disableCoredumps.image }}
-        command:
-        - /bin/sh
-        - -c
-        - sleep infinity
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 65534
-          capabilities:
-            drop: ["ALL"]
-        resources:
-          {{- toYaml .Values.disableCoredumps.resources.pauseContainer | nindent 10 }}
-        readinessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - test "$(cat /proc/sys/kernel/core_pattern)" = "|/bin/false"
-          initialDelaySeconds: 5
-          periodSeconds: 30
-          timeoutSeconds: 5
-          failureThreshold: 1
+        image: {{ .Values.disableCoredumps.pauseContainer.image}}
 {{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -133,26 +133,30 @@ properties:
         description: |
           Enable DaemonSet to disable core dumps on all nodes.
           This prevents core dumps from filling up disk storage.
-      image:
-        type: string
-        description: |
-          Container image to use for the DaemonSet
-      resources:
+      pauseContainer:
+        type: object
+        required:
+        - image
+        properties:
+          image:
+            type: string
+            description: |
+              Container image to use for the DaemonSet's pause container
+      initContainer:
         type: object
         additionalProperties: false
-        description: |
-          Resource requests and limits for the DaemonSet containers
+        required:
+        - image
         properties:
-          initContainer:
+          image:
+            type: string
+            description: |
+              Container image to use for the DaemonSet's initcontainer
+          resources:
             type: object
             additionalProperties: true
             description: |
               Resources for the init container that sets kernel.core_pattern
-          pauseContainer:
-            type: object
-            additionalProperties: true
-            description: |
-              Resources for the pause container that monitors the setting
 
   prometheusIngressAuthSecret:
     type: object

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -501,18 +501,14 @@ nvidiaDevicePlugin:
 # Configure DaemonSet to disable core dumps
 # This prevents core dumps from filling up disk storage
 disableCoredumps:
-  enabled: false
-  image: busybox:1.36.1
-  resources:
-    initContainer:
-      limits:
-        cpu: 10m
-        memory: 32Mi
-      requests:
-        cpu: 1m
-        memory: 16Mi
-    # Don't set any requests or limits here, as it's ok for it to be best effort qos
-    pauseContainer: {}
+  enabled: true
+  initContainer:
+    image: busybox:1.36.1
+    # Intentionally don't set any limits here, as that sometimes
+    # spooks schedulers on full nodes
+    resources: {}
+  pauseContainer:
+    image: registry.k8s.io/pause:3.10.1
 
 # Setup a separate storageClass specifically for prometheus data
 prometheusStorageClass:


### PR DESCRIPTION
- Using the critical addon causes problems on GCP, so let's not use those
- Setting any resources at all seems to make it hard to schedule on some full nodes, so let's not. We only run one syscstl command, and it is fine if it fails.
- Use the 'pause' container, as we don't really need to do anything after the daemonset starts. It can just... be.
- Roll this out everywhere, because we forgot to

Follow-up to https://github.com/2i2c-org/infrastructure/pull/7588