### PR TITLE
Explicitly set oauth_callback_url for earthscope hubs

### DIFF
--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -19,6 +19,7 @@ basehub:
           authorize_url: https://login.earthscope.org/authorize
           userdata_url: https://login.earthscope.org/userinfo
           logout_redirect_url: https://login.earthscope.org/v2/logout?client_id=2PbhUTbRU6e7uIaaEZIShotx15MbvsJJ
+          oauth_callback_url: https://geolab.earthscope.cloud/hub/oauth_callback
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.earthscope.org

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -25,6 +25,7 @@ basehub:
           authorize_url: https://login-dev.earthscope.org/authorize
           userdata_url: https://login-dev.earthscope.org/userinfo
           logout_redirect_url: https://login-dev.earthscope.org/v2/logout?client_id=Kn6kSKtw9TqgrSrEmDS0rlBM7Sc69BkL
+          oauth_callback_url: https://staging.geolab.earthscope.cloud/hub/oauth_callback
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.dev.earthscope.org


### PR DESCRIPTION
Without this, oauth_callback_url is guessed in
oauthenticator (https://github.com/jupyterhub/oauthenticator/blob/fcef83144a2ce6b1d61743ab5d437a1f0c7ffab3/oauthenticator/oauth2.py#L928). This gets the scheme wrong, causing a login failure.

Explicitly set this so we don't have to deal with the scheme mismatch