### PR TITLE
NASA GHG hub: deploy usage quota viewer to the staging hub

### DIFF
--- a/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
@@ -12,13 +12,13 @@ basehub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2026-04-16T06:53:49Z"
-      enc: CiUA4OM7eN32H1AebM3ff8QBDateAcJR7mVxfh1ZqRiq30U7OYsGEkkAPHlbme3rW651l4dv7VgnFVspURZjh/xd6KmunvywG77Zw8g/tSO21AHPrhfez4MHSW//qrlmZGi2pKomEaLOM3zFfv28gObQ
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-04-16T06:53:49Z'
+    enc: CiUA4OM7eN32H1AebM3ff8QBDateAcJR7mVxfh1ZqRiq30U7OYsGEkkAPHlbme3rW651l4dv7VgnFVspURZjh/xd6KmunvywG77Zw8g/tSO21AHPrhfez4MHSW//qrlmZGi2pKomEaLOM3zFfv28gObQ
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-16T06:53:50Z"
+  lastmodified: '2026-04-16T06:53:50Z'
   mac: ENC[AES256_GCM,data:4I2az84vIMqzqd+Qei4kRSMb8dAXikFD7dIjgzKHe0tKQJvABcdn0h1EijppZtnKweclHD1WDDamSkE6xKwMuy78otv7KzoG68mQDcJFHWDOAxt8Gj5Mvo+LFm5GZpVNFNK1rh8HSKTn5bAGoU/cR0yNi7MgUVisZFIkpjifn9A=,iv:Yw5CCBQ5g2BqbC0wm19L6NpAVkINYC8N18dcTYEpeuw=,tag:5A7CRu0SAk1sEfSaYo7rsQ==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
@@ -3,19 +3,23 @@ basehub:
     hub:
       config:
         GitHubOAuthenticator:
-          client_id: ENC[AES256_GCM,data:XJQLJ9fKPq4ZcUAS4I8egmzI3GI=,iv:Eaeeihi1S0lO1GdaAdUFtfyqdte0fZax11HCJZST/H4=,tag:LO5aWSy+5GvpY7hBkIw3sA==,type:str]
-          client_secret: ENC[AES256_GCM,data:2Mnj3Lh03GWt6DQEgP5gOw6tHVvnxQECgQK6RaKwitAWJbIEvf7tVg==,iv:xOY2NY+iFtFfQOD2BAYR8/vLb0wBstxUUnMcn4gYVNE=,tag:1JnXWtuxOQzyzXbFndbOpg==,type:str]
+          client_id: ENC[AES256_GCM,data:aRm3zmd+jye27BXbpUBZzmJa0Q0=,iv:TrAoXo+0LGMg0+T6QGO22nYO7RrhjHUzSKMqEX5tjUg=,tag:4ue3k6h/ZnTjyDwzXPxRMw==,type:str]
+          client_secret: ENC[AES256_GCM,data:Hv76c9oyDkEp5H51X3kVjq6sGPiGV8xHhCnbonS1UnVrPWN20IRd+Q==,iv:EuYDQhu77/I+xil+srb2RLX12Z/lK3fz1gbQA7fns4k=,tag:YYqiahmoZyBcvtsOhVRI9Q==,type:str]
+      services:
+        usage-quota:
+          environment:
+            JUPYTERHUB_USAGE_QUOTAS_SESSION_SECRET_KEY: ENC[AES256_GCM,data:cF3Zyz5tmVn0gLmJ/tVQeA5++2gxetMBEKOhSoQMFiLbTZhaid0BgmfNo0nZtcDWdnso/SCqM4j3DW+cr+ZLAw==,iv:O6vJgNgYZDj/mYwIWz9j576g7sQgitxPYSzv7k+cQW4=,tag:LTpt7ITrH6ymsLox94EAtg==,type:str]
 sops:
   kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-08-01T03:55:27Z'
-    enc: CiUA4OM7eDkAyEm+WOk2kpDriqmsxX67lI9PpEDRg+HZY7zYPhneEkkAyiwFHE+CoDK4jv//nRkm+0vFhOpC4xE9hRoyYf49PSQfz8ZVmzOsPjYWrdG3noePT1QzUaOIpXtj2M+AYQPjfi0budEg/RRM
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2026-04-16T06:53:49Z"
+      enc: CiUA4OM7eN32H1AebM3ff8QBDateAcJR7mVxfh1ZqRiq30U7OYsGEkkAPHlbme3rW651l4dv7VgnFVspURZjh/xd6KmunvywG77Zw8g/tSO21AHPrhfez4MHSW//qrlmZGi2pKomEaLOM3zFfv28gObQ
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2023-08-01T03:55:27Z'
-  mac: ENC[AES256_GCM,data:lWZuZt62DAl1do5osikdw38X5nvDIvtJSicu8DM0/DpQI4q8hr+3LTB36E56fRR8iJAAXQ3sIJqEyYt+r+t4WHq2qeigcnX3DGeySzqLctmHiCSAAjZ4fFGC4u9KZAYPl6brMNLuTN7wPFoRYbhq/ju2DNkQu6DcSEcIJySNyMI=,iv:TcLcHiVJwmxZu1SyqUbWfj+d1nGEyyGROUzLvBceRp4=,tag:F8STOIUYHeziDaDV3eOAwA==,type:str]
+  lastmodified: "2026-04-16T06:53:50Z"
+  mac: ENC[AES256_GCM,data:4I2az84vIMqzqd+Qei4kRSMb8dAXikFD7dIjgzKHe0tKQJvABcdn0h1EijppZtnKweclHD1WDDamSkE6xKwMuy78otv7KzoG68mQDcJFHWDOAxt8Gj5Mvo+LFm5GZpVNFNK1rh8HSKTn5bAGoU/cR0yNi7MgUVisZFIkpjifn9A=,iv:Yw5CCBQ5g2BqbC0wm19L6NpAVkINYC8N18dcTYEpeuw=,tag:5A7CRu0SAk1sEfSaYo7rsQ==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.9.0

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -25,12 +25,81 @@ basehub:
         gitRepoBranch: staging
         gitRepoUrl: https://github.com/US-GHG-Center/ghgc-hub-homepage
     hub:
+      image:
+        name: quay.io/2i2c/jupyterhub-usage-quotas
+        tag: 8fbdaf8ce82e245a
       config:
         GitHubOAuthenticator:
           oauth_callback_url: https://staging.ghg.2i2c.cloud/hub/oauth_callback
+      extraConfig:
+        11-usage-quotas-viewer: |
+          from jupyterhub_usage_quotas import setup_usage_quotas
+          setup_usage_quotas(c)
+      services:
+        usage-quota:
+          url: http://hub:9000
+          display: false
+          oauth_no_confirm: true
+          command:
+            - "python"
+            - "-m"
+            - "jupyterhub_usage_quotas.services.usage_viewer"
+            - "--port=9000"
+            - "--public-hub-url=https://staging.ghg.2i2c.cloud"
+            - "--prometheus-url=http://support-prometheus-server.support.svc.cluster.local"
+            - "--hub-namespace=staging"
+      loadRoles:
+        usage-quota-service:
+          scopes:
+          - read:users
+          services:
+          - usage-quota
+        user:
+          scopes:
+          - self
+          - access:services!service=usage-quota
+      service:
+        extraPorts:
+        - port: 9000
+          targetPort: 9000
+          name: usage-quota
+      networkPolicy:
+        ingress:
+        - ports:
+          - port: 9000
+          from:
+          # Allow traffic from the hub pod itself for Jupyterhub's internal healthchecks
+          # for hub managed services.
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/component: hub
+                app.kubernetes.io/name: jupyterhub
+          # Allow traffic from the proxy api pod
+          - podSelector:
+              matchLabels:
+                hub.jupyter.org/network-access-hub: "true"
+        - ports:
+          - port: 8081
+          from:
+          # Allow traffic from the hub pod itself for oauth calls from the usage-quota service to the hub api.
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/component: hub
+                app.kubernetes.io/name: jupyterhub
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging
+    proxy:
+      chp:
+        networkPolicy:
+          egress:
+          - to:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: jupyterhub
+                  app.kubernetes.io/component: hub
+            ports:
+            - port: 9000
 
   binderhub-service:
     dockerApi:

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -41,13 +41,13 @@ basehub:
           display: false
           oauth_no_confirm: true
           command:
-            - "python"
-            - "-m"
-            - "jupyterhub_usage_quotas.services.usage_viewer"
-            - "--port=9000"
-            - "--public-hub-url=https://staging.ghg.2i2c.cloud"
-            - "--prometheus-url=http://support-prometheus-server.support.svc.cluster.local"
-            - "--hub-namespace=staging"
+          - python
+          - -m
+          - jupyterhub_usage_quotas.services.usage_viewer
+          - --port=9000
+          - --public-hub-url=https://staging.ghg.2i2c.cloud
+          - --prometheus-url=http://support-prometheus-server.support.svc.cluster.local
+          - --hub-namespace=staging
       loadRoles:
         usage-quota-service:
           scopes:
@@ -77,7 +77,7 @@ basehub:
           # Allow traffic from the proxy api pod
           - podSelector:
               matchLabels:
-                hub.jupyter.org/network-access-hub: "true"
+                hub.jupyter.org/network-access-hub: 'true'
         - ports:
           - port: 8081
           from:

--- a/helm-charts/images/hub/quotas-requirements.txt
+++ b/helm-charts/images/hub/quotas-requirements.txt
@@ -1,2 +1,2 @@
-jupyterhub-usage-quotas[service]==0.1.0b1
+jupyterhub-usage-quotas[service] @ git+https://github.com/2i2c-org/jupyterhub-usage-quotas@8fbdaf8ce82e245a7c7aac32023ee9b4a71b2886
 jupyterhub-fancy-profiles==0.6.0


### PR DESCRIPTION
related to https://github.com/2i2c-org/infrastructure/issues/7558. cc @jnywong

One issue that took me a while to debug: the hub pod kept crash-looping because the hub process couldn't reach the usage-quota service, even though the service itself showed no signs of failure in the logs.

The root cause was that JupyterHub [waits for managed services to become reachable](https://github.com/jupyterhub/jupyterhub/blob/9928efd66dedc0fed181093396e3a829f16ee808/jupyterhub/app.py#L3680-L3687) on startup, and this check was timing out. Our network policy was blocking requests from the hub process to the service URL (hub:9000) on the same pod -- something I hadn't anticipated.

The fix was adding an explicit network policy rule to allow that traffic. 