### PR TITLE
Enable (external) lambda function calls in cryocloud

### DIFF
--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -73,6 +73,11 @@ hub_cloud_permissions = {
                   "arn:aws:s3:::ghgc-data-store/*"
 
                 ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": "lambda:InvokeFunction",
+                "Resource": "arn:aws:lambda:us-west-2:429435741471:function:process-morton-cell"
             }
         ]
       }
@@ -107,6 +112,11 @@ hub_cloud_permissions = {
                   "arn:aws:s3:::ghgc-data-store",
                   "arn:aws:s3:::ghgc-data-store/*"
                 ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": "lambda:InvokeFunction",
+                "Resource": "arn:aws:lambda:us-west-2:429435741471:function:process-morton-cell"
             }
         ]
       }


### PR DESCRIPTION
This PR adds lambda caller functionality to cryocloud to prototype using lambdas as a non-dask scaling option. We'd like to set this up to test during our upcoming hackdays next week; lambda calls would route to our (i.e, [englacial's](https://englacial.org)) AWS account / billing for now while we prototype. 

  ## Summary

  - Adds `lambda:InvokeFunction` to the `extra_iam_policy` for both staging and prod hubs on the nasa-cryo cluster
  - Scoped to a single Lambda function (`process-morton-cell`) in account `429435741471` in us-west-2
  - Enables CryoCloud users to run distributed ICESat-2 aggregation via the [magg](https://github.com/englacial/magg) library (library name will change soonish)

  ## Context

The magg library processes earthaccess data by distributing work across AWS Lambda invocations. This change allows CryoCloud user pods (via their existing IRSA roles) to invoke that function cross-account.

A corresponding resource-based policy on the Lambda side (our account) will be added to allow the `nasa-cryo-staging` and `nasa-cryo-prod` roles as callers.

  ## Security

  - Permission is scoped to one specific function ARN -- no wildcard access to other Lambda functions in the target account
  - Uses the existing IRSA credential chain (short-lived STS tokens, auto-refreshed by kubelet)
  - No new IAM roles or service accounts are created

@tsnow03 and I have discussed :-) 