### PR TITLE
cloudbank: Disable continuous pre-puller for gpu-demo

### DIFF
--- a/config/clusters/cloudbank/gpu-demo.values.yaml
+++ b/config/clusters/cloudbank/gpu-demo.values.yaml
@@ -16,7 +16,9 @@ jupyterhub:
       value: present
       effect: NoSchedule
     continuous:
-      enabled: true
+      # We don't need this right now, and it's causing alert
+      # failures
+      enabled: false
   ingress:
     hosts: [gpu-demo.cloudbank.2i2c.cloud]
     tls:


### PR DESCRIPTION
This was taking 20+m to pull, triggering alerts. We had this enabled for a workshop, didn't have to have it on now.