### PR TITLE
Tune down cloudbank CPU requests for nfs server

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -29,10 +29,10 @@ jupyterhub-home-nfs:
   quotaEnforcer:
     resources:
       requests:
-        cpu: 0.1
+        cpu: 0.001
         memory: 256M
       limits:
-        cpu: 0.4
+        cpu: 0.2
         memory: 1G
     config:
       QuotaManager:
@@ -40,6 +40,18 @@ jupyterhub-home-nfs:
   nfsServer:
     resources:
       requests:
+        cpu: 0.02
         memory: 512M
       limits:
+        cpu: 0.1
         memory: 1.5G
+  nodeExporter:
+    resources:
+      requests:
+        cpu: 0.001
+      limits:
+        cpu: 0.1
+  autoResizer:
+    resources:
+      requests:
+        cpu: 0.001


### PR DESCRIPTION
Observed usage shows these are heavily overprovisioned, and we are paying a lot for CPU on core nodes we aren't using.

<img width="1805" height="683" alt="image" src="https://github.com/user-attachments/assets/56463101-f95b-4864-adc0-6faea2cb5530" />

Follow-up to https://github.com/2i2c-org/infrastructure/pull/8046