### PR TITLE
Move authentication from nginx to prometheus level 

### DIFF
--- a/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:Y9YBU79Th7DZ0hZW8FqfP2BmmTnrliVrwzawOqAQ73F89VR8kfmuRZwZy/39X8DbhTL2WQQuFszZzjkWG1wdtedNYEjF7Ew0HoNDh+Crx2R/YQ+qywP+AczlDWKFr6gTBIrdGHbuxkYY0ArTAZxCyymMSewkhSXJRfAMKLX6oGHUAsTbLi0DwFcQ+z5TxnTeP5O21Af1GBDiXEuZ,iv:tUaaHs1tpvy23Mot7UDvIAyckiEEYUShurGIMThSGzo=,tag:UuBoELhRrFysh2ckflH3Yw==,type:comment]
+  #ENC[AES256_GCM,data:XR4q42Yxndmvl8WqlNdPDvfnh2pmxWRgXtZCduZI1kTa9EVZehLCwB88QdwWGk1hx39Bo8+I7bjplZ5UvUW0Qt0UxNms2m3OcTfAU/16nBDLv3ZrD6nXUg1XfyujtgSzbV8pvG4svAmwKQjH17r9DmThLccorZUzJRBAxq7FvRjk5BmlqrPUlwpvQ7VWMw4aHnWT2A6v27CZTpD9,iv:66BxLrRUmcHmx874lBrLHB5+F6fWSLyoJFi0Uzk+huA=,tag:L6Lqo5quZFIpcP/JPhLF6Q==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:RyHeHH6Qkmoy6Xs7NIgFAbi463+M+0NWfHvKbqpTu34rlyij+DxA7WdSxSppgREEyTCtYGHac0Em1QdHSVj1hg==,iv:4k8SFw20JIu7gU99GgEFCVg2Ky9TpPenw5BwuUbQzbI=,tag:mAooT1c6DU4BI4v5Ho+4zA==,type:str]
-    password: ENC[AES256_GCM,data:yas04nAehmMPpgNXBuF2bevxFULJrlb08DcXQWmdtZjhmrG4rudZx+mWPjG3rBzC3NiHcTXxIvfKCROBoL/E1w==,iv:vvNhYJeviN2Sr0blQiV/N/2l+Enszg2aujhNt7fvsC8=,tag:y33FaHE/4RXNZhKAcx2ogA==,type:str]
+  - username: ENC[AES256_GCM,data:gRBDwKApMkmDkLM/I/uiCbNEdAJjQzJIbpUFXWpHCMEGfvHwpcry6q2+tPYNUhxc3L1LwEAEwO8YIdcYkHkXkA==,iv:16aAIs3xf+BOKtG1G9c5wOyIlN1cPqGgF30qcqOAjb4=,tag:Ntpjy/6ksGD63A/WcamL8Q==,type:str]
+    password: ENC[AES256_GCM,data:EWGuZAMLP/FD6C9OcVPgexeLDQ0hBD4LtTDVAwIu2nBax0oNnVExk+kZqg6mnco1swvJaTYHeq4bXVLclzoYFw==,iv:5TsXu67vEenljjIZMxqjl8Au9xOw9zaprEL01byAm8w=,tag:kTFAgAq/zXJKDpZNeG8BtA==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:1GNVqMDzvgl8s24nvNZQcB+Rlxs=,iv:Z9uvg0YlF4uBDw95jJyPYznUwg6aJb37RoomvxwqcHI=,tag:TrMQk2Wxfv4FnHlvBaKv/g==,type:str]
-      client_secret: ENC[AES256_GCM,data:1QNixTP5xV31WruOswGIYLLtldAZZYkOm39wWZVW7dqBjuEY02iJdA==,iv:iXUBICVhRJAHp6Sz5YmhZyu4ORlpATghRXAQNqpjMhs=,tag:k8rMzsXPX/4mTFkhkPQ3Kg==,type:str]
+      client_id: ENC[AES256_GCM,data:X5Yhzh8gBiU1a5pqDZIw3rsJzsA=,iv:gdyYAiI9aCCS3GQh1UtszLXA0qxjf71xA4HVv5rcOf0=,tag:R8O0nUd4v55SAmMf9Jy9Lg==,type:str]
+      client_secret: ENC[AES256_GCM,data:MiR2duRu+n570arbKJZh5+9D/fxEm+JNC99Pu9kUa4eMJtVyF5bNGA==,iv:dEpd6b3+KmRRq/YK1/nqkgAtU/H2BtdiKCFhL3Pmtlw=,tag:W3rpfhVLfA2RQKffEOoNuQ==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:g1OfJlsmL9RKpiwwJg==,iv:9NppvLz3qgaubih6v4drmYRe2/XYutojVy+utGd5FZA=,tag:0vVsVPQYTT4poFauvTWNow==,type:str]
+      value: ENC[AES256_GCM,data:9LlcNvegZSDkNgyqOau3enFujpeWd41CeyCxnzu27waycavEBgPnGLhKDMRJnW60I+5LBzLFVb8OyS6N7sg10EGWPaWNXJ/b1QnHvC5QhQJvgijKwFI4qtgRf4EyY6hX1FeBcb/xWBvJSE598whwoI5TJeG+JSe2PHm92oN6eT2+aXwynDEl6Z6m3fnHwDd9qyHKA/1VgmgsNV+3iP8y/87iioNNcqDxqF+Y0D6FCa4XWg==,iv:nqT891h0EPtpi+sCu4UOfJdRsQvfI4D2EJIHdC+UQLY=,tag:5A5HHLQzouqevoqwtaGhtQ==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:r+A1Wmst8UJdKFkWCQCZdRNp712nHdte5ofYEDQj1GC9XgWh2v6CQnWsbFi6KgoGQEIQjtiQDaTSggEZFH9uSg==,iv:d+GCh2Z+WHV+yWjxC4+YQ7IaPsa/Ryg6NlbhsBNJFio=,tag:CU1gDKrShOmaYvFJ+NVulw==,type:str]
+        password: ENC[AES256_GCM,data:v71TXUj0zmplL30SpfM/TwnOjUxj0wNK2Fihw/G2goIRGnG62pbnumZ2YvLq1kAN419OTgWz45AAG2Tw1KXKtw==,iv:7O9c4M8SuSxu8S3bKvwunAoKzwSsvtML7np6clLqjBM=,tag:fWJByRskBxAXMgiFqLdYSw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        hptZ5drzQA0LCXw7RMCMSBYt5KCPL1F45fUm72RGew3kDIIvkEJfIDvUGFFaBYe6: ENC[AES256_GCM,data:1kyBMa2YzoQpC1h36LyQiYxuOv30kaOkR8taj7PCe6i4DCdIhBTjQ5VnA9PsIE9jVVHhvXc/3i5UQi7A,iv:UDNpv1HO3MkOJxJ/PUEeeGTgZztHiBI2QTQQq0dg8KI=,tag:ftcaLdxVT0U5uUy64wxyyg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:05Z'
-    enc: CiUA4OM7eD57oHMfCsjm+Gwvq96yCuZ1cGTcdDlN1fjBp68O+Xx9EkkAZoeZpgoRToPD06a94x9S8ii31wPxceTwSanA/ICb1973UQs26861Zy+7F0J3VTNpCLSQoa/9PPay/d6fFPtoCrQ3TKm4Fbj7
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:06Z'
-  mac: ENC[AES256_GCM,data:n4rEiEXCUiDJUHXKOYJUCPgOBpk+wAkTzJHcTC2fEQvNJkzJ7QMI8cHpcbA1UnZvZDufG/jY4kL+ISo4/r4iWMhEQAAmwCu7+0pi1f7sCS3bJwfR/L5C0SQERvi22Gm78hy/soBYdevLqiI2wIlp6tt6TdU323MKrvQwjHoYlfI=,iv:oSRoe1wzp8bAzUQcxKYZzsvd/85hEQNKcp6Kb4gb8+g=,tag:jCkDv87AKeeu/xW5LS0sYA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:54Z'
+    enc: CiUA4OM7eEdNpcXCknOKhcysSEK/PtxxY3jOtMwDG7ohbf1H25R8EkkAPHlbmTnsgj4R0g5Pu6Ocjqij2uIESRIR9QkZAYWoh+PP8wvktuyqWkNtq1qTNbDeq7wO94Y4P7S/U8TMJE7hJFB02gJ4GY0Z
+  lastmodified: '2026-04-16T19:32:54Z'
+  mac: ENC[AES256_GCM,data:OQGGKkDCxgJpoRA2ZnTzCRXSzM0HMTHd3n51COXSZKe3pV8qfPBsUW48qi7UlkZpEuIo3ApBunTuSVJRx/7a+rQfkNrD0QpvgOCTRsLn3SE2r5MHVOMzLeR5RBe3R/4hBP7pUe/etBWKPfNGv5Prbye8m+2eEKUS3kYwbYh9SHM=,iv:BwO6j2xQLTuFHP9Z2xGsgySr12BErmUAWxjixbMecZc=,tag:dT1fXRo9/lMHtMqyAa0/5g==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:XR4q42Yxndmvl8WqlNdPDvfnh2pmxWRgXtZCduZI1kTa9EVZehLCwB88QdwWGk1hx39Bo8+I7bjplZ5UvUW0Qt0UxNms2m3OcTfAU/16nBDLv3ZrD6nXUg1XfyujtgSzbV8pvG4svAmwKQjH17r9DmThLccorZUzJRBAxq7FvRjk5BmlqrPUlwpvQ7VWMw4aHnWT2A6v27CZTpD9,iv:66BxLrRUmcHmx874lBrLHB5+F6fWSLyoJFi0Uzk+huA=,tag:L6Lqo5quZFIpcP/JPhLF6Q==,type:comment]
+  #ENC[AES256_GCM,data:yKVL32StUwpmHKrndVW6baB4n4OAHnlK5pw2XMBToTQV7SFxbcrj6q0h7zGLkq6d64TGQtM9gVrElvX98NDWu9jQ0/Pl1XiDK4D/VBQ/fnKDkdMIWLqarHOaRj2PKEoyiYF3uzsuZRib9e8C27p4MHw8HG/SItPDlMAltkSgNOgoXNz1fW2NTcADkhodrAAOs0DYs8vvdLCk+qKK,iv:Wlf2Rc1QBbVs5SW4HLrJYqlbVS0HzksUI2ahZv9CyPg=,tag:b9MHdW9lSxnycOQzTbyBQQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:gRBDwKApMkmDkLM/I/uiCbNEdAJjQzJIbpUFXWpHCMEGfvHwpcry6q2+tPYNUhxc3L1LwEAEwO8YIdcYkHkXkA==,iv:16aAIs3xf+BOKtG1G9c5wOyIlN1cPqGgF30qcqOAjb4=,tag:Ntpjy/6ksGD63A/WcamL8Q==,type:str]
-    password: ENC[AES256_GCM,data:EWGuZAMLP/FD6C9OcVPgexeLDQ0hBD4LtTDVAwIu2nBax0oNnVExk+kZqg6mnco1swvJaTYHeq4bXVLclzoYFw==,iv:5TsXu67vEenljjIZMxqjl8Au9xOw9zaprEL01byAm8w=,tag:kTFAgAq/zXJKDpZNeG8BtA==,type:str]
+  - username: ENC[AES256_GCM,data:dFvYQX0nD4tu4FpRgMkTX6IZ3PYONvorF+cvCyrLqid8M8dHWzgQkuHLnkcXwA4YwHghhCEPf6hLOhYqG8wE0Q==,iv:YnABTH2NJE51iKCyZQqowf8Gy9w/N6iU1QqclF3igJ8=,tag:wPBa7Sg9teGrdwRITDmKRg==,type:str]
+    password: ENC[AES256_GCM,data:Caw5968VirRPZeMYeTccwKKyAxkB83/uvzdTp97XH8yx51RWNGzjHeldc+T96PDF4NpxPqXBGBtrK23fQydp5Q==,iv:KpiIFz6lOFIKcC/ufCDgQb3L3xwc6Cp2q+6yX/cBjY8=,tag:99soYXdwYgRRnb07kkfw3Q==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:X5Yhzh8gBiU1a5pqDZIw3rsJzsA=,iv:gdyYAiI9aCCS3GQh1UtszLXA0qxjf71xA4HVv5rcOf0=,tag:R8O0nUd4v55SAmMf9Jy9Lg==,type:str]
-      client_secret: ENC[AES256_GCM,data:MiR2duRu+n570arbKJZh5+9D/fxEm+JNC99Pu9kUa4eMJtVyF5bNGA==,iv:dEpd6b3+KmRRq/YK1/nqkgAtU/H2BtdiKCFhL3Pmtlw=,tag:W3rpfhVLfA2RQKffEOoNuQ==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:xQ==,iv:rKzX2Yc2R0hLoW58oC53vCKKYoy8Qzl92k+/fqsFmYg=,tag:2pJHiao2L48ONLovCswN7A==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:k1I0WBnXgRDolA==,iv:Hz85Gs8XCkAjK848fKIzufcSBiRkSlyhXu/BiN9MIaA=,tag:rIlV2kOvBx8Nc97vXYUpmw==,type:str]
+        orgId: ENC[AES256_GCM,data:wQ==,iv:rYZTVOimmiqOw2HMy1oWuxCYAj0fGdS33jxi7D5CpmI=,tag:NugqwxZCTbEkXEfX9Ht0sQ==,type:int]
+        type: ENC[AES256_GCM,data:GNzxpvGJyYZtog==,iv:O/66/AtPu5dW5ir8vt2OwiYfz5MxovnZVTLz16LLkfs=,tag:2bj6qZojOLJBYs0APxcwLw==,type:str]
+        url: ENC[AES256_GCM,data:Q7wKEngjWRaPbTt5ouZeCIRpF4j+XFWykUFwDNKx2l8=,iv:QXQIC1NzHmyR7d62fuM9jq9bSwQ7S7lvvpw4OAK/ads=,tag:MQ6UKCNMCo67Wtvi47j7fw==,type:str]
+        access: ENC[AES256_GCM,data:5dX3Iz0=,iv:9ioDmp9hui143YiAC3C+MRBYTiwLgIbdYrKI61hemFI=,tag:/tYfoXFJCo2Gk6WP3oeUZg==,type:str]
+        isDefault: ENC[AES256_GCM,data:OnPj1Yo=,iv:Jy0hlcnaYtyIqQTk1MXVmuxmfmPvNd4yczXzUP+8o1I=,tag:WthqjgYy9KflM+S4svUumw==,type:bool]
+        editable: ENC[AES256_GCM,data:vBO2FRk=,iv:czBWrC1oKofHRrKOtyqGEhgUp023ompwT+YFcUiqbKg=,tag:vQmSXorEBMMYtAwIJrp1Lw==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:I6fabg==,iv:tnzObtnJkgnVNQJdwMcKY00/vLCYqiIm3eCEI56dHz0=,tag:0pKTiXqOwMRGFyV27Ck6tA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:QlNy224T1udeFDuY3ceIQDK+5FqDaMSxElOHIo0zncbzIl0SQDmhgDBLgO3FD4iQJK4emNFnMG1GRmQ8WBQfXA==,iv:ssx0iHnCYWRRdjvjpmsa7DIc6TGe9B2P03pj9w6C+ME=,tag:khve2kWJkmOtWCyGQGj/sg==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:3rCi/ZRcIziwksFkO1z/1WezOWsPRLl2kA5LkTMJBDxSBRViuzywNeFVfWGihW0RtC9dhR2DVs/T/oIzwpAbzQ==,iv:5SEWnXbT+wpUmwgX581XJHsDuwCfXBZVoCJkC5X/5J8=,tag:FPl0pje+89QhuBp51GUZOA==,type:str]
+      - name: ENC[AES256_GCM,data:pgb6EN5IA2IIPWFPAScrbsTIz07UzcEkrQIc3AtyDw==,iv:G2lD2+EJqFSpib/oUR7VHMdxAOwDhO1fhxda9EghAXI=,tag:w2GlPme3CBdC+zsIseqLPw==,type:str]
+        type: ENC[AES256_GCM,data:BdHbEnGp9HQidF+qU1WtwOP3RfA2ALx4l6+EZKK7qA==,iv:Vo5qYrs6dR7MGfYKgTpgmfTMkXQ/RMASrC9yDO0qp+c=,tag:hnJAYJ3fS88NjccQD9Ujcg==,type:str]
+        isDefault: ENC[AES256_GCM,data:4h4fVmc=,iv:dfDI++y0cvml9LMwhBkEApZZjUQEZ1Naww8lpNfezOA=,tag:YMaPvbFHKmQgEL+Fnmzrww==,type:bool]
+        editable: ENC[AES256_GCM,data:1Q3VTA==,iv:4TzZfGqGodYxwQ5cGd4A1snqkDTj41g/dUdRTJVdwek=,tag:LeYgT6rVPw5HonAFA/WSbg==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:g1OfJlsmL9RKpiwwJg==,iv:9NppvLz3qgaubih6v4drmYRe2/XYutojVy+utGd5FZA=,tag:0vVsVPQYTT4poFauvTWNow==,type:str]
-      value: ENC[AES256_GCM,data:9LlcNvegZSDkNgyqOau3enFujpeWd41CeyCxnzu27waycavEBgPnGLhKDMRJnW60I+5LBzLFVb8OyS6N7sg10EGWPaWNXJ/b1QnHvC5QhQJvgijKwFI4qtgRf4EyY6hX1FeBcb/xWBvJSE598whwoI5TJeG+JSe2PHm92oN6eT2+aXwynDEl6Z6m3fnHwDd9qyHKA/1VgmgsNV+3iP8y/87iioNNcqDxqF+Y0D6FCa4XWg==,iv:nqT891h0EPtpi+sCu4UOfJdRsQvfI4D2EJIHdC+UQLY=,tag:5A5HHLQzouqevoqwtaGhtQ==,type:str]
+    - name: ENC[AES256_GCM,data:36LbSciIbDBwTvcUPQ==,iv:EN1ZrQoiNAdWYuXtgZ9e9LrZ/lzX7O33gD1KGUWTLhk=,tag:BwPgZCGvMXIkHwkgsDwInQ==,type:str]
+      value: ENC[AES256_GCM,data:lD4ZL+fKXpntFsczPV1S6dhenf8nIQ6CCWupXwj8EX7OrAHYkRZxnfT2tI5iw4cMSPaYjcvtT9UlWt6PMazBJ4zC/XRR64USIme24iqxNvSO6wlC5JzKMWDwao026aStErEmxuQ3aJ5f7CgwJtxbwp7MfQ5tOJHGjhEdldzwC2AecyrGnIvaBqZ8CGv2YKlxfIpanHCXgdlo68Hw2l6aDlA5c4lzKPw3brrOKy+NH+p82w==,iv:HBzNU+hDKHBB+4RQXO4NEaCNbJl45wQYjgxSKEYzgdA=,tag:Sx+q7C4adD4vFDyoldno7A==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:r+A1Wmst8UJdKFkWCQCZdRNp712nHdte5ofYEDQj1GC9XgWh2v6CQnWsbFi6KgoGQEIQjtiQDaTSggEZFH9uSg==,iv:d+GCh2Z+WHV+yWjxC4+YQ7IaPsa/Ryg6NlbhsBNJFio=,tag:CU1gDKrShOmaYvFJ+NVulw==,type:str]
-        password: ENC[AES256_GCM,data:v71TXUj0zmplL30SpfM/TwnOjUxj0wNK2Fihw/G2goIRGnG62pbnumZ2YvLq1kAN419OTgWz45AAG2Tw1KXKtw==,iv:7O9c4M8SuSxu8S3bKvwunAoKzwSsvtML7np6clLqjBM=,tag:fWJByRskBxAXMgiFqLdYSw==,type:str]
+        username: ENC[AES256_GCM,data:ViTbDoCnFctZ+0gGJNFkpRq/QgcPXJRP0HjPaE7VNPGvElYX+HpojuzOmesN3RmU8gaBaC7wpXkH+RtJGahPgA==,iv:FBOBQ1K35DS8KH/5bWCaR3HS2UTzPuxQS9fo1yR45m0=,tag:o3T8wC1q9Wg2UwZ6/st56w==,type:str]
+        password: ENC[AES256_GCM,data:qTi8cqA5K/kLBdNKpKqYLUDNNBLRqr/JE2pHHhsV/vr4C+ilzk63IeWJqp1kzquQU/KZftjI+Bfhd+r3ukatbw==,iv:8uI0YW8snIHgHPTzku+3E5JzuBqV84+VzbAmMA3edFg=,tag:4jNm/yyikbPTaXlt3T7HgA==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        hptZ5drzQA0LCXw7RMCMSBYt5KCPL1F45fUm72RGew3kDIIvkEJfIDvUGFFaBYe6: ENC[AES256_GCM,data:1kyBMa2YzoQpC1h36LyQiYxuOv30kaOkR8taj7PCe6i4DCdIhBTjQ5VnA9PsIE9jVVHhvXc/3i5UQi7A,iv:UDNpv1HO3MkOJxJ/PUEeeGTgZztHiBI2QTQQq0dg8KI=,tag:ftcaLdxVT0U5uUy64wxyyg==,type:str]
+        hptZ5drzQA0LCXw7RMCMSBYt5KCPL1F45fUm72RGew3kDIIvkEJfIDvUGFFaBYe6: ENC[AES256_GCM,data:32+GmLJfhqHht9CGky/KGfJStYYtGJPjHn4D8NVpK6f0CQa03RcNMmg4lW93+IJwb8iTLeiDrt2xNuvL,iv:k5RcgzldNZnhui7sMc5zUnDY7P8nq1kg/ARWhspeKUM=,tag:pT+M/y8su9QIZxcSlBS34g==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:54Z'
-    enc: CiUA4OM7eEdNpcXCknOKhcysSEK/PtxxY3jOtMwDG7ohbf1H25R8EkkAPHlbmTnsgj4R0g5Pu6Ocjqij2uIESRIR9QkZAYWoh+PP8wvktuyqWkNtq1qTNbDeq7wO94Y4P7S/U8TMJE7hJFB02gJ4GY0Z
-  lastmodified: '2026-04-16T19:32:54Z'
-  mac: ENC[AES256_GCM,data:OQGGKkDCxgJpoRA2ZnTzCRXSzM0HMTHd3n51COXSZKe3pV8qfPBsUW48qi7UlkZpEuIo3ApBunTuSVJRx/7a+rQfkNrD0QpvgOCTRsLn3SE2r5MHVOMzLeR5RBe3R/4hBP7pUe/etBWKPfNGv5Prbye8m+2eEKUS3kYwbYh9SHM=,iv:BwO6j2xQLTuFHP9Z2xGsgySr12BErmUAWxjixbMecZc=,tag:dT1fXRo9/lMHtMqyAa0/5g==,type:str]
+    created_at: '2026-04-17T08:24:18Z'
+    enc: CiUA4OM7eLrOFl5vWH6y3k+nEIgXHx8yvu3+8qeV5psnlvF6MRDxEkkAPHlbmf+d8XTAW+nXtUVGork/lsbEHPGN+NAkZNd6Y70A/zZiZDDO6dYc7UDt6uN5DeeSKOsVtzxU2P5MS8Tiwxo1Gzygb/Zn
+  lastmodified: '2026-04-17T08:24:19Z'
+  mac: ENC[AES256_GCM,data:Son/9XhGNAJzNOdeEHWShIfptemf0C77cZlfUZ+xYcepcJgtSYtuAtzi7c7nh6E/rla2HAv/xAXxULVi+Ng8mtfkxRlZDmX0CPWA3IsM4swOjcxWJdN8iWg2i0whqDBBSRCi8VkNcRVL9QSvvzuV6WkV4cNTbX85cXaXoT50dAs=,iv:ILkbnx3EWMKH5mXpzxhcecnxzEFfsusDU3f1D8xVXqc=,tag:TRScLw1cGpSstRi8cK3D1Q==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 nginx-ingress:
   enabled: true

--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -47,6 +47,8 @@ prometheus:
     persistentVolume:
       size: 500Gi
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 cluster-autoscaler:
   enabled: true
   autoDiscovery:

--- a/config/clusters/2i2c-uk/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-uk/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:h0lL9L6BYYBsrnPrj4LXlDWzkC0d6RQz5+OOIumkEs50HOU4FADwt2XtmKgUqnmXtEREKhMI7XuUI2iACll16ItygqqhVTgy5Q4jvITyhbkLq43pp8huJBreUpZbBWWqL7tQVAWnB0uMfCth8ogZhva6rsAI6F63aAbEJXQOnTblRURwjbHORtQPoknOrsER3HM/Kl4wpaWEWY87,iv:KEOADY38rTfNsyA121PlAA515LBQru9gKTzHo3nlnkM=,tag:3AOW1W3TozTHuB7GbC+meg==,type:comment]
+  #ENC[AES256_GCM,data:ktXJg+ryw3rxF2Obtu1K5RJ0KeCMTyD3pbQkAyNT9Gr0hKOFS3aoJyYGq5jItVOpir5u8g6766JbxpPRINMj61vZTiravtCUnxgxynrhVeaAW0pm+4poLS2y/vwy2gh4J7nx5Ukwo1DeXFBHXyIY2LI8mGck+VG4Z8hRq2V/bXSvRvJwxyLusysHWwm6QswesI6ljJ3amWt/8IyI,iv:kWKQavKHpjq92gU8KECwc1ddmhFNJS8ECcN8SZw+iKw=,tag:eQqEzx5Alxk+XsDasaXYpA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:5iBOGjiCpWHNoao8ap/FCR8uu4MoN3SUUx5okV6mUy+CMMMI9e3F9lGL3XmOvW3+Nx4413057r5bLd0A8MopAg==,iv:qT8n8IF4bl0IXAT6b/LbPrabAVWR8ITylxFc57qN4W0=,tag:donosnkK+hrIhasQ0j9poQ==,type:str]
-    password: ENC[AES256_GCM,data:BUwDEL0ti803k5PxZS4gMTRrFeifONGJk6a9+7RhWgirtYqhTa6TUR9Ej5dl1+wgPH1OXYFfbRTkDsYohWeZgA==,iv:vaWM3Va9jXbO1SZnSzhhPLORrD/NMDujrdJUiI8X6/Q=,tag:z5IK11W5z++g5ECUvxAQwQ==,type:str]
+  - username: ENC[AES256_GCM,data:f7Rjc+lcHrYUr9cUWh2G4/KBFtQym72oLt5Ac/LU7KYSyYWPrVQGwltRUIK4WeyOyNPQAci8188J0v6g4OLChg==,iv:GwmECizuuUpR5Op8myrXBU3pdaYsBvm7FYGgcKoNibk=,tag:Njy4xXREwTQsLw+SYE9LPw==,type:str]
+    password: ENC[AES256_GCM,data:Cs2EucljrfanKvqZqhEwDe/54Zp6tt5HApy1TlcQFYl3adY5a8K6U5bSNodHie9iD7fkPhuxGrwz/KOEo659NQ==,iv:6zz5ACqgy2hvN2Lqaeg7Te1EoSbU+Sm+eNO6dXPrtzQ=,tag:9mj06OlWYnyYflhFcx75sQ==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:DsiJ6rOG4OIy4XhjKAdpKWZbIRI=,iv:unXYiPGyEWrtRI4OcqD3we2sr9C89GSWNsyzHCoOdFc=,tag:I/75GPZMjqo2FqPkjZok/Q==,type:str]
-      client_secret: ENC[AES256_GCM,data:ndLSP6KlTRjIF71U/tvW00ivbelehCT6CC6zXt2OAJhCciWKzeiuMQ==,iv:LT63mUIavIunlq0alTBBsBioXgzXTOW5S3gyPQ2rQ+k=,tag:pBkDbbCdFfGoNN6kffXiew==,type:str]
+      client_id: ENC[AES256_GCM,data:XNXui7DMOx5n3J7gwd/w6zQJeTo=,iv:wjY7+ij+owtZSEiOU8fM5wqNqND9IzltB3P8zgb8jF4=,tag:RI9zTxGGhL54+/GUtslBZQ==,type:str]
+      client_secret: ENC[AES256_GCM,data:cXgVYdBmmYAH+aoJMYr6edY3u/Y38Xpz2xAxmAFRxHyjPTt3hCy7jA==,iv:k4fy+FZJWe4YIjPeCjtzZKtQqd3caVFbpkJUFeYlHn4=,tag:9bzlBIoP1W9WDdR9sEUnGA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:UHXAcPiNF3UPx3FAHg==,iv:jXXRzwDWTIsGmIQIHB/4fGYXpGbXZ7+xDUrGIbJ++bM=,tag:rnmb4RdbmnrMMuNKKKcNcA==,type:str]
+      value: ENC[AES256_GCM,data:svHzJRkankaLfQ6q+TcJHFcKMJE0k71yPJOqGT2pY8+cQkNQTM5/G0UVqTp1HzHXkMaJpR/e19SB09uGDz7regjBqFYsqca4/GXPjHnCWbfIIXg2Hm/u0b91aqX/cP1qFyOHgiLoPzkjOiKxnCKJ22EMtJ8T6GAD6Rehj91kC7qMtzIm6afuxAgKdJSdw1rV8EDyAFzyOO6KkC2tlaU5ZYoLW5Xlvw/+v0y7zvBY0LPLFA==,iv:TD5UT/uPnbEngymIfm5sC676pX6Gnys8dUKsYYh+HwU=,tag:2EWN9M/G9X3quykrPJ8MWg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:NoTu3uAbj0dP2qfKQLQb7kEgR8KySXA19sbda4o4Kwgzbx+cpmsQt1xCxYT803GFW7usRSLNleCxvdAwD5RPFw==,iv:SJUNYheZDeOghA3yQNV+y/0fz/CXptaI2vaZyg497Mo=,tag:BvqMKKOV4M5Gb98glEFTrQ==,type:str]
+        password: ENC[AES256_GCM,data:E/WO0M12j4yQgk/ea3/LSZJJfHNx0b3m/b3mhWIoiHVgl0tUE0fjklPXFCqq5Ur7GamiYViMgkZOYpS6oRnV5Q==,iv:NQsJD33b0EUV2VO64akS0qRLBygqzHV2NKgKxsHo7V0=,tag:ZsEp2XyUhvddiTaX33hHOg==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        hLdo4Vmj7JiHKF7xPBJn1KEBuBx6Fj3iGg3lXZnxuMZ8OoWqQyRL6bA6mWXXne8z: ENC[AES256_GCM,data:Pwfw9JqQnoJlKYrZqFFmYHu7vddKEBY2FEEDuH3DnhPB/b91bUjxl6qx209gNwRMwrRGa6pH/YrRH65E,iv:9hOQa4jnjHm/y/sHsEwrTbHQPrwEVcSMXELd0iXxqds=,tag:YKh78pECOpxNX9UQt2YKEQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:19Z'
-    enc: CiUA4OM7eHToUMIVQmzcSE3zYbMvYKmnfyWrJbS+gg1oVah+CrJ3EkgAZoeZpvHGIfMgMXr+iresAHtiB6ezKTmoH5iXEm34AIICSeYnbHms5G5SJor445ylDTSpPpAF0nPC0KKqhqAkZuFaY7mBm28=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:19Z'
-  mac: ENC[AES256_GCM,data:okJazg+TFX78/QbW+MVtb7Tyhm+CjMvxdvpYHHwFH9TdFc5s0n9WeN8OzuZtX/dC7YHp7begvVtkVtU/xPW2W+SRrQ8v+vFYQ2/2o2BEH0Xmh6K7cJ3w/AWIclNLMu1q3piy0d5oRiCNT7tmY+U/3QPEkLmRntGeJ+gnxpEho1Y=,iv:L9RCFqLiM0d7vwp+ZVgAJcAYqT/tEIeUAEGuuvdl0Bw=,tag:RpdXLMEBWf/ws6nyxUw0aQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:58Z'
+    enc: CiUA4OM7eAj1u3SuMvJBIXVxy+c0602e4AsOLHz0jRRMJIQ7dKcpEkkAPHlbmavtz2Ni41dvC24FWGhVA7YO+OeqR31uz0KH/DK4CF2lZdgF1DV+eTYHqD8QCAQJRHdyFOtKwJ+rxAjaPCkrb54yqUr1
+  lastmodified: '2026-04-16T19:34:01Z'
+  mac: ENC[AES256_GCM,data:9l4N0TcZFthH03kKAsIhSlTQ/OP2bNkLEfWVs1Rkk1sFRM0Ry5bpAptqRFuzubZ+PNZlasyI7Zyup7yQFYhvrVdAaXHPZyQa7mYxxmgfrSJbgyPiRFW6KvlieEnV6Hg0IAF4Jg1kK4yHrFxN0FmuVxJr2DSz5ygFxjZXwmnEuxY=,iv:mQZ3grok8Su1cZTaK4sdd8kkCB66zyaRgzvGAZCwlh0=,tag:hbwf6eNaBIt+IAn0rMrSKA==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/2i2c-uk/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c-uk/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:ktXJg+ryw3rxF2Obtu1K5RJ0KeCMTyD3pbQkAyNT9Gr0hKOFS3aoJyYGq5jItVOpir5u8g6766JbxpPRINMj61vZTiravtCUnxgxynrhVeaAW0pm+4poLS2y/vwy2gh4J7nx5Ukwo1DeXFBHXyIY2LI8mGck+VG4Z8hRq2V/bXSvRvJwxyLusysHWwm6QswesI6ljJ3amWt/8IyI,iv:kWKQavKHpjq92gU8KECwc1ddmhFNJS8ECcN8SZw+iKw=,tag:eQqEzx5Alxk+XsDasaXYpA==,type:comment]
+  #ENC[AES256_GCM,data:3Z9ZSGsyIW+15EEHMNrK3QsmDWKPYth0JlMFBgNihqDdSu70y+Duvoh9fYJcnLnqYprS3JslhsgFKvQVGus3jtiA7f7mV3VXyfxOCcwYF/tRlg1Bbea9p1lW9szV6Mw2YQKG6bnwLm5MSMGmox/OWFzu76d1yWkYSczqkbUmPTPe054A/mSr7/w2XvAF80tz5msO8YI1fbnZ5Ng7,iv:IIEzJbmJ3y7yO1A+dihqq2nrLJtk9wy38fFTH3Q7IY8=,tag:VR8G1e+k5eotoitv9/HZtw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:f7Rjc+lcHrYUr9cUWh2G4/KBFtQym72oLt5Ac/LU7KYSyYWPrVQGwltRUIK4WeyOyNPQAci8188J0v6g4OLChg==,iv:GwmECizuuUpR5Op8myrXBU3pdaYsBvm7FYGgcKoNibk=,tag:Njy4xXREwTQsLw+SYE9LPw==,type:str]
-    password: ENC[AES256_GCM,data:Cs2EucljrfanKvqZqhEwDe/54Zp6tt5HApy1TlcQFYl3adY5a8K6U5bSNodHie9iD7fkPhuxGrwz/KOEo659NQ==,iv:6zz5ACqgy2hvN2Lqaeg7Te1EoSbU+Sm+eNO6dXPrtzQ=,tag:9mj06OlWYnyYflhFcx75sQ==,type:str]
+  - username: ENC[AES256_GCM,data:PfyrDYD4KPwXFpynSl/JkX1rDeR+/XeZ5vKE/VfQUSBHdeu18s72og+BJldgQaC677/xE8UOObBvsfoYxMZvXw==,iv:n406xtMB4/t6mySH2x2z6sdbZsCrWAcmZx0zoNsMfeM=,tag:NL12qmgc88+ot8wjtO6mRw==,type:str]
+    password: ENC[AES256_GCM,data:0dTnhV/eShrLb1Y0zNT4L+Qxuo4hnmighTbnah1q6VkCDKVATbjnECZZIrNEmB+gorUB92Dn32uKIFqjeMe/lQ==,iv:5YpB55vLmmzwkKr0/0+QfhrUUiHhbzE4CXtSOWp+pEs=,tag:/E626blpg4j1A8F1O/N/iQ==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:XNXui7DMOx5n3J7gwd/w6zQJeTo=,iv:wjY7+ij+owtZSEiOU8fM5wqNqND9IzltB3P8zgb8jF4=,tag:RI9zTxGGhL54+/GUtslBZQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:cXgVYdBmmYAH+aoJMYr6edY3u/Y38Xpz2xAxmAFRxHyjPTt3hCy7jA==,iv:k4fy+FZJWe4YIjPeCjtzZKtQqd3caVFbpkJUFeYlHn4=,tag:9bzlBIoP1W9WDdR9sEUnGA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:fQ==,iv:VWBcK8UgO8QK2omV/iFA73JWnVYkR+gvOLacFDHIvYY=,tag:r4QfjH4PF6EJhrR9E2gSGQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:UZHLzE4Nj+voEg==,iv:OioiLaN4+NRTzzPwOwx9eksdosWhp2GWAvUbzd9wSqw=,tag:peorUGK+2Lf+ClbBkB/YjQ==,type:str]
+        orgId: ENC[AES256_GCM,data:SQ==,iv:U2fOEuP6ftf5C8OLYeohIZPc6JrK4EMG5siz6O9T4s8=,tag:whw4X1u/kMczWFBHDbhnaA==,type:int]
+        type: ENC[AES256_GCM,data:YaMuFpQdoUkXdQ==,iv:QghvzC0hzTYOzsCPIOYx0edWvP/3xV6jGk7wLGRz9oA=,tag:5sWkoxeZRWjuZ19t7pbPzQ==,type:str]
+        url: ENC[AES256_GCM,data:1DnuVT24plUoPmEjCEMmR/VjCQuM7WnVd3kuBMtt4Iw=,iv:1VEZnt7QfkEmDnjmDQzPeGMhqcJ5c/odOGa3KRuOE64=,tag:CINWC2mAbgMGgJ3DMIXvig==,type:str]
+        access: ENC[AES256_GCM,data:+zFWqy4=,iv:h7848zZtgfFNBRs4BFSeRR2/hzzVd20oMAK7QYMIF38=,tag:yGJRTvQwwqAtHxq/m/mIfQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:ZqdnX2A=,iv:n2X8Jkf4I4dTFnW2Y4VwW2olqP68LwQHSChTfX9yIyI=,tag:vJCA/IWTERsq79tumhcuiQ==,type:bool]
+        editable: ENC[AES256_GCM,data:cpIWVSE=,iv:pYNcTrAQVxvo6XQkYQaGo+7OB0UsF6j4HyGJkdbARz4=,tag:ja1pBD8esHVPxS5fHOO5LQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:Lx9qSA==,iv:0ddL2eYASiBD8dERMTOZYCAliRWR3X0NS3FMBV6d4aU=,tag:wR2QyKr3LxfGVwMitG9aSQ==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:MbebmmN+j1THR+zOKrDTzO1aTCEwTy4DTtV42ITZgkkUXYloZIYnlAmK7I8XIycqXpHpdqH2D280DF12XzyBgA==,iv:MwwntZS0vvTUAPbC6WxJEhDrtz36P6ZL+xUucOoC+8A=,tag:9AeE2tx6AOdSQbUN5TKBew==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:CBlkhBgxVf9Sf8srU56h65ORjPeLgxv9JN9maQiAuPB1SXuuzLTwXYYnzpRZWTmv1902bZCPoDs79UnePLZ2MA==,iv:h045PNGVN7VDiPF9mLBcwzYgYlyF9q0W6xsMRXF9ius=,tag:yLwf2aKgyGtao/u/KLJ+1Q==,type:str]
+      - name: ENC[AES256_GCM,data:OM7eG7tU+BsNN7/ckxaav7BXB9XKI/9UZ6St2O6uTA==,iv:OZRFiKLDkXrCHc43bFDq5rxDUuHSwXVRcTO2+BbPHN4=,tag:belZ9qmFdtovkRY+Ms+iqA==,type:str]
+        type: ENC[AES256_GCM,data:5W1ORUCjY5hN7zzYPL90GN6t8ttgKSGdqzgr4ifk4A==,iv:RFY8MZgbgP9P7JOEbkZ3ZRQiMqogty8M6OD6PZEZiK0=,tag:KnOkVLOR32xTv2obhIVJKA==,type:str]
+        isDefault: ENC[AES256_GCM,data:GluxrAE=,iv:n+ANfCrkFnuDMDilElmvvRmJi8sMClLsyLVZ6LUlN6Y=,tag:53cMJbJgbJHn2lphumQj2g==,type:bool]
+        editable: ENC[AES256_GCM,data:38rWGQ==,iv:KSGTjeRWKCPvJPlC2JPtJ63QMEVXC3rQ3fhEyHtpmcU=,tag:KEMRjzS9URjNWmoLu4WoHA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:UHXAcPiNF3UPx3FAHg==,iv:jXXRzwDWTIsGmIQIHB/4fGYXpGbXZ7+xDUrGIbJ++bM=,tag:rnmb4RdbmnrMMuNKKKcNcA==,type:str]
-      value: ENC[AES256_GCM,data:svHzJRkankaLfQ6q+TcJHFcKMJE0k71yPJOqGT2pY8+cQkNQTM5/G0UVqTp1HzHXkMaJpR/e19SB09uGDz7regjBqFYsqca4/GXPjHnCWbfIIXg2Hm/u0b91aqX/cP1qFyOHgiLoPzkjOiKxnCKJ22EMtJ8T6GAD6Rehj91kC7qMtzIm6afuxAgKdJSdw1rV8EDyAFzyOO6KkC2tlaU5ZYoLW5Xlvw/+v0y7zvBY0LPLFA==,iv:TD5UT/uPnbEngymIfm5sC676pX6Gnys8dUKsYYh+HwU=,tag:2EWN9M/G9X3quykrPJ8MWg==,type:str]
+    - name: ENC[AES256_GCM,data:A9j4cbfaWXfMskd2Dg==,iv:W9fvQ8oWnQM9kIRIl4R+/Aj+l6Hkc1Unn+n44xyrcvI=,tag:Xhn8VRUhv6OZIdDpEFLQqw==,type:str]
+      value: ENC[AES256_GCM,data:Lfa107tiq+idZCZoMyEVVu+vbL+SkoCew4ITeLm4XI/1ThuCQkt6VWm9WEwVtpvyq+rW67LnA2yHZt/4/81M/ALvGcJR0utnbUu1hSJ5utthnSy8x8yBR3nbQV0M4Tfyes/3fJHjelHR1UDStphZTBaaS/SJo7Y1DKQTXCoRtlkdTH7SEjrH0kGeCnZG3+MrNpdV1m8l9Da32GMMrymRpkx4S6+0XH23odXMPHI2Sihesg==,iv:i5S3LrSWVGYNh5XoEVE1rNkCUPS+cy7CSq1JRwi5m5Y=,tag:WFDl7I6c+9OfkzB3E0PAZQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:NoTu3uAbj0dP2qfKQLQb7kEgR8KySXA19sbda4o4Kwgzbx+cpmsQt1xCxYT803GFW7usRSLNleCxvdAwD5RPFw==,iv:SJUNYheZDeOghA3yQNV+y/0fz/CXptaI2vaZyg497Mo=,tag:BvqMKKOV4M5Gb98glEFTrQ==,type:str]
-        password: ENC[AES256_GCM,data:E/WO0M12j4yQgk/ea3/LSZJJfHNx0b3m/b3mhWIoiHVgl0tUE0fjklPXFCqq5Ur7GamiYViMgkZOYpS6oRnV5Q==,iv:NQsJD33b0EUV2VO64akS0qRLBygqzHV2NKgKxsHo7V0=,tag:ZsEp2XyUhvddiTaX33hHOg==,type:str]
+        username: ENC[AES256_GCM,data:6rMW5g0QGvMbVr6qH/MQHl46ZydlKgWpUGOIR/rxuleGqykUdZu/4/rGGsEC/e5oh8hlgeC5njED2acg/lTz/w==,iv:YRfOzZjxd4DEyQ0TlSJw/+Q5pRr/Yig4iv4yzN7/7AY=,tag:e9pr81AqzOLGv/bQ44nHPQ==,type:str]
+        password: ENC[AES256_GCM,data:khEPL/BXrCKJSI8Bg+hv0tqSOvsSIM3ilInUbzdvMSDm8QLb2N/raTl79OkIEGwUeLsUI/2bwTL6vdHQtAocRQ==,iv:JXGveijeynz1ugTVuNhDxRmVHv7gBNyuvsbC9tHIdsQ=,tag:/Zj/bT52ZK0LbAdsyqn/Ww==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        hLdo4Vmj7JiHKF7xPBJn1KEBuBx6Fj3iGg3lXZnxuMZ8OoWqQyRL6bA6mWXXne8z: ENC[AES256_GCM,data:Pwfw9JqQnoJlKYrZqFFmYHu7vddKEBY2FEEDuH3DnhPB/b91bUjxl6qx209gNwRMwrRGa6pH/YrRH65E,iv:9hOQa4jnjHm/y/sHsEwrTbHQPrwEVcSMXELd0iXxqds=,tag:YKh78pECOpxNX9UQt2YKEQ==,type:str]
+        hLdo4Vmj7JiHKF7xPBJn1KEBuBx6Fj3iGg3lXZnxuMZ8OoWqQyRL6bA6mWXXne8z: ENC[AES256_GCM,data:5hOzqHK3BKKFNKrjV4GMq/wzeDZHFuzBiwJoLNMxNUOLRspoyM/QucbhvnTAWStn3WgdrKEDU6wXlFNI,iv:/anVHfhAiM6MdYP3Tc+F4OHZsvVlI+DzeNEh85/5gX4=,tag:GWtS5EodED5EvRrM2NYgYQ==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:58Z'
-    enc: CiUA4OM7eAj1u3SuMvJBIXVxy+c0602e4AsOLHz0jRRMJIQ7dKcpEkkAPHlbmavtz2Ni41dvC24FWGhVA7YO+OeqR31uz0KH/DK4CF2lZdgF1DV+eTYHqD8QCAQJRHdyFOtKwJ+rxAjaPCkrb54yqUr1
-  lastmodified: '2026-04-16T19:34:01Z'
-  mac: ENC[AES256_GCM,data:9l4N0TcZFthH03kKAsIhSlTQ/OP2bNkLEfWVs1Rkk1sFRM0Ry5bpAptqRFuzubZ+PNZlasyI7Zyup7yQFYhvrVdAaXHPZyQa7mYxxmgfrSJbgyPiRFW6KvlieEnV6Hg0IAF4Jg1kK4yHrFxN0FmuVxJr2DSz5ygFxjZXwmnEuxY=,iv:mQZ3grok8Su1cZTaK4sdd8kkCB66zyaRgzvGAZCwlh0=,tag:hbwf6eNaBIt+IAn0rMrSKA==,type:str]
+    created_at: '2026-04-17T08:25:22Z'
+    enc: CiUA4OM7eATLLHR/I/GWZVx8ZtRDvtJ6sqAqad5CoIpndQnGkkf8EkkAPHlbmbKP+uzgkEQtuz0let+XBQXKFzaZkmMiLXuUHKXCaNbcNI5F38Rrs55lM4zQqWN1mEV5lYW2mbvmhv/DuAwDGahHv+wT
+  lastmodified: '2026-04-17T08:25:22Z'
+  mac: ENC[AES256_GCM,data:NDHdXV9MEo7gajX8kqU3QBQijVaaCHXPRjBH8lp3tN8q2gzXLQeQ0F1B1S/XirRgu9/mMkYtwlDZAflxpydjtznuoW8p153nM9kTZyR8KDDiHQiG7nncD6hj2b5X0JjvxJPZDXQhPoFGN2BMBvL4z8V5lMJHVZvf5OyvT/2gIMM=,iv:fsCmetRSdICEh+s7XFLEG+QX+Eu4Mcb3HhlZsAtnK7E=,tag:9DWo+OrJ5DYBZ3jljtJqWw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/2i2c-uk/support.values.yaml
+++ b/config/clusters/2i2c-uk/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.uk.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/2i2c-uk/support.values.yaml
+++ b/config/clusters/2i2c-uk/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:W0G6H+16dxKihTFt0BHYwS4tgUxj14VshZffW52nHpAMY8M0vCkxfY6WCwP5G9jRmGQ1Ccb3RDJX8n4WS5VjOivzRz1r0N7YxGKncc5RsdDFEDO+ghhU7SoBPg3dujqhOD4At1KYGPONMNO6TNMQ55xLdO4f+OvtPOR1QrVB69QEBNQhlFejyEhd2s/9+reJ0jL2AW571ubGBT7I,iv:Qxxr+yDjhJwoZqCEFCf7+Pg9KNF5nzaWZDzDItK/FXQ=,tag:LtoQJy5TRz8DrCdJnCsJHw==,type:comment]
+  #ENC[AES256_GCM,data:yoBKgjW+Ev/OoqZdqnVHQvfI41cs+qxvNTAApullxtKs4JwDf8ohhz/tE2Tn7OWGq2yIJa0mSdqqLXYd8VacxK2oKA/zthb6lR1ITJgm/ZAWKM5ac4v9aLh/EBSG3DFJLal6v8hfTn//z5QqjQjrN1FzgT3n7jJHMzYy0Fvu90sRhZRN4fEEL9MRvx+dS1nErFls3kVhyh+lSiHe,iv:v6eLx+fJ4ED9c3FMm20elI3Dx96tSF2QELqCXd9YOeQ=,tag:XG+8AL84CIJE5V00q5ajNw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:2Jp7e6sQeEjpt2ay5QjzBMcPfOAMzJH7RYts+tZRs+YmwacHcbfDhSwNdkmyeO6xJuDo6pAkdwIGS+ukNAKOBg==,iv:CkGI9nsrqKQVqQy2PzaOuG4piPZ9niLGisybQspYM2Q=,tag:m2MP8g83pcMqsSYBA6Ponw==,type:str]
-    password: ENC[AES256_GCM,data:R8jKbcQ6bmptGfOF8pX+rT2hO70UE8aVgxTrwezecBSP4MAfB12VYTVlx3wjbDA3SjrXSOzH+eWU1AmM8yw4sg==,iv:9GNZx0ZB1dY6ciInybzm0xKG1sUwmx+mpKcVfPuZ4i8=,tag:pDawR/bbvw7jtcXqO4zwuQ==,type:str]
+  - username: ENC[AES256_GCM,data:zQS+6dfAoZb1WC2WUdzKrdWojJ91Hf76RffzPuIMnshklWAA16BOKfKXKoUPshrQcI6NhQieJgRCs6mi9BJ3kA==,iv:W339mB0J2KLAU0jN6jYoVmW+5YOXwVG50zJTk6na/cs=,tag:Bf58CRb4wsg05Q4rS6k2Ow==,type:str]
+    password: ENC[AES256_GCM,data:FRncFpNVJPTxTJViowbA7XIrcQYe4Rc20PSRWLFba2BzQQqqlLPrvPgjYVvcB3r0ee9rq2P+mCxpSdllrRK3MA==,iv:Xgg3pyuZh9D8KrdQ+79J2F8yBq5OK9ynEcHvus0hfCk=,tag:X8bRgmq14D1tsT56LIQ9bw==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:awkOJ+Q7cKcK9zOIrZ6lnAJ0vkk=,iv:sU1sSLrLEdEY03G06TLcC/1rF8eC69D+77xAVSiYjRo=,tag:AELDcubVAgviuqbBwq+bEg==,type:str]
-      client_secret: ENC[AES256_GCM,data:6RImEO7oyYzS6GYzP78XJxQLl3PjASjgKbEM44o4DhW1F5sKrcVbBQ==,iv:3t5xV4DazfT5Bwy4kIy6A4uJUsbzbnAn3CAhJjiduMo=,tag:AZeH29a0V/GgHMRdevbD0Q==,type:str]
+      client_id: ENC[AES256_GCM,data:lk7l1SEPI8pIiyt5v5dLYmymUU8=,iv:TvYGllsySbfPU7fqaKSCOf/JlQRxwpvSVOrkH8rrVOk=,tag:Oo/g3q5VtNIcZmflVUPK4g==,type:str]
+      client_secret: ENC[AES256_GCM,data:LUM0GoeT0jI5h9gwhA3fi48/DXm7+Slb0yMGvaMFFlTMbS9UvHQ/Ng==,iv:pYbouoZzxD7DOxXd/ZnLUTUD+MrPaqSnidScY1cTogs=,tag:LBfY9FuYsugSQ064qhkvWA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:FyC8secRwo2fHi1Duw==,iv:V030grvWwOEEuCr7ReuDFQ+EzjmVYf/K1d48I6DOVwg=,tag:GSkGI7k+em2SLx/AsmYfzg==,type:str]
+      value: ENC[AES256_GCM,data:EW8FRdHqEnF+XKXLAIJl1jKTL4si6LVZD4u+tRHBKkeCRgdqn0DJotQhywZFlEKM7z3N1Do5Nsv6PSE8smN3fnHUUrcfQjcmUaSpCwqqFLVIlSmx3lpBP18cL2fe6yZmbWlnG3966bK5ClT4knR69BsQC3GLaIEqFaMBnQDa5Zy3+G+K3pZSWvJzEjBylh6jtU+8PJ1ABTAswLXMud8Bv0VOb9in9OhPmNajTLRtjZx5lA==,iv:xWicqgGGQR8nJm/CL09phNHfgNkrFTbOnvG8IW3JtcI=,tag:VM/7Ht2AIxX5dhmecay6kw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:beRT2Xre/JqYBnALPacAatFLfY1MAjyyibbY+FWVrq/XX4FD+wOX91QzI6lU+eEPqnPehY37QhoS5VKLISrrmQ==,iv:0I1xeXqEnHVz1iNrgZQQmnpu3/T0mON0rM9GOejKgM0=,tag:KIoEzBa1MwDfzP2DQqItdw==,type:str]
+        password: ENC[AES256_GCM,data:MqcY9Uo5ZmL749aioA/oDqXix0/+IbXp5daJnV6Ch1NI/p0pn55hsymcEABufNSdgtz1ipVWzAlmbiQMqUDFJQ==,iv:GL+jANZD3PA4oIFaMBnhm7UBjFN3tu1lBg71PoCPT5o=,tag:mhiT2qesNIUiH6va78ZV0w==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        toshiphuuVah0rahMae5bahD6Pee0teiPh1ohlie8elool6shookaishahShohCi: ENC[AES256_GCM,data:OisaQ82E+JZ99g0NSzxL1X84/V5DAlu1BjkITfYTTAhcz0iQh5mK0WNpMEiuOM1k76Rk2goUJMc/WqR2,iv:WeIAqhCHlWBVbhKj8AjAioORJjhQv8i7oSC5hsQENSo=,tag:+tONHNHDekzO3S3tF70REA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:11Z'
-    enc: CiUA4OM7eHiDYvlRsfXsLusWmoIgoYTS4zp+fRRF8e9PysWz4KC5EkkAZoeZppKP/ednLsPK93qP9JZ3621jDb5tHhBNMdWnsWgbpctEZokVxnEOdu5ijzNR5xA4ErxnQvwS9n+ysnBNpfgUjFpOI8y5
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:11Z'
-  mac: ENC[AES256_GCM,data:PXRnwWBlklg7CgEPGRspXi7X0kClJ1Y5EYsOen46vicc3t3ljmx9AzzU5hnBuQdTGnrxROnSXSz94kimzgnz+oQjMqRrOebd6hGHn3qd1kpb+a2q+Vu/v7JCvNrQHKTvhWg25/RfDCrZ6uPa9iYmKGXyAfvv0j7t9VFgS3rvgsI=,iv:eb3mKfTS0c4aM6spz4qvULmZomg3yP8iSYKkp8FvJwQ=,tag:GfGs49A+I6iu3KlO7R01nw==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:17Z'
+    enc: CiUA4OM7ePSSraB2PEAnbxiKvGog2va7JBlzkylwGcFz0LPkL3eUEkkAPHlbmVgNrxgsjoVtF5TYHPaotpY319xDBcQRYfs2iN6aO9bYaL1HYr/NzUlUF5Y75V3TkUueUcE7tUjgyGbtfOSGV/8uuJjN
+  lastmodified: '2026-04-16T19:33:18Z'
+  mac: ENC[AES256_GCM,data:34nK8b9FIFsRV55rSiUhUB+Y1FZiMI0qbIqDjHd0nOlK7opQoczhn0JBjI8V36f7lLG0yJANLEtW/icsMpjsarT5A8r/2q35LLeEttwZKtD3a6hYhrMafq6oH5ElmNBaJAsTEqMJFpLkiaknLIDMFRN+46//o9kU9Fqs/zKvHR4=,iv:za20bK7q3vn+eGPGv+vIgHZGrb+DqxYgU3jJgCzdfLc=,tag:qvwdtZl2d8FHeAQoXu7i2Q==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/2i2c/enc-support.secret.values.yaml
+++ b/config/clusters/2i2c/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:yoBKgjW+Ev/OoqZdqnVHQvfI41cs+qxvNTAApullxtKs4JwDf8ohhz/tE2Tn7OWGq2yIJa0mSdqqLXYd8VacxK2oKA/zthb6lR1ITJgm/ZAWKM5ac4v9aLh/EBSG3DFJLal6v8hfTn//z5QqjQjrN1FzgT3n7jJHMzYy0Fvu90sRhZRN4fEEL9MRvx+dS1nErFls3kVhyh+lSiHe,iv:v6eLx+fJ4ED9c3FMm20elI3Dx96tSF2QELqCXd9YOeQ=,tag:XG+8AL84CIJE5V00q5ajNw==,type:comment]
+  #ENC[AES256_GCM,data:vEQa8qWnd1RggBftaeuzroAOC3FMw/dfBvU+QCgEOiYRvWAdpUzSXZgwRqLHHKDgDmJ4/D0+n1m8wOzSjKiil4VRFQIEr3V/vFvV38KbnguH/pcSqY6r7YhUFTWItR3rpVykF8awBJJHONva/o+rnnY8NpMAnf7i8lxP4arJZnfB65HqQKyNrFK7ou/BEuBSxl8LpHZjKhB11HdO,iv:USR/L8F3FpnbgCmvIshaHVIrqpQ6Cu4xejrTrD90IF4=,tag:ZWw6oNLWmDtBSPjWpetL9Q==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:zQS+6dfAoZb1WC2WUdzKrdWojJ91Hf76RffzPuIMnshklWAA16BOKfKXKoUPshrQcI6NhQieJgRCs6mi9BJ3kA==,iv:W339mB0J2KLAU0jN6jYoVmW+5YOXwVG50zJTk6na/cs=,tag:Bf58CRb4wsg05Q4rS6k2Ow==,type:str]
-    password: ENC[AES256_GCM,data:FRncFpNVJPTxTJViowbA7XIrcQYe4Rc20PSRWLFba2BzQQqqlLPrvPgjYVvcB3r0ee9rq2P+mCxpSdllrRK3MA==,iv:Xgg3pyuZh9D8KrdQ+79J2F8yBq5OK9ynEcHvus0hfCk=,tag:X8bRgmq14D1tsT56LIQ9bw==,type:str]
+  - username: ENC[AES256_GCM,data:jSbM0dw7qFqLJhebZ9My804UGtIq0bc6/xyaFnBbJkHe5zdNEQkvhb4fBpwplb1M0TycLNRfmoaA9O4L5nNqug==,iv:sSxvtJRQnswrmqQN93oLzn6SRVGG5D0S6wFTkPRS/xU=,tag:TAEdQ2vWk+A6mSWZ602ZYg==,type:str]
+    password: ENC[AES256_GCM,data:fvZzCIRhz9/of7BUe+oqjU3KkJFgNhjBSRpv7RpD7hEonjMAEdBrIE4qkxPe08fDiG/Vn9J65XeJj4ceCUZ13Q==,iv:MlSTuVDcyRvqzWVVqTOXt5yIb+FPSRhbKwAREqMmC60=,tag:lwi+Fhu1c2hXo6ZySEIwFA==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:lk7l1SEPI8pIiyt5v5dLYmymUU8=,iv:TvYGllsySbfPU7fqaKSCOf/JlQRxwpvSVOrkH8rrVOk=,tag:Oo/g3q5VtNIcZmflVUPK4g==,type:str]
-      client_secret: ENC[AES256_GCM,data:LUM0GoeT0jI5h9gwhA3fi48/DXm7+Slb0yMGvaMFFlTMbS9UvHQ/Ng==,iv:pYbouoZzxD7DOxXd/ZnLUTUD+MrPaqSnidScY1cTogs=,tag:LBfY9FuYsugSQ064qhkvWA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Fg==,iv:2eyD8KGF+jGcbzXbXsMHuQCvMP1XDqPGsnaw6vKmfD4=,tag:Gt99ibsVupIuIGJaL5xdxw==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:gIM6pIdj+IB72w==,iv:yXP+dPT7/70igcpOmi/WcD9remATTQYSm9IfL9mUMIY=,tag:nvToPZWG9pnvswM4twVeKw==,type:str]
+        orgId: ENC[AES256_GCM,data:PQ==,iv:xi07suxlVedVJ2NbwD87P8otXbFmo7whHnZEimpyctE=,tag:bM04P4hYLe22ipFJe8UHgA==,type:int]
+        type: ENC[AES256_GCM,data:hVgTFvtdOlGWRQ==,iv:iPVgQdHB6qWeUonJw/AipHrgL2Osee4FQDCdHD5Kg48=,tag:jL06hVpW8OepsWzBQoD9sQ==,type:str]
+        url: ENC[AES256_GCM,data:4lC8cd7bKoS+CkMy5ZuODPoquIk2DKYohKb/uLwu7Vw=,iv:Pbfrm/jCwNS9Uak2yR+JE9cqoJAIYgR3bljl4HM5dBI=,tag:GN+zgyPyw0FeYq+RBszagA==,type:str]
+        access: ENC[AES256_GCM,data:qrqKed4=,iv:bgaJrNpvqC+yB9pmTHpwmdROtS0c8ins33vKv4k5Ny8=,tag:1RoGlNwoV7ELYL+WrjbnCA==,type:str]
+        isDefault: ENC[AES256_GCM,data:ZtxfwdM=,iv:4ganVgWOrc9Wt6ax7WxoUKCWL8hYoJusN7mLtxnsX3E=,tag:eEtAbizKEY4R+b4J7bkRtg==,type:bool]
+        editable: ENC[AES256_GCM,data:CtKlgsU=,iv:/KMVzxVl0P1CY65rofs026tCetLGPtTMdEsmOf+o40M=,tag:8FFV93Cwr/scdzSTU9xe+A==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:qbIYqA==,iv:KSlbXuK4IlBxdg3JpCo1MdxtvStAxAElb2kQyhqieC4=,tag:e82EB4+4Kdp5XceV6olISg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:aMMxVlNbWQ0CFo69Z4aHoQ5u4SqhqNf1lsyO8kBG0DDJ1ryAt4H07oEFcU4Ap4BvKtb0QiIGQFwjad4/TBIBaQ==,iv:eLcKQdykh0DIhueGdQFayJeCeOelVDQ/ngq7VVtBCAA=,tag:oRlD9AF4riGKk1VXOczQ+Q==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:Klx8QKV6NxDeFsO1ZZ02NQ+xeFTv3log8LYfOoqEtwZ1B6XJjGEDwIZr41xEYrbS70B9wE4nO8SNrAX5hlFQpA==,iv:bPOd9GD+rQPdawZAlHdR/W4iV4qt+avW5l67LRpEs4U=,tag:8b+XBUivZaABRokoWho74w==,type:str]
+      - name: ENC[AES256_GCM,data:lDG53LAfJyMCZ+I6kPfyszls9hVnKQTapA4DC2AFLQ==,iv:nAlN+ZaY59/Rb5mdgQvkNV+GXQ1H1/Fe2c6hrlKF9pY=,tag:p+TlUzl2kKZJvIBAdI89ng==,type:str]
+        type: ENC[AES256_GCM,data:bcY4tQjXgX9lEKpdqt343KTx6JjqtmO8sGKRwlW0HA==,iv:GsLB3nqPbwUVdcj/xKNgTxRrJS/xbzg/1gzwpuJGYf8=,tag:j7/phkgNMs7XV3pbOMuGYQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:XVMsrPE=,iv:KgcRfoYfSJQdh+m6YejfeqqxArnbWFQOJs9PsEr0nqs=,tag:GKOzyKGaT34CTlZzjAuPdQ==,type:bool]
+        editable: ENC[AES256_GCM,data:1BkxBQ==,iv:MiasShf6ClOsKJ5u16Kt9rWKDHphDx0zETbap7RqZTo=,tag:MeIw2TRqdUAMGKPK78CfLQ==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:FyC8secRwo2fHi1Duw==,iv:V030grvWwOEEuCr7ReuDFQ+EzjmVYf/K1d48I6DOVwg=,tag:GSkGI7k+em2SLx/AsmYfzg==,type:str]
-      value: ENC[AES256_GCM,data:EW8FRdHqEnF+XKXLAIJl1jKTL4si6LVZD4u+tRHBKkeCRgdqn0DJotQhywZFlEKM7z3N1Do5Nsv6PSE8smN3fnHUUrcfQjcmUaSpCwqqFLVIlSmx3lpBP18cL2fe6yZmbWlnG3966bK5ClT4knR69BsQC3GLaIEqFaMBnQDa5Zy3+G+K3pZSWvJzEjBylh6jtU+8PJ1ABTAswLXMud8Bv0VOb9in9OhPmNajTLRtjZx5lA==,iv:xWicqgGGQR8nJm/CL09phNHfgNkrFTbOnvG8IW3JtcI=,tag:VM/7Ht2AIxX5dhmecay6kw==,type:str]
+    - name: ENC[AES256_GCM,data:loBMXYjeSovGMmy25Q==,iv:e1hRF3giTPXApLRqOGkVibodjkp/3nuCQ1ooUk0Zb1A=,tag:dSUJ7AEJ+Vu/kXcDhig0yA==,type:str]
+      value: ENC[AES256_GCM,data:TzZGNKGadc8Oli/o4tYwhtd5VNaFeWyUcfCKUjVC5Nt0Y5q1Pt4Q2jDS3RfsWmIuoPE3C2LDrvm9fWbayJksIOT+r633Xkr0oK4N3JiXuqJ+QHpGqG1tjbRfaIU3ie7iJb/8mdB39z8Kig/tsUmd4PYwlijhJAfZQyHILN0r1U6qKeSyZvzvjtm4G2J5+knNGYRCmigZbLcg7sctnFerC+u1mPNFvVDx/DR6twQdsOMCYg==,iv:SZjFQMuUg3tGAxgt8JqZ5kuLke6Zuxq92sE7Yst5YpU=,tag:tOUyFRS4EhqYjgULlmBY5g==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:beRT2Xre/JqYBnALPacAatFLfY1MAjyyibbY+FWVrq/XX4FD+wOX91QzI6lU+eEPqnPehY37QhoS5VKLISrrmQ==,iv:0I1xeXqEnHVz1iNrgZQQmnpu3/T0mON0rM9GOejKgM0=,tag:KIoEzBa1MwDfzP2DQqItdw==,type:str]
-        password: ENC[AES256_GCM,data:MqcY9Uo5ZmL749aioA/oDqXix0/+IbXp5daJnV6Ch1NI/p0pn55hsymcEABufNSdgtz1ipVWzAlmbiQMqUDFJQ==,iv:GL+jANZD3PA4oIFaMBnhm7UBjFN3tu1lBg71PoCPT5o=,tag:mhiT2qesNIUiH6va78ZV0w==,type:str]
+        username: ENC[AES256_GCM,data:Z90+hTgw4lprH4W3KsDX2Bbf1B1ijALZRSfTdZnhztMr0DoqS+X7TIwDHs5iG9tuzD1kd1sMi34DljBO12Chpw==,iv:gWZA9I7OzC/gJ2NALwdYBi6kb+GpOkAB0fJF5qSTuOs=,tag:Djp+ml0x9yKhQ5lFUTklaQ==,type:str]
+        password: ENC[AES256_GCM,data:KPTweSygE5CtMx2w4aHN5cEj3TGyc0mvQteG5nWsSa3fanRUsGk5Hndc59K+BcX0mVn7Ql+PxrHanzZaFgl+kA==,iv:fcdluVaEd0NWUV+nsvW9ixVOfaZvXkiFqMu21jKul+w=,tag:ywGRZH/ajyV8i7NPmLvqIQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        toshiphuuVah0rahMae5bahD6Pee0teiPh1ohlie8elool6shookaishahShohCi: ENC[AES256_GCM,data:OisaQ82E+JZ99g0NSzxL1X84/V5DAlu1BjkITfYTTAhcz0iQh5mK0WNpMEiuOM1k76Rk2goUJMc/WqR2,iv:WeIAqhCHlWBVbhKj8AjAioORJjhQv8i7oSC5hsQENSo=,tag:+tONHNHDekzO3S3tF70REA==,type:str]
+        toshiphuuVah0rahMae5bahD6Pee0teiPh1ohlie8elool6shookaishahShohCi: ENC[AES256_GCM,data:UqVD0NeMatpIpBIZtGpTDI2P5Y2WXZxiKFqiXCTGNM8CvpJTKbNJLktRCtUEG2uAYvift6vzpsbXkpUc,iv:kokv0m3pfgctVLbw6pmLfMI2buayyvxQ1lm+mbGivuM=,tag:L0DYCyLzFWdrmnRJNVMT6w==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:17Z'
-    enc: CiUA4OM7ePSSraB2PEAnbxiKvGog2va7JBlzkylwGcFz0LPkL3eUEkkAPHlbmVgNrxgsjoVtF5TYHPaotpY319xDBcQRYfs2iN6aO9bYaL1HYr/NzUlUF5Y75V3TkUueUcE7tUjgyGbtfOSGV/8uuJjN
-  lastmodified: '2026-04-16T19:33:18Z'
-  mac: ENC[AES256_GCM,data:34nK8b9FIFsRV55rSiUhUB+Y1FZiMI0qbIqDjHd0nOlK7opQoczhn0JBjI8V36f7lLG0yJANLEtW/icsMpjsarT5A8r/2q35LLeEttwZKtD3a6hYhrMafq6oH5ElmNBaJAsTEqMJFpLkiaknLIDMFRN+46//o9kU9Fqs/zKvHR4=,iv:za20bK7q3vn+eGPGv+vIgHZGrb+DqxYgU3jJgCzdfLc=,tag:qvwdtZl2d8FHeAQoXu7i2Q==,type:str]
+    created_at: '2026-04-17T08:24:41Z'
+    enc: CiUA4OM7eOLw4pFIAvXDn3w0IVmR10WUM3iX1NbxnobKFpV0tV5NEkkAPHlbmcC5BF8N9P+60yNXzWRHE00js/C8FH6pp3WSLEUybBYAo28IEe0v6Zoaza7vMq0ewYbeBefz4Y/JLA3I30KLF4ZFpUPD
+  lastmodified: '2026-04-17T08:24:42Z'
+  mac: ENC[AES256_GCM,data:YhqTxFeD/D8cpBNQyxKjKbNBIDCog37pL4XYkYXZSpJwHwTKGkkKmOUcHphToPqNnw4RL+br5Hrw4XrLq5LAoWdHy1ujve/mPKJTloE+CxSh8n0WuvobycB2UnNBwn190oot9X4nLdYX9Or2RHByaXxxhHdJMtNrftdcMuwmFbc=,iv:XTi1C2CECnh5zHJYpNNPUgaM2JPfffDrejfdZn5wLu8=,tag:t6FQibGVgQdVylNy3iAGYg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheusStorageClass:
   gke:

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -20,6 +20,8 @@ prometheus:
         hosts:
         - prometheus.pilot.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/aimatx-2i2c-hub/enc-support.secret.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:Yz4tMg3ZWQ99+R5hWAuS/90rhG6H10M4Dd8ZfEwSSxF/N990YLqzcjAaWSI+F2S1uwCr+w2wGypbJ4V1sy0tLG2qtba0JQuCU+X/8+gj9DSO7hPYU1j72tGoZaa+wl6RG/enVuv6JQUe0J8dOkDNoOsWQLr7mScO6nLE5CDiQA8wlbGEAGlWvfi/FYZKAK09S61dgPNEbN6m4+bE,iv:xQ6t8YW0Mz2bterE80ZtOTSIoWmhzUHRsbCLCa1/Gic=,tag:mVJ6RdAm50pIQlfnPkhCQw==,type:comment]
+  #ENC[AES256_GCM,data:wJCy0QKqgHZSDYCJbiFz1clnlJuCPezFM+tZAUpCuh8GQ+wtpim60tsOy72wjPziOdXLL3uSF8vv/896tTEhA8mz6Fkwm7YC4AHeiEWikV9zyVLYmlxebXhq8ic/qXwH6kF3YcEjY2otufjOsd2GDA8ZSoIvkE0CKbNqOa3dBlTphNk8qV3ZLDmDLI6/mFiCCoLZheIPOwPIiVAq,iv:XKQU54T5gs6mHsXz5+++LU9kd9sINeW1Vp3bDM8lyFY=,tag:cf4J0L9GbjOj3LuVG50lqw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:uNwkS54H3rzaO/JtVdG2jeIHb8w5aLB7VqTDb6cdDUJ3VDOZDZROcNZjcNVmXgjESmncv1lix09MUsI1DOFgXg==,iv:/BOtpanVNZeMvERs1KvOm7zr/fD1AWJF0VjmKDsTDFc=,tag:Qx5tM/2iSBMMcxta6nQzbA==,type:str]
-    password: ENC[AES256_GCM,data:Nd/eV4RbUe934uPap1mKQdTG43kxGE4pepcm/bGhMyEY8lTkl1wgNZMNXe+hzuhvtJ2K+x71SL8l/Qo+bfJ7bg==,iv:muC3oN1d3a00n0LOis7sX6HdF2mpluDfGG3rcapGKY4=,tag:n0jCISTJlYpKRNTiRc6Y4g==,type:str]
+  - username: ENC[AES256_GCM,data:UUBZndas/mF7pPrZBcyJiicslAX31SSvtBFZCuoS52hIYjsoiw0qj+JEaKETzVwueuhkgay2ZDR05MXSPQcZWQ==,iv:pfF3fbF1QoZbWmFrCFz/0Vfs5E5D+2KTqV3aWEkq4RA=,tag:uNRo/2ScgiftszGoASdtHQ==,type:str]
+    password: ENC[AES256_GCM,data:zPj7pNC1pvm/gHteYhE6NhmfJaSgGTyFpGNkae07cPDHtfhiZc1HSA40nPeiMwdr0BxSG3oihtiWZD9m6QDAVg==,iv:aosFcVHZn7qMAv+JBKhI7HcruxGYfy3oDf065mefQYE=,tag:b1+esJay9SjsQBaSmRmc5g==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:qaeYh9Dmk8cjD5wt6w==,iv:Z8Lc3ukiqbh286O1741Q57r7XJK9X1j8WYr4UYaP/eM=,tag:LTEqm2TsufununrY0XRTUw==,type:str]
+      value: ENC[AES256_GCM,data:QsaOllTvfOKpS4CDgVOVecJdYnTGqPDwcKtxdwblWttsipx+jbP7nn00uLD2M3OcBWMnIZwGkZ/Eg/huVcFRekTNxRVl3jXLkZOeqP4OsOAKOdbeoZv30vGCdnQCpgNXWmrPhhwDBy8SZ59Fj2kk7qV29PXm8XOkMVmdFNFaAR5sqA5fRYwhOs2JLX4JCKsQfQpvyBTNnecHiynZBlIEwdFMxafSbnDp2uXb/2zFqSJxRg==,iv:qC+9LyRW9mS1xyIDpsPc2BpJkNrfdT7chNRf5CRsD2U=,tag:X6Xsivtd2UiMXnbc7B7giA==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:VEf8/kwOHVsc2WEzpMet2rP/CUgAN640uol8qvrehLTVBG462Vz/sI9jXe6XIZ8cDeOvFpPfaP99MfV26po3Rw==,iv:8qxZtk6URQa7STgEuS8ei41mm5tuL6XCQcWFNjceoBM=,tag:1r1DlpwnwEK2x1kfKVbJ7w==,type:str]
+        password: ENC[AES256_GCM,data:LP+QKoZp8Pmi2XlI1eAvnuiBkrt06YoJQRMdTdn9hKNIRjuqj0gQTbfaPdzh60dnIQGAzKU2MJE67LSj4V2O0w==,iv:QZY60OBKh1WpxYKec86pfLkypKoqdjWNI334ErWAr4Q=,tag:q3xiZAQ6iDhITpAs/iOxbw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        TRZdTFOy4K4FSxvLNImzO5NCzsXcYAHBQbAzSDZl9nG0EpE1dLUQKYQqxaKqiSjy: ENC[AES256_GCM,data:tvHdVEj/wPy29VaaC0qyWpX98kVy5cCywlkXeYFbp4sCJNPfF9IMtPsTBGS/sqZVmFokcrqdCJ83jX8y,iv:QB4rv0ij6wBlbo+ZT4GPk75fF20Mpp80kRwIwFrWtnw=,tag:yWQnm8s4FE33wnZiLpzOeg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:04Z'
-    enc: CiUA4OM7eBSy/DD0LT7IItj9gafXhbbp1DT+/LcXvnoYK07I5IMkEkkAZoeZppv+gMxqnKkmSxkxlx2YUddNTAuJ379IL/eevXM/wgQxkHwbj6M4So9djkVXtwhw9mtCiXinhLi5GCqa7WGUPpY3z5Dd
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:04Z'
-  mac: ENC[AES256_GCM,data:8itFTFkFHlbc5fKOkEiKGcGHzVR1WsJY26d1w2yl6dF9wzShGRO3BYsh/Sz/UmpGzizmgnKE1LKkvij4LyHIva9dD2COx82Zuq5aMIoYbqeiEP0+U6cu48PR1vaE5fNDqbu9GjxNNfvVzaDDuhKhX0vRG0hKRLk0zQtYSIrmsJo=,iv:AhQYWwMN46eWZcImppc3qxrz5HTXyur7nnteutekA6k=,tag:s8/EPryk30eA1p+KTC01eQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:45Z'
+    enc: CiUA4OM7eJwkfjPejiNqgcBgXeU/BTYXRjlrpQnHxFcuJRiboGiVEkkAPHlbmQfPksMFMM6W53RyKpVWZbdlR5Pc0iMFX/fwSrDiSLEds1vjEMx4uLSGvcWcLMIhV0NKqyDFe01TeN8c6Ejn/z84nAWj
+  lastmodified: '2026-04-16T19:32:46Z'
+  mac: ENC[AES256_GCM,data:xTr0j+/u2vXqjQaotz4g+Xw+curlwr46Fs8W0eLv+MQjVHJEeTBsirxPrI9IeiIf0RGbEkugSc2gbh+NSI571fDLfXjAdpnC4kTn+YCkY9CyLSgLy+cHKMXLjPKDIC8yiyYS6HcMx4oAUhAMS55TaAldCV9aRt1tQlPaCh4ALcM=,iv:RJNdTkNXge0ek8L23FwLp3aV8KYit4J3ZyEAP1mfPJQ=,tag:gnNzCLBXl0RwhTAEF3shPw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/aimatx-2i2c-hub/enc-support.secret.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:wJCy0QKqgHZSDYCJbiFz1clnlJuCPezFM+tZAUpCuh8GQ+wtpim60tsOy72wjPziOdXLL3uSF8vv/896tTEhA8mz6Fkwm7YC4AHeiEWikV9zyVLYmlxebXhq8ic/qXwH6kF3YcEjY2otufjOsd2GDA8ZSoIvkE0CKbNqOa3dBlTphNk8qV3ZLDmDLI6/mFiCCoLZheIPOwPIiVAq,iv:XKQU54T5gs6mHsXz5+++LU9kd9sINeW1Vp3bDM8lyFY=,tag:cf4J0L9GbjOj3LuVG50lqw==,type:comment]
+  #ENC[AES256_GCM,data:Yom+Dv4lcBNN17e88dbC9Zd9Tvm5TzTu8ntD96puMwYEykgBW3UZymr1bIKKF4MXy76LTL4AhSg2fqlDP6NHJOZXyaXYMTmQLxCr57U0XRJPH2gWR6LNSik4Ql89KOFyqmyUV/3HuZ+2lgI5GEEgiCrIyuQgrHxiMtRFF5H1iYCku9Gt3iPWLuMIQprFGJkkIg0RsLNnyVlLyPQw,iv:r4V1BXcMxoG+xxKYA6C2ZvtROYrxzFsnH3FMn48j2TY=,tag:YfwAaWtVzTwLSJ0JVJmUUg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:UUBZndas/mF7pPrZBcyJiicslAX31SSvtBFZCuoS52hIYjsoiw0qj+JEaKETzVwueuhkgay2ZDR05MXSPQcZWQ==,iv:pfF3fbF1QoZbWmFrCFz/0Vfs5E5D+2KTqV3aWEkq4RA=,tag:uNRo/2ScgiftszGoASdtHQ==,type:str]
-    password: ENC[AES256_GCM,data:zPj7pNC1pvm/gHteYhE6NhmfJaSgGTyFpGNkae07cPDHtfhiZc1HSA40nPeiMwdr0BxSG3oihtiWZD9m6QDAVg==,iv:aosFcVHZn7qMAv+JBKhI7HcruxGYfy3oDf065mefQYE=,tag:b1+esJay9SjsQBaSmRmc5g==,type:str]
+  - username: ENC[AES256_GCM,data:8AVQNuPNal9QxORxdY6V78MFU5tBIiXb+DEwlDZTR/XrBVYKq21o5kcumhwZ4V9Uy2cjMU6MBNmPnKzBT2lwmg==,iv:qXhmb8ZXFLcLBUbmSwqfqFV0pokHoIJePkD5z0dyvbQ=,tag:oxKhG8rI0tKWny2KM7fqeQ==,type:str]
+    password: ENC[AES256_GCM,data:pZSZOZEwZ+nsC8b6/pM0oRXthPcOGFyloWz27JsxJomRq0sIB/fJRCPaAg3ltxeDp7LnBAJidQZJu4hbVC4OyA==,iv:KJM9dQROBFurTQoFijN1yt8RTjljBmalMm/65IKNjKQ=,tag:Z1gVamluj4S7XdMGyT8xlA==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:qaeYh9Dmk8cjD5wt6w==,iv:Z8Lc3ukiqbh286O1741Q57r7XJK9X1j8WYr4UYaP/eM=,tag:LTEqm2TsufununrY0XRTUw==,type:str]
-      value: ENC[AES256_GCM,data:QsaOllTvfOKpS4CDgVOVecJdYnTGqPDwcKtxdwblWttsipx+jbP7nn00uLD2M3OcBWMnIZwGkZ/Eg/huVcFRekTNxRVl3jXLkZOeqP4OsOAKOdbeoZv30vGCdnQCpgNXWmrPhhwDBy8SZ59Fj2kk7qV29PXm8XOkMVmdFNFaAR5sqA5fRYwhOs2JLX4JCKsQfQpvyBTNnecHiynZBlIEwdFMxafSbnDp2uXb/2zFqSJxRg==,iv:qC+9LyRW9mS1xyIDpsPc2BpJkNrfdT7chNRf5CRsD2U=,tag:X6Xsivtd2UiMXnbc7B7giA==,type:str]
+    - name: ENC[AES256_GCM,data:i1+3vAibZ1ctvY0eAg==,iv:0V4f+JnxE9xNFCtUv+iGsYRgle1I0xJKGOEnKY3vJHY=,tag:641Dc6rcEC0ECLPxSAGuuQ==,type:str]
+      value: ENC[AES256_GCM,data:bUX744JSH5Zned3FuxjCp75E8iHqJ75VVL6QZj3gY90U9zWVMlWwib3PKkkVlmwQ9OCBs9JhLkHY2TqQ1lkbBI+qDLgNfa5wYYn5Q2i4H5Kccr0qektaWOByNayen0uQyAD01w18n4Y2yAAqbxLUpuwMsndHRVKs2+gO6woBQnNzOhDNVTiITmi2lXr++cVWhZXELicK/uxlPtfgmQ4y9XDuGEAGEnk9fWZ94RX7U47uNQ==,iv:RhbthXpyYrfTHIHIQZyjbzDmfm832OTI9tY0IZ3YymQ=,tag:RnVDHNwbLrVqim6wVmeVVQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:VEf8/kwOHVsc2WEzpMet2rP/CUgAN640uol8qvrehLTVBG462Vz/sI9jXe6XIZ8cDeOvFpPfaP99MfV26po3Rw==,iv:8qxZtk6URQa7STgEuS8ei41mm5tuL6XCQcWFNjceoBM=,tag:1r1DlpwnwEK2x1kfKVbJ7w==,type:str]
-        password: ENC[AES256_GCM,data:LP+QKoZp8Pmi2XlI1eAvnuiBkrt06YoJQRMdTdn9hKNIRjuqj0gQTbfaPdzh60dnIQGAzKU2MJE67LSj4V2O0w==,iv:QZY60OBKh1WpxYKec86pfLkypKoqdjWNI334ErWAr4Q=,tag:q3xiZAQ6iDhITpAs/iOxbw==,type:str]
+        username: ENC[AES256_GCM,data:ceFaHMiZWZm5qFBunBFl8uBgc9cbW6IWe0ECWkFP8cMn1/puzNEdieKXQHzrWGWwej6t2wjVjQlunv5z4+wggw==,iv:pkmPQW3BlZdLPwKKqnp7gMocbRAIPgtfW1Mzi0Vv9w0=,tag:fHlyps93Hvvm1SnncsdisA==,type:str]
+        password: ENC[AES256_GCM,data:n90Xzt5pHR1PVUoxevjt5Zdp1sR5x1N1ysR+Cdg6509ssgNtZMHBojrBOZJsEr6k5Apl/FymRm35TF2j/aF9aA==,iv:sKpXf0T6l+4qZbKo+0/TkrI6PQLeRskGBFQs2BI2Y1I=,tag:7qgFoVOoMbg4rxD/1qAoZQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        TRZdTFOy4K4FSxvLNImzO5NCzsXcYAHBQbAzSDZl9nG0EpE1dLUQKYQqxaKqiSjy: ENC[AES256_GCM,data:tvHdVEj/wPy29VaaC0qyWpX98kVy5cCywlkXeYFbp4sCJNPfF9IMtPsTBGS/sqZVmFokcrqdCJ83jX8y,iv:QB4rv0ij6wBlbo+ZT4GPk75fF20Mpp80kRwIwFrWtnw=,tag:yWQnm8s4FE33wnZiLpzOeg==,type:str]
+        TRZdTFOy4K4FSxvLNImzO5NCzsXcYAHBQbAzSDZl9nG0EpE1dLUQKYQqxaKqiSjy: ENC[AES256_GCM,data:wdqyeFyrTbPcj8DSRfU+mP/+Fb13YccsiweiYzi5AWPPBpYoLb0rjcd/ynrVl3Q8rSzjVtUcRyUH2SNA,iv:VBQvtJ0jCtIGw0D8cs2UssEgNpbpNAo6DCn3dnYNBGk=,tag:dNyTcljKlJ4r9dyImVQz8w==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:8A==,iv:W80geh6C5zuXxQZ/mrc8AAJ2OtsBheKFZtQDM+sJXDs=,tag:tvbgXhl1VHeVnJPYCRExXA==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:zbsp+txT1MzaeA==,iv:ZnDW9VsLcUO3aeiWTyd1ckPvGFpKkN6rXGkZRgTHUKs=,tag:lvlKHSCnyfk9tfOg5PG4WQ==,type:str]
+        orgId: ENC[AES256_GCM,data:8g==,iv:2ZbDgeQR1oLAUweJ1jo/VvQZxDgmBxH+99kkKdQyY9Y=,tag:y5SzOaV/r45Yzs86XIfpiw==,type:int]
+        type: ENC[AES256_GCM,data:/O7w9w7bvu9YwQ==,iv:4h1mhaPVpjqaezoKAdrw51h6PAlaeG+IGr/aEmjpFQY=,tag:0xqPrDy9rFP86PZvQXQ4Rg==,type:str]
+        url: ENC[AES256_GCM,data:GzIdWiHqcVA26WLve1xYCQFZqglEygMoSB0YGug8MGE=,iv:Ogp41qi1kglLFktuVhOa52i90fiTDhTpUbtmhzfeNq8=,tag:+2D8+U/rcdH4rSyfAl89bA==,type:str]
+        access: ENC[AES256_GCM,data:WHlLfDk=,iv:CgAGMkhIO7DLOvujg7a1TjFXqxsp5/hxQzT3ECLSFsU=,tag:VyrDHfBmMChRu4pVEMXjxg==,type:str]
+        isDefault: ENC[AES256_GCM,data:2mZoZJI=,iv:wIkKiV+mOKo4IAEFzPYbKH4w3WOPUtpW0M86bKiHr88=,tag:kZezBAHoEekbfO3zXzCAFA==,type:bool]
+        editable: ENC[AES256_GCM,data:aiMTKw4=,iv:lMfH1G61zFaMMDcyxiFNlosTblyzFR90x75vpdJOkMY=,tag:HVwnANWoI1+X5+Ik3d0w3A==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:U9snKQ==,iv:Yrat0BxdMqgidS7m7gRnETv+SVtmmRmyS596XwSQ3Jc=,tag:paJCLQyGjOgzXK/oh80m7Q==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:J2R+j6Ft4W2vybzVuAWtRuuvV78DIdlje4SkZZOIHUi0Fwwa9KEPaT5A88nrzY6TeWm7h4RVEgD9Fp+obqYNPg==,iv:UiKNR8fpbBI6yXJQtFjR2YxTftHBeWSnxLMmFVkn0Us=,tag:6q1/AzEOS95ghhBJP20G+g==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:GIWoUXajWLiRc5ajx6pghppWeyN6mnhzHA1KkrajvrR5HUgzLJtWPT71gHWG2eqNipPfj3qmb5KS57WGSR3Img==,iv:0ucY4MAmBo+9t7q4zolvxoNARWdivRx/rt9mBnWF/NQ=,tag:7xIFKtAUuAApZiPJtsBlnQ==,type:str]
+      - name: ENC[AES256_GCM,data:ueBKl65forVYaPFkfDSmjw6i1uJg7nuScU3tf/tMsQ==,iv:jwAIQbnG8yXFkhqy5t+X5Gljk/QPzh1l62zFsJpHqlc=,tag:I9YV6A8vvtggjUM4TxfRDA==,type:str]
+        type: ENC[AES256_GCM,data:lpXI491x3WFxIOoOQHz3OoF0BA7Jwj5fqxtsQYYdAQ==,iv:tjUbxmDmkkdIuqt4SFst1zdDBrME/lg1eCBAqyiT/zE=,tag:7cUsF9XtPY0Z0ltrISRX1A==,type:str]
+        isDefault: ENC[AES256_GCM,data:DWHT9Jc=,iv:zBjEgoX0cQ7CIbqNtHaO8d/mNDiTGQ8JQABItsHhyrs=,tag:MWggJl6D8Zq/TdI2wh/+nw==,type:bool]
+        editable: ENC[AES256_GCM,data:aWksRw==,iv:Wcpv22G8c4Xa36iI4LnRAqs+WxH8geWxYUY5QtfnLmE=,tag:kbeTK2WPA8AaQBvFlGZKKQ==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:45Z'
-    enc: CiUA4OM7eJwkfjPejiNqgcBgXeU/BTYXRjlrpQnHxFcuJRiboGiVEkkAPHlbmQfPksMFMM6W53RyKpVWZbdlR5Pc0iMFX/fwSrDiSLEds1vjEMx4uLSGvcWcLMIhV0NKqyDFe01TeN8c6Ejn/z84nAWj
-  lastmodified: '2026-04-16T19:32:46Z'
-  mac: ENC[AES256_GCM,data:xTr0j+/u2vXqjQaotz4g+Xw+curlwr46Fs8W0eLv+MQjVHJEeTBsirxPrI9IeiIf0RGbEkugSc2gbh+NSI571fDLfXjAdpnC4kTn+YCkY9CyLSgLy+cHKMXLjPKDIC8yiyYS6HcMx4oAUhAMS55TaAldCV9aRt1tQlPaCh4ALcM=,iv:RJNdTkNXge0ek8L23FwLp3aV8KYit4J3ZyEAP1mfPJQ=,tag:gnNzCLBXl0RwhTAEF3shPw==,type:str]
+    created_at: '2026-04-17T08:24:12Z'
+    enc: CiUA4OM7eI5knne4v9mW2+5G6w2BBIpXfIVgfkPyEYZoZV7N67HgEkkAPHlbmVml77gv4Of/o81kRPadB6C2Sd8dhIBJRfWq5y3ShR+YRd3IcbXxirEb3mT/VGhMNrxODZuV93D6gSCOpynIMwd9F2vm
+  lastmodified: '2026-04-17T08:24:13Z'
+  mac: ENC[AES256_GCM,data:JqQYCj1VaOTYHuDl5bO6ZBFII+PMtISWXJXd4pFQjl2xK1zvs8asbqaRB6gsNBr+l31z4DZlROn7dMze1iI0geD9k2S2VcoqAvw2BAb/rwelF/+rYA4NMJk69RSiuxm8wTcwGZ3EnM8ZXbKuof6xXg4SRwERlPUNZirLoBk+hbw=,iv:EVJDPWhEzU3rqMOf09+S+J6jrHTlBDtMoe0FgspB1nw=,tag:beMJdHLAiCBbUrAdNb1N8w==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/aimatx-2i2c-hub/support.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 
 

--- a/config/clusters/aimatx-2i2c-hub/support.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/support.values.yaml
@@ -16,6 +16,8 @@ prometheus:
         hosts:
         - prometheus.aimatx.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/awi-ciroh/enc-support.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:RyLTHdvoMAohMp2AbsXkl8XLwZJl65AvnLnfMK7LV8eBylO2+P9N3HoPvDnFMsPZZZjpuCz4wdT1/ZORdcJa+3Ir4VFlU/400IxTtFVVzk+15jVH2lN+n3nnuSXIVDr0RF8gZXX1pyZKn/5py7p7xZ6x+FK0vv8A/zB3p04mA+KJg6WcSzyU04tMBo+a7BpV1iOLeto8grNsIRNB,iv:mfOfywI0TuMAv8/US6VYNfy1r1dh857QFlqgkDl2/34=,tag:GdzFt38UBrAWPkzprnl8mQ==,type:comment]
+  #ENC[AES256_GCM,data:UBe8JrzpHZhRl13gFBeePp92dUEYofocE0U1Y29rZLALJjvZj+bkPVaFWcMN0RxE6xuTUbZU//CC5pq1d9GU8lHYcAbEyjmfO96R/8V6NCN476RavMAJjwlNy2b1ChQlBV+Cxt7tAk5WqlbT057D0b2yFBDCSqUls7xkiwe1yj61scwmn4iIRTt0Ip1Xxs/L4bW/vcw6yDoRi83l,iv:Vstgc0ad0VMClN75e38tHwHbQ8pNbniI6/Nf8yPVrsQ=,tag:v+hm8zZeyQUa3FMn1a3Rhg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:s0BiqJesc2Asp7FkXjHx6FNdIE3oOvT5b0pyJFT87sSOUwpGB593bbqODYq8Bq88799u7BjLZoEIh2vX6k+P5g==,iv:9u0zbQXs3M/mersrEMBerTCbEoqSS2uBpb/LjGr0kpc=,tag:X0DYjFWDVh29HKoDP+jLtw==,type:str]
-    password: ENC[AES256_GCM,data:hoK0NjYeur6Jzt/or3/9MWmr1LhoUJhVFtNSGCvkEL0D70BXAZfHN/o1LZt9fI/JVmwUDS2q/YkiQ5B+S2137g==,iv:bV9RAKHGjVVfMk6A6udfPE0Hl2yciHW3SfamnRRg+t8=,tag:wO6obCVj699wDuq+URiE3A==,type:str]
+  - username: ENC[AES256_GCM,data:B/zVvJ8H9q92nKi+wRcoFjv95SvDD1DNCouD/ppQl/jDPa2U4bGXqMqlhn4rX5W8qPnPGmVknwEgzDxUq05Htg==,iv:Ja/MQj6+D3608OcGJ7t+1dbIsYrCWy+iWgxddMTOYe4=,tag:jJ7vIrFPNN9TJiQLuisr/Q==,type:str]
+    password: ENC[AES256_GCM,data:ZKoCSl8KtnbRJMWHXH5qoEcVLo1FqyYu6bGQqm3ENnnq+eUP77lma4zxlXltDOb5vQf8fblfS8GexeXxpM54WQ==,iv:UOkP6Ilpt1pW1HHY9CrjQgtbxnF/bUnkkKH/DfVY2ek=,tag:UKfxrqbB1rgkJcsoJEOUvg==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:DVSfZ6WNZW7YqXIA1Gp3ydiwbQQ=,iv:iL+7nUbO84nJ18RFdT1fYZZU2heETYPBTvqzSjhfOMk=,tag:Py+zVS11sFYHFdsgsqfKJQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:0eZtEPhtuq6nxJVhHzUO2mYDzJWPojIUuz7AANQ8JQulw98zMvxZGw==,iv:sIZtlNRlkhnctPuuzfUlvXo73r2pXOLlBelzoPvqfCI=,tag:vm/bz50eZzZgukiPQGCwmg==,type:str]
+      client_id: ENC[AES256_GCM,data:A4piXQ/LvTQSUq6TtwIhqyKsU5Q=,iv:u/rgiaH/h0vq2VAcfrfo98KAQxKozy2IL0lGrVV+8qk=,tag:BkHpaD2oLmLuf2oZYVFatQ==,type:str]
+      client_secret: ENC[AES256_GCM,data:SRJ/EkUT/NXKVhTVZRHa5w4A6uE2h8eIPUUuFdTLrB90spjYUeUujQ==,iv:YRWzelNM9Hr5y/xbJRVys7f5wiefa3cRInUV6xTAKC0=,tag:sOLuCDqriqsztxEgVLxmBA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:pSQInXuzLq0nixZGfg==,iv:Pk9VQYwQPjpeM54EqN0zIDrNHUdnvTl8HShrKhk8oW4=,tag:jWyGZbbhoEXe7RZaXwo4zw==,type:str]
+      value: ENC[AES256_GCM,data:rFnrZuvwlB5RxWZ03Esw7UKHcfP/ucduOYgQaq29JaCDiTyfm0Wyb3mo7vV4GdTSeQmOnZD3wnLrQvAB9+RP5CrN1QZKfyAjtqezBVMBke1tyqphdtyIZxpRtdgrvCbtrB5SZt8otcmSjVlVrA3r46vVBG7OF2HMEwp7thX/pMxp0G/YBZJ+boXPwTeNu4GLaTZS/Z2dHEmu67cKDVWpQiv8WXnj7VHVPN8N9Jsa5L/kRQ==,iv:hrLR6xizlcRQ+cKEQmHDjQA4JymPGpKadRfN5XgTNbo=,tag:ensLzhsRmLTcbln84LVbFg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:o4fJ0xcfoYQhacH3hl1HM71j19vyA+K+JZECGyZfdBBsCspnrKUxm8MlSCHVQ0RSXIKjK6YDsJyIV3BCmqQcYQ==,iv:DAuhKgjB0lWNrW3gPqz1bAcTi3Vj8dHU1DK+mHY5/vo=,tag:PMlBqb2cQq05I5AvldbE1A==,type:str]
+        password: ENC[AES256_GCM,data:Vt54/WWrRcgXHcBbm6hH1wf3pgGmI4FRjP+7WLvQq55ThmnjWURM6Df5o+ufLIetSBRdHDEXQq/94C4mskppFQ==,iv:Lx7HDW95xhibLaTJWfrOD7clJ88/X4dl6ioatLYpMJE=,tag:WADcHoAKEuPxyn2FSlaQ0w==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        1thEnH5ksw6UOJnpFAWabOJfUwReU0czdcYzU7H3tAYtsVA2NDfRZyGWj8YtTsmx: ENC[AES256_GCM,data:FujkHJqy/+y4XzORTjTbhC8TMF2yxTYUclmRHVAMHBVzU0ICXsPfkv/AcNh4V4JsV4BYMqbMq/pEspt7,iv:Z6Oq9aAoXPP/bWygG60mvasIplebbOE4VnNPc4Mvw1M=,tag:L372MWynDy07JscI69y1cw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:10Z'
-    enc: CiUA4OM7eJF7eMFs4cLEpEqlexk4P6XawAbcuU9XdWiME26MOIH3EkkAZoeZppxvrOsYIAZNOKjN2umyaGkDV6wxWRUv/hSJKLbEwGUwdqJic8u6FEac+bUrB40i804KZMxVjOKXVVDNqcf2rAo9MMib
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:10Z'
-  mac: ENC[AES256_GCM,data:UtldWhWiS42IJbcae+Aon4ZGt2Z+9DDCnGlal0tu3HJUJojSwtKshRsB1YmMeVo/713R7KVzZdZpb+qS2EyEibROQbAYKxjOpgeYArtfg2FSJuxUvAxkIBTaIE3GpC4/lYt0+ti2RKk34pjz3YHU9Me/4WUGp3GI0mQpkkGsv2Q=,iv:RWWbXw1o02alDnXHnHruTplqVm0XQLoAMC06xsw5X2w=,tag:M1iXiZMWgZnIAjO7IBXZlA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:11Z'
+    enc: CiUA4OM7eAfpfvMuKVsZNJNBta65wamFF7uS/yKfPz8TnupAvV1vEkkAPHlbmTfgQKT9+Hea6keoeDCQ2VjGnoJyyFTpiutAc0n49A/yymoq26daRzC2ZpclbDvcnHZGiLi92B2qscqJNniOONbdSdjE
+  lastmodified: '2026-04-16T19:33:11Z'
+  mac: ENC[AES256_GCM,data:VTkGzYPykbSIo1Kmn9E0LRg4qmHVj3JRgD7vt16VcVX2mq1BzzcfYfYJiIE0HD/YN/nG+QJtXZgXsuhFp0DQcQUw8sFm0YbIbRCZHicZngImAh8SVaepM+EMeq8V8QdhYsWT+wOA+62kROj4DQjDp9RFN5WvJri6Wvt77XnSncA=,iv:3tFUcXq49InAVp/Q7Xa9t4WtxKwzuawIGPV68afIFdQ=,tag:S1Cw+GanVRP2DpeuuSr11w==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/awi-ciroh/enc-support.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:UBe8JrzpHZhRl13gFBeePp92dUEYofocE0U1Y29rZLALJjvZj+bkPVaFWcMN0RxE6xuTUbZU//CC5pq1d9GU8lHYcAbEyjmfO96R/8V6NCN476RavMAJjwlNy2b1ChQlBV+Cxt7tAk5WqlbT057D0b2yFBDCSqUls7xkiwe1yj61scwmn4iIRTt0Ip1Xxs/L4bW/vcw6yDoRi83l,iv:Vstgc0ad0VMClN75e38tHwHbQ8pNbniI6/Nf8yPVrsQ=,tag:v+hm8zZeyQUa3FMn1a3Rhg==,type:comment]
+  #ENC[AES256_GCM,data:JbINneoRFV8c209f1FOPxoT5mkf3KczAZIpkZNt4k6UxMuzNOjxTsdQYQwjFFMT7VMltLOFa/4V4BIC2YtPXrV25CFvmxSlRBOCD63tp76vqfBVTyqz06u+5CCTwvpG297dH79BzYP/fb5saaHelUm3XaXAwGeaSgynK2eJZkpl9jPkTMIOfGi6XFDgSskhSbu7i0nXqo7kmo5f4,iv:YZFGKYF4syjfZtCcFQl/z+oCnhf3KKQdIeKXhN9PGfY=,tag:R5iifF8wGyVvXAwwiy5i2Q==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:B/zVvJ8H9q92nKi+wRcoFjv95SvDD1DNCouD/ppQl/jDPa2U4bGXqMqlhn4rX5W8qPnPGmVknwEgzDxUq05Htg==,iv:Ja/MQj6+D3608OcGJ7t+1dbIsYrCWy+iWgxddMTOYe4=,tag:jJ7vIrFPNN9TJiQLuisr/Q==,type:str]
-    password: ENC[AES256_GCM,data:ZKoCSl8KtnbRJMWHXH5qoEcVLo1FqyYu6bGQqm3ENnnq+eUP77lma4zxlXltDOb5vQf8fblfS8GexeXxpM54WQ==,iv:UOkP6Ilpt1pW1HHY9CrjQgtbxnF/bUnkkKH/DfVY2ek=,tag:UKfxrqbB1rgkJcsoJEOUvg==,type:str]
+  - username: ENC[AES256_GCM,data:zCN3D0FzDoFMpWQmpnW6Ux6kRnCvdK5wv36mpPduHdQPQY/vZ3KudNo6OEaJ4ZKAYpS4U6zkeX+Bv+0n/MCyZg==,iv:AUmcOiT0mOPzDbJ3/T4yMnskMUoXSL2JRYtYTamQE/w=,tag:ZfL9xzSROse0pGFwiHMqoQ==,type:str]
+    password: ENC[AES256_GCM,data:JUADO4e6kVTq+OQC6jKws0auAv8xrYix46PTMNQ75HWJl1sIWa0Mu6FQ0cX9XUkl9Wm3c1EUYhE7f6u7Lyx/7w==,iv:InZclbgNPNZcOSPluijeAoOWrOehyzM4cxQBRu6gmG0=,tag:Q2ppf1pt9+YAbezg6B2s0A==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:A4piXQ/LvTQSUq6TtwIhqyKsU5Q=,iv:u/rgiaH/h0vq2VAcfrfo98KAQxKozy2IL0lGrVV+8qk=,tag:BkHpaD2oLmLuf2oZYVFatQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:SRJ/EkUT/NXKVhTVZRHa5w4A6uE2h8eIPUUuFdTLrB90spjYUeUujQ==,iv:YRWzelNM9Hr5y/xbJRVys7f5wiefa3cRInUV6xTAKC0=,tag:sOLuCDqriqsztxEgVLxmBA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:pw==,iv:YDx7LsNT//dUjN6/O/mmPvbT1MGGkkWmwWW+yC5yWqU=,tag:CQRYzhGiKCLTjfq7ADVEaQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:YUB6gkKrse51ow==,iv:JJAjgUvEwdfJJi5Mgj0uLJN7lZxgLobGzX62kxWIlZM=,tag:h/0+kb/ctj4VGETUacF4hg==,type:str]
+        orgId: ENC[AES256_GCM,data:Dg==,iv:2/+vJ1BAE6UCRkIcnh9FN5uORsFZ5bx6s9rqOGhx1Xs=,tag:iQqQAv85IZ3oJ02AxE/8Hw==,type:int]
+        type: ENC[AES256_GCM,data:MsbTFjZHWe0jgQ==,iv:mwWMSIH4wmj3aAUqmwqfaKU9WdEDVrS+LX0gR1Y8qIM=,tag:H8kbMfFx7ORhW5hSVFQ2VQ==,type:str]
+        url: ENC[AES256_GCM,data:3Zznyx7g3ZIhHr1GJNhkyQJgAUOfNtY0Z4Mmd3KxD7U=,iv:BvXaUy+U4RHctq0UyzrzVXKALrjKLL3wnrEXQs+3qXQ=,tag:Cg6Tcfzk4LrPHpq8BoNL6A==,type:str]
+        access: ENC[AES256_GCM,data:XP1nWoc=,iv:1PbZbb0lAM0BL60ZCr7m0UeSWfheCCRqfo2L+gniN8o=,tag:3eQ080ZqDIe/gT0/TVc3Lw==,type:str]
+        isDefault: ENC[AES256_GCM,data:fa2zet4=,iv:Qp4IynksnEEf3k4r9IOOHBn7BKsUS5ErU/YpRjJoOOs=,tag:Ph28D7NE9KyUwdnf0LCPeg==,type:bool]
+        editable: ENC[AES256_GCM,data:yVkltcY=,iv:AGzJVPzuTtMgNUbsZLcc/SQ6dDs4SXN5ob+W63t15pw=,tag:b8AiXf8P6eO7TrEbDmkS6Q==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:Lfwa7g==,iv:ImcxFlV76sj8BMPE267rtutphlcDo4wQIIF7LA+xzXw=,tag:VG+S5U/XEjRHl5Ch+xjNfg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:I0LriBqMmEFLUf0yVpinS3WkGoAhZLiyF3r+tA9GJQyHjHu5Xp286Np0MpQqOYUBAbpMmd9CNJPTdoYNOpYYYQ==,iv:VAc8f3krWL5tTXBRMOJPLVBbo2uWqKlGeLC1mU1Cqro=,tag:cwCPFX/uo8SQclG6hKzpOA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:bPHGGw4nbzwewg1bAH7ylXi8cDkszJ4JcyY3zazvby8iAhSAV3nKX10TGP1ZAy0NaJMTh5DlcBtzriKMYWdUZA==,iv:ZRL0ZmSfSbWun10YVwSqVXLS4khBcC7eWoP/OsgYa6U=,tag:BZgdYCWPzqufzVDDJIihtw==,type:str]
+      - name: ENC[AES256_GCM,data:fqbbgqF1Zn9ewnxUm1LuyC/J5CNE1yYIbuHJIkwtdA==,iv:640nSfNkIfsAdhKpPjhbMtuNTU3mQXd8g5fXl/aj+KQ=,tag:iH9n08A+Tdf67S6mEB1bag==,type:str]
+        type: ENC[AES256_GCM,data:pY63QKP/HXjO5lUCK0fhdLfDr44SKuNU+REP8icMPA==,iv:vLwZN3XVYDLH7/xfjnULNnFV+wCcw1dkhk4eo3j7X4k=,tag:XF63Ao5UJ4nmT59uzVbtSw==,type:str]
+        isDefault: ENC[AES256_GCM,data:uox3b80=,iv:9XETYvYMNSUDkGdskA5M1gm0tRRNQbt/UCywmx5/GgE=,tag:BvIcDsQInJ/ldbg5w9O+Pg==,type:bool]
+        editable: ENC[AES256_GCM,data:jyq9Qw==,iv:XRwBAPFfSR4y/fskipJfn/DbaBMpWIecGwih5uGRH1Q=,tag:QTzBqc8wfh9jTTLglPLjWg==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:pSQInXuzLq0nixZGfg==,iv:Pk9VQYwQPjpeM54EqN0zIDrNHUdnvTl8HShrKhk8oW4=,tag:jWyGZbbhoEXe7RZaXwo4zw==,type:str]
-      value: ENC[AES256_GCM,data:rFnrZuvwlB5RxWZ03Esw7UKHcfP/ucduOYgQaq29JaCDiTyfm0Wyb3mo7vV4GdTSeQmOnZD3wnLrQvAB9+RP5CrN1QZKfyAjtqezBVMBke1tyqphdtyIZxpRtdgrvCbtrB5SZt8otcmSjVlVrA3r46vVBG7OF2HMEwp7thX/pMxp0G/YBZJ+boXPwTeNu4GLaTZS/Z2dHEmu67cKDVWpQiv8WXnj7VHVPN8N9Jsa5L/kRQ==,iv:hrLR6xizlcRQ+cKEQmHDjQA4JymPGpKadRfN5XgTNbo=,tag:ensLzhsRmLTcbln84LVbFg==,type:str]
+    - name: ENC[AES256_GCM,data:XwnGbNOzzsZOGLSZ1A==,iv:ISzz3luVjgHhVCdmmj/9/JE5SkQ0UOE5KT5FXtBG5DQ=,tag:FTE/6ff+AjZ9Fpp6vwioDg==,type:str]
+      value: ENC[AES256_GCM,data:FmuMKOQ+HclAlo4nA8BBsYXkZsaNfRuL6WJeS2rUdK56OASZqyOZzdTBAmOHXt9e49WSSwBHTEdoTOB6rW5X+ax9ADNdkzLaPShsQzN5A/rXzC2Dl1OCaVhh6kxOZ2sU56jWMHzGZ/klPw7MrYQMkn5vWfmdu6nMTv6SK1fhS4rYUuD5CE3wqrKSv6ur2d+R6dOI3t43TexDswCiL30x5Dq+Q5vGt+rC8slzsZ385YCj4Q==,iv:jSAysmS5rpMhcSuwW7ZDssob23o9vUMvayQmBtxYLF4=,tag:MgejyUOV3ZbVYeIYpQwq1w==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:o4fJ0xcfoYQhacH3hl1HM71j19vyA+K+JZECGyZfdBBsCspnrKUxm8MlSCHVQ0RSXIKjK6YDsJyIV3BCmqQcYQ==,iv:DAuhKgjB0lWNrW3gPqz1bAcTi3Vj8dHU1DK+mHY5/vo=,tag:PMlBqb2cQq05I5AvldbE1A==,type:str]
-        password: ENC[AES256_GCM,data:Vt54/WWrRcgXHcBbm6hH1wf3pgGmI4FRjP+7WLvQq55ThmnjWURM6Df5o+ufLIetSBRdHDEXQq/94C4mskppFQ==,iv:Lx7HDW95xhibLaTJWfrOD7clJ88/X4dl6ioatLYpMJE=,tag:WADcHoAKEuPxyn2FSlaQ0w==,type:str]
+        username: ENC[AES256_GCM,data:7azIc5foq5aPKMIlcGECLjysjATLtBxh1Dn+8OCdzyHIbnmUtzRL/3rLfOqVWJlABDkC46l8aKiw9aW11aXFrw==,iv:qSeSepfZdDJ71yYI1Z3TunM/dZBT+MxH9ynKr5LB38E=,tag:k7ojAUbVODMhwrPmQAkoIw==,type:str]
+        password: ENC[AES256_GCM,data:O9khRP1ZR5rAzewymmgta3xh+cwFXaYHuFk11smgD8SA1daVs8cqN9Ir5Bv8PJMNSWY5oGDs0O1Dk6xS4zK6Dw==,iv:79bA4v3wgRvccmLqsyg4BxkmqN6SbnCeEa2LcIq32vA=,tag:kPDIg/iYpM7PcbiOPd9fqw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        1thEnH5ksw6UOJnpFAWabOJfUwReU0czdcYzU7H3tAYtsVA2NDfRZyGWj8YtTsmx: ENC[AES256_GCM,data:FujkHJqy/+y4XzORTjTbhC8TMF2yxTYUclmRHVAMHBVzU0ICXsPfkv/AcNh4V4JsV4BYMqbMq/pEspt7,iv:Z6Oq9aAoXPP/bWygG60mvasIplebbOE4VnNPc4Mvw1M=,tag:L372MWynDy07JscI69y1cw==,type:str]
+        1thEnH5ksw6UOJnpFAWabOJfUwReU0czdcYzU7H3tAYtsVA2NDfRZyGWj8YtTsmx: ENC[AES256_GCM,data:7w71YpYTy5WI6hFijByon9VbMWWHmMMZN204HVwHz4oUv0NvSZCSyvc2ZVgzQeRHVOCQ+hZAcbGgjSCv,iv:2rszbqTD8wV1xxlGo0QK9K4u2OkNGEEb4eT2ousUl1Y=,tag:Rwc12Ae05kuQqpX/y+20xQ==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:11Z'
-    enc: CiUA4OM7eAfpfvMuKVsZNJNBta65wamFF7uS/yKfPz8TnupAvV1vEkkAPHlbmTfgQKT9+Hea6keoeDCQ2VjGnoJyyFTpiutAc0n49A/yymoq26daRzC2ZpclbDvcnHZGiLi92B2qscqJNniOONbdSdjE
-  lastmodified: '2026-04-16T19:33:11Z'
-  mac: ENC[AES256_GCM,data:VTkGzYPykbSIo1Kmn9E0LRg4qmHVj3JRgD7vt16VcVX2mq1BzzcfYfYJiIE0HD/YN/nG+QJtXZgXsuhFp0DQcQUw8sFm0YbIbRCZHicZngImAh8SVaepM+EMeq8V8QdhYsWT+wOA+62kROj4DQjDp9RFN5WvJri6Wvt77XnSncA=,iv:3tFUcXq49InAVp/Q7Xa9t4WtxKwzuawIGPV68afIFdQ=,tag:S1Cw+GanVRP2DpeuuSr11w==,type:str]
+    created_at: '2026-04-17T08:24:35Z'
+    enc: CiUA4OM7ePe2SwYBXSWaQbBuRHBmeuBL/LMgZAYZj6+BBvcQBcdeEkkAPHlbmQkBekq85H0HrZU1E8bfK9S/ii3CS3W5IDn/GYsyIzMwMIHJNynBcRwfdPb9KfJapwnf0nbmCAwSw8R7lwTLKz1QdgJk
+  lastmodified: '2026-04-17T08:24:35Z'
+  mac: ENC[AES256_GCM,data:w7d4dX5K4OHbxSiKM4g4ivhHzakj5Rnr/hjxZEXg6I6Lrane/t2dAnbYqfBDGlrngnO5s59P32rgUuz8aITQ84CGUvMase2R+9B0T3NgENFTXTLib2/LgAJ/wQYfA0ZQ28XuVMG5cdV+Iflr2VzK2OijLOnKmWCVcKgzjGn/WRA=,iv:ulBZvfDu84CVCYwsa0NL0WXXjDGy97Skxa4L3CEq5Bg=,tag:HBqdpPgM/6oRNyACYVSGYA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/awi-ciroh/support.values.yaml
+++ b/config/clusters/awi-ciroh/support.values.yaml
@@ -44,3 +44,5 @@ prometheus:
       - secretName: prometheus-tls
         hosts:
         - prometheus.ciroh.awi.2i2c.cloud
+    extraArgs:
+      web.config.file: /etc/config/web.yml

--- a/config/clusters/awi-ciroh/support.values.yaml
+++ b/config/clusters/awi-ciroh/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 grafana:
   grafana.ini:

--- a/config/clusters/berkeley-geojupyter/enc-support.secret.values.yaml
+++ b/config/clusters/berkeley-geojupyter/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:wLPYdftbsS1gcSNtHR5DHnEEgyb82IVL4AncA/8r3Ux7I4qmov8QcmCGV/C9BdNQ9igNo/QNVCRZz+qCySa5/qDZ7k6o1R1XbLguy7i9seJ91A/oxD0hfhQcv0LS49rhMQTMmESuc8MMOO01KK9UG0JZdr0mcqWuKG3j9HQQKyMLSAfMB4tadBJJjiT262e3VLVkRaquzMKiepE3,iv:W0YN+CA/5GxEiJ5ZGLjsfz96+3TO1jR4v8ePPCrkJAQ=,tag:82ICuzv9srXnS/kt5UDqWg==,type:comment]
+  #ENC[AES256_GCM,data:xZvyqqh15OwFqss1bheyJbrFCOVke+9cg9gTE+HUDotwCWW3GomGkoURb09N29xQE2bz9YCcKzCLsE/47khZYpsDdmBGSa3IwqwlBP9vyepzgXGTY89pN6qyayYFP9OFS3bGZc3uvFKfNhUykUBstMFspR/44B6WUsjlMJBBH+E4D0KKye9w28d+jYxBSCn0A8ZOCazip8i758Kg,iv:tiJf9GS+MdRhs2xpx6oWqqiuSZ4Pw8+EIg1kud7iRxw=,tag:51wEGluhaq3hH57V5q1//A==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:5STTKC92XkoSUh8oGcVjGKr6Yl9t0O2YOicLy00ZKirrRu0p6EPDE7lU3U9CQLGTAnBGOVTTOyl2fyz2oK1+IQ==,iv:M03YNaKlri2WQcPp87WrvMH6wu7ldyleMu8KaMpY5HE=,tag:ZAZ2vRV8Pr230ukdf9YUCw==,type:str]
-    password: ENC[AES256_GCM,data:uJLyTaxK4HpJEzOS7beZ2NPQqA311wo2N4DHyCcyaaCO2+qE8kWMvV1AjQptp3TkfI/PdkSH6/8eRgSy/W72BQ==,iv:biHw+TMskLzhe7RUZMn7vE/IorEI5iG8U8aAnmbvvvE=,tag:JBqFCFkNB31JU23Xl+PFEg==,type:str]
+  - username: ENC[AES256_GCM,data:gYgpXHUY14NZOCigadHKaoRd1giHS+5vmxx4ebMN15B5Amca9dnP2Vdbdb/6c9o/tPsIhgzt2ArWu5PcfAuL2g==,iv:TltTf56flOJ1/yFZguY1Y8iXiwLFF/OhQcw25xDEAx4=,tag:uugl18K3LC94AgpV/8FOPQ==,type:str]
+    password: ENC[AES256_GCM,data:SUnd4pEDED/SHajm1EDH5MXQvlscVuSuqq3EW8sQsJ+IszzzO4k4oSTET+t1wIF6s8gsUADXGyGDYH4Z2I+9ag==,iv:TzKUiEsIbawCVXwcefoD0l0GbFgAPgHXKWrssVvo4dE=,tag:EfEL5NoQ1Fv2t9BwYfbJVg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:jnjgUrZrX/2NOpPnxA==,iv:dqjuMI293kEQ8VnTwshtIYGcYegaeB8gAenNqUOQaU0=,tag:QR9MnxM/0G21DI+F8gt3jw==,type:str]
+      value: ENC[AES256_GCM,data:TjC6EJCwReTUZhGGdZGOkFkB9o4BIgdJWRcDkitJ8AwTVZfJWY6GD0MCq1SrABmNZhXp3L62NpXGZVclAgkV9iboF8wTqGserUPCy34VewbpqfkJCxZLMA/IuMp0Oy4cMMvleVHNFgUcaLne9k55plk/ZsNpPWyo2JXLmsihxG6O5SQMqPylzA8CdRhSL3D3nXyFiilADRfnB1O4xP1KSx2y8WJgSj5aiXwWVmJd30UwHA==,iv:Fyqpiv9TbKmY3VnCJh34H91HcljHcaCmlRWUey8MD0I=,tag:kBC7W60+pmJ72Fzdof5aqw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:STUfVEOo5t9bWSWCXsNil0pg4P5dwpOaoaWhOlnGDrCCcPiqTaz7MAhtzuydoZ4LkYOfAQviYGfVNxeYF1FLZQ==,iv:ToRUH8YN4C4qJB+nR6AZ/2UbUdsYKmazblr3wW9R3+0=,tag:XUqNU/8geG4Xg++6H6Qm6A==,type:str]
+        password: ENC[AES256_GCM,data:S6vp9py99Jn8FJhCYYNa6YixGiY+R2nDOjcXWeaRxfqWbmVAQGDP3VNgsMTtvZCqwIrlWWRkjuf30A8FAZP0CQ==,iv:LFkyae5iMTmhOOm9ryM7lTDpuzyT4HtCvWTBtjbAPWU=,tag:HYnVNrT2fHBSgixhEUdsPw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        W9oHidAdpoHYau9kw6cLcYrzfueKUETjqXuohZEqIM7DPM4FAut4T41Q6fhhoWdZ: ENC[AES256_GCM,data:WqpXuZHBxtDkQY67y4MV81ioVsQbMbevF+onyGU8JjhTnMDA3GK8HTiV5gefzOPJpc1nZ3yEz0OnaCs6,iv:gcsoUBV8yoAxWXBnmuU9jD9HCl3wsA6t0JXmAlrabF0=,tag:E3RxXT+Jgh6zuKWxxGRcpg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:02Z'
-    enc: CiUA4OM7ePLJ6r5VniSH5S3Gks7GRzm3oVHzqemy6WT4PmEeKVFAEkgAZoeZpsOf3DxCz/6JCEvIMJkTJoSqtEWbzcX4nbwENfG9aHQPGV8z8F4l2+T9a5rmWrghbbFb+GcE/25H+bTVBA3e8Bjwby8=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:02Z'
-  mac: ENC[AES256_GCM,data:732z2RYOcCTGKUgtJBL/U8aXBggmhl3ws8MZgkbOF9h/Nd/QV0bWD/qkuSmMG9mxU9UxCr3gjBbYC4oOdIunhEEtRiFZdC9PyGGPMKHI/31uMVkOR7BaCHmL2TH4BsrwzLdAbUWhdbrq/TkstdyocihaSLKT+ov4HbUxg/xqUPk=,iv:If7Ux5yH18oJ6Y7jAl08M4ado2ZzZsg8vS6OPF1fiDg=,tag:oCAu37qNK6dkRL/0xp/zKQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:34Z'
+    enc: CiUA4OM7eFpT1qeO0Jxe1Hctfx4nkhZuKAGbl5KrixrpWRviMZkPEkkAPHlbmQTxHkD7Tsmjx2vgyU+7j+3zAsLMKb6Q4Xfn7CulkqjhD9/c7E9HQDg1uuXZ9ZyMzzVZ1a64IwT1qqekykGPGNg2ATJz
+  lastmodified: '2026-04-16T19:32:35Z'
+  mac: ENC[AES256_GCM,data:aAC04JVVyJumyg7x0ftVzd4x9wePiZMMJzX3T7lPe3qjA/ARv/3JqepCLuw23PQ03Mdyvv0RqPusqMQa457j15hOSOeVfzvwwAyJBim/AlutpfFyAa+mtxVcg0ffa7vlxazk5HmEhC5Mf4lHHTEV8idi4zYpMYTAbp1LACgfzDs=,iv:SC+/0v3K+ui0zGRc8OfnC4JFqQ2tI2FpqX1W3IUNNhg=,tag:c0eD2UVXBWjJ/NFdDGubeA==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/berkeley-geojupyter/enc-support.secret.values.yaml
+++ b/config/clusters/berkeley-geojupyter/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:xZvyqqh15OwFqss1bheyJbrFCOVke+9cg9gTE+HUDotwCWW3GomGkoURb09N29xQE2bz9YCcKzCLsE/47khZYpsDdmBGSa3IwqwlBP9vyepzgXGTY89pN6qyayYFP9OFS3bGZc3uvFKfNhUykUBstMFspR/44B6WUsjlMJBBH+E4D0KKye9w28d+jYxBSCn0A8ZOCazip8i758Kg,iv:tiJf9GS+MdRhs2xpx6oWqqiuSZ4Pw8+EIg1kud7iRxw=,tag:51wEGluhaq3hH57V5q1//A==,type:comment]
+  #ENC[AES256_GCM,data:tMZexCh0FEXYil5cbozGiiQwzQ6NbJ4TOfduDQeOFiYEjqqyHXUlKEUVdDH3LAxiyzOsx+Q7WvZ2pFqo7FDXzkbLxrbmYPdYTB+ne5E90VR/Om2x/9EPoOWunoBY32n2goCQDrpe4SlvhgBHBYgLh6dXCQ03D5J5t0mBaOkYU4VxfJq8n6Qvysmk92mMife1Fi5iVF+UfFJAezW4,iv:42ltnRR7JHvDDLVpvhmGwti1jj1LFjdX3k9oTN6akjc=,tag:hYv2TDzUvHnTSclmFu2Z1A==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:gYgpXHUY14NZOCigadHKaoRd1giHS+5vmxx4ebMN15B5Amca9dnP2Vdbdb/6c9o/tPsIhgzt2ArWu5PcfAuL2g==,iv:TltTf56flOJ1/yFZguY1Y8iXiwLFF/OhQcw25xDEAx4=,tag:uugl18K3LC94AgpV/8FOPQ==,type:str]
-    password: ENC[AES256_GCM,data:SUnd4pEDED/SHajm1EDH5MXQvlscVuSuqq3EW8sQsJ+IszzzO4k4oSTET+t1wIF6s8gsUADXGyGDYH4Z2I+9ag==,iv:TzKUiEsIbawCVXwcefoD0l0GbFgAPgHXKWrssVvo4dE=,tag:EfEL5NoQ1Fv2t9BwYfbJVg==,type:str]
+  - username: ENC[AES256_GCM,data:avKUCbO4aT6gTvtMEtnseUjxhgeSul0XF92vyYEybKLQBpSZ/HYlyz7c3/1QHXULxt+SbwPy9uGds6nTrlkvUA==,iv:BcJ1yzIrZzHFmS7q4S4qwBw/sTFfwHxQV4fA53gb32w=,tag:84PD2Byh+IxI446OPvnGMw==,type:str]
+    password: ENC[AES256_GCM,data:L77j45tFX3f4y+VsSOTQ/+AAndS25RxE0V/6H698lNfoOwcj325VAYAToGA8E/u8EpwBob4eQGkJFB3UIHEnRA==,iv:mnX2PRvXe+yIFjCQTuy47n6KA+44wh+lDthEXTfxzbU=,tag:7zjfkE+KOy3uM1Vktwtaxg==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:jnjgUrZrX/2NOpPnxA==,iv:dqjuMI293kEQ8VnTwshtIYGcYegaeB8gAenNqUOQaU0=,tag:QR9MnxM/0G21DI+F8gt3jw==,type:str]
-      value: ENC[AES256_GCM,data:TjC6EJCwReTUZhGGdZGOkFkB9o4BIgdJWRcDkitJ8AwTVZfJWY6GD0MCq1SrABmNZhXp3L62NpXGZVclAgkV9iboF8wTqGserUPCy34VewbpqfkJCxZLMA/IuMp0Oy4cMMvleVHNFgUcaLne9k55plk/ZsNpPWyo2JXLmsihxG6O5SQMqPylzA8CdRhSL3D3nXyFiilADRfnB1O4xP1KSx2y8WJgSj5aiXwWVmJd30UwHA==,iv:Fyqpiv9TbKmY3VnCJh34H91HcljHcaCmlRWUey8MD0I=,tag:kBC7W60+pmJ72Fzdof5aqw==,type:str]
+    - name: ENC[AES256_GCM,data:T3U1O6X3tOCb1auUbw==,iv:AKt8EW1IlczLurUawO48JI9fQuJy2WeiuIAerPs1xJE=,tag:xNd8XSDacOtHuZL5URJAYg==,type:str]
+      value: ENC[AES256_GCM,data:CWoXpCAaTu8b2RaElCXg2R80iytdJmZkkShsOBijmM3of7CZJ8dpJE5/mci2WEaXD+LYx6w/VPtBfHkjXgtbgiF/3sAIZXq4/+/IbbuKqm16pl5Jnjs3PPLaUfL6o21jGay8oStd2/PLSwGsF9LRAh8ZkhbfDfUhqIkMRMQ1TeaTdQrPmWVTR2QZS65VPQtf7hIdmucPkJMZOPSfduey+zMNEgud6IF3V2+R9bHDaaUhSA==,iv:x8H+ARCbp8uqrtOqKdNeftb3DS+Jal0bEJSGghtBOQs=,tag:XIImcywCb7K8iuDcPWixcg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:STUfVEOo5t9bWSWCXsNil0pg4P5dwpOaoaWhOlnGDrCCcPiqTaz7MAhtzuydoZ4LkYOfAQviYGfVNxeYF1FLZQ==,iv:ToRUH8YN4C4qJB+nR6AZ/2UbUdsYKmazblr3wW9R3+0=,tag:XUqNU/8geG4Xg++6H6Qm6A==,type:str]
-        password: ENC[AES256_GCM,data:S6vp9py99Jn8FJhCYYNa6YixGiY+R2nDOjcXWeaRxfqWbmVAQGDP3VNgsMTtvZCqwIrlWWRkjuf30A8FAZP0CQ==,iv:LFkyae5iMTmhOOm9ryM7lTDpuzyT4HtCvWTBtjbAPWU=,tag:HYnVNrT2fHBSgixhEUdsPw==,type:str]
+        username: ENC[AES256_GCM,data:F9HSmUqlMSHrRoIwiP9pAitDp5ym/iIrJn2BW9vDXxnubBlfwBfbqKfZkJh6PL3g6pnMh7pvmujwRG7cU7956g==,iv:fqUDeWRCBWxGKhlNPS+/B8Li2gYPRVSIkskEeyoRzWA=,tag:fP31IqNs5DhX7Al7jZT/NA==,type:str]
+        password: ENC[AES256_GCM,data:sTqy2f2E63rQwNMM0OE9jW+Vgrhd4hD9/wIzdI9tVdZWosLfX/jQ3IzGpfWPrpEb+QzyfozxrGJX6wT1lO7x9w==,iv:jYO8JRpe5xO95/oQyQbJGEChPUkvgNiByjz2Fj29SiU=,tag:C9ZImsAxF/VOrX7uCWLhnQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        W9oHidAdpoHYau9kw6cLcYrzfueKUETjqXuohZEqIM7DPM4FAut4T41Q6fhhoWdZ: ENC[AES256_GCM,data:WqpXuZHBxtDkQY67y4MV81ioVsQbMbevF+onyGU8JjhTnMDA3GK8HTiV5gefzOPJpc1nZ3yEz0OnaCs6,iv:gcsoUBV8yoAxWXBnmuU9jD9HCl3wsA6t0JXmAlrabF0=,tag:E3RxXT+Jgh6zuKWxxGRcpg==,type:str]
+        W9oHidAdpoHYau9kw6cLcYrzfueKUETjqXuohZEqIM7DPM4FAut4T41Q6fhhoWdZ: ENC[AES256_GCM,data:xr7MojSDs3SU2W8mjXdYJdV9etbbZHQVQMuZLYzoT9jlbN1Vd89Idcf4dbbZEQ1NgynnFWf7TKDoE62B,iv:AO/QsyONdF9+VzmpaueweupjDwWDS9HYqFMnCrDin1o=,tag:2ZopLAwgtMfyHdr7dl2V2Q==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:eQ==,iv:LBF7cWICxJSgHvK3nG9v06m+EocVl4Stu84Tf3BuOqk=,tag:Nf46kLN4/+g2T5G1dbWL4A==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:gI/V/47UdQlQZw==,iv:vDw9CfmECgWiGf0ATcYx3pQmuq0/71kor5NWYLBDo4Y=,tag:4TFuGJOEzMQSKKaiDuA/pw==,type:str]
+        orgId: ENC[AES256_GCM,data:gQ==,iv:ANFgsq2B40K27x9hMNOPOhfTL6PRkxTAGhcx0hzkmwM=,tag:w0q5+QfJ+xMjpPK2LLRy4Q==,type:int]
+        type: ENC[AES256_GCM,data:hFICSw03bQG4DQ==,iv:PEr04jkfsBodIkLqG0nbQmZ+va80XIH36YEGoZ522so=,tag:5bMN1Sndd7v6wJHZkiC2QA==,type:str]
+        url: ENC[AES256_GCM,data:Yhx27flYKFSUEIK/4hjfTCZpGSOCIgo7m835ubhAOHE=,iv:0WpGnGJp3KVFOKAjTFaCvZnHLLyypZUNVS1EEl6Y2MY=,tag:tnZWuD/Y4maj+NZsyhhJVQ==,type:str]
+        access: ENC[AES256_GCM,data:3dBCxe4=,iv:eF22yIN6zoJkR+t6bqnDYhAMBVUieDvAVqR2WtqIaFo=,tag:6K4JKwIDhnbOWIwuYysMVw==,type:str]
+        isDefault: ENC[AES256_GCM,data:D6+hCwE=,iv:NWJRdV9PV/d80TaL+aMU3KpStuTUcmpmD57M6RMNsJg=,tag:lBzJkeRf8MZyNNGKPuAusg==,type:bool]
+        editable: ENC[AES256_GCM,data:x48aP3U=,iv:0gaDP1GainMp5bvh323KedZxRAOr8AoEQeWnk1v9BlI=,tag:CodJRhD9J4QJogF2cszXrA==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:mtCKZg==,iv:GiTfjWKJPdemeZxWgEX+cmLmKHNobboW9bk4zcvN4RA=,tag:J9zcQrJWb28a6Wk8NJ7QEQ==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:dimvBhBZ8hfTd0V4+VnG9Q416W42uqhgj7EK0zeggS4areyv6l4E0pXOS87tNnYOdlVUUztde4vPFhGUTY55/w==,iv:dp09ShZ/Xi4zWVnhnoaEvvB3T9bVmfDpXgdFFt7LRqE=,tag:GshER0CEI6FoDzEbqXWdhA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:9v6/TWr5We0ai32v3EYxyKE7faKIAWwwptIfNZFsrtZ8onvkTK/gknKrEsq2civLoIC4nDT4hJVGiOZrkJnGNw==,iv:Ya2B35hD9P0h+Vi0feWm5klVSY15Id/kN2jLMrD6Bps=,tag:cXSc54dCSht/wRVG25VeSA==,type:str]
+      - name: ENC[AES256_GCM,data:h/qJLpCX71+PKvtRNu8wm79tUUGFGtJ47RnMpve49Q==,iv:b+4S6RORKm7WRL+dpbOSGqqW6YvSUjjVLK9ZzD6HhLk=,tag:Kvr36DMUwwdRy8s5IgV/Tw==,type:str]
+        type: ENC[AES256_GCM,data:uwb+VfJkjvXlN6OkKMSh+TA3z9DRiiTn8R5lD1Fucg==,iv:+SR72Jai+Y+nZyDP8lY23TcxIkNwNtsR0k16RrNbSLA=,tag:50FuCpSDOYQ5tBzsK2pY0A==,type:str]
+        isDefault: ENC[AES256_GCM,data:x+vzPHI=,iv:op55IF5KM9LgzJJdVEpf0piaDoHHBmV7Qq3IdWkdrEQ=,tag:6czVIn3nNLAyb8FSMwJrsA==,type:bool]
+        editable: ENC[AES256_GCM,data:3Z8OWg==,iv:nvVhgk2d98LP4go4wh5mA4aDBe8LxXpiw+76069/3rA=,tag:+GZM4qPOxGz9sdTyHz6Epw==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:34Z'
-    enc: CiUA4OM7eFpT1qeO0Jxe1Hctfx4nkhZuKAGbl5KrixrpWRviMZkPEkkAPHlbmQTxHkD7Tsmjx2vgyU+7j+3zAsLMKb6Q4Xfn7CulkqjhD9/c7E9HQDg1uuXZ9ZyMzzVZ1a64IwT1qqekykGPGNg2ATJz
-  lastmodified: '2026-04-16T19:32:35Z'
-  mac: ENC[AES256_GCM,data:aAC04JVVyJumyg7x0ftVzd4x9wePiZMMJzX3T7lPe3qjA/ARv/3JqepCLuw23PQ03Mdyvv0RqPusqMQa457j15hOSOeVfzvwwAyJBim/AlutpfFyAa+mtxVcg0ffa7vlxazk5HmEhC5Mf4lHHTEV8idi4zYpMYTAbp1LACgfzDs=,iv:SC+/0v3K+ui0zGRc8OfnC4JFqQ2tI2FpqX1W3IUNNhg=,tag:c0eD2UVXBWjJ/NFdDGubeA==,type:str]
+    created_at: '2026-04-17T08:24:04Z'
+    enc: CiUA4OM7eOon7pc3n93W1AI7uaNHSu/BXVUdw5oQY6lUkC4zXs6JEkkAPHlbmcY7K1gyhSkcmrgTbI54ig9ZxzD/chd/q/6MUu/FLKdd+dxWxAj/Xee8jI/Q9S+OJwVPJJPOInX4cbsnN1Df25PcVkFE
+  lastmodified: '2026-04-17T08:24:04Z'
+  mac: ENC[AES256_GCM,data:Q7PqAuR2twEmDUre1PVduuiK2M4+Au1RTPw4F3pcDI9CjN5gwimI3krzf1r3X0VgkL5b140eReFPkE0ydbFUOThBp7ztKLiMmsX7hOVRioR3CxN9HBXdSthYyxn8WjD9WdUSTBsZyn/WnqovN+QbNNqq5jAjY69XRhSKdOguhJM=,iv:65oAH+j3laon4KGvXdpCrY5Ysb4C6MHBvi8VbEOlPhI=,tag:89NCQdIM0pEscS4hjsy5IQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/berkeley-geojupyter/support.values.yaml
+++ b/config/clusters/berkeley-geojupyter/support.values.yaml
@@ -14,6 +14,8 @@ prometheus:
         hosts:
         - prometheus.berkeley-geojupyter.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/berkeley-geojupyter/support.values.yaml
+++ b/config/clusters/berkeley-geojupyter/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/bnext-bio/enc-support.secret.values.yaml
+++ b/config/clusters/bnext-bio/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:o1KcKEYx0plinyL0Osh35bokcJRg28VrfarnH1bX5lVRSJ2gGsBDHiD1mgkxYbXPZW6BY7+gTsTC98+u0uoutXIpPU/dIf+iEGOU0lk/YsJZPxB6d3DEIcrtP3ASllLFurMRfBIMB0ZCjL2rjMWE1wIrGJzivz7rrgM3LdZci/FPntxVG1n/x5gAGETZDazMPNnE4r8r6rALm0Xk,iv:ncKVyueCb+G+ImfmppxlQw5nE5IpU7l7JyUk9lxHaLw=,tag:isQuMdokL46ZUr/h55IiWw==,type:comment]
+  #ENC[AES256_GCM,data:uIXJtRMvTyd+hsIKgA4O29O/ZtAbbkAd4vs++PcQXngtez6bhij02Pk+HbzE1YQp0SXzDSFuMJwZaLlW4JQOvN5v7mDE0JikvL0e62R0w8pq8w1+shIRjE2Rof/O8vT+t4+dCUl3DAgq8+Ox8nEHoyhadcJhfdOJr0vmSF8k2zmTHMJZYnghvc6b9mq3EUDGeDV3AkEvYua0a2jM,iv:4/0uuDHwGMh+gTImMtIAJ39NxLCjaerBhvjn3KUv/uQ=,tag:MByL5oWdNytDM62swfGPwQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Di/XUMnacjRdZhzRih5pWIxrsdwSM2UWgGeFwzotatr0g43zkyCOyPXhK6WWBFhOCXxP4Vrv9Sd7zVf5g+bBrQ==,iv:Gi2B4pi2QxagCICBNc06oqIvcoj8R+7Uqu8dQ8c10cU=,tag:8UzOvo3lAptpolw7RZBwwA==,type:str]
-    password: ENC[AES256_GCM,data:u77OQpkArOFpArBL59j1u+JKpS2OPdIBO4NeP8mdlaALKz394xO3OEMScOualACEf+9Lw6vRE/t0dZrNjiLcsw==,iv:5/Aq32ECYzGq5Q+/g7qKnnNqqYTxAYb/DYROZeh3la0=,tag:rEc6uRnfubpw98fmzUrjmA==,type:str]
+  - username: ENC[AES256_GCM,data:V3k29SqfbHzcbuSVjnlD/+kmXBNTkrx08pehSTSEjwV6ghpe8K/ndeqRtegzSPLnBYBy4wbQMaG3zxbTm3M+JQ==,iv:7y+FBeqERLbWQND+TNbwOfZyitGOjKerk/VUUXFNxWU=,tag:iDHiKmJVg/rnBB5Aq3pf0A==,type:str]
+    password: ENC[AES256_GCM,data:AsCZRuJnzVBiOjGeSgvTUqQW73uzfX7o0M/uM9IWmMXswtBL75hkR7puRS1PpdFhH3n0VM/17wgwHzpkEJ9Btw==,iv:5eaP8zwJ2wOkdxGiNa2sdHnS037w12d/i0uENPKTVAI=,tag:kfl6prloxB9m/PCyjoxeDw==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:1I5ecmc06+ogow34PA==,iv:y9NsnlzyOAyP6w5qp53i+cAvXQ+r865+I7pOFwpgQ/A=,tag:i4OYSvH2ZtgHDEKjxBBeMw==,type:str]
-      value: ENC[AES256_GCM,data:mEca+oRhjN15Ljff7x9EvzPaZJmrCzVl1C7LaOjzR9oG1MikljZ/TP4aW81vhFNWi3+t0BhjWtiT9786C+Bxr0Wm4VojvBdC5ZAuGTxYxrQN9JYpP+A4nQ84ysHCeb6tj6z5FHLcYAFgCgryXfx4cg+ikC9RYjQ2qUO2LiSIpq/v13P79QTAY/Unct65UWLDSRDxztAaWgpFNVczukNI6m2YSf1D7Mqx0ZE/xGPsB6mqpQ==,iv:qOYWUCJN5mumgkw50fm7yH6vDjXPuwRckMuQ1HhdmYY=,tag:k2HWNBvjRFTIQoScRGTeVg==,type:str]
+    - name: ENC[AES256_GCM,data:xP2FSDxWGCZXLqRpvA==,iv:H2LjTizHfNh9JxG8L8skg97Ds0/Wp9EF1So7NWmMW5Y=,tag:MUWenq5aJpENL6/QQKPKXQ==,type:str]
+      value: ENC[AES256_GCM,data:EqcZ17G8VEE9fJO2KlE4PmsbVOeOflBSbpFL9ogE1NPgbEQFnor3YCBhKwatyK3XU2vEgdOekN9yA/FGe+PeYS45Im35q1JRElnM0S1YsA0oP7DebhGyxFB5jcN/Ly8C9nI6ghJJfnMO0aNdZl88MjNhsyWlNPDPwuUnUtSwqnEto3QFRL3dYXepNQO9n7VXkCmlHTskAez4eKO0PI7mwwMVT/mCNGe8Ws6uq2Hm51Bcdw==,iv:K8E8YtfNR12ZiCTKPtgEhIEeQGCZFcBebLl09R/p1gA=,tag:LtKP61O1bCrXErOTy8tvig==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:t9Cxp9ZlF/aFLBD6puObY/VTESTVnIp53Cbjt9HrelxwWt/liExZ0JSdn19uIV75mZhajItq882J7WKGjXxOrg==,iv:Ob1BWE0fz/AMZdx3kCU+r4CaOC2P0BPUwTGPDhpGNjE=,tag:CXNmbqccnGBFqBqVPWDmiA==,type:str]
-        password: ENC[AES256_GCM,data:k8nK5KmPOPtfkSpQNxYlYm9uVD++kgTxtBTGUl5LMCm9yKt7tRKixmT1i/zHoViImMajGMVR3i3AtiQbAJCBUQ==,iv:K3pxIOtUTULIhsKVP8w6m6Xrol4Fk7S0jPCPaI89OwY=,tag:S1d4iO2BX3K1shZv3Rs04A==,type:str]
+        username: ENC[AES256_GCM,data:g4aqH3C02u2ODEAjoESAOG+RVeB74Wd4kILWPV/X1B4hoHasXzvUVZ17S0NRERmweOPd7/1/Sc29b+EedwwnTg==,iv:48Mx0rr2Z8byax7du9F9oprvMKXuDyScSBEs5jS/uYU=,tag:gelTr56WS0b4DqdPRyX/4A==,type:str]
+        password: ENC[AES256_GCM,data:0YxLzPf9jppwsaiJMKqDzlAeCl9iqUvdP0JAU/42Fu5XF41G9c0f91kRhq7oFGuyNYZQwJAVMiD+YM+xqSpaLw==,iv:crYAb8yhNqBwFlAv0YKIs5+0ZOvU8cFm2UONijQDHHk=,tag:6OX14FrV1V5f3JAkDSqBpw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        haZKNVqTzKp0rZcfR2U65WeIWc9dJWmWkN1R4EyH1B6wzJTSG830chWOsFQdmgwZ: ENC[AES256_GCM,data:k2N6lgV0gNFKlIDPf1e54DDy9KPGcRsy7floPqcpmZ1cma5O5FZGBu2qOHTat9Lwk/ZTmE3UkKpsxbe6,iv:QC04nxxZlNhEdEg+hzxZWIolIlIQZs+NgvVw81XtRCA=,tag:yz2302ZfBNFOrUvTphim4g==,type:str]
+        haZKNVqTzKp0rZcfR2U65WeIWc9dJWmWkN1R4EyH1B6wzJTSG830chWOsFQdmgwZ: ENC[AES256_GCM,data:v+HIy6pDD6bl/a6dbpVZmHNTqT5xhQr+jlsbEEWCI/uSW8plUR5ygTbJvGocmZuMltBd6pteG5QBi7cK,iv:bngE66PRrVhYj7kSxOSyHW/yWQSd8rMWzzRShHVvDOg=,tag:QKbBOqfn8xya2zl5lRXEJg==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:ZQ==,iv:LB9U31eqJTwaoJb5FzNHROBDzXw6XvJdLzkK9PUmTmI=,tag:9VOMNcVfut5BNj11b9fuHg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:GmcoZeYUvIcSjw==,iv:mx/BgwgFPG+SlEqUZrzrfTrqVyOHaNLQCWmB07QuL8A=,tag:g2cHAFqtC9G6gg8oFzlI8w==,type:str]
+        orgId: ENC[AES256_GCM,data:JQ==,iv:5GN5TRxfMBm/WzHnYWASyNlwJf7yR0BFsflTiZP3rxE=,tag:SnmF+PjsCK181uP3te4Mvg==,type:int]
+        type: ENC[AES256_GCM,data:P0b5PnsheBt7mg==,iv:smP9pJXNUJy+tLrE+6WqWVsz0dYsDl0cvevneL8sJK0=,tag:lJkE7iwIuhXlOxd6vRf59g==,type:str]
+        url: ENC[AES256_GCM,data:npR7UWbghcZhyIdK/99YdCYIY7chJHqgplscs3icVr8=,iv:3h+G90CUlTFIeC+nyrK9cXonOBAWGg5ecVtHcKju8Nk=,tag:RE5sAfo0WLrlySgj/nX1+g==,type:str]
+        access: ENC[AES256_GCM,data:qhFaCPs=,iv:ZVi0FNZER6mD2Knj2ocyPZRJEoQmvjs4D4BijQ9U2KY=,tag:e6b8lI/oW7bjwfhZ/2pK9A==,type:str]
+        isDefault: ENC[AES256_GCM,data:6IyObnE=,iv:sdWD2Oe7lLnuTDTa9m0PoKxd7rG2xkiYg5DIxBamYck=,tag:b6xtLB7Km1GT6E6zDdqtfA==,type:bool]
+        editable: ENC[AES256_GCM,data:x2IhGyY=,iv:uamobuSAQnhdjDjJUFibaehM8h3a1KWgW7CbTmO5sPs=,tag:Ac4TfD8f/Yhdl0+kctCQAQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:EOTl6g==,iv:GhPXqluP37+uqCl+7L4v2dFA184hx2UyS3c9HJRyLJ4=,tag:6r8GE6t39ZGfvlo4fi21+g==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:os5yPSgWmPwRwrxlyPPxmgBXulrNtjD5rbHTMlU5+UeAecu7IVwtK2iybNJBBUZgMbLH1ZfgdefXnMIT5cqBKQ==,iv:r5ANS4gVCymeV5QtNmIdopjp1jJ5EkVuT31Ma1hciNw=,tag:oXfC3IolTs8HdYzOvo9Bsg==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:Hu4f9aP9D0GUeF9AUpvvgS+9cCeEnjHifgYytY+kFBBbVqMWG1/fzvLiL1B8eTZbMAgU6unmBcb1lg6192SnqA==,iv:4P0idNMRGeKlMSVG2dIneEwgYU2kKqInNCJZEJ3qtp8=,tag:q3BBWIaUsu46Ht5P43pI5g==,type:str]
+      - name: ENC[AES256_GCM,data:GbmLZYBP1hVUEOT6RzyoOsozWwpM+iqoycChb561BQ==,iv:i+Wrr0SETNgg03o1BkiXB47L9r3WdgbOkg2FRUgWkY8=,tag:jSuJLnu1VxMZG0nP6Xm8xQ==,type:str]
+        type: ENC[AES256_GCM,data:v6i9H6lW+rwHmUxt4DFcDtaERd8ezHtKIWUl25w40Q==,iv:t5fHAdbY8eHlDSNi7B/mIvYDe1bdEhcU2HRjw8hi8vM=,tag:gElpXk9e4QnUQh/P/LU+6g==,type:str]
+        isDefault: ENC[AES256_GCM,data:OBBteGY=,iv:nd9VOpwO1jkzLe3DaAVLoOR5NHUuu5YALvO+cgzI/wY=,tag:lw/aUQf1gLNwO03KbVdK6A==,type:bool]
+        editable: ENC[AES256_GCM,data:Rs31KA==,iv:LdnvwGKYjaK7kQ0g7qLbbMOgt4oV+Zw7U8jTVQUEHvE=,tag:DTMonwhq/lBLGmjbIf5I8A==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:51Z'
-    enc: CiUA4OM7eK5Htp6Ntw7QO8kL11idtZIJwjpUDdNfjYJLomSfd5rGEkkAPHlbmYi6+OTFDTyS3gkbmOGrpqh/7yNcfPksK/vu+8gESw3/eQjjpl6iBTX3Yx0Z8c8lxNPsyuLbjmrSCpkYhhUoXE7iBn1N
-  lastmodified: '2026-04-16T19:33:52Z'
-  mac: ENC[AES256_GCM,data:RAAujOAATfSV2znOQJiWPOkr02YSZfQ6jwvDVOk/awytLf4eTzcFpDMuCgtIq7TLE4aX1N73UMoNgQloevqGZL10CN7DOBQlNq68aI423xM8tq4SMU+Wc581xGRRLuBBEYC6RnBAw4ibKqvXKfyyIqO1VaA0Z57ax1GpzZakfOQ=,iv:/lc8ZRF8Duw8pHIZ9fndICMgrkc2jtMtUmBX+Bkvv5I=,tag:mFvF73KuTQGXwe8ZisiH6Q==,type:str]
+    created_at: '2026-04-17T08:25:15Z'
+    enc: CiUA4OM7eAjfi/n13+N4q6g4XHHinX5jDUyPOlrdzHxxoukroPmGEkkAPHlbmYU/vHOGWunA3Io903OObr01JGwpAlLBwuLkXWt+dAQ95mFtPnm8P9MJJEoqitXTwhDDVShpUy2bvG/bGk4O/aCFm56K
+  lastmodified: '2026-04-17T08:25:15Z'
+  mac: ENC[AES256_GCM,data:V9buWouS10nkWHAl//n9VA/qDkuY9RFOspwwqezK8wvMGdSDPRm/vW38QUIIIp3R3yQb31+DS72Thb3luLf7AbWaInhsL/TBO2/9hEDaeW86bq5ptkW7YCNlrkRFb/uemeCiA7AaiDdWETG4wxETQqPZCzxut01a84S5euEAiOw=,iv:DxbKre5W/yXIPWhTG0japMIbBzmgrHUlfXL8p2BFZgQ=,tag:svVg/KWfQq0EVHgE2pNPYA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/bnext-bio/enc-support.secret.values.yaml
+++ b/config/clusters/bnext-bio/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:v67glZpAsM/bJPz3VyYZ4yt93tlpL7WE+9069O3YEOOaaAwytQtkIKh8wclZENXqPLxURTuWR0jW874xjVBGcikk05E0cZGRe7uSOqFFVMOHg3Ql0Lc8zwOqdxkwX/jd3sN/JirxAhg8s9zcj0FVUaJClVGjAZ5kLfG0WzFnE8yYeFLsM2xTGiQ/J9lUxXpev1u3CsehHVuf9GNq,iv:mVl54HkVT61zGFUedyAyjQJMTBBtYYvqq9fkCor4BhA=,tag:1vlKSsvCWpEX9wFenpAL5g==,type:comment]
+  #ENC[AES256_GCM,data:o1KcKEYx0plinyL0Osh35bokcJRg28VrfarnH1bX5lVRSJ2gGsBDHiD1mgkxYbXPZW6BY7+gTsTC98+u0uoutXIpPU/dIf+iEGOU0lk/YsJZPxB6d3DEIcrtP3ASllLFurMRfBIMB0ZCjL2rjMWE1wIrGJzivz7rrgM3LdZci/FPntxVG1n/x5gAGETZDazMPNnE4r8r6rALm0Xk,iv:ncKVyueCb+G+ImfmppxlQw5nE5IpU7l7JyUk9lxHaLw=,tag:isQuMdokL46ZUr/h55IiWw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:G5vJC8Thf9tcS9xy7ugeHPf2uY9L7rz23XWpv5+44C6p/37OPAv6RrT4oryd6t4RGRPBhawyMjO92lEtxHzJTQ==,iv:DU8B3pIO1y1Pl+mmuHtzuRipuHmlELaOGb1+fB56xMI=,tag:0Ckl2ZE4Ye979nRyC9rh6g==,type:str]
-    password: ENC[AES256_GCM,data:M4mUOuK2FPq1MDi95ABR5M0wbd043ieiQ82I44CEbGtjc9Spz9hyXbNwJTJW20vmH4JM1FMdtjOL8g7FRHdOrg==,iv:Kzu8ZkoJBcyb4IUnpNSx7uce9unRD3hbSW+vuOYTBjg=,tag:NdwTce7/GM+3uxW3buVCOA==,type:str]
+  - username: ENC[AES256_GCM,data:Di/XUMnacjRdZhzRih5pWIxrsdwSM2UWgGeFwzotatr0g43zkyCOyPXhK6WWBFhOCXxP4Vrv9Sd7zVf5g+bBrQ==,iv:Gi2B4pi2QxagCICBNc06oqIvcoj8R+7Uqu8dQ8c10cU=,tag:8UzOvo3lAptpolw7RZBwwA==,type:str]
+    password: ENC[AES256_GCM,data:u77OQpkArOFpArBL59j1u+JKpS2OPdIBO4NeP8mdlaALKz394xO3OEMScOualACEf+9Lw6vRE/t0dZrNjiLcsw==,iv:5/Aq32ECYzGq5Q+/g7qKnnNqqYTxAYb/DYROZeh3la0=,tag:rEc6uRnfubpw98fmzUrjmA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:1I5ecmc06+ogow34PA==,iv:y9NsnlzyOAyP6w5qp53i+cAvXQ+r865+I7pOFwpgQ/A=,tag:i4OYSvH2ZtgHDEKjxBBeMw==,type:str]
+      value: ENC[AES256_GCM,data:mEca+oRhjN15Ljff7x9EvzPaZJmrCzVl1C7LaOjzR9oG1MikljZ/TP4aW81vhFNWi3+t0BhjWtiT9786C+Bxr0Wm4VojvBdC5ZAuGTxYxrQN9JYpP+A4nQ84ysHCeb6tj6z5FHLcYAFgCgryXfx4cg+ikC9RYjQ2qUO2LiSIpq/v13P79QTAY/Unct65UWLDSRDxztAaWgpFNVczukNI6m2YSf1D7Mqx0ZE/xGPsB6mqpQ==,iv:qOYWUCJN5mumgkw50fm7yH6vDjXPuwRckMuQ1HhdmYY=,tag:k2HWNBvjRFTIQoScRGTeVg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:t9Cxp9ZlF/aFLBD6puObY/VTESTVnIp53Cbjt9HrelxwWt/liExZ0JSdn19uIV75mZhajItq882J7WKGjXxOrg==,iv:Ob1BWE0fz/AMZdx3kCU+r4CaOC2P0BPUwTGPDhpGNjE=,tag:CXNmbqccnGBFqBqVPWDmiA==,type:str]
+        password: ENC[AES256_GCM,data:k8nK5KmPOPtfkSpQNxYlYm9uVD++kgTxtBTGUl5LMCm9yKt7tRKixmT1i/zHoViImMajGMVR3i3AtiQbAJCBUQ==,iv:K3pxIOtUTULIhsKVP8w6m6Xrol4Fk7S0jPCPaI89OwY=,tag:S1d4iO2BX3K1shZv3Rs04A==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        haZKNVqTzKp0rZcfR2U65WeIWc9dJWmWkN1R4EyH1B6wzJTSG830chWOsFQdmgwZ: ENC[AES256_GCM,data:k2N6lgV0gNFKlIDPf1e54DDy9KPGcRsy7floPqcpmZ1cma5O5FZGBu2qOHTat9Lwk/ZTmE3UkKpsxbe6,iv:QC04nxxZlNhEdEg+hzxZWIolIlIQZs+NgvVw81XtRCA=,tag:yz2302ZfBNFOrUvTphim4g==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:17Z'
-    enc: CiUA4OM7eDAd+Dg76fSNLkrTuXf9TvUsF73Hdf03pY7k2uBwW3nmEkkAZoeZpkZRLC5cubeI9v1lqKWTC6oZNELFTM0qr8XOTXh5DXFnaOw4L3XrrF3260dw6rfdDeaD1BaXIOjF5KBTkQKfQ1FXrygp
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:18Z'
-  mac: ENC[AES256_GCM,data:2dV907tLhdPpvnKw18QJEFnJmmpCnQ9YNQVPicyYSzp79odV+fUNV3H6MwzkYBWJovD0LDfwWi27Tnoa17CfD0ISzQrYohcFF+IMjjpfUbn2d+986K03zIn7+RDAwv7iIZs4xfpacb69iSZNa8juV45zfHhKLVIgTIVoc6ujmLI=,iv:/tCStgBQjRSrFKogDzeT3wY5Clw+ymVsfDkDSHimWJM=,tag:9topEmjOX5Q/PVhMdJOqZg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:51Z'
+    enc: CiUA4OM7eK5Htp6Ntw7QO8kL11idtZIJwjpUDdNfjYJLomSfd5rGEkkAPHlbmYi6+OTFDTyS3gkbmOGrpqh/7yNcfPksK/vu+8gESw3/eQjjpl6iBTX3Yx0Z8c8lxNPsyuLbjmrSCpkYhhUoXE7iBn1N
+  lastmodified: '2026-04-16T19:33:52Z'
+  mac: ENC[AES256_GCM,data:RAAujOAATfSV2znOQJiWPOkr02YSZfQ6jwvDVOk/awytLf4eTzcFpDMuCgtIq7TLE4aX1N73UMoNgQloevqGZL10CN7DOBQlNq68aI423xM8tq4SMU+Wc581xGRRLuBBEYC6RnBAw4ibKqvXKfyyIqO1VaA0Z57ax1GpzZakfOQ=,iv:/lc8ZRF8Duw8pHIZ9fndICMgrkc2jtMtUmBX+Bkvv5I=,tag:mFvF73KuTQGXwe8ZisiH6Q==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/bnext-bio/support.values.yaml
+++ b/config/clusters/bnext-bio/support.values.yaml
@@ -14,6 +14,8 @@ prometheus:
         hosts:
         - prometheus.bnext-bio.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/bnext-bio/support.values.yaml
+++ b/config/clusters/bnext-bio/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/cloudbank/enc-support.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:mxVIl/3qBMPj6wEsjXWC6zTwSSB49M6XzEujo5qTCNEEdAwPFUBDn56hIpdIVYUv1DwfWJ3OHP/wEFRZmVPEc/tI+TZtrrAUh2txD9AoMHa8ddPqsISinDexGUUPq55uNey242sjrsq1jBpWfBrlDY5LsMt5wD6IlnJVJo06JCvcmm21Lz7rXioUWdbenfDbbc4LPOyiLACK4enw,iv:gTwEu2xKjIZOTVDupe1711BxldsYo3hkv8X+G8ZvFSk=,tag:1rtD0RSONphfjTFh8wdz8w==,type:comment]
+  #ENC[AES256_GCM,data:R7L3RiIfeQz9mjyHRwct6RSgAF1yGX9MHo4udfLFX+MKN+x/Zm0PpH7h7fuEIw3XacXTZ+AFltg/zHwxNX7jm1soisduqsJFzu4kwTo9g7y9ECrb0ua1U7AHNR0HHqsl57C0m5aBKhiFcFYI/VvX7wK8Z82buf/5GFhDZI9UDlXagxgrvTxvsoH46eq1ggS7ZuIRd/GZ3Vv77F0g,iv:11KN69a7GV3yQiVyS8ftWarKQ15mZvOB48qqGgzSoW0=,tag:sDeKnO2BfXFxVmG0eD4kZg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:ylJd9vG2XpQOGVJ0Xo9w8mZxBsLemEu7oO7hCmyaGXWcKyvLEVheLZwxi9pySLT8m5ckjE/jtDpeXchSiphAiA==,iv:d7ihgVuZkXbZiULF4cl1w+zlIcd/odRzFqR5TpQLN7U=,tag:ri6VSXXOQXsLGdTWKFOm3w==,type:str]
-    password: ENC[AES256_GCM,data:wUgkO5MJWkhDRffbBYGe9zAq3BXrj2iC2NubfPEOuchku5UEGfPOcMPHwiKPgJsZwfs/A73IvCbbxUXYid+x+g==,iv:P4S19KDjMcYE+hfPsnBxheXrf4E37wHccpn/hfm8TYU=,tag:hTZkJJObriQ/dYI7Cmh3VA==,type:str]
+  - username: ENC[AES256_GCM,data:Tiza8IpcSmM2/BtWwjv/joijpZgEsD57QmozEskbJVrrL0x2ZRq2Z54pQ8/BRbmFGU32f6nM+cF6axX9Q55V4w==,iv:O2FIjRTbQKzcPUsF22ydTWbkn5ex6rhDk8H7keWSHYM=,tag:pfOG2NapYFi3t4jylDbuYw==,type:str]
+    password: ENC[AES256_GCM,data:CM/aTOMniPUfURkeFpTcfu/E4eIJXjVLLckiBZATVJPE5CL8pPGYM7/wuDcU+H2dLlz4dtKA+JaG+BLfqxuB+w==,iv:ntP3ht3Dkw1ni50n3l+xIoAaKRFiOOvgUomNd4ZKsaQ=,tag:zr7Hg7emyo3lVyMXLiHT5g==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:lL+Qwik7OTFs8xZRezh7g276Jf8=,iv:eWC0tBsPttnX0/Ob3EHsofrEscN6q/KD6zrpAaA1SuA=,tag:RxTMPnt28qYLBAg4Q01kAg==,type:str]
-      client_secret: ENC[AES256_GCM,data:nrCsiVZssbI9PmKnarKzC3Qp9SWAHfy+hOiLBnpvHvhS0YkJnEfy+w==,iv:kw5IHgN8ZhoYAwaDguwpzS7wl2ldMdFtKU8ULAFHnzU=,tag:cLxaVcbTJ6xakPjgZvYCHw==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:wA==,iv:wsXZoo1Cpn341jEopJy89wAcbxlIHT1bj3JKHTMf0Po=,tag:7Ci/NSJhSnSJQ7ZDmDnpeQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:UvK9Uo8sbEbcmw==,iv:DbF/N2Ft+t75swxFx5Xj1AYAvZos/NwRf6Q9Srxyubc=,tag:SIdBNBHuWPRUYYJXs2/toA==,type:str]
+        orgId: ENC[AES256_GCM,data:yQ==,iv:F2+ALR8/uq4kmpvrCf8UqgibpFSCOatIAqC+MjBTiv8=,tag:PVMe/II/EQQIJP5dPGRhUg==,type:int]
+        type: ENC[AES256_GCM,data:Clik7UerQI0UGA==,iv:pvfE3n2SlmUUyZXY7rBxEcgavZo2ktH6QJfrXY+roEI=,tag:novCIZ+AzxcaPcQAbo3vmA==,type:str]
+        url: ENC[AES256_GCM,data:zJeEWKi2myOGqjawfUQTGPHyd4cR5fKr0giqT0wuEo0=,iv:9vgDwwHHF+9WoDc7tGPaYZdL8QoUZsU/KhzMPok6GOg=,tag:pZbx7vUS/MQfwj5aFbCmsg==,type:str]
+        access: ENC[AES256_GCM,data:XC4n/ZM=,iv:rJi3gVup5rDhm8nwSH1SkBlc/mNO8eOgmEGx0zpTBbE=,tag:rPgIVeynDB8cuc7iM2Tz+g==,type:str]
+        isDefault: ENC[AES256_GCM,data:x9nGRzg=,iv:VrQO5LjH5I2rup6547yPcWoLo8cNQW9hbW/hMGuLrdE=,tag:M/ps2BFo25EvQikmwfMqBQ==,type:bool]
+        editable: ENC[AES256_GCM,data:9HR9Zyk=,iv:RW6yQIi0PtXAh7STuE6uCbe+8WamaMciKmviFqpY+ww=,tag:gcnaTuusmV2ucn6FRqMBwg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:4O9Wug==,iv:j7s90CBCxjW/nscg8oyk4MqZL83ky01MsF2iiSG04f8=,tag:eWZQE3eNz41N5CRWugzZHQ==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:40LrYn/IpBmS665lFnNfzrgPfolBBr/oHscxITQbOWPEdrGXLA868EHjRgNFP1yjN2xzLIF/vr2kA9ynVUMZEQ==,iv:6aQ57pr/U84KVP3inyozRAvvPOt2AY9mdTXJ2upUTs4=,tag:aN0JddLWg98M19JCa3drOA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:EUyYci9gLgJ6mwnaGOzNt0ADjHNvVgDcKMOFwjYVQBiZLA/Cy7qio0H65HUTKxpqcqlAPCDcq0YmVjzcARsfKQ==,iv:i1gYfZuizI7Y2A3OUGg6i/uvU5nVvjl1k5Y7NcikVfQ=,tag:d7WzCIqjYNP2+2QDOvNpWw==,type:str]
+      - name: ENC[AES256_GCM,data:YJVRE1QpR4QxgoApiB0h2tczAwQubSuMQtACnOs4PA==,iv:1o8QBSgI0gmsGVfc4IxO40rrNsThRQY3xai7Y2+zxX0=,tag:rceiXJUOZquBJZit05rAeA==,type:str]
+        type: ENC[AES256_GCM,data:Kppd4E/bO505vKELVsuxlu6mPh7SipQPtIbpecNxQw==,iv:jHxvjVdKPWdaDdQ5c+VAntbBV+fzhlZZVMfbOhLyiok=,tag:+TZpmT5hlbGneQg5W/D8Aw==,type:str]
+        isDefault: ENC[AES256_GCM,data:ojtr9mo=,iv:LSjQGcqhIQ+5AXqTRrcewOZENGG8rPpbTW+OXUCZwZk=,tag:E1cT4/WI0X3z7ES9wdqEnQ==,type:bool]
+        editable: ENC[AES256_GCM,data:USHj2w==,iv:odxLT0tiUKeP9uC5RkXhVa6SpExnar/IxZqxZ5rOaHA=,tag:eQl5vamNYiyn7bgFt6tnxQ==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:I/uAyQC4CqYkziPQxg==,iv:r2CUTunzvmEDFhTcl4myDrLwQ825epMOJWSFijThhyQ=,tag:W8ENhQKsBog0teRWPbUGTQ==,type:str]
-      value: ENC[AES256_GCM,data:6r9TSbY781rFDLgVp/lZmj3L/lEnkYYO4s5sZ4k9iq8KIP9eWsbUZdGBO0UOdmstzq4eqMSZsvPRCgD8qowvZF9NTsnV/oiFeVA6bPCfLpqybE8rCkGgeAzdqejsUNdvu7Lu51yFyjDOYSnrMjhJiyYF0cC60i8F3yM5Kavoac7VlYvMlolqw6VcGVeOg/vc9u9sAfH0CbObSJD/nqaJ1uAM9rv2GpUEG5lnPfJE+QMAbA==,iv:j0vSkXEcPnYn0QU0qWkQe0dmVVGTIrj10O7HKwGSqZ8=,tag:NBsA7XEtdbHixlL455DqLA==,type:str]
+    - name: ENC[AES256_GCM,data:WSQIbRSQXnMAYSEdBg==,iv:3225h+vuXafz3Fz5CDoy+UMp2/Krgb8N9efoPxvbA/E=,tag:NaMbTyKKI9iVPz9EEfCMdw==,type:str]
+      value: ENC[AES256_GCM,data:ewJ7yYb33pSr02tXQT/6f55Shcjo65fVcPIDTdry3831RZrTLIbLsOjWHQa5QZ1c04TYD5WmR3azmAOMeNLGnU70s6BLCdkpkqVQGX9TPiY+HVw+L1+Dol6r2DVpttKkPdib/1Z0Qzs+wuYmX9qQKrv7riLe40gunnW2LqKH+eruwpVpZ+I7wsU8nMMaMm6Vtqi67m0exQkZuzCPbZ/bYbd0MFhtfLK0dt6EiGHvR/AMNw==,iv:7Ie3U85GCiSQT9y0YEBV4Rrq39QC/yytN34RSphXmuM=,tag:pp9LS0lzheSryirjF8lKvg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:jR1knOmj1c/8FzYDEPVThrg1XrFeZf/MB1IGMUXE4OWw4x1BJ3NRi2a+EL63KFY/afO5W+EAtT+0PXANUjTzgg==,iv:HM6V3JM02EcAykKA3uCoatKfDTkxsBlqHk3rJC2Pnlo=,tag:OyAsDBHezpPln/TpVYD+zQ==,type:str]
-        password: ENC[AES256_GCM,data:fSstQYpAof0Bd3YX9G7oGK6+L+jg6LcA04XsL3Eoz8de417up7Uh9S3WWJ2Ngs2Yuq529s2apXQp7eddEO5MJg==,iv:9QJrtQvZ2bhiNopOGQVfnvx6D6/H7m676UeiekJmKmY=,tag:VeVO/JkPaOE9+afH9cb/JQ==,type:str]
+        username: ENC[AES256_GCM,data:8QwUGRKuaMrNTx1Hvyq0c6nX+c3IbLDLIXcq4gP8UpKo7oLJCCgZ+15xicIxjha1vxluUDr5ELJ3YRYcUbAjGA==,iv:3wqx8wfJstMVb4sO6dtjAaXTrhOZhXr7164OMSuXHFI=,tag:Cku5sV2066jJLEJUf078Tw==,type:str]
+        password: ENC[AES256_GCM,data:14Zpir+NBIVHaCyIGxmsK5K5euqeKMc+K8iktAasCeEDuuj5xFo1lW1klNl/IviEo+sWrp9/8Sz69n5FYAAIQg==,iv:uy3ebEG7n5YWs1Yc0SrfE9G4pRabWFU4tIQYtvaEl4A=,tag:NmxNjp/hlneO9Bi3R8viVA==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        zaepio2aingap5eehohneiLoo8ooHaht8kiezieTh2oneiRaitovoLeenemah6ti: ENC[AES256_GCM,data:Wf3gWE37zXh6hp3TDbHkzeakkHrgmeXKBeYVGvXIzUBgtY+tMyTQgftwEoNjOU1X98ygkjLgNXPGxAN5,iv:TPk77g4dkj2FcYP8Gqq6O8VRGFqsu61VbSoI/5k7J5U=,tag:1SHZnbWNIuzhLmS5tqr+nQ==,type:str]
+        zaepio2aingap5eehohneiLoo8ooHaht8kiezieTh2oneiRaitovoLeenemah6ti: ENC[AES256_GCM,data:AgWbQ7KF9IHX9HrwcHK+Th5LYpKsKUOz4D/QaKO2+8hcBPPVpa7RZHXvgTz4pHSPyDYh5GXnhaDSFLxF,iv:vzgmqq0u+u3DyPOk8oBeu3eqUoz5os5zMgP2BEwG7j4=,tag:oIsn09nSdZre8frNoFH3zw==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:48Z'
-    enc: CiUA4OM7eOZkPdvPfvuX7FNInHLH6yG4S9Q/6Pe24yJbsT40K3hHEkkAPHlbmXrarZ6XGRfuiouBUyh3HPlGavdMoYg5nSE+xOzG87jxsI0xhtNLibEAiC0dUXzyEo0YmqoOzJea2TW8OdLE8W+kk9GT
-  lastmodified: '2026-04-16T19:33:49Z'
-  mac: ENC[AES256_GCM,data:+LJBRtYgA7zaNJij5BknkKzAPz9e46wl3Qmaj+eYKxg/kD9f9ahvgQuHW8bavWaP68KP2Kk7ylWGeDtWC0BYRrpDU98kXmc7X0mBwIIHU2BqB7867zJ6SyJlcSI3KiMvAqo9InzQKbLB/FRRgGXAa83Yfd96Q9Ji+zZarwbFnZ4=,iv:PK8XoH0WaQhY9lUUEG8wks1vszo1S+jXMFhJyNu8D2A=,tag:OTpY7eUtHaDqQGfm19GOEQ==,type:str]
+    created_at: '2026-04-17T08:25:12Z'
+    enc: CiUA4OM7eBSTlbr3i2LCgsJv2vDptdcIVWdVFaGwVhGMP0RHd/7UEkkAPHlbmTzNbA9SJMno0FF2TmUJ50mzjLzipzwpZBfZ8+41C7ADhq5r8bCASdnmfq8DralTz9LtsNfvIROUg2P7DpnDiXaklFCM
+  lastmodified: '2026-04-17T08:25:12Z'
+  mac: ENC[AES256_GCM,data:Pn5mcQaJhwfEwRyQv3obOP3uu8M8B1VcuBgb9wdnOu0aSX6XYTyXCSAIZ/ek/VhQCm1sQi2RM+vbf3/e15IT9u+XgjhCeyOdyypjrY6VNyAY3JAyWz1dYhkKTP0X8AGkp+qarsP5GXRYjImbpx2DihketFAtK3UNFVJ4dPn0BLA=,iv:KF4z/jDWA6vBiJkWmQg1bkbMi2pL6xzOY/NmLMLh1qM=,tag:6edhsEsneO24Igh9pZPExQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/cloudbank/enc-support.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:rdOq7zG9u/sp49MVBHHkfIMjMrl2X/Gu1bxU2xVpXzJNNS3pw1y4kzj1VGo9pIn9aOv5KTD+cnahb49rWlnfl69GkmAiwvkzFc6Gc8V5MTcHQ2Zs/jWw/uc5xQ64+Gi8nrS5j1lXDPD9PoEliY1OcuPR3i7W0e7pE5s73xVGzKEaHC7sJJPU/oIsgpQBTO/D7b/DYF3qtJHRr2rW,iv:Ezx6zjrMrqGy56XIH9iriNwvtpW/TiyShNTro55oiQ8=,tag:WQ4CX50Ay1v35tqiTZMnXA==,type:comment]
+  #ENC[AES256_GCM,data:mxVIl/3qBMPj6wEsjXWC6zTwSSB49M6XzEujo5qTCNEEdAwPFUBDn56hIpdIVYUv1DwfWJ3OHP/wEFRZmVPEc/tI+TZtrrAUh2txD9AoMHa8ddPqsISinDexGUUPq55uNey242sjrsq1jBpWfBrlDY5LsMt5wD6IlnJVJo06JCvcmm21Lz7rXioUWdbenfDbbc4LPOyiLACK4enw,iv:gTwEu2xKjIZOTVDupe1711BxldsYo3hkv8X+G8ZvFSk=,tag:1rtD0RSONphfjTFh8wdz8w==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:zTqtuff7Y6rE3F+kKFG4z4MTZCh2p/hgcYw93v5sr7UKXiQJaw545xWHfZvomvWBrFIc+Bx1g9xm3+DN3ns2Sw==,iv:otL4WhPTSq+bABRBlsIP0utFveGfMMQG4/0LtHkTeTQ=,tag:qNQWzy9A7b7rRih5OdyVHg==,type:str]
-    password: ENC[AES256_GCM,data:wfC0B46/1xdVyWh9XSs2oEQi3atkE6H6FMVjsW//x7846z3soyGLGopREC1grHwAFILFBdhZb2DSuVRCSInm7Q==,iv:IQLS6Rnv3p7WZc6fJ6QZR5xwj57T27818J9D2xa4JZA=,tag:5QaWcnXouhHL+m4r5OQrYQ==,type:str]
+  - username: ENC[AES256_GCM,data:ylJd9vG2XpQOGVJ0Xo9w8mZxBsLemEu7oO7hCmyaGXWcKyvLEVheLZwxi9pySLT8m5ckjE/jtDpeXchSiphAiA==,iv:d7ihgVuZkXbZiULF4cl1w+zlIcd/odRzFqR5TpQLN7U=,tag:ri6VSXXOQXsLGdTWKFOm3w==,type:str]
+    password: ENC[AES256_GCM,data:wUgkO5MJWkhDRffbBYGe9zAq3BXrj2iC2NubfPEOuchku5UEGfPOcMPHwiKPgJsZwfs/A73IvCbbxUXYid+x+g==,iv:P4S19KDjMcYE+hfPsnBxheXrf4E37wHccpn/hfm8TYU=,tag:hTZkJJObriQ/dYI7Cmh3VA==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:VsxXHFgd2Krpr8oZ9kWnmAM6dT8=,iv:+ClI4lP8qf5lfbmPezmwHPKt6Yk8LXAgKWjc89BUiw4=,tag:bocd9PwJvL+u05hj4+Myuw==,type:str]
-      client_secret: ENC[AES256_GCM,data:obeUnpXxRGbTHAjBPa9rwSAuHgxCkdlERLButhjrAJmSdwY3BJ6VdA==,iv:Xi+FGlIsjdtPf/Epd0qXVh+nzu7MF9P7kpDRMUJeiQU=,tag:2JAcT9BLCmxBaNBxUkccvg==,type:str]
+      client_id: ENC[AES256_GCM,data:lL+Qwik7OTFs8xZRezh7g276Jf8=,iv:eWC0tBsPttnX0/Ob3EHsofrEscN6q/KD6zrpAaA1SuA=,tag:RxTMPnt28qYLBAg4Q01kAg==,type:str]
+      client_secret: ENC[AES256_GCM,data:nrCsiVZssbI9PmKnarKzC3Qp9SWAHfy+hOiLBnpvHvhS0YkJnEfy+w==,iv:kw5IHgN8ZhoYAwaDguwpzS7wl2ldMdFtKU8ULAFHnzU=,tag:cLxaVcbTJ6xakPjgZvYCHw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:I/uAyQC4CqYkziPQxg==,iv:r2CUTunzvmEDFhTcl4myDrLwQ825epMOJWSFijThhyQ=,tag:W8ENhQKsBog0teRWPbUGTQ==,type:str]
+      value: ENC[AES256_GCM,data:6r9TSbY781rFDLgVp/lZmj3L/lEnkYYO4s5sZ4k9iq8KIP9eWsbUZdGBO0UOdmstzq4eqMSZsvPRCgD8qowvZF9NTsnV/oiFeVA6bPCfLpqybE8rCkGgeAzdqejsUNdvu7Lu51yFyjDOYSnrMjhJiyYF0cC60i8F3yM5Kavoac7VlYvMlolqw6VcGVeOg/vc9u9sAfH0CbObSJD/nqaJ1uAM9rv2GpUEG5lnPfJE+QMAbA==,iv:j0vSkXEcPnYn0QU0qWkQe0dmVVGTIrj10O7HKwGSqZ8=,tag:NBsA7XEtdbHixlL455DqLA==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:jR1knOmj1c/8FzYDEPVThrg1XrFeZf/MB1IGMUXE4OWw4x1BJ3NRi2a+EL63KFY/afO5W+EAtT+0PXANUjTzgg==,iv:HM6V3JM02EcAykKA3uCoatKfDTkxsBlqHk3rJC2Pnlo=,tag:OyAsDBHezpPln/TpVYD+zQ==,type:str]
+        password: ENC[AES256_GCM,data:fSstQYpAof0Bd3YX9G7oGK6+L+jg6LcA04XsL3Eoz8de417up7Uh9S3WWJ2Ngs2Yuq529s2apXQp7eddEO5MJg==,iv:9QJrtQvZ2bhiNopOGQVfnvx6D6/H7m676UeiekJmKmY=,tag:VeVO/JkPaOE9+afH9cb/JQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        zaepio2aingap5eehohneiLoo8ooHaht8kiezieTh2oneiRaitovoLeenemah6ti: ENC[AES256_GCM,data:Wf3gWE37zXh6hp3TDbHkzeakkHrgmeXKBeYVGvXIzUBgtY+tMyTQgftwEoNjOU1X98ygkjLgNXPGxAN5,iv:TPk77g4dkj2FcYP8Gqq6O8VRGFqsu61VbSoI/5k7J5U=,tag:1SHZnbWNIuzhLmS5tqr+nQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:17Z'
-    enc: CiUA4OM7eN7fsB8A9Za8/R30V3OwD8bbx9PJLx+V8psiTE11gTqoEkkAZoeZpr3zsj8jqWLCS1Gx1hv+g1PupCagsJxLwr+ooD+tUc3kVfgJdS9l2P07dKk4udvHQ0DnIlC7uZxzHqMFrwx0vVtx3mlH
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:17Z'
-  mac: ENC[AES256_GCM,data:lL8d42fB9WpE4ztPBOIG3GxSmQdpFy+SaF3Nv+9gsb+scgyWwoem03HwBjgmIppOTBVimtbZa6BfDbCsGcWEAPa6NCHzla9JX74AbJ+pNgKnV2HsQzHCCO4dws8170rWE7bJyd0hm1QgA2D7+2jbAwbtq8LtWbxwrRzK4Pudz80=,iv:SQDpAfcrciXKeYUzzfpsqDsK7d3MjDDOIpUJ401d9Gg=,tag:a02NM+HXi7RbBcNl0xaYzg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:48Z'
+    enc: CiUA4OM7eOZkPdvPfvuX7FNInHLH6yG4S9Q/6Pe24yJbsT40K3hHEkkAPHlbmXrarZ6XGRfuiouBUyh3HPlGavdMoYg5nSE+xOzG87jxsI0xhtNLibEAiC0dUXzyEo0YmqoOzJea2TW8OdLE8W+kk9GT
+  lastmodified: '2026-04-16T19:33:49Z'
+  mac: ENC[AES256_GCM,data:+LJBRtYgA7zaNJij5BknkKzAPz9e46wl3Qmaj+eYKxg/kD9f9ahvgQuHW8bavWaP68KP2Kk7ylWGeDtWC0BYRrpDU98kXmc7X0mBwIIHU2BqB7867zJ6SyJlcSI3KiMvAqo9InzQKbLB/FRRgGXAa83Yfd96Q9Ji+zZarwbFnZ4=,iv:PK8XoH0WaQhY9lUUEG8wks1vszo1S+jXMFhJyNu8D2A=,tag:OTpY7eUtHaDqQGfm19GOEQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -19,6 +19,8 @@ prometheus:
         hosts:
         - prometheus.cloudbank.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/disasters/enc-support.secret.values.yaml
+++ b/config/clusters/disasters/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:DfjxdpXj64JRWo2OSqFZiE72AegOUysv40zpH9J8M0S75gbaehxXCO0Gc2sa5gIRrYOTYRRDcL//IVagPq8lx2dzXCiRpqrBtaTBArUFlEtMnla/M0Jo+bWRNn0RXQWaNTouEFwcZKyXor4ejhhjLsp7wrcgNSEEU/ftc/vZnI3O72j3RhGpCNP466CNQvFMcLIgk+ZFMZJMkmxB,iv:YQGb/qTVvzxv+6Z6nOzs8tIU2D7MkW6HT6YQzdSAAac=,tag:SBMVXJVHL7FT8o2mP+8KyA==,type:comment]
+  #ENC[AES256_GCM,data:A1XpZ2v59+thbq0oGcbzsvZ/sYl6v9pO1k/YGhsmgNeqq2dALujJtQWfU6db6/jdXloXyLF+86xV4ckOMD6815J6bFR9Nm61O7wqp7WbqlVZbUh102e7xkbQs3PU04YqlVVcBcKi1Z8lgKmNRjXh9TTX78DnjEtyd7bqQzgllbO8BuSJwNwAIuhMRyUN7OIm+VX5k74GM5mCvui3,iv:tpT5gzNk6N/Zx8kpOHjzoakpSyH4WcBGQWt1tNfEGe0=,tag:fsjv8KP9hil6SITXz849Ig==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:XG5IHsVcNnMBEhAC/3D3MwwHNMjHdAFFgg5dNE/gle7+vjxBHFw0mcUNeWbz6oRnBcfPqOi2fWlFTRoJaWEP+w==,iv:RgzoHuHmDGiaCpifnynmxJcO4F2y+3MTEbHZkavQuho=,tag:uCT/6FsL6OcUVWxA0Gb9Ww==,type:str]
-    password: ENC[AES256_GCM,data:tfNnrUUp7SladNwxeTxkXTKPaxFzAKrYW69Qn4kXLKZ9TTft5dnbJfkxi9CQWHFKVUa1V7sfSg/0E80bjW6JIQ==,iv:GvtNqkz5G4hK6AEUcQsrF7thHomhbFDqjNQiaC4PBhM=,tag:m48d7MQDqUug/XjXsOsXAg==,type:str]
+  - username: ENC[AES256_GCM,data:cNSjZ+gL8Von4nJTUnsD3hTKXzW6DQvna2tBQKpnQqT9b6IOQKd2r+hp9Gxy6DxL0sMszCNY+y8E7k24hqWO1w==,iv:zU8jBjJHrn+fb5siRWuM1hKMNn6UyKIRgZ4o3/yXQXc=,tag:WW/WghNf2b8ZANA2yDoipA==,type:str]
+    password: ENC[AES256_GCM,data:sR24D9+zhiqCEq73fT6z06JrnHPEG9mxNSozFaL4LEevHD4GX6F5Xw/AaeKbkUX3JO5Z1jt5wQRKD5CQpXUGpg==,iv:sahAgtueh0t2dCMCtoa4ceFjHHOgRthD5RAGRgSyYMo=,tag:o+UXNLFvLS5wzj7kJizv2A==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:hPNAt7W71j+IVFKdvA==,iv:yAajaIj1BMruF+l9KJOQ0mUfWy99u+tpeCBv+7GI/A8=,tag:qFnFZQIC4XC0P2hjplokgw==,type:str]
+      value: ENC[AES256_GCM,data:tF6YwExDTuNMpMaCDJWlzMesvncMnRQJFPffMruET+NhDMqOeCmgZk16kD+IsloyR/jB+VwF3f1Mf6M9E1oolG9okdnOGgBpClBI0dHdSAQtmE2DxuE2PBwbECclDm8aMNpK48ezI6Qew1rvkMEe/+7U0toL2qDDO0uyA+7cHWkUay896LHZHBLuHEK33WyD8vdKUegU0Yf/JAzOcWmFO1KL/Dta589CqQ/lNZLoInTT8Q==,iv:46N2+ho7X5w8bIvrm9Kq3Uwpm17xDPyTAu86Y2V3E8g=,tag:oEsgpX9wofyKUYigttSWsg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:tUwE+crCD34UX45P08JRkM6vqpgMVcbzaP4wcFXtTvIISLQmOgJAbZgphcRy6vmjS/7ET6LwbW1ySLUScuh0BQ==,iv:MsdhPflMhkf8GHzT+V5I4lKiDJohZVVpOSUNeZCf0WE=,tag:SsbEvSx+2KRsK97cEAfQ3g==,type:str]
+        password: ENC[AES256_GCM,data:5l1kZdppY0fmN14UU5ar7jP4wfnWLsDZEN4zZxnwK4UMWPV+zOwXUHGbew4NC2u6jkF+2lcZ6VRGtOhtXZwEug==,iv:ZsHcDO09ZGBMum6IuYxd6qz47c/VciFdw3bxcKLOQgE=,tag:Y3f4D80dXy+DZRzvOgfZPw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        Gm2pjLMUB9cj15epxYJQqLKI8oobQzLLTpSf9yAEyKxzvRNu91C95lE9dtLXd92m: ENC[AES256_GCM,data:P4wEjePVNhjR3sI10Z4lFkcJoGeIMwUcFXARTci6cX2JEIIz/Tbi2oWOTlg+uHf9/BbiistljhYTzPev,iv:U2o4gSjT9krkzswgH38oYsle3/yQf3c9rbfUXN73QOY=,tag:D4WKlkNkOLqwZx9BZPDJPQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:03Z'
-    enc: CiUA4OM7eI6o8TGhbIN3gduvWwSHSKJhOQwz/JimzuhlG/W2l4SjEkkAZoeZppcVTfJt8OAqsa4BCm6MSAvCzT1VoS7cQU4l4ctOXvTJ9+A3Qr3py1/XEUWttqHHjF6nAOp9M6rEbrwcV/663nmUDDGh
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:03Z'
-  mac: ENC[AES256_GCM,data:IGi9EIp59bkIfYctXah1WM/e+h3xgCpg9p+LUE/9qc1AjaRZN6j4tRo6soPwNpQDfbpilMwKjuPcZejDwRDxRadMkB9CUlsqa5DVHo97osW/YBj9wDy9g5c/FwommiPeG9p+fqyD1Jo/fFZbCnkKiY7867bnknh9nzk7cZZhBzI=,iv:3O1BceDyuEf0mLoS/nO1CzMasdAraW69q3MmzMD4B+I=,tag:27LjiYusVoXsvg7CSD7vZQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:38Z'
+    enc: CiUA4OM7eBqlKQDnIiqlzSQd++uNvC5TTgkYEeT4+8Y/KRPL/BUWEkgAPHlbmRXB8tnkPM/au6mzmgEHb5AB2mBgta8azSdun5Lmk3ByAiGsB4Fo1R2Z3PgPiNitN6Rp7oh7lTv5wl013uyrZaTcRO4=
+  lastmodified: '2026-04-16T19:32:38Z'
+  mac: ENC[AES256_GCM,data:7avhlgXCztoFfLlE9yRRPNDUbJYkm5rSx5QNkeN0euSi1T0Q0kYqNIB0bmdZTzOr9SafsoYrhye5JroanCtakXHsEWwWF2QVHebKhcYGgLLD/OyyFAfd68QX/qt5JAou5pS++zixil7MbfH3dLBhDKc/19qR8tyDXcpUI4rud9M=,iv:rY210e4+BiJNNHAwkg4IIg2MxMTKYV8KHwroB2iR+Sk=,tag:WOd0NEW/c36FMRnf4caElg==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/disasters/enc-support.secret.values.yaml
+++ b/config/clusters/disasters/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:A1XpZ2v59+thbq0oGcbzsvZ/sYl6v9pO1k/YGhsmgNeqq2dALujJtQWfU6db6/jdXloXyLF+86xV4ckOMD6815J6bFR9Nm61O7wqp7WbqlVZbUh102e7xkbQs3PU04YqlVVcBcKi1Z8lgKmNRjXh9TTX78DnjEtyd7bqQzgllbO8BuSJwNwAIuhMRyUN7OIm+VX5k74GM5mCvui3,iv:tpT5gzNk6N/Zx8kpOHjzoakpSyH4WcBGQWt1tNfEGe0=,tag:fsjv8KP9hil6SITXz849Ig==,type:comment]
+  #ENC[AES256_GCM,data:yMfBGezjbWlIP7Li0UF4q+6hto+PgHHzR9nQkI7vt+ovknc8qicIXAPVYlZyMVJZAXMJcrVfzUUhCQyazZMO9smRKrlgjswj9FCwKLPZfIPcVuBF3oyvNRdFSDez3uD2LeoCUFodqY7dYe2WtLadDhBGkpYqy5XKK650TDkEMb+IAKLhw6TkCTrY8LHAsc0aWWEZcQqG5wJKqmoU,iv:s5jrdh+2P5hb4q6hL24WxVnciiaJvgsAtXon1ipdEjM=,tag:iv6jBjVMxGiTMMYb5Pzl6Q==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:cNSjZ+gL8Von4nJTUnsD3hTKXzW6DQvna2tBQKpnQqT9b6IOQKd2r+hp9Gxy6DxL0sMszCNY+y8E7k24hqWO1w==,iv:zU8jBjJHrn+fb5siRWuM1hKMNn6UyKIRgZ4o3/yXQXc=,tag:WW/WghNf2b8ZANA2yDoipA==,type:str]
-    password: ENC[AES256_GCM,data:sR24D9+zhiqCEq73fT6z06JrnHPEG9mxNSozFaL4LEevHD4GX6F5Xw/AaeKbkUX3JO5Z1jt5wQRKD5CQpXUGpg==,iv:sahAgtueh0t2dCMCtoa4ceFjHHOgRthD5RAGRgSyYMo=,tag:o+UXNLFvLS5wzj7kJizv2A==,type:str]
+  - username: ENC[AES256_GCM,data:yaTwFkbph3zKgYo9Jte6XVbbbMtB5cocC2XwmJFoAyxb2erhjsBLoPDirQU0nO0n+O3z3XSKqzFSgodVYaxd3A==,iv:DWmcvIL5NwyDnnGgV4kkff7ARP2BS8avmol2Nw3IDp4=,tag:oHIDg7fCfq1HuGiP7AdLLw==,type:str]
+    password: ENC[AES256_GCM,data:sGAvDuUwqp9e/V7zJJwVVl2VZWC6qvpenMewY+ky4t8ctvfu4mbW9/467XreteAYP3zIM/WRrGGPjVeYNhzniA==,iv:UHXpHiCmwGgzP6qMVAWEqqVCTQ1h6s36iPx+tkmXRu0=,tag:McpR1adgnyZLpiJbVwhrZA==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:hPNAt7W71j+IVFKdvA==,iv:yAajaIj1BMruF+l9KJOQ0mUfWy99u+tpeCBv+7GI/A8=,tag:qFnFZQIC4XC0P2hjplokgw==,type:str]
-      value: ENC[AES256_GCM,data:tF6YwExDTuNMpMaCDJWlzMesvncMnRQJFPffMruET+NhDMqOeCmgZk16kD+IsloyR/jB+VwF3f1Mf6M9E1oolG9okdnOGgBpClBI0dHdSAQtmE2DxuE2PBwbECclDm8aMNpK48ezI6Qew1rvkMEe/+7U0toL2qDDO0uyA+7cHWkUay896LHZHBLuHEK33WyD8vdKUegU0Yf/JAzOcWmFO1KL/Dta589CqQ/lNZLoInTT8Q==,iv:46N2+ho7X5w8bIvrm9Kq3Uwpm17xDPyTAu86Y2V3E8g=,tag:oEsgpX9wofyKUYigttSWsg==,type:str]
+    - name: ENC[AES256_GCM,data:lxxpJpk504grD/9DWA==,iv:JBB/zpLk8n5p/N6VweXHCPt1En2PFkRz4/WvbfMsP1Q=,tag:2DySlVcSejmA/wmuTb5r+g==,type:str]
+      value: ENC[AES256_GCM,data:F/8xQHXkK2toE4sRj1RBHXmY0av7xa26Sx2zAcRuH/K6CJr0VQKTBMdh90UrLJ8d8XzpRaQRjoxSBOdEF0SJ1M2yAfAx0WCO+UmTggLk8uvqRjNdPnnOLiSwfLPRgiS6IPPDar70f/WDw2ZNKS31y3dvTJD0lVchrSQ2jibnCCUQV2usmAkwUUkCUYTJOc7uI96zu1lpbSR0DDXCm1Awm1BQKR4pb5XaUUzn7/XKj/sFhQ==,iv:VgJHj5KPKZa/kShBg/uWliZX0twxZTxSLJyY+O8eZ3I=,tag:WPowUTVtHy4GjArbvEbe6A==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:tUwE+crCD34UX45P08JRkM6vqpgMVcbzaP4wcFXtTvIISLQmOgJAbZgphcRy6vmjS/7ET6LwbW1ySLUScuh0BQ==,iv:MsdhPflMhkf8GHzT+V5I4lKiDJohZVVpOSUNeZCf0WE=,tag:SsbEvSx+2KRsK97cEAfQ3g==,type:str]
-        password: ENC[AES256_GCM,data:5l1kZdppY0fmN14UU5ar7jP4wfnWLsDZEN4zZxnwK4UMWPV+zOwXUHGbew4NC2u6jkF+2lcZ6VRGtOhtXZwEug==,iv:ZsHcDO09ZGBMum6IuYxd6qz47c/VciFdw3bxcKLOQgE=,tag:Y3f4D80dXy+DZRzvOgfZPw==,type:str]
+        username: ENC[AES256_GCM,data:XA4ncAUr+mD5TCqsXSliGF9NV/YYtxrhrNd/9XzYunnuA/B000GiH0dEAPcTEfbXb8BQQ1rAPW40kfp86D/sqQ==,iv:d2G1Jb+4nZFTUJnNwJGDYl4+X/EtZFMTVcdtJvBaIV0=,tag:CgRcoKQ+CSdXRPS/sz0nBg==,type:str]
+        password: ENC[AES256_GCM,data:PCJAXFUW9SN7R0xLmVaGvdSxMpCjY9Fb1ygV0WRHkMDpKqxfZaUaFnJpsn1hC9kzrwLUlE6weVKOzHHyHDagyg==,iv:jPeSeCWtraquA/nhnjOLRNOXRM97RHQTm/iZv6kOld8=,tag:ZealKFwAgUhYguszmsT8Cw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        Gm2pjLMUB9cj15epxYJQqLKI8oobQzLLTpSf9yAEyKxzvRNu91C95lE9dtLXd92m: ENC[AES256_GCM,data:P4wEjePVNhjR3sI10Z4lFkcJoGeIMwUcFXARTci6cX2JEIIz/Tbi2oWOTlg+uHf9/BbiistljhYTzPev,iv:U2o4gSjT9krkzswgH38oYsle3/yQf3c9rbfUXN73QOY=,tag:D4WKlkNkOLqwZx9BZPDJPQ==,type:str]
+        Gm2pjLMUB9cj15epxYJQqLKI8oobQzLLTpSf9yAEyKxzvRNu91C95lE9dtLXd92m: ENC[AES256_GCM,data:0zi3J6CPF4mJa3DoBP9hg2kA8dmq7nxChdvM9H1tO39uRXpZALzpNzo4bL0+NQofs7sLiF1l/6vTOtnK,iv:udMZ9oDXjXTbDI0IgjHRI8XhIRwnJ/DMckccT27m5hM=,tag:Jt2h0hyYk1F0xJ1HXrZdXw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Wg==,iv:rwriuV8IDujyUoVwJKe5DxtjVUhJ7iM2ZidBFxEJZMA=,tag:c5CYhEeclAPIEhXt5vwg1g==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:3fwtr3aDr1XQwg==,iv:iRP2H2tT8EaEWj8hgKsETImMV9VZjAZcgUNzoQNqvvU=,tag:AzUv2X9xw6r+NQpkcGCVNw==,type:str]
+        orgId: ENC[AES256_GCM,data:0Q==,iv:UGjt74Ok4RIvZnwoq3fy26/22vQU40wvkcJ/8GxTXrY=,tag:XdEkKbl8EKoS1P773AyCJg==,type:int]
+        type: ENC[AES256_GCM,data:23lCjIYWQRXzOA==,iv:zj+OxzqZ1M/HnFkq0SZy5PBhO7nN/6wxYxdRmrtI0cM=,tag:LWToRc/lO2dDh3QCEh3RIg==,type:str]
+        url: ENC[AES256_GCM,data:PGEe3feFjK9QEZWbtEJeaHIgjSRbOobMGDk/ltWkvMo=,iv:hky4fEbzNDkcjr2lrtW1nGC3W1kkCHsgYeBDI5gNQE8=,tag:12BtzDDyPSUjrF5YbDv5Xw==,type:str]
+        access: ENC[AES256_GCM,data:UWyjO5o=,iv:bZQTOz3IXCK95mx5uUyTxmsAK3lDQ5SIH4ss8UjNcYU=,tag:KyqOkgMrD8uWL51kbc+Aqg==,type:str]
+        isDefault: ENC[AES256_GCM,data:NKnaQOM=,iv:k26vS3E2ML1DWWJLPoL48UJcqgT4aE95Yo/UI6ROz60=,tag:P5DHsAX9Dh7C2LQj1xwRtQ==,type:bool]
+        editable: ENC[AES256_GCM,data:2geHrjA=,iv:hhpg3dGE6Nbq89pBob4jOxGHZ+oQCTcoOCIm6ZaFwFA=,tag:K2h9Oc7hT8HLRy1fPmTa4w==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:/Yh3/w==,iv:s9G/YvkGXsQLYZFECOszIJtCuRMmd39kI/d1/sUv6V8=,tag:lK04I58e15DbzhiLPf1oJw==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:77rpci84MEOnBkMWefBZ++9g7NYL9iLD1NL/98X6sGG63P+Rvt2/eETYj6HMz/b5NXHakN/iJ3HfzG8gY0lD8Q==,iv:7IBxIPTFediwTzFmVnU62iSZ4+8U/Xze4Zx4L9SZC24=,tag:/O8olJb+D+ajwFx78WRbKw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:n2bHp9IW0czq/AB+VZswTeHDAK+EJy/aHKmPOSGDiqTORQ+Xp6XtIG23fT1IruqLqsi5zBOm2pi+xHLlEQoDjA==,iv:cZR55XiRLfv/bmWCTSVVRIryOIOASIBayycGX3rLofA=,tag:a2WdSHTiK6UZCRqwZzp3eg==,type:str]
+      - name: ENC[AES256_GCM,data:+gfASY0tDfM6fxh8KWn19m+cTna5tiO4dVnjGMataQ==,iv:fiicV5I6wqUmcjaQ+AhC8fUsOX3Gf2U8xpEeaA6CYRw=,tag:SM25C2A4p4Rvi5NhEqvfVw==,type:str]
+        type: ENC[AES256_GCM,data:3l1FqN5lXCSJ3YemQicCeyVztZuxDjONQsfvONyjfA==,iv:I134//D4JLFJndHwNOR05l8VahfM/fYSEJ7LEsHtMMk=,tag:A672vfoTSD/d3Rk0fxYS6A==,type:str]
+        isDefault: ENC[AES256_GCM,data:PYp6KuI=,iv:4+pEthfU8RUPaeqg/h5PevgS74yj3MYz/m2+ui2Wg1E=,tag:LWnBFzCmAtj3VOFZbA8TUA==,type:bool]
+        editable: ENC[AES256_GCM,data:PQyfMA==,iv:KwFH70eyfqLKzGz7gWykkqOotWqc/u5/cdCrroigim0=,tag:JECvslmbQoWqJkX7+TxLzA==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:38Z'
-    enc: CiUA4OM7eBqlKQDnIiqlzSQd++uNvC5TTgkYEeT4+8Y/KRPL/BUWEkgAPHlbmRXB8tnkPM/au6mzmgEHb5AB2mBgta8azSdun5Lmk3ByAiGsB4Fo1R2Z3PgPiNitN6Rp7oh7lTv5wl013uyrZaTcRO4=
-  lastmodified: '2026-04-16T19:32:38Z'
-  mac: ENC[AES256_GCM,data:7avhlgXCztoFfLlE9yRRPNDUbJYkm5rSx5QNkeN0euSi1T0Q0kYqNIB0bmdZTzOr9SafsoYrhye5JroanCtakXHsEWwWF2QVHebKhcYGgLLD/OyyFAfd68QX/qt5JAou5pS++zixil7MbfH3dLBhDKc/19qR8tyDXcpUI4rud9M=,iv:rY210e4+BiJNNHAwkg4IIg2MxMTKYV8KHwroB2iR+Sk=,tag:WOd0NEW/c36FMRnf4caElg==,type:str]
+    created_at: '2026-04-17T08:24:07Z'
+    enc: CiUA4OM7eGLmSoJ66EQEuGr3TsVUK9HXgojlNzFccDV+bvKTf03eEkkAPHlbmdZ5fozs1xYiQ4xC88c1QTeTTZK/fJ+u5TnBXaXOj7gBEViBlREY4m1RBTjODL9y+B5tY4Os2/GIf1nMy5KFosdGasfu
+  lastmodified: '2026-04-17T08:24:07Z'
+  mac: ENC[AES256_GCM,data:+/5w2a7lLtMZ3v/JMpXykVs1judZznkUKRa4OA3cpJqc14jys8/2pBJ0tZoWla/Q8P8Sl6v1nbzbcc+tvy/+jYpa9I5OjlullDftigA9b1C9zaiDoNe7HUpsNBbkgdWCuX7mVkN4DkhXDohf94fRoB3Kyqcy6DAoC1Or4qbwvFY=,iv:Bv6b+MbzHvquXfbF1GnErmKoDfLNzQkKjfWoE0T5l3w=,tag:mP20/QooFfgHx8SURKS5yA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/disasters/support.values.yaml
+++ b/config/clusters/disasters/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/disasters/support.values.yaml
+++ b/config/clusters/disasters/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.disasters.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/dubois/enc-support.secret.values.yaml
+++ b/config/clusters/dubois/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:iVcIpC9cd54y6ieK04IawxOEnmrrnFuSL35RmJ7ZlCEgTwjJ+39kWZmwhti9q7FG1P9OLKCo9nzjkl214JVcyZDjV1ofRtrMcqfc87+HghUxyLJQlPqizSbEDEnxt4VLDVM89BafcoFg1lOKKAP4LAqKxBi7cnXjXxfrjRyNZhDSwofmACKJooFtNKip4dn7Lij3sclgtvfcPPGo,iv:GDvySinfqdXbM5zPTjIAS4/S/uK2TKgXUuqe/RJ515A=,tag:4ZqpLsuV9Oae9Q9V2P308w==,type:comment]
+  #ENC[AES256_GCM,data:YdG4PpP1u8c0UaPi8qzV8ufSTq5vCAj1oJXUuuVsa9oielcKk2oJxuyUgg76CFAQf13GTUC5KtSKvHMTpd0TGMTmfZbUmqjHhah90aW0lnoW+t5wZJXHYCacRSM3769PO3toaS+Lt4wVRSDG5+lplE5sy9i7m4Eaz+v4+Nl3FOcqMcj5dADSB50fob3yRCMiaCOHAiNuebQMzmma,iv:uEoEPuckynNibtXB7w5aLb+zYpVsnux1CgcCyF2xEGo=,tag:iQk+RUJph4U8pYI7+PcB1g==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:3eD2Lfyk82nJXaoCRNtYGzeW1Pqd/R06ieyMaOz4jIt/CpPwE2hEKe8wrcWnqOblMnVhpHgOcjGthaHeSYBmHg==,iv:4tsBw2ifNyGJ/zh2mkffAgfsE5+z4S/oiPLu/b5UIfc=,tag:hlSs6W4xmg7zGZYcn1TScw==,type:str]
-    password: ENC[AES256_GCM,data:P9MP4Hk7t1jDPMGCgBS0xlbZEakt2vKKcgiNd0Epa5z1MAJVMhoUxJS1wNhgvEYVkwdDD5IvjMMYE6s82YMNfg==,iv:k5CWX/3TgHC1XrKUekl54sfQm4EcDpFGLiQztzwsrGA=,tag:on0/vh5dvnDnT7GMf987Mg==,type:str]
+  - username: ENC[AES256_GCM,data:bNsG0coa/JS/iI0Ki0JE+gN+q2hkDj78ShBtbTkI+TU1wR/kHd5DpyPmgcP3dzK47YT0NHAyJVwR5eLkTBZAww==,iv:tb4Bp8eV64dpGW8rECTOqHtAkhuVPaU7wwlO3+WDfBg=,tag:pcBUFhk+UFV3mVPloOXmXg==,type:str]
+    password: ENC[AES256_GCM,data:CGHtFdTsrrnXQZ1W6S6KcxafV7IY12m7Slk879DGZl02299EiY+u90YB4rsWprAOdKVKcYrS7qPI/r3ADNAXrg==,iv:0fkB4BfQpuNTs36S6ves1FTcGxwFPxBTGSQOgNE45QY=,tag:yIqS28jlTaGM7mj9AtCKSA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:01WfjYCLQaSyvoQ36g==,iv:6cbNF0I4hU+KPl8UJ3IXgvScWZKeO4W8yyESTRiDomo=,tag:AQaAvnJLU5rBrN8nTaq0gg==,type:str]
+      value: ENC[AES256_GCM,data:qspKCbhi3hTlDlLAk4qnGhOyuhugWAJWNG3itZ0K9f5xTFSGX/c8g2oMaoI/qpogSbeVzF7KSiZKRxGLKkm0WLrJMmN8HH0VUaqQGBNmRP7P4DuJL0EHOA06fW3KIUQIr6B03w4gPaDg6VB0DLT/S99GHsst+Sc8qOA+XaTOD2s5xRLjB0TOdh0aYn/OxHy1ZUerGtE2x9ur5Fbd0BiBxyxxeIV3Ag+J7N3Lu9bqPP+xww==,iv:Jslr3VsQrDIUJEFAmawHdm5vCoYyR4rFzjwzdH/u72c=,tag:451XDrSVzZxobBFDpUH91w==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:36hw/o9gVZ6noLsHWJqkqoAI7RZ/tO2DiKkJezRaWCJmiHhJtpTKpSGj0RXxiEXdAqVe4abMk0LBEdKwCSoT3g==,iv:USwy1kriSxEpDon54PKM+41c9zQrXkPig3WJk6O/DHE=,tag:yHLy2jUes/dzMn7fBSl8mA==,type:str]
+        password: ENC[AES256_GCM,data:cnUAa6sbgZX4zVUamW16ACfU3VUmTCyK95lpw//7T6T5UXcXBECTnvm3C305GcCDtWNdSq8jJdh0BJJ6tzz36Q==,iv:AneVcI6fhtuFlA0ooR3bHXu9bc4e30tbe2dlINS1zds=,tag:eMIgX+7/erLjJf+7EeAtug==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        iIDrjTmdNs4PwqkW4EIvGVI451pyAuMXdEeIrViqEupoQkLtmOwZb4EMUyZQJoLf: ENC[AES256_GCM,data:fQL4yuiDUhWVrewYPlOYtoig/Gnq9maliyf8au+vhZOh863s2xrqOmosGK2BXnMj9r8Ygo0KlE7wnf65,iv:1qPHEkoSUQXWZ8YJ/NjsYMZ66fC2YPkL9+IeBLx/vDw=,tag:7OUOA2UGPeY+ouSo9wWuZg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:13Z'
-    enc: CiUA4OM7eO6vjF+DHf1y/ieS0SCtY/ZnVzu3MDZPb5kJ73ePZ5WQEkgAZoeZprawzMfanxnH7LJ2a59bfz+rNjIKFxhtdYzDYTMq1N1xIgYfN0ToL3Itd8K1cvIJT0gQXZzOnQxVa9xqALJ2gkkP6e0=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:13Z'
-  mac: ENC[AES256_GCM,data:Ll0jRTS1RDg8oj1JfY9wwkMjTrhvDBuBsihv9GfE3sw/6xGQqclEJGkURBe0um6qkfODIZBkzdUijtS/7CTk7wDpQqt/GVEc36KVuAWIb8mhS46ZMOyeduU8g5cHzCiTpYyfRN2YBtJyLTkB+6X3+hwVNnRYRpntrGkUImCEBu8=,iv:xLH2JyP/xAP/2OQvgBNEjmGXrYrIVG26JCjjTgE9oRU=,tag:qjV/KSo4SYofRQ5dgP1DsA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:25Z'
+    enc: CiUA4OM7eL/Tq7Kgq0OqEysNSMvdL8hbX92pol6WxV2r3Y19GnBtEkkAPHlbmUJBpegdGBJn8B8ZjXLP+CFqvyi2BAFVDZV5NqDg12AFwYA7Rt7itajbQTXQQmjmc94fEb52E/iXX6skWBcMNQtTiACb
+  lastmodified: '2026-04-16T19:33:26Z'
+  mac: ENC[AES256_GCM,data:IIzh7zql/J0UEIVFpIGI3xnIHA7jweddwWmmFt3ca8z8LdP5n7SyeN8wjJymRuGTDtq6/W4Wtvsy1X2az3Wotv5BUU6axtreS2QT0f2/KKS2QRZlMwXYATvZStnFMD1TKGxUo/UmP1sS9V59sSLmvhXG8UG9zSK5EfaVjLN5AqE=,iv:I+ZKHVcIqxW0m9hUYj+hAwfyJB7UOxcQ+pCBz6tJmm8=,tag:ms0xEVfYfHT36q1ppzj5Ow==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/dubois/enc-support.secret.values.yaml
+++ b/config/clusters/dubois/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:YdG4PpP1u8c0UaPi8qzV8ufSTq5vCAj1oJXUuuVsa9oielcKk2oJxuyUgg76CFAQf13GTUC5KtSKvHMTpd0TGMTmfZbUmqjHhah90aW0lnoW+t5wZJXHYCacRSM3769PO3toaS+Lt4wVRSDG5+lplE5sy9i7m4Eaz+v4+Nl3FOcqMcj5dADSB50fob3yRCMiaCOHAiNuebQMzmma,iv:uEoEPuckynNibtXB7w5aLb+zYpVsnux1CgcCyF2xEGo=,tag:iQk+RUJph4U8pYI7+PcB1g==,type:comment]
+  #ENC[AES256_GCM,data:dsF5VeQpCGuWiZ3pHWn7BIkkA0w85TXsBEWtirVX2Vs2qDxikICZugpDU4hOqnCWgsR3PAJOqloz7BCdbvUzIeRMHtlxJMt36V0cD723s45awAmuIX3Wvbqh04UmexyXVkUWYindKmC4XCMJ/15iIZeuCXwdp9as7rNyuELg8RnGS8RvgbzscsbyOnkiA3iwqRfLClY9Z/UzRRlb,iv:KJ6Im1iuvZ1GKfdcvrcT5+hFz/G38nUFEAYh9UAaNkk=,tag:MxLkrJqxgnHSjVwQbGVhrA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:bNsG0coa/JS/iI0Ki0JE+gN+q2hkDj78ShBtbTkI+TU1wR/kHd5DpyPmgcP3dzK47YT0NHAyJVwR5eLkTBZAww==,iv:tb4Bp8eV64dpGW8rECTOqHtAkhuVPaU7wwlO3+WDfBg=,tag:pcBUFhk+UFV3mVPloOXmXg==,type:str]
-    password: ENC[AES256_GCM,data:CGHtFdTsrrnXQZ1W6S6KcxafV7IY12m7Slk879DGZl02299EiY+u90YB4rsWprAOdKVKcYrS7qPI/r3ADNAXrg==,iv:0fkB4BfQpuNTs36S6ves1FTcGxwFPxBTGSQOgNE45QY=,tag:yIqS28jlTaGM7mj9AtCKSA==,type:str]
+  - username: ENC[AES256_GCM,data:HDYwiZ4qcEKY3m6LGUlsIJTX+ZBpce3wyF5DAHL97YMpudyYgrcdeInBQEEVA9/afZ0Bw5krDuEr9N44Xx9+0w==,iv:S3JyJOXfyfwoCKGT2LmwHVsFYxF8KYC+GfzXXjrPbbk=,tag:vdeAazfcQTQbNGuQrFLqDQ==,type:str]
+    password: ENC[AES256_GCM,data:9wm5H1zpcaapaGzOtALp9MhZ4QlmFAoRH7n8qER3BUhJ+cfkFSCzLsdpNeJSYjCRImaYSEAVV6G9kg64iTl3ag==,iv:iXKsUOC4o+6Y8b27jdctgU0wJGVm0zltJJT2bCMtl9c=,tag:AP+VeAEnFMnMjG+cMNHX1w==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:01WfjYCLQaSyvoQ36g==,iv:6cbNF0I4hU+KPl8UJ3IXgvScWZKeO4W8yyESTRiDomo=,tag:AQaAvnJLU5rBrN8nTaq0gg==,type:str]
-      value: ENC[AES256_GCM,data:qspKCbhi3hTlDlLAk4qnGhOyuhugWAJWNG3itZ0K9f5xTFSGX/c8g2oMaoI/qpogSbeVzF7KSiZKRxGLKkm0WLrJMmN8HH0VUaqQGBNmRP7P4DuJL0EHOA06fW3KIUQIr6B03w4gPaDg6VB0DLT/S99GHsst+Sc8qOA+XaTOD2s5xRLjB0TOdh0aYn/OxHy1ZUerGtE2x9ur5Fbd0BiBxyxxeIV3Ag+J7N3Lu9bqPP+xww==,iv:Jslr3VsQrDIUJEFAmawHdm5vCoYyR4rFzjwzdH/u72c=,tag:451XDrSVzZxobBFDpUH91w==,type:str]
+    - name: ENC[AES256_GCM,data:QxPK3lOURuiHVFYIZw==,iv:tKdI37sy5RmawhFjkJYqQC5tV0T+r6I1VHbG9GJjAJQ=,tag:zlnRDQmygAuLvgUXMHdoxA==,type:str]
+      value: ENC[AES256_GCM,data:8n9ycRoZC3pTmml93WmlNAsqeJ3dp6hZuN1CAcejgQSUST/cbd3tLT8xQ+0CHls2RZq5sli84y6JpFg/NsIPKOafLUgNkMOCc4vrelk4CqxaZ1Rnr97VUHiNjP2NuYMom8V4i9YaoaUnjpyQ0ePHPzxzbbegbl5TsQMOO4ESbcAHR8Ehd0hSq4Y9/yI185NJV3MuqKZLjTDyYpFdv+KrAPALshijeH5/BdW6+SV2rHApTA==,iv:SZ5EkJ1TKf0bLgSiE2sgiARIp0parnblPc7RMmaWuII=,tag:yxytdjVnb9wNwC8Nm9n9Jw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:36hw/o9gVZ6noLsHWJqkqoAI7RZ/tO2DiKkJezRaWCJmiHhJtpTKpSGj0RXxiEXdAqVe4abMk0LBEdKwCSoT3g==,iv:USwy1kriSxEpDon54PKM+41c9zQrXkPig3WJk6O/DHE=,tag:yHLy2jUes/dzMn7fBSl8mA==,type:str]
-        password: ENC[AES256_GCM,data:cnUAa6sbgZX4zVUamW16ACfU3VUmTCyK95lpw//7T6T5UXcXBECTnvm3C305GcCDtWNdSq8jJdh0BJJ6tzz36Q==,iv:AneVcI6fhtuFlA0ooR3bHXu9bc4e30tbe2dlINS1zds=,tag:eMIgX+7/erLjJf+7EeAtug==,type:str]
+        username: ENC[AES256_GCM,data:DPgjitDznOLjsQ2Yw4Nq2eJPt0eR6v1FT1U1341BogwOHQi0G0ltgFVFhts4pV7ldxYIn0mVD8g0Pv1VrrWa+A==,iv:B5hAGkA67W8h7VxjTtetTDeh53RSxgykKeWdyHsJ9VU=,tag:2wRD1YDtIErGmR1Zhs+UXQ==,type:str]
+        password: ENC[AES256_GCM,data:XkegVsJATOQNkwqtZxFlputKWiCEss5jaBxQutD4u2hXTBWixo3VrdZ44/qzpq3hFw/ie+B5444uWKxD4QvOzA==,iv:GZ6StLiakuhu+73V6cwbdvUhfqjaqkMIPpR9EUurFDc=,tag:Cj7eea9dLP+JzBijo5J/hA==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        iIDrjTmdNs4PwqkW4EIvGVI451pyAuMXdEeIrViqEupoQkLtmOwZb4EMUyZQJoLf: ENC[AES256_GCM,data:fQL4yuiDUhWVrewYPlOYtoig/Gnq9maliyf8au+vhZOh863s2xrqOmosGK2BXnMj9r8Ygo0KlE7wnf65,iv:1qPHEkoSUQXWZ8YJ/NjsYMZ66fC2YPkL9+IeBLx/vDw=,tag:7OUOA2UGPeY+ouSo9wWuZg==,type:str]
+        iIDrjTmdNs4PwqkW4EIvGVI451pyAuMXdEeIrViqEupoQkLtmOwZb4EMUyZQJoLf: ENC[AES256_GCM,data:Knhxy15EfBEWgi/XeoXwfsY1O/9y0+WgOm10NbZXuMQFjydfvcJrYkNN6sOZsj2taVl9m7+FPtq9lJXU,iv:9qosjjbonZ+gqpWOp79LUcabyQwSON/ZLHhbtL2gMqc=,tag:6gd8LgWOYo54eFFpHQ13OQ==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Ww==,iv:tdIV3uyg8JsSY9UFswjnOpIqZfhow7pWb4aVbsZ/GTg=,tag:UjUFergNL2KcWuXmsLkWmQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:PXI6if2QvNJxew==,iv:RUTeU3HwrE5uV2afvCbgM8+uf4soWnoWezKLoR9og+4=,tag:F/DJPU4vGkiJZbUDc/oU1g==,type:str]
+        orgId: ENC[AES256_GCM,data:QQ==,iv:chUWWa3deEm7dnxJLNkXwCqn2p1XSDCQRs6d3A339+s=,tag:kVpggn4QDOfuNL8xUXZbqA==,type:int]
+        type: ENC[AES256_GCM,data:554R5A2PYUGKIg==,iv:/+ZbDNZ+Izl/g7D3EzCBilfJEnmhWduaNxTMXXAkHho=,tag:PPHnKTQbx7ZAtYpXVZOV/g==,type:str]
+        url: ENC[AES256_GCM,data:rD3piU0wIsPNUGxNMz6UjoYSSxKX2Ubwl7CBGbk/VaY=,iv:jNuROiu8ot7gOhHvQ6QyCrArMaSCzhXVnhMOeyRuu1w=,tag:MoHRfvAehvnpDV9a50fFyg==,type:str]
+        access: ENC[AES256_GCM,data:HC19ll8=,iv:CmXutESdwWnz0tKEjNb+qNFdmmEtalQFogZZSoyBAGs=,tag:V8NPPzIlbcj4/MuQFNhOZQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:TDbERUI=,iv:nucuuYuHxrTjbEPge+Z8BOSElnev0a5KxrtjNQSSAmA=,tag:pOzXTXLd5rCQ44iKUiGsMg==,type:bool]
+        editable: ENC[AES256_GCM,data:pIZ5tWs=,iv:RN+fCdObrgHSf634g4n3by1grLFQ1JhXg96XR8NgKgo=,tag:1N9TNtqdiWDDkuvsQjlTXw==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:ViRLHQ==,iv:nFaSx11NlcV+VQLynpeqHRSsa0z/ch7TNBoFXKrePDc=,tag:g5P+5qoE+z6qjRFS089gTw==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:yeWTblcYkRBWupk429Sz5ULkZb7eFPl2Vh4GqMAy0urH/43ALL3dRNlVBXH1TzvHh7lH6gI/b1WuV/MQqTylFQ==,iv:c003zc/AreVBSFruv7ef3/Bn8+lLoYIBy6LXDIx6NkE=,tag:WZ6BOPu0Mx8Kc5rnIJ4XOA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:3+MSJGPE7kC77KyddgCMyw8lvAaX7poX0Pk6Lq+opfikKLzdooERJhHdszJlizqMhgqSfbZy8XySfBng60B/Gg==,iv:yQLTBaYl6R+eHS3r7HayX3I0c7Y1L/GH71b2qfjgA88=,tag:StHHlAGywzlT3ShM3ow0wg==,type:str]
+      - name: ENC[AES256_GCM,data:OTpEb4UpWYHHHLG7Y1gWG8B2nYv/4UHQocWhoeGTpw==,iv:5XrBbLHpbdDjOVOH73umdLx/DUyj/0t/f5gszgxaA8o=,tag:0tWH3qCH0UxvOuSYE2Pdyw==,type:str]
+        type: ENC[AES256_GCM,data:ZYZ7tXUAQaVgZWTBxQ+6/j+0FsXMTqRvyHoblDwn5w==,iv:w4dfWI4ryX6tYk67ZcEgFTQ81q+oSTBJvTNX9K6iYj8=,tag:oLo4z69XNgyHmXvVGDkelw==,type:str]
+        isDefault: ENC[AES256_GCM,data:XOUxRIc=,iv:o01ATUO3N6crgBEEBhaZ3o0dlu0AjzJhX4Ctc/OopBk=,tag:ILYmIf9wYKQgZb73WZR3uQ==,type:bool]
+        editable: ENC[AES256_GCM,data:H/wwnw==,iv:3rr8I7GjKV++MQCfKKLZ77w2zbJATcsnWCyAAIUgSN4=,tag:pPa9QhteaP6rRDBR2w1DJQ==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:25Z'
-    enc: CiUA4OM7eL/Tq7Kgq0OqEysNSMvdL8hbX92pol6WxV2r3Y19GnBtEkkAPHlbmUJBpegdGBJn8B8ZjXLP+CFqvyi2BAFVDZV5NqDg12AFwYA7Rt7itajbQTXQQmjmc94fEb52E/iXX6skWBcMNQtTiACb
-  lastmodified: '2026-04-16T19:33:26Z'
-  mac: ENC[AES256_GCM,data:IIzh7zql/J0UEIVFpIGI3xnIHA7jweddwWmmFt3ca8z8LdP5n7SyeN8wjJymRuGTDtq6/W4Wtvsy1X2az3Wotv5BUU6axtreS2QT0f2/KKS2QRZlMwXYATvZStnFMD1TKGxUo/UmP1sS9V59sSLmvhXG8UG9zSK5EfaVjLN5AqE=,iv:I+ZKHVcIqxW0m9hUYj+hAwfyJB7UOxcQ+pCBz6tJmm8=,tag:ms0xEVfYfHT36q1ppzj5Ow==,type:str]
+    created_at: '2026-04-17T08:24:50Z'
+    enc: CiUA4OM7eL5KbW+VC5iqnqGoq2/iSFFh+WqlQCUjQwZPL4mTMH/yEkkAPHlbma96Q1JOwx/f8qdUmk1v1FwJTlaqQGtHK68cvSmHb1HAPFW1XCYn6RbNECw5MPgegmP4yGaQpcz1MprTViCVXaA9zGCX
+  lastmodified: '2026-04-17T08:24:50Z'
+  mac: ENC[AES256_GCM,data:bxifYR0i9y3gANd84S4HqkWjlgqf9g2Miu7XSlNeArfCyw7Of6yAnLT2GtpF1ZgG/E0U1XHCjSLszw7qsOrBEki54aM1ZQIeISgqnwixMcQReMBNIcU1ieEhH4T5V5Poso1AoAvlAwyzelsY1xQIvpXBRhjUuz1mDTPXkb7xlK0=,iv:RTj5yPSlOo6O4HVNYpFb3JiNpsC5JdHOflnUwQg//bo=,tag:7/vvaMCW8tbCvuxjcPwEFQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/dubois/support.values.yaml
+++ b/config/clusters/dubois/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.dubois.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/dubois/support.values.yaml
+++ b/config/clusters/dubois/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/earthscope/enc-support.secret.values.yaml
+++ b/config/clusters/earthscope/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:ryczX9VKB+WMQD4ukRi/MAf6h/NVVyItc+ytXs/AsOXMWEPnPKvsfngDCpq3koASOH/Lq2I5IQninMvGO9aeZ0orA/LOowL9wcmw1WRTZGNK+tIgmr+cvYzbgkzosW2CxZ2Q8wsKgY/cFEUBrioo6bVHIEEmdsqccXasV3AWg0zSeuWQmiJMnxPiw8vbPgMpeeZHEV/30xR35r1I,iv:hWW8qSar0EHWquXgqhEZ4qy7QKF8wInGsWcs6jAUvWw=,tag:WM/tX5efvE6c7wPY+hL1pA==,type:comment]
+  #ENC[AES256_GCM,data:g5YXqsafvD2rDwr4fBLsD7AKz+04+KyneONklf/mxleSnbCuKzu/uP6t6Crk8yYmCV926ptwVXuTzpq+HEauQTBMyWmmbbCI4RhaL0GDDiBxWazP42gm5BWUObN5Bu4bMnEOWnUBUiBPbdSNEK/vqkgpR9zfjPKlXmtYSzc5OfxCHFnwAKxYWt4Gmts99PZnZRedDiE5xTfkLMRq,iv:uSLQABhcD6WOLaLH/C5KU/a9WGnV9Q5u6n0HwBe+imQ=,tag:o5IkQVy1kJ/RHMl8hzgPBw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:EAmJTlFSOOhgMG+s3Gv1lGxufT99LtYcm4JjDJuIx0nu+DGzad93hHiMyWey+BRtbV6jf1v/G/tKLWKgAf47eg==,iv:4jAs5U0VXnVyt9OXZ+Vbl3PhjD/MwYZAQr7OUPX3sG8=,tag:rR7n34u52d3I9wKAwrwj7g==,type:str]
-    password: ENC[AES256_GCM,data:xUzBoVOS31/nqZjg9rUaBoe09LQbxvXbx+3uft8BVfVBBZzrGL8fVGMG//KyS4DT1ze9viS/DWt+JzC1d8SiHA==,iv:9PQRDGlmBnS192Go8BRoZRx8GxkEQUTqqZDizHeGOwM=,tag:Pj0dfqnsWp4kMdFKAbcljg==,type:str]
+  - username: ENC[AES256_GCM,data:0MtthfVlokjUE9doi9K4z+3gcZ2WQ5NdAkd3ePXApSsfi1sNF3W2NN/jShoJUvTg7TebseQM3iZVuf/bDP6l2g==,iv:YMviHJ/Y1wBKRAuUUylfiGqO+HxBPQp+jnfKrYcLu8Q=,tag:K+jzc8QJiHah6LWOt/dn8Q==,type:str]
+    password: ENC[AES256_GCM,data:v2s/KmB9yq3qXTP8/SXxNS/Be2RPI/rJD1gcp3gxt8RcWbJ4zzcZiEJruMgOVsuHui7zAiBSyp2nBU4RDxsOtg==,iv:g0EmoYPfJdjCId5cB4kyStkx3g1skxsS2cE+H0yAxyQ=,tag:AS9HPfHxTHBJBIcJhCdLPw==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:6jerRc7x8iV1PZutwQ==,iv:fh/iCA0CeAsTHPBRrRD3uekuMRt2GhRl6F6AQjFU0GY=,tag:kquJLqsrlyM92mwMH1HsWw==,type:str]
-      value: ENC[AES256_GCM,data:zOLf6VR32VqJ67of5MBTUsstorVwDenmxxLJk2gLVqGfC2n56tmLvd9QH5pWMYWNedqbVmZcf/dngAKb51LtT/VyuFK0FkBt6wa1XZ99kCcRWEY9bbrEpC2HmfGA2IiorssYB2QYxvJ1n3+QAORxDZDCejersGscPz7sJcfc8WYkAX9xJDWz1OJmZPCX4iNxgbLPCMFK51JKg/IAOOqmRl4oGsmYa1CJpA4Wr8wZiijRHQ==,iv:qlqvSEa8+QvvbBGlIbm/PzV1Nq6xWl34vdxIQvDneN4=,tag:iRjfO6E5i++XayHcZQ8swA==,type:str]
+    - name: ENC[AES256_GCM,data:EuEZScjOLJq/lazNsw==,iv:aVGBT3Fuc+Qj+l4rkkCQgYLFqor0x8ZnKEi5cyN/pw8=,tag:vjNHafpL6scJrJo5uLequw==,type:str]
+      value: ENC[AES256_GCM,data:bOX/25criq7awBSzgujZEQwmHwP/BxqCUh5opS0Dfd8b9Bo/Fj7LsExjn16Ws+Wvok4NWeFvehekRxB+DpqKOztg4oE5EbOXy+fQiXQtamYs1xGmpUaxY4YsJ72wlVXd+y9mHM+/gwiR0fOIgjzPPqfJtjlDYBJFWUm8YSK9EIE6tkgIct3po4w/5aI0A5nxLAqygZlX2P3l6E/LGQRxLf6N12qIRwN0r5BD3/LxBAIJ7A==,iv:l4PI8fHPtbE1X5GNkojwnGVJjpefqsV0TNf5al7iFPU=,tag:KOldFaouDc5R3QmIMdrR2A==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:lIH5rNQepsaa5yvZo5QZ3K4qCQz0hnJ7M4p8IHspwsosJ++5SbOMiU87lTi0Ff1vo8eCwiMAmaxRl1ZQJvlnxQ==,iv:djz7BBEGsBbT/we6kg9pj6lA6Nb8GLDFIQ/J+PzJBEw=,tag:UYUBMBMSANw6t8Rh+ksCUA==,type:str]
-        password: ENC[AES256_GCM,data:9fwiMaPBQP+R5Kws4fz8gMFGi3fwWJS1hYF/FYH4Rn9qs2Qt8nM7dStiWvG6KUl0gTORDtSU62xVbrR+J/NMtA==,iv:qzt+K0WYU+gUtUFx9Q7S2hqY4AaCFAdvCqh/ltGTWzM=,tag:214++HOFaJUiWb2LjDdoOw==,type:str]
+        username: ENC[AES256_GCM,data:LQDiz3RE3itVkwr/452IetSukIrGLkhcwXb1gwIqi+aIifgW7YWsoZmbwmVwsVsG4BwrwFtJUXVcQtg18nk+YA==,iv:bHklVxgKleXWztu+t/pTcPGq0e8dqxe94qN7qEtqkOY=,tag:8agTlNtnkGgBRCN2w6xssA==,type:str]
+        password: ENC[AES256_GCM,data:s/EuKWaK46w2WyRPOdMvJldMj53jSQdeBu4Yo3EwFxe1/k0zcQWlQty3U/rGFBQVadZFglHasva/m1fyaRBBoQ==,iv:qfAcT//sbQpcXeV6rnofBzAyjrCUoWKJFWvd5bPLuxc=,tag:PXtWuXD6WPu6QrlONucjqA==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:O/wh5zm7Z7Uf5PTs40zXxrIxHF8WsGXI7ay6iqKvlVSJ/LmzspHVFwx+IMXn4RYragBZs0bYTaI+BYK8,iv:voTHstrKg7qMgeJbZcIMI4tLZHZnQhZQLhGleZ/qRW0=,tag:yUyk/SRvaZz7RJ9tICcDQw==,type:str]
+        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:d01wwk52lW1IMOPwf2YRqeKwYAhZp1ZeREb7ZCvKzdplNeGQq09XKXOYHGVxLgjI+sYXuXe4/Wn9DWu3,iv:pQkXF7XFYLOlrjL4ojxk4ty+WyLNsJOqaGv+cgvaIkg=,tag:VHlXlgyA0MlujrtsxeMurw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:fw==,iv:JFsMJycENHkXauLmU7clWsSfp1UT/NaPyLT9ETBRsqU=,tag:bL67uZcpuh/vOHm+o9DckQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:NMJJA7tvsQdZWA==,iv:aql8GcQGJN8UTsehW+kugaeW9RlxzY5/CdCJ2JhbdFA=,tag:lpJBOBfG5r14QF0rL62Yng==,type:str]
+        orgId: ENC[AES256_GCM,data:bQ==,iv:6h4QMjvpCyDB2n7i3xWlrYGm87Jp8xztEb/g2ulCjqk=,tag:SNSUQPVAaYgLoyWd5qynRQ==,type:int]
+        type: ENC[AES256_GCM,data:5z79YOazAizo4A==,iv:bIMBkztZklrUSJ19p29041f8/BgWctuy7rqOCi7T3YQ=,tag:DQrl43FhdXuME8VaBu6AmQ==,type:str]
+        url: ENC[AES256_GCM,data:0WzY6Pa6VSebSiM+EgLL7rZyKwJ01nhWTqLz+tTSqE4=,iv:EuJtEc8oK/yrRk59LjhAM2dZYSkdbeeXEEvwuP0crXo=,tag:pzQd2NkBrAAWf0vQWifXLw==,type:str]
+        access: ENC[AES256_GCM,data:1sTgUuo=,iv:Gkui6okqho3R+6t6ZIwcQ/1zD89biJhHQtcCNG1lauk=,tag:tbKQgYh68tsEgoY67Wsrlg==,type:str]
+        isDefault: ENC[AES256_GCM,data:kJj0/8w=,iv:6DCLlla8iheCowMhUiK9SLJoM8dUPWNZ0NfkQoVrNY8=,tag:OJwjQLigxzLha3yMjX3WZA==,type:bool]
+        editable: ENC[AES256_GCM,data:rqaq/+E=,iv:OB4lZiYroz1R44DyzumaZAkVaG7Ja40FOKZ+c2XBX/g=,tag:kWcRrqFV4kVsaWgeL3+/8w==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:6be0vQ==,iv:XZQce1UG0fbffCXH3gROwCvr2GnlzyLeJdiU7TftK9w=,tag:nQciR6C1Ph3dmgeiXt6smg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:XJYUdxVoJtVz7oiDnRlZRYXhQIrwnoFVQSkhPm6nxCccBLOwwoFRXoMbOrJGW1e3AoIe+IugoKdmdkllXza/vw==,iv:OyT2CtyVsfHykDo+O0qdxVEMZ3Psw2UKOeEgg9CJz+4=,tag:odDJ7wqCGC1YgQ7wpS5wkw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:XGVDWS8acQILEA3EbWEvcjmsCa7W16LMkpVAC6IXIuFUK9NKsJTy/y4/CYt0PA1sHSiKIu7z2IfvS0Vl28F1/w==,iv:hxZuDh1InJLuKGwixB+Qf7BsVhC3hHW2mKbxgMWE+Kw=,tag:ac1G1XrK3mNovtWgBlPlNA==,type:str]
+      - name: ENC[AES256_GCM,data:LurcubeH/7DhJS5O9ryXGzV2gHvE9ZdCkS/HJoGtfA==,iv:aCaHH8X2FxXXZil5OI/vbpeSKjSfp+fbfSpt8JVxZbA=,tag:k9fzOcrZNY9kWm8SDJccbw==,type:str]
+        type: ENC[AES256_GCM,data:dQh5sSATDB3GuSxmKfW5lwyyMHy+m4ncxStUw+Albw==,iv:eAuG49nhz+p8q/ijCtRO0TT22Oxc57laCOG3zVhWKj0=,tag:AUetAZX44K7gvxyGaf/SJA==,type:str]
+        isDefault: ENC[AES256_GCM,data:dBQsvnU=,iv:0cBfmbY6XHWTVThWyYrTrmGsBnAPlsVIA0hpIHMIacA=,tag:YUEe08iv60WX9Fdf+eGvtQ==,type:bool]
+        editable: ENC[AES256_GCM,data:SpqOTA==,iv:+vC0skWpuVgLWPVEG+ou0+PN/WrcoSanka5IC+y5bK0=,tag:VeFqQt3NFDcxUy88H8uMjg==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-17T06:50:53Z'
-    enc: CiUA4OM7eNmBYnjq7gtfsuctVDF6IPGrOkJOYiaXHF5c2C8Nvk0YEkkAPHlbmX0loJ7HA8mwK4LF/nkTDftKMVdD3pp+dqudnQOm9acf4Pc3dme68elbVVREAdOp9lj+EXfzt/1LM64addYXExWgS6VT
-  lastmodified: '2026-04-17T06:50:54Z'
-  mac: ENC[AES256_GCM,data:c1Qip84/U7bAyFU5llbGCCLSwWEvmGEwYDCnASAyjskdD/diZ+ZHNDxLRXXEC8pKrC0EI4VIopYTQT5z/6O6tSJjDtO8+pfD9FqRsKODdcXuh4KCRp/oDI2i0mK9Xt3xs3oP2v2Jnr8J7FnewMZMvSPQ3KjEb+1/VpiSEQil5o8=,iv:gH10wBqT490ltTeNcPXgBgidDmyHL0WXri10ISMRsJI=,tag:EwLsaNVukCXl2+TaOXHsRw==,type:str]
+    created_at: '2026-04-17T08:25:24Z'
+    enc: CiUA4OM7eDYWD7JpYPKiX7bbaZ/ia/2tjGo05oWYjzcTALNqv/IfEkkAPHlbmTQ7woJUAFvqX7SoTBeJKGFIVBYPl0LanAROgJg1NMG1z6edgw/xEBy2VrpFMON75ZsbqVlgESJR9iKbIUNZxMeJMm8j
+  lastmodified: '2026-04-17T08:25:25Z'
+  mac: ENC[AES256_GCM,data:5l/bRDWvYjl5Ttu/IikWE8EK5krDeIsMk/j2daVkFyH0h6GP04jpA8F29fIlrMQSdARc+YAQw1pb3B6JWBOCqfKHEQsqHB7ZOxIBpY84Ls19cIejJaYo4Rd6AVq/W1dCv8/BjB7obMB2RYyQcshzTebRIbs6zonHGeMkZd1jSmg=,iv:5DoOfl/qkT6EIaAdCXnRKgNIKHtxgWaM3y+91FRQu5Q=,tag:0Qu9zXjNAUixNJNYho2dxQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/earthscope/enc-support.secret.values.yaml
+++ b/config/clusters/earthscope/enc-support.secret.values.yaml
@@ -1,21 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:wXKw+Ja+AhLBbfK99QHw66W+Z2TGwy67nRlDVbH5tePt8DoX8TXlHdljb/MWiFI8mZRs2rhcpHnX6D+WTloySowWje/1a6TYK5VgUAnM+XMqXxCNjgI/K9UsC66rsJQoSU0Qyx20mF+mmyzFS70ooVOpXAB0y358qv7sx6YT2sYbRXzZS4ooI5P6F8vdpLmDaDOvHWhdZN/qx6bB,iv:nc5hoMbLtNdzw5cseHWlxIpuLpTSRr2DevjH32SubwI=,tag:Ra/RKcvWFYGrSnzSXIRC1w==,type:comment]
+  #ENC[AES256_GCM,data:ryczX9VKB+WMQD4ukRi/MAf6h/NVVyItc+ytXs/AsOXMWEPnPKvsfngDCpq3koASOH/Lq2I5IQninMvGO9aeZ0orA/LOowL9wcmw1WRTZGNK+tIgmr+cvYzbgkzosW2CxZ2Q8wsKgY/cFEUBrioo6bVHIEEmdsqccXasV3AWg0zSeuWQmiJMnxPiw8vbPgMpeeZHEV/30xR35r1I,iv:hWW8qSar0EHWquXgqhEZ4qy7QKF8wInGsWcs6jAUvWw=,tag:WM/tX5efvE6c7wPY+hL1pA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:qqdNv3z9WT8LEq+4QTY8vAgxD7kA3FKTOCERGjNCU70WArOC89stce0nL2nsC82xGax9yYL85AS5LhUgWJpWOQ==,iv:05EXVSglD/2yV5uh2mPn/pH2RHUb9zN90+aPnL4SiMY=,tag:r6qrcNGJ20aNxJehDmvL/Q==,type:str]
-    password: ENC[AES256_GCM,data:t/ldKEKzCXAsy8fPn/p0m8jtVnMrx3XmJ4U3XeLtbFDzbIPSri3v+GOK4XLoFqm/fdgDdbvE2hCko//tEk0q+Q==,iv:y131tow+6oDAg/LilRwlPTSBLEWWUtI7Oy2gKdCLCzw=,tag:iyig0o1K6Jk6gXy34KmWPA==,type:str]
-  - username: ENC[AES256_GCM,data:RsDbW2/3zVxJN4liACW3Na/K1HmfVdKCNnM3h8Ci2bD0VEJB9KN+sH1h+1gLllVj6ZnvlA+cCY26yaQNSDdUqw==,iv:kpBgE7YbOe/h5lrphWH5D/dJ1cR2v3t9skG8pnCrtlI=,tag:vILQIc9YlXZTVv+vvdwG5w==,type:str]
-    password: ENC[AES256_GCM,data:7euF2BDNpDbaqOrl4J/HGNqZOwDN/aqwl+Tb7mBPPsDo+jKVT/pSWpBSfcW/7QAlmjfLbs1tDcMeBaL4yd35Fg==,iv:bRZArngXI1HFW2F/WfgcXOPmtkSordnhWk6hc74N0nk=,tag:9tYJVh8SdIjeZYyMNiZvWA==,type:str]
+  - username: ENC[AES256_GCM,data:EAmJTlFSOOhgMG+s3Gv1lGxufT99LtYcm4JjDJuIx0nu+DGzad93hHiMyWey+BRtbV6jf1v/G/tKLWKgAf47eg==,iv:4jAs5U0VXnVyt9OXZ+Vbl3PhjD/MwYZAQr7OUPX3sG8=,tag:rR7n34u52d3I9wKAwrwj7g==,type:str]
+    password: ENC[AES256_GCM,data:xUzBoVOS31/nqZjg9rUaBoe09LQbxvXbx+3uft8BVfVBBZzrGL8fVGMG//KyS4DT1ze9viS/DWt+JzC1d8SiHA==,iv:9PQRDGlmBnS192Go8BRoZRx8GxkEQUTqqZDizHeGOwM=,tag:Pj0dfqnsWp4kMdFKAbcljg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:6jerRc7x8iV1PZutwQ==,iv:fh/iCA0CeAsTHPBRrRD3uekuMRt2GhRl6F6AQjFU0GY=,tag:kquJLqsrlyM92mwMH1HsWw==,type:str]
+      value: ENC[AES256_GCM,data:zOLf6VR32VqJ67of5MBTUsstorVwDenmxxLJk2gLVqGfC2n56tmLvd9QH5pWMYWNedqbVmZcf/dngAKb51LtT/VyuFK0FkBt6wa1XZ99kCcRWEY9bbrEpC2HmfGA2IiorssYB2QYxvJ1n3+QAORxDZDCejersGscPz7sJcfc8WYkAX9xJDWz1OJmZPCX4iNxgbLPCMFK51JKg/IAOOqmRl4oGsmYa1CJpA4Wr8wZiijRHQ==,iv:qlqvSEa8+QvvbBGlIbm/PzV1Nq6xWl34vdxIQvDneN4=,tag:iRjfO6E5i++XayHcZQ8swA==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:lIH5rNQepsaa5yvZo5QZ3K4qCQz0hnJ7M4p8IHspwsosJ++5SbOMiU87lTi0Ff1vo8eCwiMAmaxRl1ZQJvlnxQ==,iv:djz7BBEGsBbT/we6kg9pj6lA6Nb8GLDFIQ/J+PzJBEw=,tag:UYUBMBMSANw6t8Rh+ksCUA==,type:str]
+        password: ENC[AES256_GCM,data:9fwiMaPBQP+R5Kws4fz8gMFGi3fwWJS1hYF/FYH4Rn9qs2Qt8nM7dStiWvG6KUl0gTORDtSU62xVbrR+J/NMtA==,iv:qzt+K0WYU+gUtUFx9Q7S2hqY4AaCFAdvCqh/ltGTWzM=,tag:214++HOFaJUiWb2LjDdoOw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:O/wh5zm7Z7Uf5PTs40zXxrIxHF8WsGXI7ay6iqKvlVSJ/LmzspHVFwx+IMXn4RYragBZs0bYTaI+BYK8,iv:voTHstrKg7qMgeJbZcIMI4tLZHZnQhZQLhGleZ/qRW0=,tag:yUyk/SRvaZz7RJ9tICcDQw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:20Z'
-    enc: CiUA4OM7eIYeMhximvFCvbDWN+FxTvDYtPbO3zJdwxSClFKDAhleEkkAZoeZphTXevHf45eiGBjJXG84HqtwSlUv1fFWxnmX8rSmunESeTQtj17pdIPtOG44lKRCLuieGCXyf73V5WhNDB/N/mQC98PT
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:49:45Z'
-  mac: ENC[AES256_GCM,data:rXVtGwGdqOYc2xNlHVUyiwXxKPt5zm8r19lbSuOA0IKekPeY7FTskqDkIesv/Aijhm4YdrgnRYw7PbyPu+wdvWLHnY8Pgr7PC25bV1SW1+bc/CA60e67AUwqJY1thiy71oU4xUKWS5LIzY9+lbvGglB6WyOqoftQqWXf9FiOA7E=,iv:pTwy4smyRsUPUoE0eLvuVj8AIy43EUpMBGFNmBQDbpU=,tag:/Bet1vWFp79aMCQ+BjJy4g==,type:str]
-  pgp: []
+    created_at: '2026-04-17T06:50:53Z'
+    enc: CiUA4OM7eNmBYnjq7gtfsuctVDF6IPGrOkJOYiaXHF5c2C8Nvk0YEkkAPHlbmX0loJ7HA8mwK4LF/nkTDftKMVdD3pp+dqudnQOm9acf4Pc3dme68elbVVREAdOp9lj+EXfzt/1LM64addYXExWgS6VT
+  lastmodified: '2026-04-17T06:50:54Z'
+  mac: ENC[AES256_GCM,data:c1Qip84/U7bAyFU5llbGCCLSwWEvmGEwYDCnASAyjskdD/diZ+ZHNDxLRXXEC8pKrC0EI4VIopYTQT5z/6O6tSJjDtO8+pfD9FqRsKODdcXuh4KCRp/oDI2i0mK9Xt3xs3oP2v2Jnr8J7FnewMZMvSPQ3KjEb+1/VpiSEQil5o8=,iv:gH10wBqT490ltTeNcPXgBgidDmyHL0WXri10ISMRsJI=,tag:EwLsaNVukCXl2+TaOXHsRw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 redirects:
   rules:
@@ -23,6 +23,8 @@ prometheus:
         hosts:
         - prometheus.earthscope.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/hhmi/enc-support.secret.values.yaml
+++ b/config/clusters/hhmi/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:QMg9Y6KjSvY+/3ZNuTkSUlYV+HdbguPaIkq7rdt7STsQcSRUa/Nggq7dnIZwjFrlYiELJNCfovKVYXlDM6foMMa80fGyQOl7+Fgm72qp7zchjzeh/L5WevBSYno/Ym+dLPuGn4hnpYrOmD3lwig6Xh4FRHjVl4peaC5jZVFjs/JNcm7TdvZEfyuValRAP5TGLWLqocGOQNalt1KQ,iv:WEcPWLt2byvof+Q0oIeGT5Ifis4FZcDFMBYhp+nrgTE=,tag:Z56Gj0/ODryffhag7+Bq5A==,type:comment]
+  #ENC[AES256_GCM,data:l9uQPuEhKjf22XTrtzWunpwVVzI7b8tj/HAY99s8c2jX2Yrd/HdjwUWObQrRM5T/M+4K/E1FFuT3UjbXSoNzqlsJ+4LbnmAGqgE4DyqA7SlhvSts+5MEaS84UstlNTj8MuZ3/IDhXBuz1xlhQaBkCaDWYG3YzdWtdE8b6YeRLKu9s9Y++wTqKeeSMwR2Gmuvrte1SM+m1aagDHSD,iv:nedt3SyD0MjcsUAnFnegNaCrzAnSRutBHDc0neXrGTA=,tag:aYnD1531Ueye2MDq7CIfKQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Q4Ei6iBA2aLCQPjznAJzfPNTTW8xLt0zlUEeqj7GWWrvd9zoiweTXsmAqig43+mcJM6cfGu96TFiVFhyLWXHzw==,iv:lrs8J+WidQyTtuZwV/ZRQc9GGEIcARhau50QOMlYXrY=,tag:pSqmewVOt9lIl9rz2B/dFA==,type:str]
-    password: ENC[AES256_GCM,data:0MJTKz5FzCCNHNqoDQmr/dcOL2fuFI5nVP5bM2KsaTBJ0mwf/NEgNrIifcXCkb6QOSSR8WrqKp3y26cs4CdkqA==,iv:cj9nfw//0mFpDmHNDwMl+7Dw5vaymZeiEkzHnL6HGZI=,tag:RSZUDHaIIqLyXbX35kVqBw==,type:str]
+  - username: ENC[AES256_GCM,data:46nue8pSPrtFFWtSKzrL0lFkmjT1Xh5TfLpOCYPjKNeQNIPnS5jlcctYhSuXKXLUBoWSkpbGG/2OQmJdRZhCWQ==,iv:WVtcqgkbJc5X2UOEwEcqueY23nRXpj7cmtGC75D/dfo=,tag:crxRwTGuywTJO/hmHjkrFw==,type:str]
+    password: ENC[AES256_GCM,data:60uUPbK038pJunI6NxAQ6muPqjJKxk0SxuJFHNRH/1PmDhTHy2Kvipc11jzrx55nklWoSsWaHLKDJaSsK+qe6Q==,iv:QeaiUl+zRkY8YsZAxjgeAbs2yAfRU2xG7XVt/qkF9rg=,tag:GOstJnp7w+VTxOqFyJm9Bw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:oZaaH/4tjlKSdpXwjQ==,iv:z2qEGBvy2bPMZk/lw9PKbdFjskCc9BfD9wBqzq4XXdg=,tag:hzG6in8qedkD1qC0YPqrng==,type:str]
+      value: ENC[AES256_GCM,data:qwN3r9ZLC71iGBKeYC/r9R72wcHbThAXIk/QDQrW2/9Oc+b+gZLtY1MGLz+XOp5kbtIbJ6WW7305rb2m+zYe65tp0YTaFYiZ61+IHr7bn+rjhPeU/qxXEF7Y5Q3p+EnTH12Xtkr5eRF/0NRzFLF4FluigkvihvBb2uDSvkwx73ErhOndQet/MalJKUE1biQ+/7SFLYHFB//QqikhS5KKAX8zmAF6K5G4TPhdnhDT95+/Bw==,iv:WtC54SSyOkGYm0L+YX+lNwab4OvUTgM3NAAV3kD9E8c=,tag:5H6LMDY+sMP3GvkDik5x+w==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:M+ceJxj5HwptDvuCrWXHR5q7FzZNXdyKK1/3iKfvlmlyUFOw/SN/Mo43KeY66R6VhrfYtzqBgVCCdKjvjuVJpw==,iv:2pGjbRtBQ4k2qE83fPYt6P1T0SklZcepHUtNi98Z2X0=,tag:NkTcHnf0Iyb14MDZQp64+g==,type:str]
+        password: ENC[AES256_GCM,data:JjuSJIpb7alWxmnxIND2GlDxw42tWZv5lf6PPuKCBC8VqZWrIHJ552EZUPdUMMu1ywfc7vBTEzsCkiw3sj5G0A==,iv:xnL/xGMcMC3TsSIc023C4FSrhONCU5oLwBxqUqgQ9CU=,tag:kASs6rVm1jEWntNfGMTOCQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        YV521IqjWCGCT8ta5qGPYpdK5PAPZmpHBtDICjDG4x6FvqFa3IBdGOq4uyJzzU5G: ENC[AES256_GCM,data:josttkdkOjW/Sk5JnJYXp8yRIaFsirTaSo6SKLxajO4ai+n4h8lFV4du4Y3POWZIkobeaCXRCL/cpjjz,iv:XqJfcmXhYkBK7AbtNHK+p5UTmjX1BoNLVDvDVyQOnDM=,tag:N+T5LfnzUPI58pi814CvQg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:18Z'
-    enc: CiUA4OM7eJK4eCP+yKNb8JwAkThrRoGKQmydzbOLjf9x6IOGUfsgEkkAZoeZpna3Q40AW2Do+TeqYymnAxE70VY3TGU0wq7pyXy4EjrphQ9YLojh7yidjFDN0So4a3DBzwps98rdSnUlVX6/FVa1WSox
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:18Z'
-  mac: ENC[AES256_GCM,data:lycjVTfLpP5U67ofhyvtQMatgopzzSfcPn24mM4Mu6dF3Z7DyT0YOkCcek6q3DrHrG/V6EfuSDlw+Tnm70f3vul2thosCtbK0JK9lj1knHUaE5fLaUp5b9KjwYx6Nyl/RmLGeVVnHTx2tKBMSmf/3NlIEQAPSrB5kqHn5q+fsMY=,iv:+qjNmmR7jO+IZr1q9M0PfnK3kjUxbY+28ZuHFnA9BZY=,tag:yaVj+6UIAEfNjajHlMeutA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:55Z'
+    enc: CiUA4OM7eNY8d+5vycYSjcnhVbhNFIRaZ75bbJcNArlBynPQ0X7fEkkAPHlbmTYhzRkvB/MKOKkMHkNKyVBv4+35WGkwSE015BtdEQe+cIJZ28WclaoUCAm+OOpAJRnngAJcRI2hFdoLy2R/o3quwNp4
+  lastmodified: '2026-04-16T19:33:56Z'
+  mac: ENC[AES256_GCM,data:fSPiUT4E1ZQJMxokgfciNyDwggutcQAe3IzREHiBwt056M6yFyO0xV7QJm9hoN2qn0Jwx9PaWOERMymEF8BZ8vB6BqvrIfK26CpWtSRu++ouejQ0LMXUhBBOw5esEzvw97zCfHjg58vX9PaltcS/xAbacuS5QZ6+wjjuqPdfWP8=,iv:uHw57ovad6D/JPI+VEvQvtFfh0JFFnAELY+Q92u3lAU=,tag:M2y68vseeVmE72YIqatf4w==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/hhmi/enc-support.secret.values.yaml
+++ b/config/clusters/hhmi/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:l9uQPuEhKjf22XTrtzWunpwVVzI7b8tj/HAY99s8c2jX2Yrd/HdjwUWObQrRM5T/M+4K/E1FFuT3UjbXSoNzqlsJ+4LbnmAGqgE4DyqA7SlhvSts+5MEaS84UstlNTj8MuZ3/IDhXBuz1xlhQaBkCaDWYG3YzdWtdE8b6YeRLKu9s9Y++wTqKeeSMwR2Gmuvrte1SM+m1aagDHSD,iv:nedt3SyD0MjcsUAnFnegNaCrzAnSRutBHDc0neXrGTA=,tag:aYnD1531Ueye2MDq7CIfKQ==,type:comment]
+  #ENC[AES256_GCM,data:dBY/LAwuioe39j8sp9wknc1gvFV3WJlcgyJm5nviQF6Eh0sEt7RyIwIQJgHMkfX011jeX1KvXlGQ2trrDUkw7ekrXW1QXDHYXjbyxE9YXQlJKlwg2nbbgubQ2qbViQOQ4SJFDv1wti5W1q92x+OMUVCDSSRF1VG6rj8/x3GWRT6RTG4p6cHOlh0U+RZn3+3Fmrx4EhL/jHsLpC5+,iv:Lj5CfTfDAMxzGf0fiFINzp53/7LfWg2YXH2OriNzFyc=,tag:WWKqJSzIjWFjnHY5lx43Rw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:46nue8pSPrtFFWtSKzrL0lFkmjT1Xh5TfLpOCYPjKNeQNIPnS5jlcctYhSuXKXLUBoWSkpbGG/2OQmJdRZhCWQ==,iv:WVtcqgkbJc5X2UOEwEcqueY23nRXpj7cmtGC75D/dfo=,tag:crxRwTGuywTJO/hmHjkrFw==,type:str]
-    password: ENC[AES256_GCM,data:60uUPbK038pJunI6NxAQ6muPqjJKxk0SxuJFHNRH/1PmDhTHy2Kvipc11jzrx55nklWoSsWaHLKDJaSsK+qe6Q==,iv:QeaiUl+zRkY8YsZAxjgeAbs2yAfRU2xG7XVt/qkF9rg=,tag:GOstJnp7w+VTxOqFyJm9Bw==,type:str]
+  - username: ENC[AES256_GCM,data:6owxZdPrR4VTkCPweXsNDaBtC3dOXAYhBhO2mvxDaL9H4Xa9Zj57I+oauXLfUHGm7qRJqIHeRVAy36OgNl6aBQ==,iv:uJ20TmMfucObBFLltlI5Z8TcY3f0/PwEj517Y/qcIz0=,tag:FxV9+GLY8Avva/5QY6VPBg==,type:str]
+    password: ENC[AES256_GCM,data:u2DHL6k8h9ffhd/SbB/F0xnum1GxEPIFTI0xpyOXrI+Tfi+o+DefOlhmcdaTagvmMMgCVFv4VQ0ReCnHBD8Xuw==,iv:VvTt9x8/FvhN4MHNaxHgAoLOmyZ29iqozivR4EC/aqA=,tag:yXOFquYwnEOEmoS/FbUsLw==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:oZaaH/4tjlKSdpXwjQ==,iv:z2qEGBvy2bPMZk/lw9PKbdFjskCc9BfD9wBqzq4XXdg=,tag:hzG6in8qedkD1qC0YPqrng==,type:str]
-      value: ENC[AES256_GCM,data:qwN3r9ZLC71iGBKeYC/r9R72wcHbThAXIk/QDQrW2/9Oc+b+gZLtY1MGLz+XOp5kbtIbJ6WW7305rb2m+zYe65tp0YTaFYiZ61+IHr7bn+rjhPeU/qxXEF7Y5Q3p+EnTH12Xtkr5eRF/0NRzFLF4FluigkvihvBb2uDSvkwx73ErhOndQet/MalJKUE1biQ+/7SFLYHFB//QqikhS5KKAX8zmAF6K5G4TPhdnhDT95+/Bw==,iv:WtC54SSyOkGYm0L+YX+lNwab4OvUTgM3NAAV3kD9E8c=,tag:5H6LMDY+sMP3GvkDik5x+w==,type:str]
+    - name: ENC[AES256_GCM,data:04rBwcE9sxp7hwXITg==,iv:UiPC1BDwcT/nd+ANlSIyP5Xq2lcbKGVilO1mGl2Qa+Y=,tag:21MqbDRzesZRttCMaO4WNA==,type:str]
+      value: ENC[AES256_GCM,data:xIAGo+pGAJF8OTcTYTU4ja2MD/BcX2VRvh4IzGHaA5zl8fEBCM2978geM19kVnlCjJeDd0l/HsYDDh8VMYTew28NdzYxDIUC/3CCFFRLReqU0Wuje1WWxWyp/X1mKOUG+rme+dRNELnQ3GySxar7hNgi78j/YS1uXxixBg/ihwLg0AbATGSvLgWxwoTFNwz2Bq7zWddGE1sAbPNlge+PvJav3Ey/+DGQX+Z6rLujzoZUyg==,iv:pAYToG+uNPNyhHETF+lLKaNaonykTdfmlyXd7jOEOoc=,tag:CkTo8rfSuS5f2ZP/mYJbdA==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:M+ceJxj5HwptDvuCrWXHR5q7FzZNXdyKK1/3iKfvlmlyUFOw/SN/Mo43KeY66R6VhrfYtzqBgVCCdKjvjuVJpw==,iv:2pGjbRtBQ4k2qE83fPYt6P1T0SklZcepHUtNi98Z2X0=,tag:NkTcHnf0Iyb14MDZQp64+g==,type:str]
-        password: ENC[AES256_GCM,data:JjuSJIpb7alWxmnxIND2GlDxw42tWZv5lf6PPuKCBC8VqZWrIHJ552EZUPdUMMu1ywfc7vBTEzsCkiw3sj5G0A==,iv:xnL/xGMcMC3TsSIc023C4FSrhONCU5oLwBxqUqgQ9CU=,tag:kASs6rVm1jEWntNfGMTOCQ==,type:str]
+        username: ENC[AES256_GCM,data:REZR+0I/zsCMHK1LMfTMTI4ThN8FGc2nE26EoDVrX1qySGpoGuf+cZHMq+73nXmMRTVC+hIBHjHQ8N8dMhnfZQ==,iv:4sEyrNvfbvEdQd5Dg8f5YLWZMXZu+5I5CQtu6iQib/8=,tag:Zzd4QjuC09iibniKkiNdlg==,type:str]
+        password: ENC[AES256_GCM,data:kB4pgYX0kRE25E6LUbD3bLmHIwjinnJyzIizsQaVIZ4+SNumNd4ZAsxHpBrAzWY6azdySK/zM3UgV+2Wr14HOA==,iv:CSlMUkw18VHAZqjZb+NeRTHPUblIL8jSZeLcsFPchLQ=,tag:StLSlMmpZ1Ftc3fi315Ztg==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        YV521IqjWCGCT8ta5qGPYpdK5PAPZmpHBtDICjDG4x6FvqFa3IBdGOq4uyJzzU5G: ENC[AES256_GCM,data:josttkdkOjW/Sk5JnJYXp8yRIaFsirTaSo6SKLxajO4ai+n4h8lFV4du4Y3POWZIkobeaCXRCL/cpjjz,iv:XqJfcmXhYkBK7AbtNHK+p5UTmjX1BoNLVDvDVyQOnDM=,tag:N+T5LfnzUPI58pi814CvQg==,type:str]
+        YV521IqjWCGCT8ta5qGPYpdK5PAPZmpHBtDICjDG4x6FvqFa3IBdGOq4uyJzzU5G: ENC[AES256_GCM,data:tEyA7Yd0lpMXKrt1/3xMQ5nq5V/xm+BM+KetsVjvVhUirTUo7GOQJwRR+abHpXugnxRVdpJzfH2Nv1hA,iv:syMnQ5WSNMPR8SVZ62BpKCbqWijbbTRErREFsXOshAk=,tag:d4hupIfuJpF5aAnwxFcb/w==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:dQ==,iv:199f6Q5q/MX03PGSNpcokvWvdNtOWUyI8bofgwRRiU4=,tag:EXGbx7DfqpkPjzKHcXVlqg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:Nw0w9BgrHzY+VQ==,iv:uOUHLyCw0s6WD2lmssu6cHa7A2cexGjU/kRDR8hyLBU=,tag:xg4V7KhMQEVSGeAbsBksDA==,type:str]
+        orgId: ENC[AES256_GCM,data:sQ==,iv:wUH85A5QPQsf5qotcwl95zTd4/Y40QpvdHxfKh0TqM8=,tag:MInWXn7MpnjAYgHzlEyXLg==,type:int]
+        type: ENC[AES256_GCM,data:htxjnKs/d2sQAQ==,iv:Z22lY9Lq0GzZpbboRQiVD5i+8+3zdgpfDXuF3XRwuX8=,tag:OpKLpmImI51g1NCCXaadcg==,type:str]
+        url: ENC[AES256_GCM,data:A7G1cvbjWX2558pF+GC4rGqOhxf/lftjUQyEhOtaLeU=,iv:i38+DimUDVqRphK6iNz60T5hebjMafSXgeqqZZjs4Mg=,tag:SSKcVJj/YuXJDq6vkL6TwA==,type:str]
+        access: ENC[AES256_GCM,data:chDrqOQ=,iv:6dMm1io01JahIn+ZarvkYSHFB2GbSh4Rj20dF4bk/GQ=,tag:+1CLc/cnyLp0Y7UDcX4yfA==,type:str]
+        isDefault: ENC[AES256_GCM,data:KsEmJiQ=,iv:0rCtew4mXTR6mXjR7N+CBQ7EfnVXZgxyncptRwiH0rE=,tag:9hzzOWBdcWGXazv2C63XWA==,type:bool]
+        editable: ENC[AES256_GCM,data:/XMtXPw=,iv:9fzxQtoLzQlbxkss+qrCyUaBjkzTADvK5AtOjAe4ujk=,tag:owwWcJYkVboYyTXTb/xXmQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:BRiKyw==,iv:AxbwYoI5rGz3EXh4Ok0i3bqR0l2ygvA2zqGgTnsORZ8=,tag:U32KLPmHAlPirciAfzxBOA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:s4eI69TPpKKaiHd2CnHoTTgMhpzowI38czOAnoXWJRl24pBH6USMOyZ90bfv72+awY+Js6VSRY12toPW/HSzUA==,iv:F0gRwHMy6517xZXU2612lWSeZWgIufx8c7BwzCp/dMg=,tag:qS4Ep046yr5/y2hdJRgYxw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:IzYBufH+S+wASBwY6eMXkI1RIeIHgjZh3g6Q+1uS6MOAX6AA9CHjlXxp8y8o+ELOUeFO3D924R+kqW5EzcF7Xw==,iv:CL/Cw1TjcqTXB+l22cfLvmBB2s2plsdtTKAh1zPE5Jo=,tag:RpZ+X9n1BD5FnOuMKcEERA==,type:str]
+      - name: ENC[AES256_GCM,data:42kS/ZsPMexUm84gjqaeJpRGWhuenpZBG7MxjIL39w==,iv:UcZYiXbyIt+S9bLnoZgKABYVf+P/Ib8KA12uQmdnDOQ=,tag:6aOPNroai2V9/lHl3oB65Q==,type:str]
+        type: ENC[AES256_GCM,data:olC6N6Oc4TO9pezlV3MDOGYaBsmlEM7j22qwaj9ggQ==,iv:HItMpv8UGLtmP3EKnxEmHqLcfwYgCKMeeUxacPnysos=,tag:7cvnj/zvulXEgRB5yCjoCw==,type:str]
+        isDefault: ENC[AES256_GCM,data:Zhj7Jmg=,iv:El2ubS/ma/38ZaPJhXy06+Yj3iRdku2cFc1MiB+44YE=,tag:mS80FAlfZKX0pV953LSUgA==,type:bool]
+        editable: ENC[AES256_GCM,data:8kXuwA==,iv:5BD2pHo/FKQmklplspVMf1PUAxD+mbNmH9UqnvONHbQ=,tag:0rjeHToN8Fqmypj1t6oUzw==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:55Z'
-    enc: CiUA4OM7eNY8d+5vycYSjcnhVbhNFIRaZ75bbJcNArlBynPQ0X7fEkkAPHlbmTYhzRkvB/MKOKkMHkNKyVBv4+35WGkwSE015BtdEQe+cIJZ28WclaoUCAm+OOpAJRnngAJcRI2hFdoLy2R/o3quwNp4
-  lastmodified: '2026-04-16T19:33:56Z'
-  mac: ENC[AES256_GCM,data:fSPiUT4E1ZQJMxokgfciNyDwggutcQAe3IzREHiBwt056M6yFyO0xV7QJm9hoN2qn0Jwx9PaWOERMymEF8BZ8vB6BqvrIfK26CpWtSRu++ouejQ0LMXUhBBOw5esEzvw97zCfHjg58vX9PaltcS/xAbacuS5QZ6+wjjuqPdfWP8=,iv:uHw57ovad6D/JPI+VEvQvtFfh0JFFnAELY+Q92u3lAU=,tag:M2y68vseeVmE72YIqatf4w==,type:str]
+    created_at: '2026-04-17T08:25:18Z'
+    enc: CiUA4OM7eLvEdikcfHzweGvxXEzqoXSzO2LdOp4SYOytP/axypy0EkkAPHlbmQp2ZBNTOYjH9AcA+0tEoT05c837qPsyd9xD+c8TSw+4yctpvCGBjm/qATn078HmWQiwdsSuFaocobz21VkFFEksjzA0
+  lastmodified: '2026-04-17T08:25:19Z'
+  mac: ENC[AES256_GCM,data:TRXLbuOf8g91ugCffe10QM7EUSNmHb8m3O7Zy4QozcTgQjSsbPYuG8y6aFu0CHD118jhjH/ASwwLmxXfGkdtJ21rVXpJvJ5EUYKF8wyWy6aeNoNhCj0Dx/Dn/8YRr0qRuTKZqYuG00XjVCzjHSvXlmJfq0DWXFUe7T6dhBK+w5I=,iv:Vo6x0z7hAlWcMCC5v+UnzspfUoxBdqXv8xDBGIj/lXA=,tag:iaAhWk21p5QoFelh6fpx8g==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/hhmi/support.values.yaml
+++ b/config/clusters/hhmi/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.hhmi.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/hhmi/support.values.yaml
+++ b/config/clusters/hhmi/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/jupyter-health/enc-support.secret.values.yaml
+++ b/config/clusters/jupyter-health/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:KZ2hE8dWCOO8OSWvuw==,iv:wGEvMDEe9uhN/ipK7GEWtQ+SjdLBwu4MRZFUmd0KpyE=,tag:cnb4eN/Ed/cCEVuOeB5GzA==,type:str]
-      value: ENC[AES256_GCM,data:YDqVTNDo0m4eJcjEiYAemqAlZzBllCmPVyiuy914GvZYFnFMKfjxKrzwVACNuPYvn9sj8DK+5tMNS/yFWQQm55isX10uCZGz9jw+ZSiWys6M+KEIjNlStTQvXKH5e3/HgNtK/s4/9JMFNXOVIa8LB7h/ARaapISrspEHbkpkxRyuSfr0Zv8EkKivvYB3M2rb/+g2pqltwnZ3ojqJf6W8UsVrUofJViXtkdn/gtIZFTKTWw==,iv:vccm+YDAEzMlTK2EK5kC+AP3AFdDX8KsSiz0mx9LRyc=,tag:o7SpTdqDisnuUZ5wKnNOYg==,type:str]
+    - name: ENC[AES256_GCM,data:V42EXP75+2nxaUA5Ng==,iv:Jdzi66/BfneIH7j4TDDYvuSaOhgHSX2Z+Qyg+Sy6VOo=,tag:rXKQA0UmT1D7TXgtrTG9/Q==,type:str]
+      value: ENC[AES256_GCM,data:NWG2xzTH5CAOHLHPPK4Els+lgtcR+u+vH0yj7rIx89QL+69nAvaUh0lozZI9gXGviGtmiPb+sDk6QR3HgFA4AxxRV9EK7IGxhdebw+IxzYSOyWMwvJfB8y4Q7mKlqmBjpi93wsw2aoS6hYzcVX/BsSsYQfnzrUcyne6Qrk4gXWsmjAn+G8Iy8pzTqJQhbsNfY48uOOJZDlLn8HXv/KiyixxjGD7vWgy9Dv4yvVtn4sAzGw==,iv:yeKlDeBHt9j3lzkM8YjpKVcqaE+niWRZ7nY7kBGmQ9s=,tag:Bse7aVRuqZISZQxnE+FyTA==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:RN0thIl13t0Wh5N8wM8fAHcXw1dskkAZRzgVyp5X8QVtkOBwckdtdM6NHFYRi1ww8H08BljtDFHgnmY9DwyEZg==,iv:QPJWh1zaGSRF5Dxy1TTyR3s6ljsYYsqXCRUWWj/NsL8=,tag:+Wz6XDWZ9LdHD4cgBSB1Xg==,type:str]
-        password: ENC[AES256_GCM,data:/imAyEUOb4wpYld1nsDXleOdfcTFRP7PUKywoqHw1UhWyj902RLjkdkhRea1jp3DyxyYDTObPnmLjyq1x+TE8Q==,iv:FM11ANHQlwMoWUP7IgUn3uDQynb8eVZBaRMg4GRSSRY=,tag:w+3fQFCMFBBCQ1t06b4p2A==,type:str]
+        username: ENC[AES256_GCM,data:GwxDcDCM8cJpOA4GKfjX4HceMWBQv4CpBiljDN2485ENLbRr0MAOEj75J3jrAq9O81W9lf4rjvxJgCBanJD2+g==,iv:ltx6eqMiUnGuYYWauY/gaLhlTlKybkpgarYE38WhDmc=,tag:eZ4wSrlzEjrZtLw9z1RKeg==,type:str]
+        password: ENC[AES256_GCM,data:M+uBFs4CJ+Qhe2/jheyaIGVrAvqxeztkpUnYJSEtANS0w6CKCg6bZM1I2o8X/Bub89VrgUO1UO6t/asyQbNElw==,iv:fEj9nIC6g5sVmaefIB2YvRHGYCgmlUZZSQLt88xu96M=,tag:MnhPCjnx3gV0/+klVpMwTQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        HL4J2oLIovCYWRg0oPemzW6GEslQ6ZeccbGwscEojHkevGhcleU9bIpXHJkthKWu: ENC[AES256_GCM,data:JJ0iRDW7XO8Fju/LfesQdmaYvq0l+PUZBkMvxo/zel5TGPP65a9f/IgUiytLSMhiwqNtTV+ZKzy+dK8I,iv:a69bpA8uaFvFxYPOwZ2y4erFA3LasrTYgq7DJzihVKA=,tag:VQPMjfBdrNLBVo7gSatkMg==,type:str]
+        HL4J2oLIovCYWRg0oPemzW6GEslQ6ZeccbGwscEojHkevGhcleU9bIpXHJkthKWu: ENC[AES256_GCM,data:C7QXV9f3fS7/QdAfiDMo5X9SmO8tLaSu0zv2cCI4oBnXQOO/iU2DhLQW6mc9hRxpOvb98ZBY8ZtTjeCu,iv:xiSCLArXuUshryufLE3np1ZVILmY8ZariNeF76f1P74=,tag:Hq1aEh8SMfOLxSRRdQvqbg==,type:str]
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:3ibOHGQ2rql3z1Uel3M1ge/NM13sMDeaEzNbZ5eRJ6X3hHxDfEGM5ppKfTTRxoLzeE+QwYkocO1NBQ857CPKrCWoquo8iVpw3DKFFWxdvGxnEkMzPEJA3MAL8MCZM0+40kdSogtolU4CvkPRA2ggZ16Amklj0OSz8qZj9ptuLs3IsdXRGDdargLRPY+CH6beLxIGCoWwiEEkjF2J,iv:8T1AmjlGkFLcOeRINTuVAu46Tf0Y+yIhVmcX+A4KWtc=,tag:6Bmx02VkGLe8YvP06gxBqg==,type:comment]
+  #ENC[AES256_GCM,data:+adYPA6Kc3KrhFGcS6ny094A6VwHSNmxPI79SXJeOgIqIm0dGxkyOQFPeRyniWCIaIV9lB1xaou8UXI5T6vqtd6nwb74nNmhqjtYLqCQ+08cowExrDtqzUOU7rc3NCs74N98MFg5Syp0neEkd+9oPzl7uYKCJQDKhdmxkAYGF/4cLpRFi5JfVCU8l4IhyrlxTYHlq9+TN60lTiQU,iv:Hj09wED6C9bfTS/B34Znu9to4kbyWECEMdr+aWeYRNU=,tag:Y1vvCHO9OyY6xesjpHhUew==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:y0q7Uy0/67OGfpzloU5NqHJynRK0UXXuXA8yig3nFAbt6Lw1wYjFfgNwdTst1QN+R4QzGG2QiXBWWbPoiW3VTg==,iv:btT6qIxRPRFGB2uFGKjPy0jXNcVp/YHrhkEp5l+ndOk=,tag:TzVoqgO+0AK+WxkwKBIwJA==,type:str]
-    password: ENC[AES256_GCM,data:SqVFAllfMhw9HB+9ojF6Pf5I3s2u/RWS/5ReIjEvxj4MxUwWG5hfmoskFXhACbT7p8UMQAsFTuwqPQbpE76+gQ==,iv:kQVFf+IXnm+Tyl1QjlfO0e2ulk/EztzXo1GpA774un0=,tag:zT3k1ff0vGViXhY/DLZBgA==,type:str]
+  - username: ENC[AES256_GCM,data:ji9vS7PrvlR+Gui1Zj3fYgcw3PQ3y3VjEzm7S9Xodf63iKwhI+OETiwKbs2lOHBjma2HKq45DozeRRkl22O51Q==,iv:L+HxayYMBiqLjp+0qzsIxD0dbKuIn+3Gdhn7FtxSzx0=,tag:YSQIOtd40F3j/WlzlGvxRg==,type:str]
+    password: ENC[AES256_GCM,data:o+U/RQPeomLQGeLW22qapa2QVqzgql2A4Y9UgWl5cm5dZh2DNGH0/7n7ADd5Im3nntn7aiGV+c2JJMpNC8JQKg==,iv:ItjXG8ncOkrwAazPFsJoAbPxRkklc2qvgwvcp1Nb5wA=,tag:Dn9z/B5JCPlFc1hMnlLNAw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:1A==,iv:0EywFUQ1E8ns03BicWAGKweySUmh+xCMW9aSspy6whw=,tag:nDU8QgEzoZZ06altSLqexg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:RKB+Ob4QJbIXAA==,iv:Izmn5cuBdboDIAMJ1XbIRFr3QLN3uccL1bORV/MBM18=,tag:ybUWQe4JliABjoBgQjpBbw==,type:str]
+        orgId: ENC[AES256_GCM,data:Zg==,iv:j9bdmgQz7MiB/r1+DsKgcF3qRnA6HWHv5bXCxQm+aXg=,tag:StQhwUh/Ylue1ygN2jtWyw==,type:int]
+        type: ENC[AES256_GCM,data:Q47+vBxrX9819g==,iv:nas7jL3wSZWSFzhs1nzNxJJ0ikPUsvT6vSk2pTzYnE8=,tag:L+CvE5XG9r4CHWxSjxxJFQ==,type:str]
+        url: ENC[AES256_GCM,data:VE+svxc3OHq6F4JUziTtTl+AFNV1gHmcbrJqfJ8jzhI=,iv:wbLCK0lchBsbHz42g6qaG6Xg0dbr4tJGIIShIa9eUFc=,tag:aYIQ+RKMzBcA1VOFnCZL7w==,type:str]
+        access: ENC[AES256_GCM,data:/P8Ap90=,iv:deCloGRvnespKV3C3A7g5rOaIdggQIB9XsEKl0wQyXg=,tag:G6EvCoTWdBXCfnTSL96U8Q==,type:str]
+        isDefault: ENC[AES256_GCM,data:Zhb8BMQ=,iv:Wty3ltaG8T55e09QuVl3yMT8X5LkVfM/Dbt5qqSJP0M=,tag:pj7kTznZgFbsu7XnaX90cQ==,type:bool]
+        editable: ENC[AES256_GCM,data:P9irxIQ=,iv:ehVBcveM1dxFMa5t673wM2tf8bZ67lvD600My62AcC8=,tag:TBKFp4piC6n8bcJ8YMEm+Q==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:hVpL8w==,iv:vKzy1jBg3jPI4r6YJkjQX8mGvD5yMrhdMwv4wH+VgVQ=,tag:rkJ8He+uHQHvc387Kqec0g==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:s+lCxOPHO5mXjZujj2qBVhCnUrniILtd70iWizxmuVeZnz46SkqMW4qJRV5EnsRcB/p12ej657fnTekk/K1ANw==,iv:VwRJ93KWhfgWsm+nFnpteozU0guf+fq/OjsTIJof+rU=,tag:b8U9VFNixkt+KiVNuYGSxA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:jVIpjKXpFFdhS2MqXLOsbWsZ9Xfc5dB+pg4teG83pABxy3rEn32ya8VRYdvuT3UBnxO6GPYCGmIw2CV25HvnlQ==,iv:y8aCCZcm6uryg4l7f82ezTcuKAiKgWLy48MliuTnJSQ=,tag:u4MJWsOiDW7Xk57TWe/PhQ==,type:str]
+      - name: ENC[AES256_GCM,data:zPOpIy6rHrZ4xDJ9223OZSVwLjut7BN0hl9lLcFyIw==,iv:cArQbzJ21ME3pRRQjnAOiwHj2q4tALOSPPcaQ8zLz/0=,tag:8Ev2ATmSobFN/nmDiTY6Ww==,type:str]
+        type: ENC[AES256_GCM,data:MQ5Bwpx/zrI7WdCR7/CMfL64hrOiUB+b4pGDFDteQQ==,iv:kSm5028Tr62qxtXMETpmJdkYWsLtndXnfHlbnxusbrA=,tag:Es+fKsFQVXKsVsCXaf827g==,type:str]
+        isDefault: ENC[AES256_GCM,data:RJrnu6o=,iv:IP7DT+eTumXexq7wrspZg4kDX7nhGlQGQkldokrrSdg=,tag:H4FxVH6TXYLCiLYCn9hO5g==,type:bool]
+        editable: ENC[AES256_GCM,data:lrcerQ==,iv:LTzVswAiGnB+KCB7vD3qhscjRXNoSoINHeK2Qgm1JiY=,tag:ChNLMIDiaEtw8IJa7FC/Uw==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:57Z'
-    enc: CiUA4OM7eGEZRplafPXJDi1j3W4utz4vKTbH6SXa7S0R79Ve6I5DEkkAPHlbmYBz1fjrgCv6VumlyagoI4ChLxh+UHggmABQPjG+eo9AkMJiHENKr63opEcq7Owg3ES+s2w5ZFJYIRBqEuSLZiBrqPfz
-  lastmodified: '2026-04-16T19:32:57Z'
-  mac: ENC[AES256_GCM,data:YKyT6p15ZkKgqjGMsQa+GCbD8UZw/lbGmo7f/+x5KbQReBCHiHutU6eG6HJ3PjN6jiaG8Rr6Mt4POyygbZPZYkl7z4HYzweQHrlebCXoA16HU1jwhI+pd/hmZruMlse718gYE39GnB3wsbt+rfQN1yYIik/EGpREWvN2ju1glAU=,iv:OWc6mf0v1oL7fUKTPDTGKo54yGooRIrvf3dLwJTZR+0=,tag:SB/IQiKt9kjLkE5Vdeh/Kg==,type:str]
+    created_at: '2026-04-17T08:24:21Z'
+    enc: CiUA4OM7ePS/neBoYmuyd+080wOvzJC1jsah65PKwZaUBK9SPYizEkkAPHlbmabOVOk7s/k2Jk5heFYuUJIZRAnySsIC/qawsCP4MS40DCqREjmds9iYzMQ956HWgTBiLm3bCr/0BpOt7K64EfDFKs4V
+  lastmodified: '2026-04-17T08:24:22Z'
+  mac: ENC[AES256_GCM,data:cR0z47STIJ/12sSdyl6PHPilWStgE/iDQJDJ2APEWpG7iw3Iy2NEJdqV1SWtvQBPHHPYvc0mpK64v0w00Xc/YLdcWAJ2wv6C46xr0ouxkIuIgG0Q3YYED15Ib1I7CnIjjYtbrfMIQz+yQLIBF4jTvzeNTj4IrN/jSdIctmdxXVk=,iv:XqkFjtV02ffagbNRr8qsqevf2y6eNlr8V4f04CyH9Vk=,tag:gKCnQA01K3ViHnmXh1D+fw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/jupyter-health/enc-support.secret.values.yaml
+++ b/config/clusters/jupyter-health/enc-support.secret.values.yaml
@@ -1,27 +1,27 @@
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:MMpqzF3IW582gfTxDA==,iv:9olv3JodGeRrIpjDEMS71Fc+PTztMllPKTcLXLYlIpk=,tag:iU0UZEPfBFgpAX+T4E94EQ==,type:str]
-      value: ENC[AES256_GCM,data:UjTjYVqkMW466U6jA950CF0EQAISfZ7v8uT77Uvnm+0HZ5IDJmvxt0poRnOrf7w6dm27GUcugW06fM1fsb2omrZfY3VH6mnEaCBBGsogTdxSeRWDIa/LXh1/8cHDWWE7+z3Izecmp9GnjfgJlFZ7PJRDIDU/516tKapUu+xVJ9JwmFmUgYHovhpFIw9vp5enZFAzwkzGDCVVaOiC8WNPS7rUwYAYhUe7JGwvJwdcxKplog==,iv:yAmw7ixfVavhwQOyatqkbRBssx2AU386Bh8eyRsH9U4=,tag:zKw3fg5aODDQfKzum3lc/w==,type:str]
+    - name: ENC[AES256_GCM,data:KZ2hE8dWCOO8OSWvuw==,iv:wGEvMDEe9uhN/ipK7GEWtQ+SjdLBwu4MRZFUmd0KpyE=,tag:cnb4eN/Ed/cCEVuOeB5GzA==,type:str]
+      value: ENC[AES256_GCM,data:YDqVTNDo0m4eJcjEiYAemqAlZzBllCmPVyiuy914GvZYFnFMKfjxKrzwVACNuPYvn9sj8DK+5tMNS/yFWQQm55isX10uCZGz9jw+ZSiWys6M+KEIjNlStTQvXKH5e3/HgNtK/s4/9JMFNXOVIa8LB7h/ARaapISrspEHbkpkxRyuSfr0Zv8EkKivvYB3M2rb/+g2pqltwnZ3ojqJf6W8UsVrUofJViXtkdn/gtIZFTKTWw==,iv:vccm+YDAEzMlTK2EK5kC+AP3AFdDX8KsSiz0mx9LRyc=,tag:o7SpTdqDisnuUZ5wKnNOYg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:CZk/Zd685PhOQ0Id4zjGZOLSob/ue8FGjtThJk1kYqitRau91pUB/NygvtvZ3tBox+taiLN2rnbpJSvB2ioR6Q==,iv:GbBxJWQNS3OsW2skTWUiVB5JfqIMhCv2saeWsZ2i9bw=,tag:x3V10RI7FtkZAIGP10VO7Q==,type:str]
-        password: ENC[AES256_GCM,data:VSFQAcEVs5LIynejwuqrJGSyLbfaAWOS64D24R6jnv8k2WkLksmNmnPCnt4pr+PhqhchTJnsSu3eycIVlDqvvw==,iv:w9uZqttu/p+9BPcAg9wCSV6UFB6Ae/1R34IB71i8kgE=,tag:fZlvHjkXS3emP6c4EJI7iQ==,type:str]
+        username: ENC[AES256_GCM,data:RN0thIl13t0Wh5N8wM8fAHcXw1dskkAZRzgVyp5X8QVtkOBwckdtdM6NHFYRi1ww8H08BljtDFHgnmY9DwyEZg==,iv:QPJWh1zaGSRF5Dxy1TTyR3s6ljsYYsqXCRUWWj/NsL8=,tag:+Wz6XDWZ9LdHD4cgBSB1Xg==,type:str]
+        password: ENC[AES256_GCM,data:/imAyEUOb4wpYld1nsDXleOdfcTFRP7PUKywoqHw1UhWyj902RLjkdkhRea1jp3DyxyYDTObPnmLjyq1x+TE8Q==,iv:FM11ANHQlwMoWUP7IgUn3uDQynb8eVZBaRMg4GRSSRY=,tag:w+3fQFCMFBBCQ1t06b4p2A==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        HL4J2oLIovCYWRg0oPemzW6GEslQ6ZeccbGwscEojHkevGhcleU9bIpXHJkthKWu: ENC[AES256_GCM,data:b1CXQ8wK5WY1pjJkO5tSvtmQZXcS9oHmSybMAod6jxHyH2NjRel2d74OMJAu9YRlv1+M8JiOwSu9o1uS,iv:bJ/x8+3vZg+TOcXrxCnNt4tfGaFH4zupCMSxyBw/xBg=,tag:/vHlsUcraBnWFl8863b0ag==,type:str]
+        HL4J2oLIovCYWRg0oPemzW6GEslQ6ZeccbGwscEojHkevGhcleU9bIpXHJkthKWu: ENC[AES256_GCM,data:JJ0iRDW7XO8Fju/LfesQdmaYvq0l+PUZBkMvxo/zel5TGPP65a9f/IgUiytLSMhiwqNtTV+ZKzy+dK8I,iv:a69bpA8uaFvFxYPOwZ2y4erFA3LasrTYgq7DJzihVKA=,tag:VQPMjfBdrNLBVo7gSatkMg==,type:str]
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:jGd99/mCF2XXLSJBp7EbIFYgMXtkTImU4yn7TsCmW/R+xlRVq/PuZEg3aXdE2gOZvWYlDozhkE6tbVZUBZMCELvJJ1GJnj0JQnMNqvpBk/k3E0BItf/bvW5Nm1VTiSiFsxpyPKfRJHrUpS7WRJM6dHbvWwvXQBCMn+cAsOD38wwyGUCBvKYp/7RIaGy0AeayP4tTr/tV4zYgd7zR,iv:DbIQmO2p2UTYhgGARH95luql0YsTaTyy3aScsfmNe7s=,tag:H4EPsDMxEZftOHJe+N22WA==,type:comment]
+  #ENC[AES256_GCM,data:3ibOHGQ2rql3z1Uel3M1ge/NM13sMDeaEzNbZ5eRJ6X3hHxDfEGM5ppKfTTRxoLzeE+QwYkocO1NBQ857CPKrCWoquo8iVpw3DKFFWxdvGxnEkMzPEJA3MAL8MCZM0+40kdSogtolU4CvkPRA2ggZ16Amklj0OSz8qZj9ptuLs3IsdXRGDdargLRPY+CH6beLxIGCoWwiEEkjF2J,iv:8T1AmjlGkFLcOeRINTuVAu46Tf0Y+yIhVmcX+A4KWtc=,tag:6Bmx02VkGLe8YvP06gxBqg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Zl4buHJ0dziTV83EldaU9oyGajvQyKUfDrefERq/xUKqrA2D7XZ1fZ1RzkbA3sL1WTQgDgZXGX1o2viN4Zqmqw==,iv:V8IBvuFfZ1wDCdZ6IkrETij0d2F+ZnV2Qj3oG/jQQno=,tag:WmzpGAgvK/CVYa6IWkRQ/A==,type:str]
-    password: ENC[AES256_GCM,data:AZ6hsRBCCkmaGPWDrSseAd4xOqh2QygRE1U2G2BJRDd6Tg8i2+6iyUS/7QRiIJ3Tr66Z7uVo8NOJFakDGOsy3Q==,iv:m0oV/iFrQuXJAhAr/kCrVJUu4lZUSLTh7IXe+rmxMtI=,tag:U2AYVr8j8NB2GM8tMRzW/Q==,type:str]
+  - username: ENC[AES256_GCM,data:y0q7Uy0/67OGfpzloU5NqHJynRK0UXXuXA8yig3nFAbt6Lw1wYjFfgNwdTst1QN+R4QzGG2QiXBWWbPoiW3VTg==,iv:btT6qIxRPRFGB2uFGKjPy0jXNcVp/YHrhkEp5l+ndOk=,tag:TzVoqgO+0AK+WxkwKBIwJA==,type:str]
+    password: ENC[AES256_GCM,data:SqVFAllfMhw9HB+9ojF6Pf5I3s2u/RWS/5ReIjEvxj4MxUwWG5hfmoskFXhACbT7p8UMQAsFTuwqPQbpE76+gQ==,iv:kQVFf+IXnm+Tyl1QjlfO0e2ulk/EztzXo1GpA774un0=,tag:zT3k1ff0vGViXhY/DLZBgA==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:07Z'
-    enc: CiUA4OM7eDNHlLejRn8K6AIw8j0xUYIOOBQmPNXc5oBPaX/6BLJCEkgAZoeZpvWT0idzKVdTACfmACMGtOWVTFCwwi80awWFFU6Yy1+/XdGiNEgTnnyG7TVyL7WCwkYx9LxpcQktdsVgkz1hjfVkwfU=
-  lastmodified: '2026-04-16T12:02:41Z'
-  mac: ENC[AES256_GCM,data:/0seyZshQs/IFdQg8yAVZNPhX7UnzbQMmmtgTin0KHsaFMfEWVgYJSrBBDKj4lRUQOnRCOKeX7I3CrBFLacDnuklyXcd61w1XDahAjwXA12dRH37M1XknaYqW5g88p6dOu7M4NsXCAyr3dK+gdMBgWPtVyvwCmZumWEu4TBK7iU=,iv:eMcgAzGtZ+isoaADAEg4CMZExYmvjJHtIoeiuV4ktQY=,tag:Grym2Yt3b8am+z2Q8ywpZw==,type:str]
+    created_at: '2026-04-16T19:32:57Z'
+    enc: CiUA4OM7eGEZRplafPXJDi1j3W4utz4vKTbH6SXa7S0R79Ve6I5DEkkAPHlbmYBz1fjrgCv6VumlyagoI4ChLxh+UHggmABQPjG+eo9AkMJiHENKr63opEcq7Owg3ES+s2w5ZFJYIRBqEuSLZiBrqPfz
+  lastmodified: '2026-04-16T19:32:57Z'
+  mac: ENC[AES256_GCM,data:YKyT6p15ZkKgqjGMsQa+GCbD8UZw/lbGmo7f/+x5KbQReBCHiHutU6eG6HJ3PjN6jiaG8Rr6Mt4POyygbZPZYkl7z4HYzweQHrlebCXoA16HU1jwhI+pd/hmZruMlse718gYE39GnB3wsbt+rfQN1yYIik/EGpREWvN2ju1glAU=,iv:OWc6mf0v1oL7fUKTPDTGKo54yGooRIrvf3dLwJTZR+0=,tag:SB/IQiKt9kjLkE5Vdeh/Kg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/jupyter-health/enc-support.secret.values.yaml
+++ b/config/clusters/jupyter-health/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:MMpqzF3IW582gfTxDA==,iv:9olv3JodGeRrIpjDEMS71Fc+PTztMllPKTcLXLYlIpk=,tag:iU0UZEPfBFgpAX+T4E94EQ==,type:str]
+      value: ENC[AES256_GCM,data:UjTjYVqkMW466U6jA950CF0EQAISfZ7v8uT77Uvnm+0HZ5IDJmvxt0poRnOrf7w6dm27GUcugW06fM1fsb2omrZfY3VH6mnEaCBBGsogTdxSeRWDIa/LXh1/8cHDWWE7+z3Izecmp9GnjfgJlFZ7PJRDIDU/516tKapUu+xVJ9JwmFmUgYHovhpFIw9vp5enZFAzwkzGDCVVaOiC8WNPS7rUwYAYhUe7JGwvJwdcxKplog==,iv:yAmw7ixfVavhwQOyatqkbRBssx2AU386Bh8eyRsH9U4=,tag:zKw3fg5aODDQfKzum3lc/w==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:CZk/Zd685PhOQ0Id4zjGZOLSob/ue8FGjtThJk1kYqitRau91pUB/NygvtvZ3tBox+taiLN2rnbpJSvB2ioR6Q==,iv:GbBxJWQNS3OsW2skTWUiVB5JfqIMhCv2saeWsZ2i9bw=,tag:x3V10RI7FtkZAIGP10VO7Q==,type:str]
+        password: ENC[AES256_GCM,data:VSFQAcEVs5LIynejwuqrJGSyLbfaAWOS64D24R6jnv8k2WkLksmNmnPCnt4pr+PhqhchTJnsSu3eycIVlDqvvw==,iv:w9uZqttu/p+9BPcAg9wCSV6UFB6Ae/1R34IB71i8kgE=,tag:fZlvHjkXS3emP6c4EJI7iQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        HL4J2oLIovCYWRg0oPemzW6GEslQ6ZeccbGwscEojHkevGhcleU9bIpXHJkthKWu: ENC[AES256_GCM,data:b1CXQ8wK5WY1pjJkO5tSvtmQZXcS9oHmSybMAod6jxHyH2NjRel2d74OMJAu9YRlv1+M8JiOwSu9o1uS,iv:bJ/x8+3vZg+TOcXrxCnNt4tfGaFH4zupCMSxyBw/xBg=,tag:/vHlsUcraBnWFl8863b0ag==,type:str]
 prometheusIngressAuthSecret:
   #ENC[AES256_GCM,data:jGd99/mCF2XXLSJBp7EbIFYgMXtkTImU4yn7TsCmW/R+xlRVq/PuZEg3aXdE2gOZvWYlDozhkE6tbVZUBZMCELvJJ1GJnj0JQnMNqvpBk/k3E0BItf/bvW5Nm1VTiSiFsxpyPKfRJHrUpS7WRJM6dHbvWwvXQBCMn+cAsOD38wwyGUCBvKYp/7RIaGy0AeayP4tTr/tV4zYgd7zR,iv:DbIQmO2p2UTYhgGARH95luql0YsTaTyy3aScsfmNe7s=,tag:H4EPsDMxEZftOHJe+N22WA==,type:comment]
   users:
   - username: ENC[AES256_GCM,data:Zl4buHJ0dziTV83EldaU9oyGajvQyKUfDrefERq/xUKqrA2D7XZ1fZ1RzkbA3sL1WTQgDgZXGX1o2viN4Zqmqw==,iv:V8IBvuFfZ1wDCdZ6IkrETij0d2F+ZnV2Qj3oG/jQQno=,tag:WmzpGAgvK/CVYa6IWkRQ/A==,type:str]
     password: ENC[AES256_GCM,data:AZ6hsRBCCkmaGPWDrSseAd4xOqh2QygRE1U2G2BJRDd6Tg8i2+6iyUS/7QRiIJ3Tr66Z7uVo8NOJFakDGOsy3Q==,iv:m0oV/iFrQuXJAhAr/kCrVJUu4lZUSLTh7IXe+rmxMtI=,tag:U2AYVr8j8NB2GM8tMRzW/Q==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2026-01-12T10:07:07Z'
     enc: CiUA4OM7eDNHlLejRn8K6AIw8j0xUYIOOBQmPNXc5oBPaX/6BLJCEkgAZoeZpvWT0idzKVdTACfmACMGtOWVTFCwwi80awWFFU6Yy1+/XdGiNEgTnnyG7TVyL7WCwkYx9LxpcQktdsVgkz1hjfVkwfU=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:07Z'
-  mac: ENC[AES256_GCM,data:46033oVAh+qB4cJniVtXaszmqVQk1E77+r/NtThPAcTmYFwi5mCirhWc7tDMUEi5aRVnxyt+wrvnGfdFWkF2hmaVJ739PlX4jMtW8O6D9cMHmf/xtWZ6D10tOSTJ17dVpEpu2iDWfgrW/xhAYIeXhvMgQmi4gRMz3E+e2OBv0Y8=,iv:BOVPU/cIswvqq9Fpl0cEoqyZaoYfGh4P4U4/MDizui0=,tag:c6Ntu2YXxYFhdlsr74HrMQ==,type:str]
-  pgp: []
+  lastmodified: '2026-04-16T12:02:41Z'
+  mac: ENC[AES256_GCM,data:/0seyZshQs/IFdQg8yAVZNPhX7UnzbQMmmtgTin0KHsaFMfEWVgYJSrBBDKj4lRUQOnRCOKeX7I3CrBFLacDnuklyXcd61w1XDahAjwXA12dRH37M1XknaYqW5g88p6dOu7M4NsXCAyr3dK+gdMBgWPtVyvwCmZumWEu4TBK7iU=,iv:eMcgAzGtZ+isoaADAEg4CMZExYmvjJHtIoeiuV4ktQY=,tag:Grym2Yt3b8am+z2Q8ywpZw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/jupyter-health/support.values.yaml
+++ b/config/clusters/jupyter-health/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:
@@ -11,7 +11,8 @@ prometheus:
       - secretName: prometheus-tls
         hosts:
         - prometheus.jupyter-health.2i2c.cloud
-
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/leap/enc-support.secret.values.yaml
+++ b/config/clusters/leap/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:nRbwnm3oYej/CAjEOg1Ntnpkg1MoNsJhTwV9GDb3IyL92HD99GqlNs0i7droHzZqZPpELUDlcvEJQRyINw5/zAyRgcmwJPMKn6t8489SG0iDOKaY4Hs0z0UXgF8QkYkk3pFddd+1G5cRmiCA84N4WqshBxWTwR0jRRY3FDDA+bQYtndEqoZTD+q9X+9iG46M1vQPyCCVIKgtDDyW,iv:WH/y2FEglp+DD4A6bdoEjDAVSSvMJLPWIbpPhEiM8PI=,tag:8pukXkf+XcdzkOvxZShGNg==,type:comment]
+  #ENC[AES256_GCM,data:lDzt5Og3807hStIce4PYpLkLlGdPf6XQevIPSi+WLaVXIMnUkNdmpYirOaVc5RtqDt9D5uTIUgC+rZAwGhvi5WwQqEPw3ZAPmqiIQAwRpWnW/BoXP3TZ8/1Manrs28f9q2hg4eEy3oAEp8C25PUpt93tnQkEDUd/J/LxtQe1Q5RQ1f7sps9RfA69ayFW/z7Xo6WVTLecW/pI83IF,iv:AjTicYzXVIBc6ouyxLWvpYClMKgL4dpHrsIifZzC8Go=,tag:Kbi5bLDBjlCktqoNIQjPlw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:vL54X1jU3H3aub0eqVheGrfSDBWmNMfy9C9VlvPaqCXzsaN1DGFjL5MZL29AIQAp43p7+UXvS2NS9wvPWMK0lA==,iv:5UQjP6xhRLtnpI6gv8SRyLPrAyZ8KtFentFOOTrLRnk=,tag:HGX0Ai0xyvVnJndDuFMdzg==,type:str]
-    password: ENC[AES256_GCM,data:Etw1rhGdelfLV2NkVtRZeyouKbRzvv7j8F5pjOQMZVdx+HAJJZ3KlVOlUPBCIw1UvS78e1MKuLtZjSKodt6/NA==,iv:4Ty6mfNH8gHuJ9rz3LoPgY2lHmH2ck+9JmNYRy/oPzg=,tag:xiPfzInSCobeibAsPV/+hQ==,type:str]
+  - username: ENC[AES256_GCM,data:VW605ShHZV8jwy96xD7AYXJvu+Ia7wTpYfDJqA0QC1zGvPAFiFnPEOqo19HL8N0kvpaBCnc3jLHL/kowyDIJTw==,iv:wI7EIXyUrtES1+cDOSO6tZAFX31qFQMVJ1CXXkjRMno=,tag:9UBfcszPJZZwkPiRgJT4mQ==,type:str]
+    password: ENC[AES256_GCM,data:H4xSMaiCuhfq2cRpq/FTs/p5E/vP1pejz3p4Auk4dErla4Jie2O531VO6wqVx2tDLvZwP7gxe1DaagffNRM9pw==,iv:rBhm7xMrMP0XTvVACMKOd+RTOSniVQWdghNu9Ila49o=,tag:whXbmlZNEgLyL63V9bblmg==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:XtOCsZufONHdzBxNcByEtrsWdJs=,iv:Yd/gORrq/lacqUO4zLaB0n0MSv9DTzSbH5Ly0tzo4h0=,tag:dF2saEMBTgD3k+8LCx1Mmg==,type:str]
-      client_secret: ENC[AES256_GCM,data:McmJK5MSrbcksner/tOvWPmfrdz6ZvN7U4fQIs5IS166yfRKBwCqUw==,iv:OlaA4ihdjp4Peyp/mGHi0Ow4k3h5Q0UDHKVk656t9Y4=,tag:EDWGm7d3uJw0qKHFKcdknw==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:0Q==,iv:WaNZWYGa2HpbfxNrIpbBqlP/B/guewi77hFVwIRQjMc=,tag:pQqVjBLLpzdW07H22zpC9Q==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:C2O7BAFrPIHI+w==,iv:U7XiOFjuPR+bCqZKJ1ITxVuruQjGjWLAnLGkX3qOkP0=,tag:oB6WpTFmubV9jciuXse3yA==,type:str]
+        orgId: ENC[AES256_GCM,data:nQ==,iv:QVfo4LlAmaQFKOUI7q36b8RgBuMwof/NAmLakOZoy9Q=,tag:itQQqxrZL3hCOZRjgcVCNA==,type:int]
+        type: ENC[AES256_GCM,data:YIxFMAtb6tRnEg==,iv:XvQWLXN1xHGsD36cFUfJCHU0GyXy+UtFZR8VkUG3IjU=,tag:H8P5b99cOBZALXL3V+kowg==,type:str]
+        url: ENC[AES256_GCM,data:6FmFwtPpgdDh+qLgpiOCcJGjLwWQUGarP/P8mRCZ5b0=,iv:apB6TZ3HotRwBaWuf9RQMqB2FoLQHgKyI+2nb1akrvw=,tag:KISY4wahGBBS7erOd4afOw==,type:str]
+        access: ENC[AES256_GCM,data:UscwhQE=,iv:HXGU52mrA0hoejMIQfxio1Wnmgx46lQktrIzb8O+ue4=,tag:0XtCuo7A1DKO1q9G+YXBxw==,type:str]
+        isDefault: ENC[AES256_GCM,data:u8u9HcM=,iv:AmJ/CC8mPi3xtp/Mq3jUx2oMiIcTPwnHaJHyIJIiwW4=,tag:Yk03vUJImmMrLg/R/4jXJg==,type:bool]
+        editable: ENC[AES256_GCM,data:54GzC/k=,iv:QeQskd12LP7Kqnru5qjcsHkGdwyCod+ZOOmLBIdtDTs=,tag:QlV95vvyIKeiweOEeuMHPA==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:brmWvw==,iv:siNEo61W4kEnKbVIb6dkERJJeNaoilo+StKZaSyNZGM=,tag:FWizJv5gKGSMqcL8Q6EOcg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:UP7oUhnP7RfzRG9zGj8wOxHtGs0vbaEvc8Qdqw8K6czbODHSI4ZxbawgT6Bt6DMbdxK7on7Z1p/t8P2Fpsv7+w==,iv:WAurtturPxYdS+/WK8UqqHeeBmDMXz++0/bKzc4oECs=,tag:I5EIJh00mOjvb9+YtGyhhQ==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:vIZ2O+uWcEDlhbkfV734WrciE2DZ6YMufSmGQVw4qVeqmkBb7ICbcF0xiJ4TIOqO3nj91XoAcz1mU2G6ErYTTg==,iv:VVdK6sqWJig/dMJr7IAraCcwEia3ObV6cQVStSd7sYY=,tag:Q+ltNk5nB/EpDRe4MDNZ3Q==,type:str]
+      - name: ENC[AES256_GCM,data:hF8G1QAi/oGP55OFKpZuKAEImNFiechSaGqHIYHqOw==,iv:SRrmI/iDFkwWEsGcDf8w4zLMzoJdOPmAijkTFKO+Hps=,tag:UUxSG85ZF/RKd7hqCipOog==,type:str]
+        type: ENC[AES256_GCM,data:s9ajVvksXyvwWkLo3ITfOX/EGWUsle7DuLCmz7F2vA==,iv:JWYQZnsgMXIzWSHNLjDoZmDNwbOeXk8AG5zDNGWjFf8=,tag:Rm3zWWvARtagwRyTxWj2iw==,type:str]
+        isDefault: ENC[AES256_GCM,data:F03kK1c=,iv:wwkP9RJpjrYqr3TOMT2fF5sqbB402gXiIcHEG+1PKLk=,tag:/JOEW36+RH3VLPsl20obxQ==,type:bool]
+        editable: ENC[AES256_GCM,data:/ABoYg==,iv:ul8YmUKd9V/RPFA5PxyBv25aVG2xokIDr16oNQCgUZI=,tag:a6KUykeHmDyjZpxtaFu3/Q==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:vMipFJ4RncVWY2k2+w==,iv:rqPWaqA6WiC8Aj/AckD1J7+dGNa8j+uA5JB/Zj9G3Tk=,tag:/Ye1cYB51VSqgsm4MlwjgA==,type:str]
-      value: ENC[AES256_GCM,data:fXCbJUgpRmiWYmlEnOVCcCSI2zQvDLFfAB0ZG45TNZMCucLmBKqmJSdzHKfVVE3293mdGjgamhYYM0g8FsqO/cTjtFXBH54dxWnWFEQETU1FOL7P9gO6QZpQbod+yUFj2AR4EFAvrNwyNTJqRn0phYZguLO5bMh2OtDbotehad+Mj5y8HflQVAZ9y8lwxbP2qhw91yc5V7a0LxxCf2E/gl6mdi854l6nCIUphvyHJXmzLQ==,iv:fRqXiTej8+N6FnLkxtjOkCucM8IGpoNIgOQyLa0Lgoc=,tag:tP6dHsoQ5TF0HiJjElYlcw==,type:str]
+    - name: ENC[AES256_GCM,data:vPwbIGqQdbAGONNMuQ==,iv:WlSkAVe/oow3sD+mBKzvc80BDLLX822xes8WSsyCjTM=,tag:ClS9xUqF9ofdaWtT5vGH3g==,type:str]
+      value: ENC[AES256_GCM,data:q0XsGi5OqoBvejB1CU7rvgtHv3a1BDN1UbgcxvH+D7pc2g3bvPKi0FRUaTbDQmNj+z/sAiaFvQbY+XjGguIk2l1u2c96rIMQU+uigFxgjbJuqfmKBSP1E6rpOkaLp4zQMumY6ifibnCAecQ2JT4DpWzy+j5N+NFLsOPmMoWVJ09uSlzGTIWp+BAPQFphCs6Ix9kHQY1Xm24rtWmcUlb8p8EX50CoejVcHQ5GfePfLgiA7Q==,iv:UnTTlztVJoNzgBKF5rgE5ydbhhdsyWKLgUGXUkNsXeI=,tag:HbKJ/BQ6elDlnUgUNNmuIg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:6pkT3wRLjLkoNhoFRrorgF8/NRzH3k509SLgwLg9Ijrt+uKfQg7JRnj9WtMjz+FEJH/UCy162EC/fyTnBKzsPQ==,iv:wNv9ZKy8XzksoNG4kLgU8IKv7ZjD9Gq8P9tshVRpbWM=,tag:dgDHwQf4nDnaEo6WDClOZw==,type:str]
-        password: ENC[AES256_GCM,data:h+yDFeXBqmpEdwQkPnT9Y7TH54lw1/rHP45YY+olDNfhziLLqnTVDTxXtjMjkpMXuQY0uGGsZ1uMDuqCNOpr7A==,iv:ns5bmh2OYuJxz3YpJ8LOisgyKxpxjL7re/9CYFcN+9M=,tag:dkpyTes0RZIphV50InExog==,type:str]
+        username: ENC[AES256_GCM,data:/iPwtnBMQu/w25zizSjPsAZWHpGsGEmdvm6meBox3UCnoZmsabN9DeWYAWnpfjocdDdBCCdGBJ6z/YpIBg+L0g==,iv:nOve7ynqevvVcLuUgQqeR831eGSwHSwoV8wgJPvpPJE=,tag:YGo4frHSp2shrjZmIRMvRA==,type:str]
+        password: ENC[AES256_GCM,data:4qibPzD8isQc4Zwr4j33mXg3KrMksbQvASg1Y0iJ/1eBicT1WFfDModS+KSK665zeO+VwSNrc7HSPT4y92AvlQ==,iv:sh+/XTUn/nYAmSW6Yrpjogjh1+EzAAgFXsq0Ds/cjcI=,tag:Yc78jAdw2smTwXhXnfvuIQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        KVCDzuJIVYDpLEMDrBsYDGWB9qF3mv60XcPALIjOCX5gyhox0gxaAgy6JcsTb8yb: ENC[AES256_GCM,data:+4pmqMMROXz8els2noEYPZjqauKWvwZfL23ISUiJyePYHPC8WSK0o0iimp/nK2B8kHtPRAQUyIngxOhi,iv:Y3zM2X6VkQTKElLEIgGfcXtkMhR7Tjpbv2gR8XPX9a0=,tag:PGcFiBok/ywHKuObSEsYag==,type:str]
+        KVCDzuJIVYDpLEMDrBsYDGWB9qF3mv60XcPALIjOCX5gyhox0gxaAgy6JcsTb8yb: ENC[AES256_GCM,data:/ktdNBx8fBMxR5KlfedWOWFvys1AQ3BgoPcI2ESxZx1/Agq4m+iZkwxyrNcvLZTJHp86+3e6GK3z495T,iv:q+NlUQvhNNOZYstpEFOleB2hkldisR08ho47NK7XExg=,tag:alKl4lXOtKXcT1T+DlRzKA==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:33Z'
-    enc: CiUA4OM7eEgNEPxlK2bwBzAd8NoJbD6YjA3jFyKkp53Txw+HBDBNEkkAPHlbmXxhBg0pFPnrYClEDTyEmmcnUSYYvYvdNLCq5+Q819Cgvu0LUdib/i9e8bBZc4285jAc5QGJ/jaJPkXHuH58/yi6LJBg
-  lastmodified: '2026-04-16T19:33:33Z'
-  mac: ENC[AES256_GCM,data:X7h83zgN56sTN1q8eKkPN9XdNoGphuXv5qKUIFr699aCOmzWZ5kxwmgTDvQUmsfSL84Dn7MVD9WBJoC7VtUx6cUmwfBPWLnFB3Y9ocUmO3JEgTiboLDvrbktp3mf9ay6+mqmSwTeKJWX1rWWquXv5cNW5bYru/9rVDV1Bis/U/Q=,iv:TUOjm2uRisEC1uBpVikbNPwqouNPo2X9LIiktI8RjzE=,tag:9ggXUy6D29HKt8R06GVflg==,type:str]
+    created_at: '2026-04-17T08:24:56Z'
+    enc: CiUA4OM7eNxOSOsr9Q7pu1A0wFQnex6RDKpo/sZxIzCfgjRTPV43EkkAPHlbmZzoFU2J/5isLbwXPIiHdfuoTchO8mIKpundz5qx9WQY0OaynbbcSJ4j3xj96340dnPbU1ANIoVEE7QWx6ZmgX9ZICu8
+  lastmodified: '2026-04-17T08:24:57Z'
+  mac: ENC[AES256_GCM,data:jGbDlPgMx8m6lOX/zkIvoWB9PHWo3Hn2PcCNZOmNOprG+WeEv9tnY03odiOlshvdElZPjlE61fq1/2TCw9/kBeGrjCXbJ43v2b36B6lY4Vj2Jvm0El9qDtnI2PaRh4ES42WaMlc4pO6qcgE8eP6ym6vJgXf3iPvXGMiVc0qFJO4=,iv:tj0S/4Z+AbmlKcvwev0oPstNIVOv8paEqQqHy8BIrWI=,tag:FcL9nhF3g0WF1AKVD6nzFQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/leap/enc-support.secret.values.yaml
+++ b/config/clusters/leap/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:TmCWc2q4Z7+/YxhOy4ajDH/GSXtjFO9DlGPXaB2ILe6mRaYz2nPeWMZ1GYZe/rrIn0mBVF0JuHyMGOyHxHz82jEr4YnZ76jmZIwMyX2uYIIeu5+lbv0t9YB7vhCurMPQc1SuWbHTYtFPY6VVEGT13sDHEphjXmVHYOwHDtjsFmYqAOQaPH7Oj9iu6s2WduaydkbIcGhG26JZoVW6,iv:0oVGojQplLf44dDdAxC8dsGyBhxqoxKV0qAj7FUFVRE=,tag:dk4jFf9XK82VG+i/HGc7zw==,type:comment]
+  #ENC[AES256_GCM,data:nRbwnm3oYej/CAjEOg1Ntnpkg1MoNsJhTwV9GDb3IyL92HD99GqlNs0i7droHzZqZPpELUDlcvEJQRyINw5/zAyRgcmwJPMKn6t8489SG0iDOKaY4Hs0z0UXgF8QkYkk3pFddd+1G5cRmiCA84N4WqshBxWTwR0jRRY3FDDA+bQYtndEqoZTD+q9X+9iG46M1vQPyCCVIKgtDDyW,iv:WH/y2FEglp+DD4A6bdoEjDAVSSvMJLPWIbpPhEiM8PI=,tag:8pukXkf+XcdzkOvxZShGNg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:HLhvGdB4kxCS5rVD3OFUqVwv7yRHdceIGVC64bS+HCB252u3ZgGgEUahH4O+REEyXO6OFh3lEjHLzNHTADvXuQ==,iv:kEnftlG1LGe/egTxYw8fulleRrWxrqb0cyiotg0j97M=,tag:f1jI1re8Mm52OHHtCtzCNQ==,type:str]
-    password: ENC[AES256_GCM,data:ViQgTVxUGwf1e3/kHEu5+82IxlkCjzSGN1F4Af0hNlXeGwIMtXFjH4Yp0C4W0LgMnWWOFEzbxi1fh2K/NyuwWw==,iv:0TfsU34CeU/YJocYkNHgL/uLdDH3fcGCCRdtHxScXeQ=,tag:mHNPalI3R2K3Jte2N2h3yg==,type:str]
+  - username: ENC[AES256_GCM,data:vL54X1jU3H3aub0eqVheGrfSDBWmNMfy9C9VlvPaqCXzsaN1DGFjL5MZL29AIQAp43p7+UXvS2NS9wvPWMK0lA==,iv:5UQjP6xhRLtnpI6gv8SRyLPrAyZ8KtFentFOOTrLRnk=,tag:HGX0Ai0xyvVnJndDuFMdzg==,type:str]
+    password: ENC[AES256_GCM,data:Etw1rhGdelfLV2NkVtRZeyouKbRzvv7j8F5pjOQMZVdx+HAJJZ3KlVOlUPBCIw1UvS78e1MKuLtZjSKodt6/NA==,iv:4Ty6mfNH8gHuJ9rz3LoPgY2lHmH2ck+9JmNYRy/oPzg=,tag:xiPfzInSCobeibAsPV/+hQ==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:Q7qmORWnROmEojAbGR23THNL7aw=,iv:Ao0/w6zNVRUFyD8ziP/LJ8CNa34o7mY7G7X5OoZ0yWA=,tag:RjeuZKiU5hMbHr8N5pcRWQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:8b9aAjQ7dyyaNGJ73/Xiov/dmfkgk1xsNvlzwB8BbkWsBaw+8ALBfw==,iv:QndpBg+u+vvjiJaEiP5PU58A9KTi/UurH0h2yJnFiRs=,tag:SQ/HVv5JhTZ002wII+2K6Q==,type:str]
+      client_id: ENC[AES256_GCM,data:XtOCsZufONHdzBxNcByEtrsWdJs=,iv:Yd/gORrq/lacqUO4zLaB0n0MSv9DTzSbH5Ly0tzo4h0=,tag:dF2saEMBTgD3k+8LCx1Mmg==,type:str]
+      client_secret: ENC[AES256_GCM,data:McmJK5MSrbcksner/tOvWPmfrdz6ZvN7U4fQIs5IS166yfRKBwCqUw==,iv:OlaA4ihdjp4Peyp/mGHi0Ow4k3h5Q0UDHKVk656t9Y4=,tag:EDWGm7d3uJw0qKHFKcdknw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:vMipFJ4RncVWY2k2+w==,iv:rqPWaqA6WiC8Aj/AckD1J7+dGNa8j+uA5JB/Zj9G3Tk=,tag:/Ye1cYB51VSqgsm4MlwjgA==,type:str]
+      value: ENC[AES256_GCM,data:fXCbJUgpRmiWYmlEnOVCcCSI2zQvDLFfAB0ZG45TNZMCucLmBKqmJSdzHKfVVE3293mdGjgamhYYM0g8FsqO/cTjtFXBH54dxWnWFEQETU1FOL7P9gO6QZpQbod+yUFj2AR4EFAvrNwyNTJqRn0phYZguLO5bMh2OtDbotehad+Mj5y8HflQVAZ9y8lwxbP2qhw91yc5V7a0LxxCf2E/gl6mdi854l6nCIUphvyHJXmzLQ==,iv:fRqXiTej8+N6FnLkxtjOkCucM8IGpoNIgOQyLa0Lgoc=,tag:tP6dHsoQ5TF0HiJjElYlcw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:6pkT3wRLjLkoNhoFRrorgF8/NRzH3k509SLgwLg9Ijrt+uKfQg7JRnj9WtMjz+FEJH/UCy162EC/fyTnBKzsPQ==,iv:wNv9ZKy8XzksoNG4kLgU8IKv7ZjD9Gq8P9tshVRpbWM=,tag:dgDHwQf4nDnaEo6WDClOZw==,type:str]
+        password: ENC[AES256_GCM,data:h+yDFeXBqmpEdwQkPnT9Y7TH54lw1/rHP45YY+olDNfhziLLqnTVDTxXtjMjkpMXuQY0uGGsZ1uMDuqCNOpr7A==,iv:ns5bmh2OYuJxz3YpJ8LOisgyKxpxjL7re/9CYFcN+9M=,tag:dkpyTes0RZIphV50InExog==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        KVCDzuJIVYDpLEMDrBsYDGWB9qF3mv60XcPALIjOCX5gyhox0gxaAgy6JcsTb8yb: ENC[AES256_GCM,data:+4pmqMMROXz8els2noEYPZjqauKWvwZfL23ISUiJyePYHPC8WSK0o0iimp/nK2B8kHtPRAQUyIngxOhi,iv:Y3zM2X6VkQTKElLEIgGfcXtkMhR7Tjpbv2gR8XPX9a0=,tag:PGcFiBok/ywHKuObSEsYag==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:14Z'
-    enc: CiUA4OM7eJBFzcyJSvK6w1cybX/kUh5Au83nJalB0vD7PjqFbgBDEkkAZoeZpglOmDWPE2I+rgrTj5k1gHncwAVGp6HLLIgko5/z/ln5xWtLPcxPsA+6T0HvK8ByJtm2AhQKIW9tNxV2f+kF0q84uyPW
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:14Z'
-  mac: ENC[AES256_GCM,data:qAOOeVG8fkH78Stl5RFviGGgu6SfWuYC22rkbE4XSk76VSkSSkCQuZQi9sqw1wsa9D63h8MxnfxvV5OVecztS0EUtarKcN86B87Gapt7sg9ckmPmzosdYwRnn340R/v9rUPRAkJxsrwG1/iXg4h/4uMaLG/dYAflMfMVmF6ux4A=,iv:uHyZh/Hcixmz36ETNFQ9OO1AuTSAN5K84V2YXEGM5rs=,tag:pNMqpCQMJZ7sW7W98YpDQg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:33Z'
+    enc: CiUA4OM7eEgNEPxlK2bwBzAd8NoJbD6YjA3jFyKkp53Txw+HBDBNEkkAPHlbmXxhBg0pFPnrYClEDTyEmmcnUSYYvYvdNLCq5+Q819Cgvu0LUdib/i9e8bBZc4285jAc5QGJ/jaJPkXHuH58/yi6LJBg
+  lastmodified: '2026-04-16T19:33:33Z'
+  mac: ENC[AES256_GCM,data:X7h83zgN56sTN1q8eKkPN9XdNoGphuXv5qKUIFr699aCOmzWZ5kxwmgTDvQUmsfSL84Dn7MVD9WBJoC7VtUx6cUmwfBPWLnFB3Y9ocUmO3JEgTiboLDvrbktp3mf9ay6+mqmSwTeKJWX1rWWquXv5cNW5bYru/9rVDV1Bis/U/Q=,iv:TUOjm2uRisEC1uBpVikbNPwqouNPo2X9LIiktI8RjzE=,tag:9ggXUy6D29HKt8R06GVflg==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/leap/support.values.yaml
+++ b/config/clusters/leap/support.values.yaml
@@ -19,6 +19,8 @@ prometheus:
       limits:
         memory: 20Gi
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/maap/enc-support.secret.values.yaml
+++ b/config/clusters/maap/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:CeaHNK8INNKgfqJbRspcGl33nTqm+VCtCzWOmFsmg1SqCRKlOMsh5IxFGf1J6N9efy0Jplay1txp83Hv/IOZoE8TR9A5MI1N8o0iCr9SxqjUhPfnC86lwf81HZEoqdanO85Dwte7eJzctoxz+hbqYCCbR8Cdkc1UPej6etdXvO0xapCe9Mg3FH0xATTYvxUlItSB9fiJei7A3A8X,iv:FTHSfT6Be+4rFjpRWYxH3PEpw9IfWn2yKqcefK/iVQY=,tag:QffYcTA3dIlKyRD+adtb+g==,type:comment]
+  #ENC[AES256_GCM,data:pp7Skvl8bZSKgBdKzVLNTAi9st935FEIK86kH1izrmvwcrnswFw2SeUoQhiML9ZcCfwGjIC6OhWEHdTEH5NK6vOSIKG6saODI862Ix4n/ayg2EdCnxCBLmz0zzVauK32GhVrH58omxSLj9+SNNxusFG2hJ4Z9kzvDRmlBkVen1H2GoxrYLny1ExGK7q3qZx8y6vosMCYXS1bqEgY,iv:jkSFgZz1/5LGqiX4ZCWywYKWUog/fuibvJ9xUZhyAR4=,tag:qyzUtJ7K1ZUG20ouyX+miA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:rzDq7NyoMdUuEYurR903+6AtzybPInUBtY1F6gl8wIPn7f20sPK9LF9vBe0o2zHR9kLe1VGv4PwU4pTtZf+ApA==,iv:RiJF3v64jnVTLU8gWypw9vn10s0g7IfKWvmkB6pIwZU=,tag:hlHI6ruO4N4JUyoZQ592yw==,type:str]
-    password: ENC[AES256_GCM,data:MegBe+t6+aWXDvYoMSGMF0KNqq9C4P4MLlsw96gQfKYa9WTJTZdo7rGmWh3XRm+luC2jOE0eXlSdJDKZtqtSJA==,iv:Fj51rF36CWzsWlwHNRojKwqLgtx/W0sBVLF6R4kKIig=,tag:MWGXDT7hOUZps1SsIdg5lg==,type:str]
+  - username: ENC[AES256_GCM,data:70i6oP+auQ1J0rAf9e+G6BJp1mq5vTfKJnqnJQelIeeGRNsBTDfSZGKZD3beTK2+qjKC9q5a48uo49VCy1XFFg==,iv:dUwm08VemMSWBKK9zSwpWP/bB5oiy76VAUlAGfH/EPY=,tag:tqZYThB5oHZ27P8/VlE84w==,type:str]
+    password: ENC[AES256_GCM,data:qKPlLWspNB0JJGEpGBwnv8kVKha7ieE7qom0wtp0MRSQtZ7PMIiEbLGKKvZj9Gwc6aLk7D1HnlQyTKmHnycLag==,iv:B2RtHPzSk0zYUsZ+p3n/0+Xvti6eQNt+DTGm+EBE01I=,tag:dvsJSA5/WzvXO73oXY64+A==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:blb3q8RrzWYrDAw6eg==,iv:O9zmoT7kuRzHhMLdUTJ9jnrqn3PsRtncgSdZg/sjKgE=,tag:tuCM1nXi9FqtOjgqW0lftQ==,type:str]
-      value: ENC[AES256_GCM,data:+IskkdFaWUY8MZgVMSF0uV9GKeEYouu5qFIXc6mrYu1MwDbFXL5dLpeP0n3T1OZ2Fg9rOvREa4jxJCRHuSoFbz/57PUlJAIZ9WEgpG5mGDUEAkSrE9kF/b44kO/YFYe6y+dv6frsTsT+bMfoEFDrD2gtlbE8haQNizdk3Rk0P7Bdf1LPbTLqHFTIgDEPnYPGfo3PV4qb2dG7BGQTMhXj1Fzow+7UjF1eAD8y/AqF6mnCuA==,iv:B3BFngWICACir22qEGjUA2/T0ypnF28ugmEZBU+OpSA=,tag:GwxZbQ19de+R9rclXI8pNQ==,type:str]
+    - name: ENC[AES256_GCM,data:ZpRQ+oVEiDB+uFKtng==,iv:uQu54IXwJiMXnjYI0rtjzR5IJgMRFYHzFBozawHe0wg=,tag:zarkIFvP9OpF0KY1+bGr4Q==,type:str]
+      value: ENC[AES256_GCM,data:YPc1HywzW5WLBoKnkynLHH1HPCJ4heIvGshwC0jnShwmehq8lMejCRQ+CaewSItgVDS3Rl6nToXy9lyiAuInvoLyv1yxeT5fVv3H79XslmvwXQSKJraJfR3kMQ8qHPBV32zFQKy9Y+ep12WwBUfHBG+V16w1PE+lKuSVYMpg82zwrsFlVMltKOjd875AZxh2I1gYbtroD7Bmkh+ea/I3IYyGDPivZMtQwp9xmhO0LFIJQQ==,iv:munYEOkF6h7nJecP/6jXk1GEWFAnmHSMW9ehE7hFxdY=,tag:MYbXNp+Q0iHi1cGAuAUFJw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:OwirExKq3YfqDQ+JKOUFJWkmqB4ETLLBbrEvlsHLPNO4ecXFq89D3wj1Dp7Opqu4b9xmnz25hO40brbxTHVWZg==,iv:OrFFbyQIDW7QEAu079MjorZNcBNS9T6YfVMOz4+IaAA=,tag:rddfZ5jkYcdmd57KCos0Rw==,type:str]
-        password: ENC[AES256_GCM,data:17wesxyDe4kFgSmLrYBpZGS2Cj6KBNgqoqNYWpDqaXpBV/huR4PA+oTTGGmlU/UlPNoSLBEdZEUmlUiphRQsbw==,iv:fWvHIuY2u+gXFnl/x4sYGTkdqeOQFYvsCvJZRRSaCis=,tag:ANtLn6idACwaUiWBgcFclQ==,type:str]
+        username: ENC[AES256_GCM,data:PoL2SaBNODfnD+U/bkYdGTfvFrrMFFH21ZuMKyY60FDB1a1WKkBz9hyQI4ZOEUzxZviABY8EvxnWxLaEIuvPdQ==,iv:+NyNpXpPOoxkupzC6CJdvErpOI+NkTXYqeNHJsTVJes=,tag:WRi+rCS9/2P5jdXsSgoDkA==,type:str]
+        password: ENC[AES256_GCM,data:+OGxQ5FFUeLt9zFrbRpPr5XhwfeAZI6d9GunaTlf4mo8YAjPDuAE6jjMJD5u627d8rq+0Au+PbWqbQWZRttCPg==,iv:rQC2w/ktiT4wwFOFbJrVtffLDW+5Lzj1FIfDFFFbxzY=,tag:6xBd7pb/cBlDa90qgiQOUw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        LHaB791vqQdCtiBB6jwx0KB4LA5zgeryfRV6ZEgqwEk3Kz7tv0aMjobp3G9ZYY2S: ENC[AES256_GCM,data:nL3fTeXzL4RTK6kMaqLbSNLOZGrJVG6nFtAABPNcuPFVpCxh5Qy5W6ST1GfH0+ha/lkT4h7p4aWNx/GT,iv:n/MCSYf8zyLwia9hokkpYOnq9tojDe7e7p261Cb9v+c=,tag:mEFd6kALEDJSVjeY33IGJA==,type:str]
+        LHaB791vqQdCtiBB6jwx0KB4LA5zgeryfRV6ZEgqwEk3Kz7tv0aMjobp3G9ZYY2S: ENC[AES256_GCM,data:PczHBb6YeCb4U7DZH1lAvTDqZ+qJ9XfDoucMHdSIYnFZu8Z/gcdHxYQJ6Q+wqwqkFvRG3bm+E9jZeZcJ,iv:uel6otoFSQ8fFME35qEcYxXClCH/S2//9FX2mbL74LU=,tag:41P7eynnBRiWU+zkhUIsOw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:lw==,iv:9zUoaXFz/LHsToAwq1qzGdmn6In0VV2iXsSsLZXhFWw=,tag:D1wbC+x6ZNwyaXZ+oxuh/Q==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:WuEAZMIDzBsMxg==,iv:z84hRcOy7fjSSTYER7fnn+2jPBL1RtQ1SK6Azxh6xbY=,tag:HgI3t8lNoPmGDSAtOlIhcA==,type:str]
+        orgId: ENC[AES256_GCM,data:Cg==,iv:hIeHDt5Bgf9+IPgdMgVIv/oZDXls6mCwgP5l1mIFM1M=,tag:ZDYm3TjDJB/9q+MefDzoag==,type:int]
+        type: ENC[AES256_GCM,data:PQBOnKoNMFuC3w==,iv:kmwhJRq+tZ9Ug9YGmf1RDre8A0xBAr14ip8oupFVGvQ=,tag:JegASopkTM/8FpZ7YM944Q==,type:str]
+        url: ENC[AES256_GCM,data:sRd1swnwJsVYVynWMOJJZDaf7Q5gHYqow+V2EJZ1GF0=,iv:/nntR8FSvo/Dsq0nJB3F9S8ptDdqyB8CqdkdT2Rn4aU=,tag:SqVWR1lZZQ5c9rFXqZOInQ==,type:str]
+        access: ENC[AES256_GCM,data:4o8Q0OE=,iv:LsaS8dv2NdAyrb15+7VaKPKupLLrI85Ku/5xgSV4WSk=,tag:HywoJotwunm3eV5NfVn7ng==,type:str]
+        isDefault: ENC[AES256_GCM,data:uY/pAHg=,iv:vfNhHPIMf5LwZbgS7F2PoV2Ww3umU7wME5/CqDzcEXk=,tag:jY2Rv1jLYlOyeuz1rlsohA==,type:bool]
+        editable: ENC[AES256_GCM,data:iiJMJqk=,iv:b7ombeVzEr+dGFyXfnsv5ZlX7Y8oQRJVLtTDmCdKtJA=,tag:zMBFyJjqu8h+a3rzRPtsrg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:jmXIuw==,iv:NwsVJBMZIuuIDgU5Ffl2Q3hMLTuoEKcHbIymXZHh/60=,tag:yWfiwbxDKElzkwPEdLiZsQ==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:oHyWdT/Mfg7FD5yjf8qamKSpt8heF5Wq8kvaed/OL1Jc5BBXHdcuzLBOrmG2G/SkhQSJceJ9TpXTgiygyrT4Gg==,iv:WbqL8K/MqyZ7lRKBjQdOymIxS2fl5cEbL51VsKN0Pmg=,tag:KW00D/kXB/gLp8XDHDLEVw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:09S1Ngzjz8c4qZc22y+U0Bt8OwbCrvOMKZRsHub4y/vDqExLo5dxVFNl83FU0WXx6LdP+6BEUF8qI4F4DTotAA==,iv:k57eogw+aWitVc7PWGcu3d0MW7YZu3zKEJxAF1wup6E=,tag:VFfpp6L2fsdFJ7CxI45QAw==,type:str]
+      - name: ENC[AES256_GCM,data:sNU2z8qfe20xDEZ/SFQYcUVwuydS3DnSMigkpB/jbw==,iv:RpRI4bxKXgmSojrAl//NOfDuQwbobwbtEKcuyZ6ShVg=,tag:KLfQ65vpQ2dMBC3ydosppQ==,type:str]
+        type: ENC[AES256_GCM,data:kB3x22e4Ho8wREoXri/OwdbWQ4Pid3NNbLCEG07Mwg==,iv:1IeMcM0s2ZkAE/ZxZkK8dVWroHO/CZGoIeqck0h+s1I=,tag:R6elrl8t0JYE+VL2jxZhzQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:h7t9utU=,iv:EBxD8is+REMsUveCzNVzZOnK/K4ood80aLNATa+rA1Q=,tag:EHaLXD3X1wsAE9McoMHxnA==,type:bool]
+        editable: ENC[AES256_GCM,data:K+7VmQ==,iv:3Ots3GrSk25JN+9Rjv0dA4i0BB5BQBMGub99KjrvOLc=,tag:qHiz6t9OkEmrUpvP/E5bLA==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:42Z'
-    enc: CiUA4OM7eIVu6eJR0kYnyPmulSu8W73dwyKeWpK7yt2bX663F90PEkkAPHlbmSfCu/0uso1ImicR8UPn9N1vKEFTOspov1UD4hexD69e2koYGUgZzqQrSx0HdjLWGRo8QGmIWbvfTyifYA6AzOAhbDmP
-  lastmodified: '2026-04-16T19:33:42Z'
-  mac: ENC[AES256_GCM,data:l9Gfh0vLF61ED9Ve230ETKHWNKnh9koE2be2PSculvPGg9QlKJuVO689L1x4zwlBveQOfBowEBf3X9/o+2vvNWm0AOQ+DWu+o3QUJiShZr17QnzxfbPTHFTHFvs+A4eJn1j2pd4cvCxCMHIzxYzd8S64E22IS800yMUEoRdGVoA=,iv:lFxC2N2G7m8dt6fxg9JMwCPQipGdcwrVCOsgEXVdMBE=,tag:awqsTh0FkcmfarLdNM2eJg==,type:str]
+    created_at: '2026-04-17T08:25:05Z'
+    enc: CiUA4OM7eIg8//nJNZJ7UjQ9JgUoiC0K6YR8n/F4XUgl8RpGUvZpEkkAPHlbmWmJC7xyyn9TAxlavYUt8nGYR/4jIyMJTo3bo7ud0B+89UFUA/LMI6eLk9WZU5s4RXN7vrbmu7oyEFBLeSeIRlj+Xm2L
+  lastmodified: '2026-04-17T08:25:06Z'
+  mac: ENC[AES256_GCM,data:ORvP6GYRK/AsdMOl2RhHhjy+kJgJpyFMPJhBl/T3ShiimydOpp9REpZRNc/O6fXHZQDGRXfPkjoJq8atvebI2K/uWUi9CrkwDT57MM3gFGwOX7ME4JzzuwrV+GBddqXRPfx0q7AKh0SrNyOcHXnmy7/LgePOdz+fvJfOgixPdWc=,iv:KrEma0YHqpVGkd/LEwWSsDPyyOgUO7fKAjO692YxHOI=,tag:WtpJAwWNLeLadrKtLEKPfA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/maap/enc-support.secret.values.yaml
+++ b/config/clusters/maap/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:kZ5Vrd66MbkRG8/XoG9MWabfoigbvLWwf0B+4BWm8CdcrLr1Eeaz9wq0NcCeqavHniXdjlNTTPQK10mLS9cQRuOcLDyLRhLmjE/AlCPmHrd59+UMlEhyHWZsvHe1oJmUTrXiIdSyWJ6cslvFlw+ZTifqZZ/PeTRrR8reyHxf+C3vkgSUmasfx1IGeuFFfX9aaCTE2zkVmt/9xEbk,iv:4F78imdKS85obfMB3qdvGK4csNQ2ht/FLbcKGLVL9C4=,tag:eqeuNqYlCbp53fJjXNiOMg==,type:comment]
+  #ENC[AES256_GCM,data:CeaHNK8INNKgfqJbRspcGl33nTqm+VCtCzWOmFsmg1SqCRKlOMsh5IxFGf1J6N9efy0Jplay1txp83Hv/IOZoE8TR9A5MI1N8o0iCr9SxqjUhPfnC86lwf81HZEoqdanO85Dwte7eJzctoxz+hbqYCCbR8Cdkc1UPej6etdXvO0xapCe9Mg3FH0xATTYvxUlItSB9fiJei7A3A8X,iv:FTHSfT6Be+4rFjpRWYxH3PEpw9IfWn2yKqcefK/iVQY=,tag:QffYcTA3dIlKyRD+adtb+g==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:PvMk7C3Gl37e2zFlnLF01VCrdHKIW1MwRV0DCorq5eQVCzmEqD1TsV1m+W2GpsF/e+LTKY8j8qgQe/HL3KYweg==,iv:NahLkIbukoroL7q7/VscABbQEwv5dwTFZOf3rZ5+IhY=,tag:5SFLD85iFVCPuSL1Wc825Q==,type:str]
-    password: ENC[AES256_GCM,data:82kR0UxC7DQdXEEETi728YYdyX/1OSYp3b0P5YQ5/0tQaMRtDWwaPLj6qAl2R3c9ElsCsuBXu9/npaKWQXq9yQ==,iv:z2D9Ed2XB8GCXwzaWF4qP8iilyfjFwObWM/h/mzFjuU=,tag:2rxksgl08IHV2uhelBGf4A==,type:str]
+  - username: ENC[AES256_GCM,data:rzDq7NyoMdUuEYurR903+6AtzybPInUBtY1F6gl8wIPn7f20sPK9LF9vBe0o2zHR9kLe1VGv4PwU4pTtZf+ApA==,iv:RiJF3v64jnVTLU8gWypw9vn10s0g7IfKWvmkB6pIwZU=,tag:hlHI6ruO4N4JUyoZQ592yw==,type:str]
+    password: ENC[AES256_GCM,data:MegBe+t6+aWXDvYoMSGMF0KNqq9C4P4MLlsw96gQfKYa9WTJTZdo7rGmWh3XRm+luC2jOE0eXlSdJDKZtqtSJA==,iv:Fj51rF36CWzsWlwHNRojKwqLgtx/W0sBVLF6R4kKIig=,tag:MWGXDT7hOUZps1SsIdg5lg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:blb3q8RrzWYrDAw6eg==,iv:O9zmoT7kuRzHhMLdUTJ9jnrqn3PsRtncgSdZg/sjKgE=,tag:tuCM1nXi9FqtOjgqW0lftQ==,type:str]
+      value: ENC[AES256_GCM,data:+IskkdFaWUY8MZgVMSF0uV9GKeEYouu5qFIXc6mrYu1MwDbFXL5dLpeP0n3T1OZ2Fg9rOvREa4jxJCRHuSoFbz/57PUlJAIZ9WEgpG5mGDUEAkSrE9kF/b44kO/YFYe6y+dv6frsTsT+bMfoEFDrD2gtlbE8haQNizdk3Rk0P7Bdf1LPbTLqHFTIgDEPnYPGfo3PV4qb2dG7BGQTMhXj1Fzow+7UjF1eAD8y/AqF6mnCuA==,iv:B3BFngWICACir22qEGjUA2/T0ypnF28ugmEZBU+OpSA=,tag:GwxZbQ19de+R9rclXI8pNQ==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:OwirExKq3YfqDQ+JKOUFJWkmqB4ETLLBbrEvlsHLPNO4ecXFq89D3wj1Dp7Opqu4b9xmnz25hO40brbxTHVWZg==,iv:OrFFbyQIDW7QEAu079MjorZNcBNS9T6YfVMOz4+IaAA=,tag:rddfZ5jkYcdmd57KCos0Rw==,type:str]
+        password: ENC[AES256_GCM,data:17wesxyDe4kFgSmLrYBpZGS2Cj6KBNgqoqNYWpDqaXpBV/huR4PA+oTTGGmlU/UlPNoSLBEdZEUmlUiphRQsbw==,iv:fWvHIuY2u+gXFnl/x4sYGTkdqeOQFYvsCvJZRRSaCis=,tag:ANtLn6idACwaUiWBgcFclQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        LHaB791vqQdCtiBB6jwx0KB4LA5zgeryfRV6ZEgqwEk3Kz7tv0aMjobp3G9ZYY2S: ENC[AES256_GCM,data:nL3fTeXzL4RTK6kMaqLbSNLOZGrJVG6nFtAABPNcuPFVpCxh5Qy5W6ST1GfH0+ha/lkT4h7p4aWNx/GT,iv:n/MCSYf8zyLwia9hokkpYOnq9tojDe7e7p261Cb9v+c=,tag:mEFd6kALEDJSVjeY33IGJA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:16Z'
-    enc: CiUA4OM7eHZfF/I43b8iIcQa2NeavkMZpmZnfsKGieTV+4XyCntLEkkAZoeZptAidavzSFcpaes9NGWItt8WMFNncVw7P7vyw4yZWKihAVF1821UzSTa530+i0Z4zFPGVQM5zxeaAXcd5E+/2ioa+j5x
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:16Z'
-  mac: ENC[AES256_GCM,data:68aHWtXeBU6qPnw8HozrnAzPqbZVk71hpc6ZcW7hjNCmpz7PmFMRTKtChlWN8cPiv9kDn5IseB5XsC5Xuiqhp6DoR3FTwGyB2xfGNkazD3S130cP2SZtRWct8WEddIeWwsLaXgpKwRz0cbJGeyiZNHlmR8gRYlAmuxF2WLqR+NU=,iv:MDAGgM4mXEdQif3esgDeLx4mVgS0dI8SkcVE2z+JF4k=,tag:Ooguj0v+rLSmB1PA2dELnw==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:42Z'
+    enc: CiUA4OM7eIVu6eJR0kYnyPmulSu8W73dwyKeWpK7yt2bX663F90PEkkAPHlbmSfCu/0uso1ImicR8UPn9N1vKEFTOspov1UD4hexD69e2koYGUgZzqQrSx0HdjLWGRo8QGmIWbvfTyifYA6AzOAhbDmP
+  lastmodified: '2026-04-16T19:33:42Z'
+  mac: ENC[AES256_GCM,data:l9Gfh0vLF61ED9Ve230ETKHWNKnh9koE2be2PSculvPGg9QlKJuVO689L1x4zwlBveQOfBowEBf3X9/o+2vvNWm0AOQ+DWu+o3QUJiShZr17QnzxfbPTHFTHFvs+A4eJn1j2pd4cvCxCMHIzxYzd8S64E22IS800yMUEoRdGVoA=,iv:lFxC2N2G7m8dt6fxg9JMwCPQipGdcwrVCOsgEXVdMBE=,tag:awqsTh0FkcmfarLdNM2eJg==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/maap/support.values.yaml
+++ b/config/clusters/maap/support.values.yaml
@@ -15,6 +15,8 @@ prometheus:
         hosts:
         - prometheus.maap.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/maap/support.values.yaml
+++ b/config/clusters/maap/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 disableCoredumps:
   enabled: true

--- a/config/clusters/nasa-cryo/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-cryo/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:AP50nNLTvmpD0D/i9qgZv8cnUUGTECCBwsxjsEeqqhFlNbOHXCjX0w0hjOfcTVw8nis4bS4nv1MjQ8C0U/VqMyhR2yZov0ibwwVFJI6YFIoB+WD4pM3nagOEZcghTbxbJKhiLwH4lkSbLMNL1pfGPfXFvV9x6OXtB2XMcVgpkdZUEmfp/6eudBgOk2RmO5Whqr9OJu9OGkb3OY85,iv:2Tn7umxvHuel6dhufnvR1CQYLorfXDIcVCcXjsdKwSY=,tag:3n1dhXcW0TYVBJ1yAqv+Fg==,type:comment]
+  #ENC[AES256_GCM,data:msw6/MR4WlkP5TgQJYdZhN/4jbcg5CNJwZ6aB7X9413fwf0Lo0CEa0mU40wMWFCYp9N7xZ5zctzCknj/LvH4pxPEdPfFD0g9Ei7bzXN0mFK534MvVJmA3LBhJiTNSSek0TRVl08iMViDOsFxwdWThqU9rDApc6n9ir7D+0aRxtKRvovxouN/XEmkwCc7TIKYQthDczkCpRx9sLaP,iv:9+e6WazLaMTi9ykPJO1OFzby6DFj1qnAMr6N9gH26rI=,tag:DimG7bwJSuiS4ZMQif/Z4g==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:OG7APEmtZwb4hSRFvApc71q5zsmM9UVhkGnZKT/v4YoCkZ8prpo6Xo6YlLvCNUBxoeuJbv4ZnFKVf/w/pxaCxg==,iv:aH5jO1UUweFxekr3vkdfQpGD8kR595Nxyg61dqt0fk4=,tag:YkgtCDH33emMPsS971Hcvg==,type:str]
-    password: ENC[AES256_GCM,data:n4n6HYQcRBLE95Q/XwTsfcrL9b3Mq6CkYNpXGZZf6qmQWvLWo9Bi7SF2sz4FaBOws3HrbWMpVa07xvXDRcJniQ==,iv:iOKHlX6ZpqFvE6WSq53ALLd29eDiwx2AEzxNFCFSt9k=,tag:fW5eWtI67eLgp0T/JQ+TMg==,type:str]
+  - username: ENC[AES256_GCM,data:qoyAU28KDQhsx+KSkRjuY3M22upYKh82dnDiSr1PBGjGKWyAlSxOmSsYzRJEivBF3Yy0pdUyxLtvOtYxQ/gM9A==,iv:ILgxkXYkvynPHrjmc6iP6nmZQKwvZuigfkH7S/O9S2M=,tag:AjQmgqEEl2IAJioXDBJayQ==,type:str]
+    password: ENC[AES256_GCM,data:5aQZywbz/KlPgEhYeIvMJN2dmNrJQY3cawYCVeMzIJwNOfUo6fdehzxFXtpybhrY9y91W5qkCMYHkoZNEiE99Q==,iv:/wA0pT8YbvnExejBx6NvsRKI/YMssyjZ2CytKz5X0Zk=,tag:7HG2CFNsJrDr03Jn6o02qQ==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:SU/i9ed3j6eAnb6id83FeaQRQzI=,iv:lGy+TakSaNR6nMVlvbUL/KfWrKgKbPIBhlh5qSy7yOc=,tag:T4j3DDvDgWzds8etA4TUiA==,type:str]
-      client_secret: ENC[AES256_GCM,data:JbVvOrgEE/lfULK/yKFsOGnKR9QRhra0Ld4H32oYiistSCdr8G0zRQ==,iv:qH6OMN4SvL7Ts2VXNmcNtTfcHyQ4dvejgkTZPeoss7M=,tag:xZUZcguQT2gblhPpkjp1Cw==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:IQ==,iv:TKE/qzd9QkOiGxePMbgsDFW1CKhHuDL56FvZHTLQYSQ=,tag:VZek0bNaJq3Wsos9DD2Jug==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:34GVobDN1Y9KEA==,iv:JgJ2uOOaPdBvUaIvqK/n18Q8/ia72HxZuR5zC/75hi4=,tag:f4dDJdmgUunA63OfRGHjxQ==,type:str]
+        orgId: ENC[AES256_GCM,data:Dw==,iv:OO35lQmtUnaybT6njfCwTgRCT4Y+SvJTijdwiSQuuEc=,tag:lXwZ2E3/VeqmTLtQZzJ7Yg==,type:int]
+        type: ENC[AES256_GCM,data:EKY20P510bfRVg==,iv:jdNmvtiCPWPggcqJ2V9XmYHCN3hn13opDk95FmedVCo=,tag:+lkIjAjZM+rQj5LtKp43cA==,type:str]
+        url: ENC[AES256_GCM,data:su8gFMncVUZba5nNofDwiWoqrP7CCUlWjXTFElEERUU=,iv:ANwpEDeMNuGhUIWazd4c405XDz2AlcwezANATXUm+PA=,tag:4mtVgrxyKPjVbZWpOLy5eA==,type:str]
+        access: ENC[AES256_GCM,data:MIzwfiA=,iv:mmqqDx1IViXqg9saiRPzmi1EnjfAi3TIi+PR8/cl6ww=,tag:gPLHdMvGChNbIVdXI+EvYA==,type:str]
+        isDefault: ENC[AES256_GCM,data:TXXC6xU=,iv:TrdwWnZtDLFjFUhVZHZC8sZj4kNg24My2YWs7Rt0e7I=,tag:+XhsuJC7vLKaePQm4HFKGg==,type:bool]
+        editable: ENC[AES256_GCM,data:4Q6YlPU=,iv:o2YYIaSCC2DRPMKaH0XF93YM67TRbh0QEj1Dc6HB5DA=,tag:3SE0zm+mhwwe9x5X5FOPHg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:7xmUkw==,iv:xR1YysAi2Ou/huobc8/PxPzRX3Tt8C9v0syFSpAUOo4=,tag:TTxMYzZg3FX1nbi+Rn0xpA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:5wYJV1YbpHgUA3Mag6Ix29YXTrDieZVJMd1h2+CEaztCH0milxfxt1oGH9oqN2gnL9GKgs4UM5eKIyKEfklLwg==,iv:+g70fqr+H7xgsTt4XyLm6v4YyG/GEg9z6V9Z5mUgnQs=,tag:8f1RPnbP4Sn1vpifXpHp1w==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:zWHKQ8wC8qR8Lez5nMeW8OUZ1bFGZZ/61zzHc7XH8C+YDf6zvYHN0NtuDxY0bb7nLXysx89tFizI4sK+YJQ2lQ==,iv:IjPxV069Ivm1PHCL83wNPVgaIFyqgfIREIj0K+ZsFd8=,tag:rbB2X946pyh9X/098Wzgdg==,type:str]
+      - name: ENC[AES256_GCM,data:AdWXjPTeG11nHwc9t+8WRTe+9GrTVJERLw3+6Ygazw==,iv:ptRTkg5BiLlN84v1dKV0wyNBGAUWnCrTz7BB3ewl47Q=,tag:lOrb+yrcI9vfjIsTRzSpGw==,type:str]
+        type: ENC[AES256_GCM,data:/LDqozR1gER3ziGMW2veBdEafFzMHXeQTd2FXwIkBw==,iv:5azyN00EQwWXLAk8tLeGRrg0ObA0Hj3eXhLiAzMQQyI=,tag:bDJdaIkm7OTJCdf5kt/4qg==,type:str]
+        isDefault: ENC[AES256_GCM,data:GomH1VM=,iv:/yhKl7XDWxHAga/VuftSgEsK4VkYGpZJvcVPOvLZXdc=,tag:+90IcK6frw/z9ttrkmbP2w==,type:bool]
+        editable: ENC[AES256_GCM,data:mwns4Q==,iv:d4QQDkU3Nct7tecDF9WaYKqwU39qcfrb1wE25FIOpVQ=,tag:cV7Uh4vtRUY84dPKkYsCpA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:3RHRjkzbP619JhlV/A==,iv:5hROAAAdEr0lhpZLOYHD0f698yJgs/pfFzplLWP/ZUc=,tag:u0vOQU+UcNPksrWqTC7J4Q==,type:str]
-      value: ENC[AES256_GCM,data:pqgIlxxQHVSDqf1Gt9ovjzcDRR9ClU/xPESKQN78ZbbMSVuSPp/vBiHP4K7iGgtXOvfF3EFfmCoswRMlLLeIBlSxpw+liFhHbWMO6o4iiCbApfJWcHNZlVkZKuDp1J0y0++HrMiiTb/Tz+2azuhNyQpaAddu8DbzTXynB1/atsn4AYLayscOkqwRXaSMt/Hf9HCtwFIbQk64/Qy8UeT2p2AH+Q23vS1CStTKajY7XjW2BQ==,iv:BZcCHRPGk2wmdan4D+mRJI/BFwCfCwATaorIAiR6HlI=,tag:UN0rhGTsPCSQydqn3m+bZg==,type:str]
+    - name: ENC[AES256_GCM,data:TkNxYnsuU68Xfr6OMQ==,iv:mwVN//BhtIKgZ3BFBGpnvdnUbQpW2XhWy9kSznSVLqA=,tag:0WTk330svL6dMdEYtGg/RA==,type:str]
+      value: ENC[AES256_GCM,data:QafUCnc+OcfcFnxMTuvJ0bwckhDwgLxXP45oZ6VIQV7bYlQrb6K+w60r6wLNGiO6u8iOHFuJdZpWeCJxmfvLeoaCpp1hCbIL4QKeHEKDA5mGxuGcimnx2lC9BMfZ5IvNWF/a86y+btDDQyaGnk69P8MzyuH3+7koQtofe2h1J6OWfzY9Ku5avLzwJ9j/FrrvbvheJWcwQ7cKCufW7E9jKsSkLBV3xFSUo/rh1uNEToN5Sw==,iv:67eyzamCbotTv/60rDXSiQFqJfXcawWRUrGat9a+HPU=,tag:aHS2KSBRcUrvIxAvdPU+uQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:uqaFlguEzS2NCGbs2geNxCRjvphDx7l07oiC51hJ1oPBDO37mj7Q6lxzTC2yYLfTfUkUVrLte0yzVHxbUXaVSg==,iv:TFwKxG13wKeemu8R6MCWuWHt86Of+EX70jFj/CsMCsk=,tag:+qzWhwGIOHmyKkHZjNrg4g==,type:str]
-        password: ENC[AES256_GCM,data:jZAyLkonBhj2bHJaV1QjKYSwGAwUXhNoKFZHRfGLKZyDuX8OKIgg9pbANiZR0ZMEZKNfBZnKFGrSRUWgCa4c7g==,iv:13U4o/DVI66YOD8A0i5fX/6+icbRUnnHZ8vWvExD1mY=,tag:c1wTVgKKbjlV+dSp49ixFQ==,type:str]
+        username: ENC[AES256_GCM,data:iA/vjJ+yMcRhtK32ccN56sIRsSmLirn4k+MGf9H5DbFV0yE/8y9lZeM3GeDVBWooV2mKmWSGx9VvMJNWK1RE/Q==,iv:ViZ3r75glqgIBmA0QkmWXq91M3+KrraeXps2xmg/qSc=,tag:X2eS/XR4uZoI54l3Xpxxfg==,type:str]
+        password: ENC[AES256_GCM,data:SHAtDL+sAVthrS0hmFrFCbQ34lxDJ5dsuBGnw0pBOw9J21PC8sA2zFIdqlnUgfBdHBPHDQEvqC6jggUgvipf8A==,iv:iFYJTfTA0oEZoxFG/4Oq2we9OWGzXbOkf+4Jz2dBzoM=,tag:sfdx9p44oaNtqPzRsgOgqw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        J0drkJz8V9PuwBTA1ctEymznzwgDri5BsAdfL2M2YT7zSOgBozmKiPaFHxh11ipU: ENC[AES256_GCM,data:YDCVSNF8mMydvN7glvuEQh3NoyPzWhMf4SzHWjp4wXt2iAxEWqKd4YxjPLjOXUEuLFOcTZZOPutVYRWc,iv:/vTCqgItWDhnn+8XYjC54fJGIYDqx4jh7LpAEI/LiTQ=,tag:p1MvQPE3yqSmYdfSzihEoQ==,type:str]
+        J0drkJz8V9PuwBTA1ctEymznzwgDri5BsAdfL2M2YT7zSOgBozmKiPaFHxh11ipU: ENC[AES256_GCM,data:q6wCIS6Iw7Aa198RqZ7artKMDjH5wY6awk7Z/n9NGW9vWKOnrNFMgLb9wINFwKHsXH17Fu/dI1rBeDnA,iv:VPPLGnqMFW3uXFZgyoI0RHPbmao5rqSCypPa/c2btJI=,tag:hXO71NddxFhQlxEhA3iuaw==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:36Z'
-    enc: CiUA4OM7ePjcjci69wq+GnShtfVttvkqEsuDFKYHOYaO1t1ZwcViEkkAPHlbmal2p29iSEH39VaA6vsND3KcXrvDnior7p6RVecuz7gDBFtA7bGQiJoztADkp7GVL7vMIG5SN6Ls83kHR3F5Bojy77HB
-  lastmodified: '2026-04-16T19:33:36Z'
-  mac: ENC[AES256_GCM,data:B3E3GCLFfJMCUG5cYVQCDS+OJHHnBYJanuDvBOsoslULKsVbwZRgzS4uHAJkrkeMMigiTougRXhehf82VOOf+q3WGxapL0JtIMBkmSWpni9gGSCK4zMxdf7O93PmtgT+F/uYbhSlzkc+ezKOYwMMbQzFnav7LQVIN+m48vvvex4=,iv:8mhJFtRG+st2E8hgn0RDPctHn+RzmJzIT06ZXJ6F20U=,tag:uk8W1hh2qQeZztc5r4fHhg==,type:str]
+    created_at: '2026-04-17T08:24:59Z'
+    enc: CiUA4OM7eNHyeZrbP9iC/JrrngmRSRjj57fSuevMZR71tDf6UVMqEkkAPHlbmassC+OpIp9W14TNlztmZP+gWH9OEYpkicTCnicqCUTUupTQFkCKzIt/2KdXTm8QlwXN2i57oJ7lrbtQ1HOBoQIPnwcz
+  lastmodified: '2026-04-17T08:25:00Z'
+  mac: ENC[AES256_GCM,data:QYQWy7Aahn6O8aKsOh3dANpamHE09WkV6xgMJKrLoflv3xbb2H3n4/XuZeQ//VcBInekQhxLLCSaWGoaObbkqq5vMQcIzfoUpdKgULgBljoyFXauCll7JwVJmKjIaX9D5NWJcQGWZkFqQn8Sp3RH2x7cXeLdJ8yAtD5eI96I95Y=,iv:/jGQvtCAqQ4NpJFMlt4SnBoGgPw1lgy3xos+n9z3WC0=,tag:y1T3Okailhl+7bUWnRZAhQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/nasa-cryo/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-cryo/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:8AQoQFwNGhlV7A6kj3AyqUvmlBIkM6+6AWYMrz6Fr0vo091Ie2dQufMu2Gri+8v8UEOZuwXmvXsN9BZ0v11R1cp1sUtwFAfy+McalJuWud76DxaMLt7pI8qDsQqRvW66fG2PBx+Ic7GI2NPOvkBGk4GPwMoahUjp6qfP4LhFXyR874t7sX38+9aNlnAdZWq7/7L3ERdWevJXeLj+,iv:JMQPF6+/7rFfn6CmVDpVkgSCaVmpVZPI0KjMj1EyMnA=,tag:0qQv+ThGHqmow/30VGYI9w==,type:comment]
+  #ENC[AES256_GCM,data:AP50nNLTvmpD0D/i9qgZv8cnUUGTECCBwsxjsEeqqhFlNbOHXCjX0w0hjOfcTVw8nis4bS4nv1MjQ8C0U/VqMyhR2yZov0ibwwVFJI6YFIoB+WD4pM3nagOEZcghTbxbJKhiLwH4lkSbLMNL1pfGPfXFvV9x6OXtB2XMcVgpkdZUEmfp/6eudBgOk2RmO5Whqr9OJu9OGkb3OY85,iv:2Tn7umxvHuel6dhufnvR1CQYLorfXDIcVCcXjsdKwSY=,tag:3n1dhXcW0TYVBJ1yAqv+Fg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:8Zlg11URnHJroRlQk9bYURKbHFQEAi7RxjXDU6pDbbp7nz7E0hA62l9KYcHXlDPCIC7JO+paeKapj1U+hkpPXw==,iv:kX1ru9taH/qaroAbP3eOOGEp4p8PhFR9yLR1CwGVF9g=,tag:NGuMJNRL5BgISWZnNkJJAw==,type:str]
-    password: ENC[AES256_GCM,data:ythGJ8t4pEDfSOxW24w8LecqbWbf8hPaKz7oLwnYeiKD/VfFICUV5x3fYSnZ/rI2wA91aZyED8NHCF5CuEBGpA==,iv:vOzT0izcrXolaD7XFDvyv76a2yl7/p5hLfzn0SE6uBE=,tag:3O4ORfAb8UzMZKA7RgrOlg==,type:str]
+  - username: ENC[AES256_GCM,data:OG7APEmtZwb4hSRFvApc71q5zsmM9UVhkGnZKT/v4YoCkZ8prpo6Xo6YlLvCNUBxoeuJbv4ZnFKVf/w/pxaCxg==,iv:aH5jO1UUweFxekr3vkdfQpGD8kR595Nxyg61dqt0fk4=,tag:YkgtCDH33emMPsS971Hcvg==,type:str]
+    password: ENC[AES256_GCM,data:n4n6HYQcRBLE95Q/XwTsfcrL9b3Mq6CkYNpXGZZf6qmQWvLWo9Bi7SF2sz4FaBOws3HrbWMpVa07xvXDRcJniQ==,iv:iOKHlX6ZpqFvE6WSq53ALLd29eDiwx2AEzxNFCFSt9k=,tag:fW5eWtI67eLgp0T/JQ+TMg==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:JNR5XzJL5se2M000uLxx3rB15wU=,iv:2y2d6ABBHtbCssdTpdY6O4zNMitKJ3BRBPhvgo4NfJI=,tag:kd9J6xNFr8SezBfOGc5F2w==,type:str]
-      client_secret: ENC[AES256_GCM,data:X72lTFr6TO3uZ1MVNnex1o57w1svleh0qwcowL9LRx8kfnSwutEK3Q==,iv:LqnjjQDClIpxrzjqcbqKOXVoJ49c+vnrXz0C0E7hyUc=,tag:AwzwwGEaVd3ba2EXT8JZrA==,type:str]
+      client_id: ENC[AES256_GCM,data:SU/i9ed3j6eAnb6id83FeaQRQzI=,iv:lGy+TakSaNR6nMVlvbUL/KfWrKgKbPIBhlh5qSy7yOc=,tag:T4j3DDvDgWzds8etA4TUiA==,type:str]
+      client_secret: ENC[AES256_GCM,data:JbVvOrgEE/lfULK/yKFsOGnKR9QRhra0Ld4H32oYiistSCdr8G0zRQ==,iv:qH6OMN4SvL7Ts2VXNmcNtTfcHyQ4dvejgkTZPeoss7M=,tag:xZUZcguQT2gblhPpkjp1Cw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:3RHRjkzbP619JhlV/A==,iv:5hROAAAdEr0lhpZLOYHD0f698yJgs/pfFzplLWP/ZUc=,tag:u0vOQU+UcNPksrWqTC7J4Q==,type:str]
+      value: ENC[AES256_GCM,data:pqgIlxxQHVSDqf1Gt9ovjzcDRR9ClU/xPESKQN78ZbbMSVuSPp/vBiHP4K7iGgtXOvfF3EFfmCoswRMlLLeIBlSxpw+liFhHbWMO6o4iiCbApfJWcHNZlVkZKuDp1J0y0++HrMiiTb/Tz+2azuhNyQpaAddu8DbzTXynB1/atsn4AYLayscOkqwRXaSMt/Hf9HCtwFIbQk64/Qy8UeT2p2AH+Q23vS1CStTKajY7XjW2BQ==,iv:BZcCHRPGk2wmdan4D+mRJI/BFwCfCwATaorIAiR6HlI=,tag:UN0rhGTsPCSQydqn3m+bZg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:uqaFlguEzS2NCGbs2geNxCRjvphDx7l07oiC51hJ1oPBDO37mj7Q6lxzTC2yYLfTfUkUVrLte0yzVHxbUXaVSg==,iv:TFwKxG13wKeemu8R6MCWuWHt86Of+EX70jFj/CsMCsk=,tag:+qzWhwGIOHmyKkHZjNrg4g==,type:str]
+        password: ENC[AES256_GCM,data:jZAyLkonBhj2bHJaV1QjKYSwGAwUXhNoKFZHRfGLKZyDuX8OKIgg9pbANiZR0ZMEZKNfBZnKFGrSRUWgCa4c7g==,iv:13U4o/DVI66YOD8A0i5fX/6+icbRUnnHZ8vWvExD1mY=,tag:c1wTVgKKbjlV+dSp49ixFQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        J0drkJz8V9PuwBTA1ctEymznzwgDri5BsAdfL2M2YT7zSOgBozmKiPaFHxh11ipU: ENC[AES256_GCM,data:YDCVSNF8mMydvN7glvuEQh3NoyPzWhMf4SzHWjp4wXt2iAxEWqKd4YxjPLjOXUEuLFOcTZZOPutVYRWc,iv:/vTCqgItWDhnn+8XYjC54fJGIYDqx4jh7LpAEI/LiTQ=,tag:p1MvQPE3yqSmYdfSzihEoQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:14Z'
-    enc: CiUA4OM7eKQggCp4DFOcEYBYQlM4zq9npZ/K+wwpNypOubTv8gXzEkkAZoeZplHVEvkeDtH6soGfsJglBCXR+JNNe7+qxIrywNQ3Tm2v2Aw9RRt654DABpFj2VlwlpDHLIs0c9X/FY0Mcbsu5ZgjTr6a
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:15Z'
-  mac: ENC[AES256_GCM,data:LZ8RWJkmTVOs+9dPdGNDLb757aNKshM+YV/p/c1ddGgAbAEMRQG/l3t4FJ1mChYBzTX7iialWY+h0wNmwF1CUBqXRLURkqV0PPKiz/YnxD2Q/ZqgQROGos8Ig2flo67LIg3HXiJVBjgerUnmO0oydw+vPjPEI7uGdejpipqLgqo=,iv:9cNIt0/P7oUVjjPe5DOrQ8gGOTUOgIMzTb664pa53E4=,tag:GSLi4YGayMG65M9igoNMtg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:36Z'
+    enc: CiUA4OM7ePjcjci69wq+GnShtfVttvkqEsuDFKYHOYaO1t1ZwcViEkkAPHlbmal2p29iSEH39VaA6vsND3KcXrvDnior7p6RVecuz7gDBFtA7bGQiJoztADkp7GVL7vMIG5SN6Ls83kHR3F5Bojy77HB
+  lastmodified: '2026-04-16T19:33:36Z'
+  mac: ENC[AES256_GCM,data:B3E3GCLFfJMCUG5cYVQCDS+OJHHnBYJanuDvBOsoslULKsVbwZRgzS4uHAJkrkeMMigiTougRXhehf82VOOf+q3WGxapL0JtIMBkmSWpni9gGSCK4zMxdf7O93PmtgT+F/uYbhSlzkc+ezKOYwMMbQzFnav7LQVIN+m48vvvex4=,iv:8mhJFtRG+st2E8hgn0RDPctHn+RzmJzIT06ZXJ6F20U=,tag:uk8W1hh2qQeZztc5r4fHhg==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/nasa-cryo/support.values.yaml
+++ b/config/clusters/nasa-cryo/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 cluster-autoscaler:
   enabled: true

--- a/config/clusters/nasa-cryo/support.values.yaml
+++ b/config/clusters/nasa-cryo/support.values.yaml
@@ -33,6 +33,8 @@ prometheus:
         hosts:
         - prometheus.cryointhecloud.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 calico:
   enabled: true
 

--- a/config/clusters/nasa-ghg-hub/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:OZthje3dnOAwIszHcH1EpRxXZYT1jd+Sp8aEWZgsMxCdEVSuyS3mTFq6F4+pv0kUx47fvNTQqzSfFZ+HfwqRP2fJafry5rKY8PJ/v1L+UeEtMRH92vshczMozutJuz9hptY24KjuSAU11RNMSNllSJ4OeAcs9Pdbz2yDQL8vHaQL9iYcI7tQ/zFVf7jX3uBC8I5Z2tFjqAqgMtY4,iv:osoSD9IBgLT/8SzowrJRBBNAblQD/29dz8mtTIcqU+8=,tag:+hg0iLx5uq22aevNTtg7GA==,type:comment]
+  #ENC[AES256_GCM,data:KSGyytjxI0IyhD4dnCPtmdTxLluO3p0w1gpCuiRllEkqRf4tpizQ4FDy9u5R4n3B8gexE1i+jy4ikmbva6dbYOvC0fB8x5GtM5LpMuk7cGkwxgymEr8jQK/7fQJQ+JHWo/T1Xb9FQrwKeu+P7Z2cMpNmQTZMU5/3vm3X9ijFsnlw50wQbFlv3gdKv9JyNX5EF9j50BZm2OSn665q,iv:d7ZVabO2t3BG7Adc/CiqCcfbkQbnzD09gVav2VpPbbQ=,tag:422tfk8xLBQ6AVMlZNtx1A==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:TtZuxq1Mm9sUfX0Ssjyx8C+5eIs1uivAOaYaOAl3YDEy3NbJXme/Vhvq8gktRAwa8x6YIRpf81eYnpUVBXWu0w==,iv:meHsA16I9ilsiAnawC4tcQa2XmbDbNBsdaxG2em+kyg=,tag:8YU0kJHu/UciBengp6+y4w==,type:str]
-    password: ENC[AES256_GCM,data:PCauic+eoQunYrFUn1qAC2jTvly51XyJQSsVF6d69mK38f6Hpsj+cEPl4zBce5zaiSlviGTtDBrYKW4+uqtweg==,iv:D4phwbnZqSBrEr7wTxJW9XbH4C6oXtbW4s2tSQIWV0w=,tag:riIeRXVv0fTn5/sDEbMO0w==,type:str]
+  - username: ENC[AES256_GCM,data:k7c9G74jWSQdgCXyWSrW76leTak1oIjhTri4m5Kcpv0ANvJ1H/elHfVE+GdeiS/Kq9VtWf8p2wnv35j0vM3raA==,iv:R4jSthJsEYRNjZQVOhA5UTr2IqM/RjxJeLGTUgBx+/o=,tag:A0bXv+kBPL8XLK/e9G7a6Q==,type:str]
+    password: ENC[AES256_GCM,data:HtKAx5a6iw6f1s/zPa0otaT8NTWXloJqcOV1hQQswNT1dr54jZOHDVvETZRSPf6n/JIr8rCyWyPIZepbXzVfWQ==,iv:NGOxh1egJueGKwgHj+yAL20BFYgS1sRR4T5kbOn3zM4=,tag:Xud5eVBnC7ZzcpgqcZDgCg==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:N6KKbM/QuEdJ8Z6Uy+j+VLtJJxw=,iv:oPhcp1eHiIW2HlV3iUNXzxqaVmkDa0Uln67IpJNzTHU=,tag:r02tfy28txjJuCO5k5bvBQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:pZjaLO48SblanrMS3eJOjM2xpIzgWAJW9Lgjfn4LVNBBAl9JoPoguQ==,iv:XwmBX3YCBPeMMPsgavFRM5kCSnxEIrJt47rxNOxM9W0=,tag:mPVBdSAUg6jwTJ3cjM0dTw==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Gg==,iv:gEXAEqfpgz+VCiaHJaCJRPFDrp8C94UhmHJWJm+m+os=,tag:zsLYcGkrtpI3J9uRuiOqFQ==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:ZWeoA7IlFmLuFQ==,iv:n1vQALNy3vlJ4YPwWsMI4KsMEJCX8+C07VGL0skt/0Q=,tag:YEsaRCvI0mVMpJGlRoXBcg==,type:str]
+        orgId: ENC[AES256_GCM,data:eA==,iv:aleGV2DbxtFAHCoAl8OYKj+Ruj/HoP1+jtRMI2v/9OU=,tag:76n8QKLGHqQxmMnNpxTCeA==,type:int]
+        type: ENC[AES256_GCM,data:/MBnm91ttfq9ag==,iv:h9fxi1gn4l15VEJM22Lh8J+UDuLjb80ZYjJX9wdisAw=,tag:7Eu9ldpMCIMlXmfkSD8lcg==,type:str]
+        url: ENC[AES256_GCM,data:GeIc2qeapGhrPkavFW/DIm5vWLd6VKkHR/ZojD/3fRc=,iv:bPo3c0KO3YgauhZ+R8PLFuFnAUfZNSZX56xzsUv8k+w=,tag:n5YQNwXYjZPx7/x2MFinKA==,type:str]
+        access: ENC[AES256_GCM,data:onNDNrs=,iv:G0ePSpz3w75tYaoZjAvAkChork0Rk6teTqHCIG61hGU=,tag:UnxDV7+BDAq4jZ3Ay/WFXw==,type:str]
+        isDefault: ENC[AES256_GCM,data:9s9ArkA=,iv:82mprEgrpD8dSzETR4peSLCx8P9K5D8u2KX0nxoClC8=,tag:lj7VRh2BXEC/3XBELotqYQ==,type:bool]
+        editable: ENC[AES256_GCM,data:LaC+uKs=,iv:J9fNahzmj671A1P8oC/k5SeDkzkkAp+eVDke7V2SKRA=,tag:KFcRyYHhetsZJnMweHcfpg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:uaSEBg==,iv:CNU+UCL4lRcCTfZm9DpSaDeWv5XZXmewzZSz5ZMur9U=,tag:Fj/SfTdGygc94HzCRjQYMg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:ongBkJDizp5cMmj5Flv7LE303I3BdtQ8oZNdmTxE1fEaLqCbPmpwkD8QE0CyQYYGIQSchYm9WL4rQNjXaEdvkA==,iv:UUgteZS0bJkTvGVQAlA3NrpPjTU9xmxTCeT6xcHlzZ4=,tag:my1/hcNa9SZaowl4bYS7Og==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:BTh+j21Jv6TrH5P3wHhIWaAX5T3a25Q3A5ESwBsQuoFRsvJbGfKjPW56yg/1rt+g+JjQ2dCOfS+LVn+qM4KgSQ==,iv:7+yL6tdq8E7Hw52lKur+i80nuwUSrhTlnFJK55jaPLA=,tag:uFOBod5UL0In2oTIr3FB1Q==,type:str]
+      - name: ENC[AES256_GCM,data:JxnQuPFeFHIhH9br0dAyjuqMQKIevct5NJino27TWw==,iv:+sJU1uAMY/KWXPAHDtSgAuD0DZokqRqCUle7Lm9FcsE=,tag:eJaNT0+YhNIOlCVRFhHtqQ==,type:str]
+        type: ENC[AES256_GCM,data:T5LgmvfxkgWdQxYLyh/EnU6yGjnFPlwTyB/Aw9gBlg==,iv:mhy4YI6rbhDztKhYOZSY//yPv3d7jPL/YeRjLlOgQN0=,tag:Z0R8YjRyLV6hyp6sh3Xlqw==,type:str]
+        isDefault: ENC[AES256_GCM,data:HyERLCg=,iv:rc/xxqY+pNI9APKdyb/uqmIHYEGAHk+cxmYC+zI6QDk=,tag:qvj+0/rngTYl+atFBQ+oWw==,type:bool]
+        editable: ENC[AES256_GCM,data:qE3P+A==,iv:n9QM+dK6OJYF4nSVFZao+q3UElyCqgn6cTN6qwS1J38=,tag:0axrH4PBp/bYYusoVZi9ig==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:DVznsLqFvQIJms/ZtA==,iv:Bq5qet9sR3/GoiIYEsLGLMLZ/KtpNY+aD5QwfOrPfmc=,tag:16ng+BnayebuS6n4+ciEAg==,type:str]
-      value: ENC[AES256_GCM,data:qo8BjyfexAutK36Q5iwT8i0sK2DIs8j71pKLTNpDbaN3V10cI+tNC+C0P98cY/BCukuXHCIYnZYfNOTejA9OiYfclLuoJt4dyZtsAuMG4uSq/pCNhbUmvDGM5kH7VI8p99wnc3y6N6foEDklKbXVE/DjLL1jJ7g5pETmHzf3MFkNibs3on7cS5NY3lG087gQLosfMdNRpUc04S1jZ9nHqmX2TYGbCDkIOis47LnS/fFvmA==,iv:IVSSHkeFpF1tsA5uV6qVjntApz/1Cnv3yJbtaNKJsdI=,tag:kcq9s4qPt260JFeZRo1Nag==,type:str]
+    - name: ENC[AES256_GCM,data:pBJo+oinCM2bcSHKCg==,iv:xuZf4psUG8NeXjySKuR36Uy7QAPOtizJ3guD9RFUQOU=,tag:QiYgNzGbx7wOul1Zs5ivWg==,type:str]
+      value: ENC[AES256_GCM,data:Ni3KN7zvF9yjLEYB49G6BwXuBLrAWVQhxbZx99GGpHA5uXB4s35vqu1d0j1G+HkMBA1Bmx6zWJyNi7H5WbQN7JXYSZdRCopKtyfiZyFin2fjOyjvpMmn6Tli4UBmcF70+qylYzFphdEsQWGyMhIRLQx1oBxEFHO05N0V+EzDHk8ZzQifVlApKHs1PqwxtYD/gYQu3YOw7TVfSkgn5996efQooDlrd64CW/iMvPTzMwxtwA==,iv:uTSPZO1cEwc1BP5HBPRQw3uZ2IETCUNjgmITovjj/iY=,tag:QZLrh7LawYWhSWPaTWtKmQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:YnF5ALgeirOvWzS1s3HdQOUgv5U7nehdZVaBY5S5ioTVfL1McGEllGMkaOPankcf2LYaJahgLkqc9n1FRE5VoA==,iv:vfrFxRRrffZsrR9fUmNWotHkvGy+vjr7eZJL0VNBYmE=,tag:0vhmc2F2SeNLVMnwUI+qrQ==,type:str]
-        password: ENC[AES256_GCM,data:goiHYBHYEyBea6dEcbMVB7RXbnsIqJf7CqDOTilmfOA7rUZfzyLXWQPQjFa90USPs+JmJXD009zJW7INFzgEww==,iv:XqfgaXTXFaWCVLa8l/m+J7wdOj8qYFKsu2O0Vdi/yvE=,tag:wH7renq8cGaLbGeNR8Fk1A==,type:str]
+        username: ENC[AES256_GCM,data:hsw01mFcd+vPjROrJI30+rFVT/ku8TBgsdSO8tnmgnrAtrDaboJUVln4OKIhed6IcPUpwODkSrEyR5lM3Rvv+Q==,iv:9xplnzDBzXAa2qqRmLAdI3RiUz2RfY95AGT6h6youso=,tag:lqlUZjX/BB2RoMqrGdf2jA==,type:str]
+        password: ENC[AES256_GCM,data:8/o5ilnGDk58tD2bIgs1edtqhtRjKzVx77d55FcQEgpUidYV+iegEytSVNy9KkzNjuzdclYgK6MVm8zIZJDEEQ==,iv:2XCnwQH9w/GtFuqei1djzRmyV+wlJENoPwqYlRmuwkA=,tag:6nDMUqMGydISZNF0EHjz1w==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        weegoh1uewojiJ1ei6ahxooh7iz8Paegaivohsh9tai7uu0che8wo9aiPiZ0BiMi: ENC[AES256_GCM,data:jvYr8VfxVhB6AvzqUSuOmy2jqCabP/6gnBgOrVu1QsQBe0FtoRgchcSGgWAvkZeYOFT9XVlJUBl27sQf,iv:vDDegt2TDChfNY5P6N7GfUSmbIpSPOhhxkwRsBC3k2I=,tag:FR2kXJSfbKwZM7Egn80rWw==,type:str]
+        weegoh1uewojiJ1ei6ahxooh7iz8Paegaivohsh9tai7uu0che8wo9aiPiZ0BiMi: ENC[AES256_GCM,data:VWjQOAmNyMGinaOOmyqwtlppj5HllvyvwJDIJt+NIpYLn4D9mz54PeMpMKegryKKK1dPjc+girx89Pgz,iv:DI5dV+1VNgty4vsY1w54Za7Rmew6Uf7FOQ7RI7OzlgQ=,tag:8bS7KQUkFcYPnnFwJX9Hxg==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:50Z'
-    enc: CiUA4OM7eAkryAD0vhlUE+DJYRDl5c/BzARUAC+9C7fZVNqNSg0uEkkAPHlbmZczo1zfhVBNMWqI2qSkjeUNpy95RXxTNzqOA34NKfvyGiIBwiUymcNKzJTAvkKasVY6b/DwkienKypSoxa/gRbST3Ti
-  lastmodified: '2026-04-16T19:32:50Z'
-  mac: ENC[AES256_GCM,data:+hmT2G7LuvNHjr85y3dIC1Fqy026MvNW7JFLTKYojxL9aYecPwwAmCcYmWfwNR0CpnByTgs6wZNpRcoRgQQAKo3yBkUBIQ07etB4NxeO92K8zx+uKqctdKD/0U6iWcj29SD8UAItzEajKdNWEMtwGvzSpbMMoqKPsbovgHZBi2c=,iv:mLhjmYJPL1V8wrjrGQ9Ql0idAmj2OvyZG9bgpw9PM1w=,tag:5clslUVZtxYuvrlXVMHquw==,type:str]
+    created_at: '2026-04-17T08:24:15Z'
+    enc: CiUA4OM7eOs7uJGvCB/9qMKNYFf2CbK84/Z4NJaIAN4qqmKaajsXEkkAPHlbmftJpHAvBiW7PH1U6YNPpkEAUNYVo0IJGgty7eW5iBnr7n2BL1kUw5wcN7zE/S33+ERN2ZhvaKckI/x8VoM3TCDVeZhS
+  lastmodified: '2026-04-17T08:24:16Z'
+  mac: ENC[AES256_GCM,data:B5GZC4vOl5+2/alWCV8N+fLcWwi8iRwVSx+HtW67ETlgJ7ZKpIsbXvsSbdwm6KHMM1caC2kmpdHJllPbuwayxgo7hTB3x9e9NEjFDIzZUF8zyJhNtKBsE5xlyNHTtsD0Kqaulb0zgfHczraBWvUkyjBIC/+4jwKRCMUYvZPL7MY=,iv:eNZwZf35LSrn+rizzWUwzVIMmMKujhV0fKWdHiToCU4=,tag:hMvvTsyNDSqm/QSqSDFhMg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/nasa-ghg-hub/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:CDmJqEavQP9PWDvaY3ojwV8BsqhYgH304iuDEHW3KLOVnRoUvryebswlWhip9z3jhW3kGCHIMGL1JOiRWCUVRu+0nBXLxFyfCOwWTiQxcbP+ulJ9yNe8ukEyiiJxvL4ie6nLmo953tjdaNMXRoRi9mke6U6zzJdSDqtLyV6VWRSeeJoof+7CADBK/EXHLGMRi4QMoVIh2TxNYpRy,iv:U2OXoBxYAcBySEsQVpB697Tj9QwWAJCWif+ACWnmpBY=,tag:B1BaM/hYw4LkSD8cckk3sQ==,type:comment]
+  #ENC[AES256_GCM,data:OZthje3dnOAwIszHcH1EpRxXZYT1jd+Sp8aEWZgsMxCdEVSuyS3mTFq6F4+pv0kUx47fvNTQqzSfFZ+HfwqRP2fJafry5rKY8PJ/v1L+UeEtMRH92vshczMozutJuz9hptY24KjuSAU11RNMSNllSJ4OeAcs9Pdbz2yDQL8vHaQL9iYcI7tQ/zFVf7jX3uBC8I5Z2tFjqAqgMtY4,iv:osoSD9IBgLT/8SzowrJRBBNAblQD/29dz8mtTIcqU+8=,tag:+hg0iLx5uq22aevNTtg7GA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:RoCyd9KJyUwn4AQzcI51JJAe9pQPpr1M5qhVHJfZYvClcSCk7mrOyJS5q8cZwu66XNOucxvPPZ3l/90VnlvmSQ==,iv:/H5AIevLiparEuPLn/NetvdqlbtL4Pjjk7Qjd3cEuks=,tag:X5/1HV6J7NAZxStHU0Fb4g==,type:str]
-    password: ENC[AES256_GCM,data:XhRPRFGTjrsYu7fjqaIgk/hfmSFNgM8jmcRSBIPXZu9wjIkvthvkaqbtjazPaOIwecXk63AMh8251VAo/MiAUA==,iv:nn+pWN1RlqHciNzY2AvTAI9tH1Q7G/RMDWhExmed0ps=,tag:qQAf3CKjQn949KsFjMtFeg==,type:str]
+  - username: ENC[AES256_GCM,data:TtZuxq1Mm9sUfX0Ssjyx8C+5eIs1uivAOaYaOAl3YDEy3NbJXme/Vhvq8gktRAwa8x6YIRpf81eYnpUVBXWu0w==,iv:meHsA16I9ilsiAnawC4tcQa2XmbDbNBsdaxG2em+kyg=,tag:8YU0kJHu/UciBengp6+y4w==,type:str]
+    password: ENC[AES256_GCM,data:PCauic+eoQunYrFUn1qAC2jTvly51XyJQSsVF6d69mK38f6Hpsj+cEPl4zBce5zaiSlviGTtDBrYKW4+uqtweg==,iv:D4phwbnZqSBrEr7wTxJW9XbH4C6oXtbW4s2tSQIWV0w=,tag:riIeRXVv0fTn5/sDEbMO0w==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:J1CRlvpYDWzSAKBxyzhO/bKm8+Q=,iv:c33cm5GHTKzYE69XW238Yrj/USFOfFGB7/pfXlZJnxY=,tag:Z4qYZbRRqPC4ChLg4FSwsA==,type:str]
-      client_secret: ENC[AES256_GCM,data:O2hHcDLHmqzI+ZZCBSchn5Lecr7Q1Ug/fcgWwdV+Egy4cn3uP8nj4Q==,iv:PW2O7RYtWFgzuOCtn6IhcMIgGn5YVvnpRTs6bqE1ANs=,tag:1Nsv8dv8wYVwtQDzUkx9xA==,type:str]
+      client_id: ENC[AES256_GCM,data:N6KKbM/QuEdJ8Z6Uy+j+VLtJJxw=,iv:oPhcp1eHiIW2HlV3iUNXzxqaVmkDa0Uln67IpJNzTHU=,tag:r02tfy28txjJuCO5k5bvBQ==,type:str]
+      client_secret: ENC[AES256_GCM,data:pZjaLO48SblanrMS3eJOjM2xpIzgWAJW9Lgjfn4LVNBBAl9JoPoguQ==,iv:XwmBX3YCBPeMMPsgavFRM5kCSnxEIrJt47rxNOxM9W0=,tag:mPVBdSAUg6jwTJ3cjM0dTw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:DVznsLqFvQIJms/ZtA==,iv:Bq5qet9sR3/GoiIYEsLGLMLZ/KtpNY+aD5QwfOrPfmc=,tag:16ng+BnayebuS6n4+ciEAg==,type:str]
+      value: ENC[AES256_GCM,data:qo8BjyfexAutK36Q5iwT8i0sK2DIs8j71pKLTNpDbaN3V10cI+tNC+C0P98cY/BCukuXHCIYnZYfNOTejA9OiYfclLuoJt4dyZtsAuMG4uSq/pCNhbUmvDGM5kH7VI8p99wnc3y6N6foEDklKbXVE/DjLL1jJ7g5pETmHzf3MFkNibs3on7cS5NY3lG087gQLosfMdNRpUc04S1jZ9nHqmX2TYGbCDkIOis47LnS/fFvmA==,iv:IVSSHkeFpF1tsA5uV6qVjntApz/1Cnv3yJbtaNKJsdI=,tag:kcq9s4qPt260JFeZRo1Nag==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:YnF5ALgeirOvWzS1s3HdQOUgv5U7nehdZVaBY5S5ioTVfL1McGEllGMkaOPankcf2LYaJahgLkqc9n1FRE5VoA==,iv:vfrFxRRrffZsrR9fUmNWotHkvGy+vjr7eZJL0VNBYmE=,tag:0vhmc2F2SeNLVMnwUI+qrQ==,type:str]
+        password: ENC[AES256_GCM,data:goiHYBHYEyBea6dEcbMVB7RXbnsIqJf7CqDOTilmfOA7rUZfzyLXWQPQjFa90USPs+JmJXD009zJW7INFzgEww==,iv:XqfgaXTXFaWCVLa8l/m+J7wdOj8qYFKsu2O0Vdi/yvE=,tag:wH7renq8cGaLbGeNR8Fk1A==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        weegoh1uewojiJ1ei6ahxooh7iz8Paegaivohsh9tai7uu0che8wo9aiPiZ0BiMi: ENC[AES256_GCM,data:jvYr8VfxVhB6AvzqUSuOmy2jqCabP/6gnBgOrVu1QsQBe0FtoRgchcSGgWAvkZeYOFT9XVlJUBl27sQf,iv:vDDegt2TDChfNY5P6N7GfUSmbIpSPOhhxkwRsBC3k2I=,tag:FR2kXJSfbKwZM7Egn80rWw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:05Z'
-    enc: CiUA4OM7eBUaDMfh6tkBJaALiyBMyR41OK1uhVBphh1fDtVwRlwEEkkAZoeZpiRlGX2f+eM4wrA1H/Xhnx4YEKQwwoabK5BSn3D9FzWH5PBCFkF8DCSRhWENekUlx40kkzCdlqwcUfJshhXK6Ea+6Jtd
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:05Z'
-  mac: ENC[AES256_GCM,data:qLETlFnpIhAE9i84mlm9pDCO5AD0o+ZDo4DwTXs+TzmKnM4K71EOX+z2Hs1EgK/Ub/xyg5ceQ8UC+cwFLHiEQClMoQFGlGI3kRB9BFlo0gIWfh8tqWtoTESDue9n7UoBoKqAJ1pOJb4qCdiL5ilP5RD1GVmWfZToq65OhTYLpXs=,iv:y/A2JPaCua6/ZSjTsCo0qFsEIULNOIhxz0ekPrqODrU=,tag:YWalMdbW/O7mARw4JC5iHQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:50Z'
+    enc: CiUA4OM7eAkryAD0vhlUE+DJYRDl5c/BzARUAC+9C7fZVNqNSg0uEkkAPHlbmZczo1zfhVBNMWqI2qSkjeUNpy95RXxTNzqOA34NKfvyGiIBwiUymcNKzJTAvkKasVY6b/DwkienKypSoxa/gRbST3Ti
+  lastmodified: '2026-04-16T19:32:50Z'
+  mac: ENC[AES256_GCM,data:+hmT2G7LuvNHjr85y3dIC1Fqy026MvNW7JFLTKYojxL9aYecPwwAmCcYmWfwNR0CpnByTgs6wZNpRcoRgQQAKo3yBkUBIQ07etB4NxeO92K8zx+uKqctdKD/0U6iWcj29SD8UAItzEajKdNWEMtwGvzSpbMMoqKPsbovgHZBi2c=,iv:mLhjmYJPL1V8wrjrGQ9Ql0idAmj2OvyZG9bgpw9PM1w=,tag:5clslUVZtxYuvrlXVMHquw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/nasa-ghg-hub/support.values.yaml
+++ b/config/clusters/nasa-ghg-hub/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 cluster-autoscaler:
   enabled: true

--- a/config/clusters/nasa-ghg-hub/support.values.yaml
+++ b/config/clusters/nasa-ghg-hub/support.values.yaml
@@ -33,6 +33,8 @@ prometheus:
         hosts:
         - prometheus.nasa-ghg.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 nginx-ingress:
   enabled: true
   controller:

--- a/config/clusters/nasa-veda/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-veda/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:y1YDg+qjXpA3AOXIrxUKDYoL9HavxmaEobv7xFHnJCMUa5HANf5T2ujjzEr9qKksbSBmt8rz4/y5x3ylea/bx2szJWNhS/d6+F5t0G6G0jZun08OcU1Jl1W1zRB6Eav/Ir6YF8gV3jn39TxyKrYM/hnkRH8vWt6f/iciC7iaRoA+A21JVFsLEuFQMiRb1qWf1ow/7S8+zhz32yNq,iv:AHKjTUFyatkrYcuIUGiJXzD2/g1KfHzAq0CWgD4qkE8=,tag:MSbYLEHs3d14Jcv4WVTOqA==,type:comment]
+  #ENC[AES256_GCM,data:NoACPGCNMaAtqn1yu1Z+JBDolPPwaWkCVALARYQ/3EwdUDW1Yv7StKFiER4URkrKPFP38XJhcxvA9QOZs6WrVGtE8NxblaytY06P+Vley5Qf8lfQqDk1Ra2tFn6GbF1cZqzNozaYKQn71l6mnUgc1Vp3ZPTh4BRC4mUWxkfhnpKjRj8J7rxDtbLBPICQ/c9et27IC6lEVfUIkP1l,iv:FZzCXFLzJM9vOJqgcXUSU4YEojauorEEuPylkCqEVEQ=,tag:RqVpJJEiVUnQMJ4JeMTy0w==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:A3oUgYzdr/7iekE8WlgVojRmJQRjrAIs0Tn+ZciC/OfO6c2ExtzCAQrMM2QTuHCKLliOtsbzL40yVzyK19ykGQ==,iv:GhP1SPKg8Svw0tYIHVj0y7vf7VkGMm35fHjmD30C5hQ=,tag:+pmAhkiIRwluyTN50PTNDg==,type:str]
-    password: ENC[AES256_GCM,data:sTCAkcZlstebi6cScyRrsCjwx01NOaB1cSFfsOdiSj3YGtxE5Ea/HXEYQFVunOlnpoBPhjPJnGq9Hm8lztTQRg==,iv:5TwUCpy9zBrvtgdL/HF+159jHK4G/OBK3a6toNoiP3c=,tag:wHC0Jb3qlUSnBoHzrZyCew==,type:str]
+  - username: ENC[AES256_GCM,data:wSOAkbsUptCHbHpwS7KDq92Sf93iccSUJb7vNFlPnMhkuRYRrisG8jrbv/eUWgQthlo9TuZpEbKZdxfR52Uv0A==,iv:GyetrXsHNecxBYjEqowzoPVEJ7QpMy/hOggE4XOcxWk=,tag:EqucKhy9WKuLayCwiEwumw==,type:str]
+    password: ENC[AES256_GCM,data:MLS8MI3vviqpitkIE3CiSMRGZJny/j2agzFDnL01rUNuqqpkCrIUk6LcMCCZcZEVKZ1vc+zmtZLAi1t/WWPQ0w==,iv:gx/XhlAZzLTsA1rrUPyX71YTFDBOsJvhx+YrS4bH5bA=,tag:S2Pj0WnbdT9wnP/HIsc/VA==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:ngfwr5ksPlAHBrJHYpaaPq7ujJw=,iv:sZxqal5SOEBFb4t7BaewnvgdESwqFXZHZqoutzXYFB8=,tag:We8msTU/DGEjKpVILFtrrg==,type:str]
-      client_secret: ENC[AES256_GCM,data:ut0sfhV2DUOcflOj3uwHNWsNCwHeoA6/VcOjUgmj2R7l7CAROubnHA==,iv:oj0Ig43kdxlBmZO0FpuzzfeZr3rLtl8AwYpSp5r5F7I=,tag:DYQtfKjt5VKQaYwAjwJPxA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:6w==,iv:bYZ4BpZYRKcwRMe4gmBo8hxc3LeEuroBu+IZsP0ut4A=,tag:7qZmFmTn7kpY0+e5eaByww==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:qXOizJ9TyTSoOA==,iv:fn9JuW48ZWSU238BqSzXMbgH3Ta5gheDa/PIWBsgCB4=,tag:sedQ1+AvSZM6qE12gRlaBw==,type:str]
+        orgId: ENC[AES256_GCM,data:1Q==,iv:DnbqNsRsOvSUA8FIkxUxnaK32rmax6TcNjyNZegR2vQ=,tag:HEMwxhZDW7IOyXqco+QQ2w==,type:int]
+        type: ENC[AES256_GCM,data:IXhYUqFBOLi5SQ==,iv:gIoTdziEtYM5qy9Lp3rVcbS6fNpLNpx9KzgVoGNqx6w=,tag:oXJ7kb6Ar7Hco4whk8F6Kg==,type:str]
+        url: ENC[AES256_GCM,data:S9XahxqNrp+Q5kuS8EEh8LZzP/WMFzkQ6+v+2pWjRHs=,iv:NWYm0QAqfLeaqaQI0jm9HhXO2uZGJtw7WxXi5KVKySE=,tag:UbUhwCbQNnCzW3ktp5C34g==,type:str]
+        access: ENC[AES256_GCM,data:jNt4ILw=,iv:Fy3AWIyCA/a8N5LWnuzrfCQSHb/f3a/1+WfSj/Z/DrI=,tag:KoTeB+RZv+95ISiwJV/sMA==,type:str]
+        isDefault: ENC[AES256_GCM,data:kMTDIu8=,iv:JG5/ianjNemARZB76MgE4reSj83R8RVsRzukYH+aXPg=,tag:gRHjGu6u/XOn3YRrSfUvvA==,type:bool]
+        editable: ENC[AES256_GCM,data:zkK1Wjo=,iv:wg74ANmppNQFhSHglNkMmptDIp2eAodz2SeBesa3Ak4=,tag:jmae4c8LQyLH//jnh/nl4g==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:Mq2z9Q==,iv:UOqiwXbxwqtEdH1EMJEHtxZqorRdMCZxdWhX3lC8PeU=,tag:NVMzT67toGLZmXhYgb2l2Q==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:WBzQJQdCX5P01thwyMVDzpwroooaMP5TcJWcpef8JVh2FuHPWGDB1fVBp+Jx8544wlVWEI089RMFiDQ67qGC8w==,iv:dL4f6VMtP4dQ/OmcvM6RJXeT11u20ZkQxzGP4MxtW6E=,tag:iavNUahbfAWLOw4YRlThPQ==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:ivQNpE48USkyNl6ooQNEpDUwp/ZN2y/TJs1Lr1jj5xSeXUS1AKDpQ9+qM/z+OtBj4rRYMO+/a9QbJlFlOL9f6Q==,iv:rs35yu3XOqPTeg1UZdHlqngMlp9FZQyZq08yeb2eKTY=,tag:AbPcp1SDfygqLV7Yh1nF7g==,type:str]
+      - name: ENC[AES256_GCM,data:VUZOZqDYQ6kNFtHTQYbaCxc2JD8/ggrl6CG6kTqHhg==,iv:M6cbh5IaEuDPUScvlD4SsB5+b1oSXVaGW1u5W3KUZZ0=,tag:k5PE3gS2BkM7LT+6f6moiw==,type:str]
+        type: ENC[AES256_GCM,data:HNVS+JA7WFkZW4C0Q5QugnlkYpKxoEGTXLy2ZhjtLg==,iv:oUF5KOT8+SpHVR5BOb5IRqFAL4tSmzWEfDCMVfkVBXg=,tag:K0latzOnFZOjdM5VOW3hEA==,type:str]
+        isDefault: ENC[AES256_GCM,data:Bd47bTU=,iv:jL1whthVDREs0oYtW7lk7t9d+fmVer7GyJW5IfJhDbw=,tag:eLVUs69F40Xu+kjrZoEn+g==,type:bool]
+        editable: ENC[AES256_GCM,data:JUyPew==,iv:NUExsW3QnKK9T7iFeazjZSVgKIZ5yR9kmS5SE1GGEWs=,tag:2VOQwlGRAPd+KgiKkO6JWA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:qkauXkwMohFpvDZO3w==,iv:Mlv4eVVlQXg4xAL8nVyChh1GP1ku+4E3bTtCJK2bkrQ=,tag:h9Ku5cdJ5P5p7TBmdmVdbA==,type:str]
-      value: ENC[AES256_GCM,data:MavrNtwmD+zX+xE1XETmMFPZswzJDRbk1QhIVDTruHCyk3pIhP4TRWYVvT2b2VPzdzOC+34J+AAAxoOrteLfJO1zSlrTtjwUE/B+3vBc0Mgcsjg/qNOn/UvdGA4d8wSrWPYjZIoUss5hwT1g6TfiaDV1PlAwAl9NxyI2T3EX66QBAEiBMnadO8erYflFsi1LO0MvUsLd8H5+UuBWSaxedlvxBskaxuAKGQPEwqv4mMWQeQ==,iv:F51BatSETHBI132+7NYwe5Zq6LNG8o8NvClldNk78q0=,tag:uOlccbux7EBbOu1iwYRvAg==,type:str]
+    - name: ENC[AES256_GCM,data:mOuEXhhLd8+PZDMkfw==,iv:dZ1T3J7Xj0/kovpHP2H9zsUnW/eoRBPSlEQSwrWcJh8=,tag:YUonye+psqfRxFxdP1MbNA==,type:str]
+      value: ENC[AES256_GCM,data:0WMa6Nz8TD6Vh8xbwfPZLC5Q25sqPrSzoxyBvo6CSZR3oZpbW5jeOgmsHYu0IZBuHsrA5VfaZs8ggPJIZwcJ4y40U0XROvLs0x6PgaUBXpqh6doHkO4iPceovXjoackvay8jqy5KKy2XDAIJXi2yTIyG88nC87fVRO4V7wf51RF2IhG0CFq8P80an36s5oZEsIuwmt2YRc2UU76mn4NvbjF5lDZCsP8LgxlFkfXTmC/aeQ==,iv:88HDA3g8ZiFg+bC1SZjcKQvjCeQYJh+jYnoF3Q+PJrk=,tag:E6qm70rRiByNBThSjsUgUQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:Bs6zXv8pr2vTTQ0uLs9IyrQXjKXWuXqEzeUO+LfjDgOMFKcaGUxyRT4nnSgXbSceuYSbKn9nUMCEmW/q9zGZ+g==,iv:DQ+tSrdwHvGWNPu6CDWtkT9yRtBt5EqVW/jipS5xMP0=,tag:Cv6ejEyUk/bNky1Lx50UhA==,type:str]
-        password: ENC[AES256_GCM,data:AVEwp7Ix+VTesnY3SCEUIisQn01Kzi/Ndp1dULTusZRefWNBAxvJycyjdHFysxz4TZ2hTRatU2LQtXHR6LqlQQ==,iv:eC/kMhn/Z/8g7TmWwOa8ehKM/wl0qUcKHb2K7rmt5i8=,tag:SK5tfj4bJSp1BHGlIkuVAA==,type:str]
+        username: ENC[AES256_GCM,data:2YocUzpumpFF73DgJQrh2IB1aPp3PAdnADaU5vWgD4ak0wrXYmBvQYYT0+AEJBvvAHzEPNvYwbfK3BITB/OLwg==,iv:vRJx2XhHfHq7tCqeJ8AAqCza1dIlYLoLdQAazUrdeXc=,tag:SuKd+XLlEyHFr04gMzv1cA==,type:str]
+        password: ENC[AES256_GCM,data:pD9dBJ76bdXHBA+pAOMBTCPc6BuxXcfD9IakuSLkHCFjrC+i6W7evh5+/mbJvdTpYVih6i/dcZUOM8ytqAbSYQ==,iv:SUO/XB9f0Jnj9zjG806oi0Ko6dN3Ndc6oOCWWwcd67c=,tag:5QspeKALHubfp+bvf7Y6rg==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        SEMpzgVnNN2gJo8iT1GUbQZiApa5Yv64sypBVsqD6ozG6H5mjoUcfRLSoSQTqWDD: ENC[AES256_GCM,data:OiHdNVkdU9ElvD2NH6onDEidCJl/FmDlbDw3ccf812oEBR46ol1v3npGHxRavVbUxmKJhjr1lTdijXxf,iv:7MD/5b0Gno4xOp6IdNedY79PIytjW58T2jKewOi/COM=,tag:1hWRNvCsZ4L0iJChJBeq2g==,type:str]
+        SEMpzgVnNN2gJo8iT1GUbQZiApa5Yv64sypBVsqD6ozG6H5mjoUcfRLSoSQTqWDD: ENC[AES256_GCM,data:rWYgMHlAgiaoAUMtOQHGgtvp92rYGb1LHO4zulj1frlAMkfQV1Xlk4USp3DG5aJdXm2uFRd/wYtzKBKF,iv:0nCglq5T5TjvPSz5xnmdLFOqL8j2I+1Y89b0x/hugP0=,tag:MTrQmitduoji0DBfqpoB9A==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:14Z'
-    enc: CiUA4OM7eK2PBQugVva6ketgREj8oUUX+FepD/9dFs0tIeFSQ0S0EkkAPHlbmddTaQy9JgUyjB/fc2O+VeNYNY2yVUWm+YR0OdBCY7mOnHcYvkt2WnKnmAZmJnxrL10yAVYH4SLwkXEPvcq4VQKrksvl
-  lastmodified: '2026-04-16T19:33:14Z'
-  mac: ENC[AES256_GCM,data:PLm5EwwJIqOKepmK2MzGy6N2NRd1iVC1djw3TypoOkLTsmAaT6GrPdD1Vey6iXxHkctb38J0aRtXood2by6m4yGvHLPO8E3kuZZbvBP+v6hIdtcHdWMLTf/5tuXJXQoWlYRA7l/UqmA+PxRLjWIb4wVBR773dRkesau27ZcKwV0=,iv:HsqaapgIZeWaCJkdNF/xmDwWbWPoiigUCEaSsXmPMmw=,tag:s5N1uck7ArUcibhgDhZtuw==,type:str]
+    created_at: '2026-04-17T08:24:37Z'
+    enc: CiUA4OM7eK6iN+crg5Dtj9xfoz7XJJpW56Ja4gXfNQvqcwTeoQ+1EkkAPHlbmYTkuXKfqY2X3wX9+zZ/eYvocT1O32Lm+LJ1ZpjsoDmvq2Wq1p0Kw5r4VIfU7wa6m0rvrIHERohw6+0e8hW0iJHsdZeM
+  lastmodified: '2026-04-17T08:24:38Z'
+  mac: ENC[AES256_GCM,data:vMbxjtXlRolbLnkolXH2UyCDqpw6+1KwCgNx25JwHQ/HIJEKgTCXdmjrI/0teZ0zyZnraxOyQYR6y3MfGfrV7bwWar9xlkXF5TPI+5FDHbKCyNnLV7AMZTGo221mjUlVDVOlyfR+8KL1vagIebq9HxCcLn6yT5KEA+oNtzFJvSY=,iv:MgOWOp9aeqBnHR8w42TjHW3sKF49mCIUgq9k7sKjUiU=,tag:B03MdTNImzUpVm8+dPfUPg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/nasa-veda/enc-support.secret.values.yaml
+++ b/config/clusters/nasa-veda/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:UHB3ilZOiXz7fhgFt8hzoGNVQXDHb8ShGHQs7yPOBCRluuv8yVlN+79amFz5qNH4EuJne3U1IfazfjTmgrZBBncJ0K2oWnd6asnhD+Bn/LnGCGfFvpsta58iZlkEv08zeADoS0aupGowEKqLGQG3RyHAXP2ibgg1g69vgqh5PGZzMf5PhyEZcRetVcVKX/ViUfK2aN7hmRzrsvlC,iv:iFywIcfda+tOq6BiuI6gaVrzBq1iCc9Zcun8WOxowSU=,tag:TicS0lVWTFJCzuuYeYaXeA==,type:comment]
+  #ENC[AES256_GCM,data:y1YDg+qjXpA3AOXIrxUKDYoL9HavxmaEobv7xFHnJCMUa5HANf5T2ujjzEr9qKksbSBmt8rz4/y5x3ylea/bx2szJWNhS/d6+F5t0G6G0jZun08OcU1Jl1W1zRB6Eav/Ir6YF8gV3jn39TxyKrYM/hnkRH8vWt6f/iciC7iaRoA+A21JVFsLEuFQMiRb1qWf1ow/7S8+zhz32yNq,iv:AHKjTUFyatkrYcuIUGiJXzD2/g1KfHzAq0CWgD4qkE8=,tag:MSbYLEHs3d14Jcv4WVTOqA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:8WOp+oepcxHVkgc01U9n3bcPXJSTxbYwNnqWt3otsS8i64KhtHXoPCPoLT9fAcPMNGJon7pV+Dp3tEkNplJhMg==,iv:iOuFl/jDABTwpZbxkwtx/Htm8eh5a0ww0pmE2Cnjuh0=,tag:IcTKUYrWALbwpRF9LL2c3Q==,type:str]
-    password: ENC[AES256_GCM,data:pXuMi4NKMFGTOWRsuhfEjIO33F/10CLyJzBQz6c3bBl7VNwAy/zdQQqSCCJsA7dZUVGc033ob5Iekm2IKJY8aQ==,iv:jSM7gT2WtKKSyBX+UC8oVb2riX7Sn8DNTJ1K7nF1+20=,tag:bvdicHaQGxUR2UZ37sgkJQ==,type:str]
+  - username: ENC[AES256_GCM,data:A3oUgYzdr/7iekE8WlgVojRmJQRjrAIs0Tn+ZciC/OfO6c2ExtzCAQrMM2QTuHCKLliOtsbzL40yVzyK19ykGQ==,iv:GhP1SPKg8Svw0tYIHVj0y7vf7VkGMm35fHjmD30C5hQ=,tag:+pmAhkiIRwluyTN50PTNDg==,type:str]
+    password: ENC[AES256_GCM,data:sTCAkcZlstebi6cScyRrsCjwx01NOaB1cSFfsOdiSj3YGtxE5Ea/HXEYQFVunOlnpoBPhjPJnGq9Hm8lztTQRg==,iv:5TwUCpy9zBrvtgdL/HF+159jHK4G/OBK3a6toNoiP3c=,tag:wHC0Jb3qlUSnBoHzrZyCew==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:mX4YwH8vZqempLnFXSd5B9avO5s=,iv:bfv7IuOTCZab2GyIinR/r4UVoK6Yz26fJiHg9GITozs=,tag:qK1/a9aQb9ace7vKfV9zMA==,type:str]
-      client_secret: ENC[AES256_GCM,data:4kKuEYFh9yUr9cDyMKVg7EoidGv+mxCA33fq31rcss/NSr9IwcfiFA==,iv:xph35TitqJQCBMgxELRMKO6sjhvR16HPKc/lVEb85DA=,tag:pHGPATWnoi14imB33sEKjw==,type:str]
+      client_id: ENC[AES256_GCM,data:ngfwr5ksPlAHBrJHYpaaPq7ujJw=,iv:sZxqal5SOEBFb4t7BaewnvgdESwqFXZHZqoutzXYFB8=,tag:We8msTU/DGEjKpVILFtrrg==,type:str]
+      client_secret: ENC[AES256_GCM,data:ut0sfhV2DUOcflOj3uwHNWsNCwHeoA6/VcOjUgmj2R7l7CAROubnHA==,iv:oj0Ig43kdxlBmZO0FpuzzfeZr3rLtl8AwYpSp5r5F7I=,tag:DYQtfKjt5VKQaYwAjwJPxA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:qkauXkwMohFpvDZO3w==,iv:Mlv4eVVlQXg4xAL8nVyChh1GP1ku+4E3bTtCJK2bkrQ=,tag:h9Ku5cdJ5P5p7TBmdmVdbA==,type:str]
+      value: ENC[AES256_GCM,data:MavrNtwmD+zX+xE1XETmMFPZswzJDRbk1QhIVDTruHCyk3pIhP4TRWYVvT2b2VPzdzOC+34J+AAAxoOrteLfJO1zSlrTtjwUE/B+3vBc0Mgcsjg/qNOn/UvdGA4d8wSrWPYjZIoUss5hwT1g6TfiaDV1PlAwAl9NxyI2T3EX66QBAEiBMnadO8erYflFsi1LO0MvUsLd8H5+UuBWSaxedlvxBskaxuAKGQPEwqv4mMWQeQ==,iv:F51BatSETHBI132+7NYwe5Zq6LNG8o8NvClldNk78q0=,tag:uOlccbux7EBbOu1iwYRvAg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:Bs6zXv8pr2vTTQ0uLs9IyrQXjKXWuXqEzeUO+LfjDgOMFKcaGUxyRT4nnSgXbSceuYSbKn9nUMCEmW/q9zGZ+g==,iv:DQ+tSrdwHvGWNPu6CDWtkT9yRtBt5EqVW/jipS5xMP0=,tag:Cv6ejEyUk/bNky1Lx50UhA==,type:str]
+        password: ENC[AES256_GCM,data:AVEwp7Ix+VTesnY3SCEUIisQn01Kzi/Ndp1dULTusZRefWNBAxvJycyjdHFysxz4TZ2hTRatU2LQtXHR6LqlQQ==,iv:eC/kMhn/Z/8g7TmWwOa8ehKM/wl0qUcKHb2K7rmt5i8=,tag:SK5tfj4bJSp1BHGlIkuVAA==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        SEMpzgVnNN2gJo8iT1GUbQZiApa5Yv64sypBVsqD6ozG6H5mjoUcfRLSoSQTqWDD: ENC[AES256_GCM,data:OiHdNVkdU9ElvD2NH6onDEidCJl/FmDlbDw3ccf812oEBR46ol1v3npGHxRavVbUxmKJhjr1lTdijXxf,iv:7MD/5b0Gno4xOp6IdNedY79PIytjW58T2jKewOi/COM=,tag:1hWRNvCsZ4L0iJChJBeq2g==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:10Z'
-    enc: CiUA4OM7eDjom/YhqyJBu4YcKUq215OYU8wOfuAQ/IhPKC0BzdkvEkkAZoeZpkoKWUGNMal1SbZzZnM8gvdAO8v6SB7Q2AEzwwF09MxW/JLPEP19Ud/RdJKp84dzL/V5xPY/e5C7lIB/K/SaKxHPqPxl
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:10Z'
-  mac: ENC[AES256_GCM,data:Oe/EpJMEQWY6RHdW2li0OQAWp12Ly86TFNTyy0UDLISAunnRbqyc/LnbB7G5mi/3cFWBeN6VvPMbjnpmmojk8hPOI8dgeHl9Y5s3FY3xKvpuTEzyVQ1k0PZ67QyjVyiWgyG0llek+noIjQlqxXbPDc/op1Rgos6TkyfSiNFwz1M=,iv:ZFp3f0rmBUc0pHGhe+uZ4sPDJaNZcCbDxE4aExLC/AI=,tag:YqxWYrvfA+Vnbr4WG4uN7g==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:14Z'
+    enc: CiUA4OM7eK2PBQugVva6ketgREj8oUUX+FepD/9dFs0tIeFSQ0S0EkkAPHlbmddTaQy9JgUyjB/fc2O+VeNYNY2yVUWm+YR0OdBCY7mOnHcYvkt2WnKnmAZmJnxrL10yAVYH4SLwkXEPvcq4VQKrksvl
+  lastmodified: '2026-04-16T19:33:14Z'
+  mac: ENC[AES256_GCM,data:PLm5EwwJIqOKepmK2MzGy6N2NRd1iVC1djw3TypoOkLTsmAaT6GrPdD1Vey6iXxHkctb38J0aRtXood2by6m4yGvHLPO8E3kuZZbvBP+v6hIdtcHdWMLTf/5tuXJXQoWlYRA7l/UqmA+PxRLjWIb4wVBR773dRkesau27ZcKwV0=,iv:HsqaapgIZeWaCJkdNF/xmDwWbWPoiigUCEaSsXmPMmw=,tag:s5N1uck7ArUcibhgDhZtuw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 cluster-autoscaler:
   enabled: true

--- a/config/clusters/nasa-veda/support.values.yaml
+++ b/config/clusters/nasa-veda/support.values.yaml
@@ -42,6 +42,8 @@ prometheus:
         hosts:
         - prometheus.nasa-veda.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 calico:
   enabled: true
 

--- a/config/clusters/nmfs-openscapes/enc-support.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:f8lY928i4TKCdoxC0pu6UMbMASWI4ycIuNX+/JtZL3zz+uaMQYpp/5/qtt6Hz59Js0ZMd5TDAQGZiPOfy9o0wtoOyVSPgNQnOSGXu6Kwau3eUzqt8Hwo+EVhlcHPb4C54OFgpKkTDYpIltRgaizVIc1FPncUqUBICFQBmEjHHpbZhxEzuUh4TEFnuVGy6LsuEtpu/UydEtf7YNRD,iv:BeXof0+xXY6XHovqnPICfmTA8TFOCyfDlFIY4oK+0Sg=,tag:oQQXFOHQWqF9844iGGpbOw==,type:comment]
+  #ENC[AES256_GCM,data:g1ZdtTONGbrNC7r/bLv0ed/JPybOUSi0WCUZbyJdU8fg7USvtq1nTfRmBGUZ5+oBU5R/0bIQrmGAu3cSnbP3A/I+50pLBXpgstyNDHgrAmmlSneBRh0J81sA1M4SE+MkDLzfM78EuNgDsoWuKIUDheAhONDCRWsyuvP3SZp3K6HuOziS704CQcSaHxI/X8jkovI5IKt+72nTwtil,iv:U39OI8pHS2SF2V05FSdEKQmppttfNTN7Ct+IJ4ZRKoQ=,tag:vQeOx6IXr6wDxkFhTMa30g==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:90K8JMI+C4BPIUJA1etuBAjj6r1lz/cmy13GiEiGtVoufCOYFAfpKAK6gCS2DbvSqhaZMlP8Pn+NFFeID46qPQ==,iv:eIaToK1dzSaBpIbFTmJTy2ZMhAg9xGjp4G9+o5cPhsc=,tag:IbT8DTukdcQrvH9TmphgBA==,type:str]
-    password: ENC[AES256_GCM,data:kGtDvk/G/mLl5djNDpq0Dk6cqIS+QoIGV5YQ+sGtSkD9XSsAaKaSmz0vb2fEV3vVxIqnSQKhG5+kc2qVU5O0zg==,iv:TOVFOBLvcGIlDqXOo6Ce4ipDcCVE4zD2NF69i5pWIWw=,tag:Db17sQ3sIEoAY0scs7VlnA==,type:str]
+  - username: ENC[AES256_GCM,data:KdW1lFOvSzofgDxViCrKWkwNmHtocZhIlcF/3gnRTTj+wOun/VHsPez0/EprW82OnwrKk/MXlbFrWhFMJDSZ6A==,iv:pYSlSrK5QXLdj6es3RgaLDcLxW0AK4Y4Ru/PWXmdq2E=,tag:cg5F/7kNOVicf3+GpmYutA==,type:str]
+    password: ENC[AES256_GCM,data:/7QZu3NGlIXu8OmFBTWHRqwsBHhx6C4508nCWT1HGd0me4urFEYJ0LvNYIkEkA+0n4LvJ1nh35t2AwmzmLtKjw==,iv:TaD3FRhqFbC2qIxqxY+wqUdV8+8UlZFT8qFo0HzdPnQ=,tag:K+2zUOL0N+KD/DAQcJdV+Q==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:rT5XoRffAdIt9Y4C0LLn7KxxV7A=,iv:NpeBjSJwizoyXYR5DLmWEV2hGK3zaQ5A22wBIy0cn88=,tag:wC2VK3ZmAFJPy0g2+ZElrw==,type:str]
-      client_secret: ENC[AES256_GCM,data:HSk5+83TGAqfM82q96A73pQMTDpSbqXf2wBjha7pGpi187vcvtsPqg==,iv:8RbA/U5i32m7sNBZSgyZ4Hz9Fp0KtVrxKA3RzBCobW8=,tag:7lJ9szGVupSsPLgv1R6X+w==,type:str]
+      client_id: ENC[AES256_GCM,data:neQKCdvTxcFlsPoIN2XzRQbAook=,iv:6jF+5AiI0gewhdpFfaQGgAEZn2xdEpLiKpvxksVndx4=,tag:gbnDivvEHkLgKLUDH7QGDQ==,type:str]
+      client_secret: ENC[AES256_GCM,data:YPBWDPTTaHT1O74tkSfDkL4jgD4OX4IDT+u1xICJxY1ROnL9/yplIQ==,iv:/I048ZEo5OSsV7CjtWQp8wHuCO17WKBn7pELFv2YItY=,tag:DT9IUyvrj41Hj6AzFw7mJA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:QWKcoSwcQzY/ueY7NA==,iv:YWIRowPlCbg2ZEnYW1DM3NgMj5zP3pdeq13qQym7PFo=,tag:biAfL75F3GUgYXjHdSCOFw==,type:str]
+      value: ENC[AES256_GCM,data:ceyIVdcr/LU7Bbo+WdyLB5SZkYnBNAszgSbaqkKkDOUEytHFzE/1hLN0mZT3TrZfn2LSJAluavP0P+mzXHpSa+No4Fq9DlnzwF1n8phbwS5JFq6Q1oBPLdbbIXIPxHTxRFlBOXarr9xXqitDWWI8IxiDjxJ63emzhdMfbQySs0RY3V277akO7fuxDpxqcp7DVC7AiBeKSHHbL0PKgzo9PlqdYM5v0tXpIf3423BoiGAcBw==,iv:/vbtBGWDPAGCsbAKVEpkHgv6qu+JKH97tgwqMn7U9As=,tag:XSV6ZoGdv+EhQBunrKW3jw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:uEakmB2MyQKuAJUyiqsXKRMj1k8SZ+jsw0LHd/uL5Tts4Yz5FYcibLuf0z/Z7JHb0kfN/COpAXVsGpuvw4K4SQ==,iv:BGmft4UtFG5RsLrNOCaXPsnr0VTFLY+EstpfjgRRZ2g=,tag:qcIna7vT37oDCetj+m85Cg==,type:str]
+        password: ENC[AES256_GCM,data:jXsjflOohXRD1ZCthn8h2w5jvDgbjjNUeZHmEXJmxsR58bUCcNzS4lfjAPVUOa24YH1GGUYvIJGqNcv3g8oM1A==,iv:Uuox5jN+jGLsGiKuBNykZ7k9G0tv+syzKhZyp95PE28=,tag:AF/k9oWttcK4vjzQua3ErQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        hhCMzo991IiqZmhKUwVmJHh5XKEU1hFc5HMf9JAS7Y6YZXHaNzrzxyc7gUSWWibn: ENC[AES256_GCM,data:MPN1R4mByJt5s29kXuJ21nJu+WCtaQ/WODOn3UY7Q36BjWTB1yHQ7nHjiLvl85nEalyeHOzBvFgLXEDZ,iv:wME7g1dbpLpPQnxPJJou1gCgpuQ9RTuRxzDE7S1q0VM=,tag:poE4j7zMIStYMQvv9HEqsw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:07Z'
-    enc: CiUA4OM7ePFi/xf5v470rIDWU5UyY+ACoo8zOm7ZEy89pLMlr/JiEkkAZoeZppGR5p+O2GE3/Vr7LmAiS47pr8w8ic9Jr99HpMw2eDRHZZgfl+vsi7XcRUuhLexE81dX2XWOqgAehIjI/knuNw5QXL4o
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:07Z'
-  mac: ENC[AES256_GCM,data:dtmLUz4VTRSoBwlFzwaCSl64jq1kZWTTOr4pV8F8WI3G+LZTmVs7pMdwvvz17YoQZLCeGLGiRT0e/8YiUZ5QnRYj28eOwohlB2NtIy6kx0e88ii9Szr4Hxfq0equ2gXevCp4EK7doEjvfzyGLFDbLegXbooCPSgsM4+MLKXthRo=,iv:sHvb06FwLH2Yk3I9JZxH6l8pEtV18vIWSmeHWuhmR94=,tag:IQeT2bR1AsVaDFR5L39hwg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:00Z'
+    enc: CiUA4OM7eCtVpQ1GKKINgevMkDmOAqKbWWLSJ2gDAbZiKLG3/CBtEkkAPHlbma6XhD0sIsuQUlYu9WDtAL4nH4GMJkwmbgjO0KMzdxLpeQZlXJJWOKV3Ye5dklR7aAeEgQD3VtzN4wuchObTXDytGO/z
+  lastmodified: '2026-04-16T19:33:00Z'
+  mac: ENC[AES256_GCM,data:FXxJJgaZEQmXrXb+LuvNIdIEMbZBPqlBCVo3Vp7kgb04TkH1F6Oc4CesJchS/fLt/jhXIAuvIC22QEbf6PxxFpDgjjBbtxS32C4GfTpSMebP9jx9CBLnXSN1Mf2yzTK7no5Ukh6NOCctiIyRbxV5g1Hpu5dT4RoZQ0m1zbNMs+8=,iv:insh3THyJpmt/H7mc+ha7k4hUJGz9jGTsuWkhzl5UHE=,tag:d6vmKG7toQJ66zY0Mbye9A==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/nmfs-openscapes/enc-support.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:g1ZdtTONGbrNC7r/bLv0ed/JPybOUSi0WCUZbyJdU8fg7USvtq1nTfRmBGUZ5+oBU5R/0bIQrmGAu3cSnbP3A/I+50pLBXpgstyNDHgrAmmlSneBRh0J81sA1M4SE+MkDLzfM78EuNgDsoWuKIUDheAhONDCRWsyuvP3SZp3K6HuOziS704CQcSaHxI/X8jkovI5IKt+72nTwtil,iv:U39OI8pHS2SF2V05FSdEKQmppttfNTN7Ct+IJ4ZRKoQ=,tag:vQeOx6IXr6wDxkFhTMa30g==,type:comment]
+  #ENC[AES256_GCM,data:HU2ACIpjgsNxw1gz5rZkkRCem8gzd4y4F3yEzHyv9B8A9R6//aTjm6TWBcznGC8oxt6hBhGVoQAbLhWLExPoghkxePiHlH2OdB4itXgb9jCDX0d8P1qULt2M2j5rvnEIdAF7Zzzqlz2AKFZ5+gWXASdJoNvZviBgixmP9bWxBp5WrEPG5KfZ98q8ETpA02jDBzFYCAM78mEpHNDp,iv:vNdVk8HL+caIQU9Y4bDArB0MJcSA8Vbz95FwUVsI+fA=,tag:pQTaptY/DVvElqxrHXTXJA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:KdW1lFOvSzofgDxViCrKWkwNmHtocZhIlcF/3gnRTTj+wOun/VHsPez0/EprW82OnwrKk/MXlbFrWhFMJDSZ6A==,iv:pYSlSrK5QXLdj6es3RgaLDcLxW0AK4Y4Ru/PWXmdq2E=,tag:cg5F/7kNOVicf3+GpmYutA==,type:str]
-    password: ENC[AES256_GCM,data:/7QZu3NGlIXu8OmFBTWHRqwsBHhx6C4508nCWT1HGd0me4urFEYJ0LvNYIkEkA+0n4LvJ1nh35t2AwmzmLtKjw==,iv:TaD3FRhqFbC2qIxqxY+wqUdV8+8UlZFT8qFo0HzdPnQ=,tag:K+2zUOL0N+KD/DAQcJdV+Q==,type:str]
+  - username: ENC[AES256_GCM,data:oRqvAT8PJeiZkF1LGhabhzodJDEtUSs1bxf99ALPa2DLwDoiLYIb0V4OPTVCYBJdPCmRKnXiqkOCWi6n/JoqKg==,iv:KlCr6iyVNmDvZA7rh4ZxKiGX5H8jglsJdkMRBfklDIk=,tag:5FaAQL1NB+1K4Hv1hwkiNw==,type:str]
+    password: ENC[AES256_GCM,data:VEPZhgxAW41KthCALqFDCuqKp+8TzqFteaL+zsIb4RcAPd4qietcEbLThhn6C/paJRoGt9WvCTpJ9HprXjBu4A==,iv:7DUMDgkAwDPH7e8gUTZYqfGehWfp9ylTnmPHfjvDvtI=,tag:OZaAd0Ckl5UzH0bxhFCDRg==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:neQKCdvTxcFlsPoIN2XzRQbAook=,iv:6jF+5AiI0gewhdpFfaQGgAEZn2xdEpLiKpvxksVndx4=,tag:gbnDivvEHkLgKLUDH7QGDQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:YPBWDPTTaHT1O74tkSfDkL4jgD4OX4IDT+u1xICJxY1ROnL9/yplIQ==,iv:/I048ZEo5OSsV7CjtWQp8wHuCO17WKBn7pELFv2YItY=,tag:DT9IUyvrj41Hj6AzFw7mJA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Bw==,iv:VPNw8MAYWaeupC5TlGsRLmW0B3moMbT/E96K/FmC8yk=,tag:nbO2JB7kvGsjdDfjKe24Ag==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:2OTpaLh8lYHl+A==,iv:IbUfVs1GEbLJ2GEgQLPA1yzzzIUJRqlBq+FwGiHErXo=,tag:oxo9yGZgGrpwnx+Z9VOFAQ==,type:str]
+        orgId: ENC[AES256_GCM,data:Dw==,iv:mnu6qZxpDPn3VNfVD6vWknIVvRepfiywgvXFcxrwYYU=,tag:Kzbu5ypkwUs0rPtDF3NCXA==,type:int]
+        type: ENC[AES256_GCM,data:pFBBzXmmF9SYuQ==,iv:4Xb+Sw5mJ4lIlQMyDmamoW6eb+iy6A026/MdODe5gOs=,tag:xA0yBQGgxZB42ztvV9LK7A==,type:str]
+        url: ENC[AES256_GCM,data:fficZS6HpyA9so0M+eV1CxfBZg6A3uaeOp8encmvPkE=,iv:WFwbb0yMNc6sBvh10NnVSb/4JPovt4P2NIeE5P1O+/Y=,tag:WjD66oK2+FzFumgyxwQWCg==,type:str]
+        access: ENC[AES256_GCM,data:2jc+nH4=,iv:GPAzRml60Luw07SlaBtSXWUVuuoRPfNvHTgQ1t7uaz8=,tag:K6+TAeSRe80K4USyDVNkPw==,type:str]
+        isDefault: ENC[AES256_GCM,data:eEpWNac=,iv:BgDGBhyS/X4LcoQ3MKN8LxuQOPu/nH0xTNfPRcq0fXs=,tag:aQ5UcC9FBZd9JJqqD5Thjw==,type:bool]
+        editable: ENC[AES256_GCM,data:2vRyINQ=,iv:ueno2YHhXcHsrbkxa4ZA/MhauIWrvxXQ2NrNMVKGcBk=,tag:lhy9S/RIECQ/EwL6dTDoDg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:DP2Kpw==,iv:Z6udJNSFuUuFsSZrn43QUbEqO9I7NfJnBjqrqMGK/IY=,tag:wQ3hQnjNuQCmxFwNmv8x9w==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:5gEuZHo+Y58qBhKYh3WFeklo9sjmN3KteEnalhudVeXJwUs/XUjJ6ORo8MURtf/ZDh3DPuVAzn/6cnqvd6CmDg==,iv:kPQjrt7Jc4a/34PbDSpXw8EQ6aHmIMIcXwEVFAAnX+E=,tag:3aw9cP9vCfosXBXKBi0yrQ==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:l/vM9Ac0YjrvKmd7AduNfp/GLs+V/Ap+1Vsd+KMxQtC0mK2LCRI3M/g8bVVZDHfDNU0SNBoR42qGoMyR5d2v3A==,iv:dQ8Hlt7NFPhdqdL9dmyBqLhw2Pi7uYKXpOJauXbFCog=,tag:rStWATbU6L8bUbhALoiCow==,type:str]
+      - name: ENC[AES256_GCM,data:f2IV8eapR2T6ghPF2A1o6QCeUzYcwqvr6apbLPA3Qg==,iv:e45300bvnnd4SBUfgEai/M2RUL3WZTYR85jNmrpNJBA=,tag:LEIyQtdFmJA1VRdEMFDZyg==,type:str]
+        type: ENC[AES256_GCM,data:1tSRerdrUqS9x/qzH+rt6wI1wMY0HaYoDsOKarzCew==,iv:WdzSAM9GVAa+ARQaPLgQcjm/00faKJh6WRcj2UvDZbY=,tag:Mk2jEP5c9E3KzTGx9X1xOw==,type:str]
+        isDefault: ENC[AES256_GCM,data:et8DC0k=,iv:9VdRwyr3CYQWKl9TeCB7BYvc//DYpKbmixzvZQ79qH8=,tag:GO9SDmLUHRaZopFjMcOCcw==,type:bool]
+        editable: ENC[AES256_GCM,data:rfxhAQ==,iv:ulHr1xMZgXVD6NT9BqUhLki8X/KYk4sHJpJ66cljuwc=,tag:tjqAOcrNNdmrm6IMUyVZUA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:QWKcoSwcQzY/ueY7NA==,iv:YWIRowPlCbg2ZEnYW1DM3NgMj5zP3pdeq13qQym7PFo=,tag:biAfL75F3GUgYXjHdSCOFw==,type:str]
-      value: ENC[AES256_GCM,data:ceyIVdcr/LU7Bbo+WdyLB5SZkYnBNAszgSbaqkKkDOUEytHFzE/1hLN0mZT3TrZfn2LSJAluavP0P+mzXHpSa+No4Fq9DlnzwF1n8phbwS5JFq6Q1oBPLdbbIXIPxHTxRFlBOXarr9xXqitDWWI8IxiDjxJ63emzhdMfbQySs0RY3V277akO7fuxDpxqcp7DVC7AiBeKSHHbL0PKgzo9PlqdYM5v0tXpIf3423BoiGAcBw==,iv:/vbtBGWDPAGCsbAKVEpkHgv6qu+JKH97tgwqMn7U9As=,tag:XSV6ZoGdv+EhQBunrKW3jw==,type:str]
+    - name: ENC[AES256_GCM,data:S93n3KVa+ICWU2SgOQ==,iv:7fXErTyUgGejs2RsGi03B3jaiOUVkUjSoNr3hfF+k6s=,tag:gMCwqGGmP6KL87ttxZOcUw==,type:str]
+      value: ENC[AES256_GCM,data:SW/YO65PrnNhiztYAIsMYWhJtUE5mjdYrODWYrIoMpOgcD4QWtgcvfACIYCxS8T6PwTGVe6rRBEEcA8R+7n7+crLPogGCL633UBX+wVFK9sNvjONe0nb5XYAQFEFXhY4YsdbXfzcKLmC1IWZJGXp64G1bRBp/1oLN3+IhBHeQWGwdNdlI0Kc9J3YUNt/6wnWqKnhnl8qHDZZGKIoZnc4QaKoQ9XH4peSiunCHOWO/z41qQ==,iv:xoKLNG9Y1QkoGgqcmuKoQuR7rCrbR3I7NqPtrJmD6Ss=,tag:iPKrRmREb/Y7IfFyXpqMTg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:uEakmB2MyQKuAJUyiqsXKRMj1k8SZ+jsw0LHd/uL5Tts4Yz5FYcibLuf0z/Z7JHb0kfN/COpAXVsGpuvw4K4SQ==,iv:BGmft4UtFG5RsLrNOCaXPsnr0VTFLY+EstpfjgRRZ2g=,tag:qcIna7vT37oDCetj+m85Cg==,type:str]
-        password: ENC[AES256_GCM,data:jXsjflOohXRD1ZCthn8h2w5jvDgbjjNUeZHmEXJmxsR58bUCcNzS4lfjAPVUOa24YH1GGUYvIJGqNcv3g8oM1A==,iv:Uuox5jN+jGLsGiKuBNykZ7k9G0tv+syzKhZyp95PE28=,tag:AF/k9oWttcK4vjzQua3ErQ==,type:str]
+        username: ENC[AES256_GCM,data:FwLEDGVxmGxAHMUXbFfn8GOdTB0nvU6likmlImDMXGbKSfSqBF6aJ/y2DbLHsDG53aR1JmR45WBTyAKAu5z7hw==,iv:Kq/qWk8m0QrSZj2k0nzB2/1/KTgndtszt3WYMENsLHw=,tag:fl8tNL3PaOEHGednOkodHQ==,type:str]
+        password: ENC[AES256_GCM,data:UBo/NF4qj5/N+emkBo3iw2RiRKUFZ3QjfC8mpYwSMLQIRGcYix4xQfnw8x/XgRCDfOx185EAKiACyim1pFhU2Q==,iv:YdB418lb58rt5mlNMGy0JuQzNaMrxBuC4aqSLBA1Nz4=,tag:S0hZW64IEeioAfNdRv9UVA==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        hhCMzo991IiqZmhKUwVmJHh5XKEU1hFc5HMf9JAS7Y6YZXHaNzrzxyc7gUSWWibn: ENC[AES256_GCM,data:MPN1R4mByJt5s29kXuJ21nJu+WCtaQ/WODOn3UY7Q36BjWTB1yHQ7nHjiLvl85nEalyeHOzBvFgLXEDZ,iv:wME7g1dbpLpPQnxPJJou1gCgpuQ9RTuRxzDE7S1q0VM=,tag:poE4j7zMIStYMQvv9HEqsw==,type:str]
+        hhCMzo991IiqZmhKUwVmJHh5XKEU1hFc5HMf9JAS7Y6YZXHaNzrzxyc7gUSWWibn: ENC[AES256_GCM,data:iZ+kfiHqgC0JaDS9e6tZtMQqr75HMIwgrJtI2jnpxksHqlKL6qUbBDkDalTiR0HO/oDytw2Nj4L8xrfd,iv:Zk1w4r7nxXj1YIoSx7JZtPNJna6OPI9vTLjns11boxQ=,tag:3NprSoSvkUkX011q8wQQOQ==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:00Z'
-    enc: CiUA4OM7eCtVpQ1GKKINgevMkDmOAqKbWWLSJ2gDAbZiKLG3/CBtEkkAPHlbma6XhD0sIsuQUlYu9WDtAL4nH4GMJkwmbgjO0KMzdxLpeQZlXJJWOKV3Ye5dklR7aAeEgQD3VtzN4wuchObTXDytGO/z
-  lastmodified: '2026-04-16T19:33:00Z'
-  mac: ENC[AES256_GCM,data:FXxJJgaZEQmXrXb+LuvNIdIEMbZBPqlBCVo3Vp7kgb04TkH1F6Oc4CesJchS/fLt/jhXIAuvIC22QEbf6PxxFpDgjjBbtxS32C4GfTpSMebP9jx9CBLnXSN1Mf2yzTK7no5Ukh6NOCctiIyRbxV5g1Hpu5dT4RoZQ0m1zbNMs+8=,iv:insh3THyJpmt/H7mc+ha7k4hUJGz9jGTsuWkhzl5UHE=,tag:d6vmKG7toQJ66zY0Mbye9A==,type:str]
+    created_at: '2026-04-17T08:24:24Z'
+    enc: CiUA4OM7eG8ZNi7v4Lt3mFTTCd2AYjQcw2xVq+5YkSTjVZAwgBi8EkkAPHlbmQ2ySxCkp2kQ8xUDESrbGCazobnQXvyLNBTEjtCKdjmpzJezsLB2KDFgrzJoEl9cWWscSwn24YAT6xwEHkWHTDMMYfmm
+  lastmodified: '2026-04-17T08:24:25Z'
+  mac: ENC[AES256_GCM,data:ZCjdSPf2vaDf9dchLYHd68pvA9v7u5UB6wzSDeJus2iNjIAc5sfKvgvoea0PmhycSesYIiISd5zV/ql2Zpe9g8NYtu55HLmwK8mAthMxC7Y4bYf5leZsYAzhMvGej3f0ZcaFJu3aldgDAKRN5bK7l7Db4uxLZc9VINO86SVJR2s=,iv:MfrR+xUpenj4aY6Mvxq0BiuZVasnsiYr0gQ1eEOYr6A=,tag:cUODaa94B3HhksXWola4dQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/nmfs-openscapes/support.values.yaml
+++ b/config/clusters/nmfs-openscapes/support.values.yaml
@@ -20,6 +20,8 @@ prometheus:
       limits:
         memory: 8Gi
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/nmfs-openscapes/support.values.yaml
+++ b/config/clusters/nmfs-openscapes/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/openscapeshub/enc-support.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:bdRHmg5c8JHhO/wNZJjlyK89MRGg2upe1O5d6t8FKAFa9x+K4vWtZXPs+//xZClh0Bvu6H5p76GYCWHAwhqC5ylk4vOxRJUkdyZoBG3snSigljVipw/HeK55IZhU48hx5lEodclrf2GM5SY851cwlpXVnL1KfJKRIuZdOpGZ53/Pl1TglROtJSAs8hPOFFRVN0zgGg8gdzTxyItD,iv:oUtM0n38IA7XCEmYY0PBXTCRef5aPcpQHpEp0jc3fSw=,tag:wjcXgVZ2hVVFBcL3dFDRUw==,type:comment]
+  #ENC[AES256_GCM,data:VFPr1jjV0yW0QaS/VBSlyrRQz8XOoRzrMefjVsMhBlyas693PPPc3lMkh0wReDzfr9G/5bBDnli3PwVjH8K4k7AuISdhlzOo3Cbp8DaWveDS1MB7s29URL/q6CyGFrJftOkbOqYaSCJvY69Dw/Aojuw1+JoxLu28MLe7BBlSyn11kWawVyamgBjuH2KeI8vUeymJEOFmp+AVuPc/,iv:g8XA0rnys16ox5dMMT8+hcX4tAFQgpSsu6DQ5zS+CmU=,tag:IMbolTLFSNcdQDsFPFTE2Q==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Bbt2vSi5m6iXef3gUOfe/9odt0kOAbv2nKNL6r3GtD4RDQbrwRtR2HECRBT+RluEgHS2kWDAlk50mKgBKLgjvg==,iv:BpPHzquV5yqeK2Iha6atmZIi1GLOwfElwLCEZbyCPLk=,tag:SriSF9P+DdGL9/U/nrtYYw==,type:str]
-    password: ENC[AES256_GCM,data:IWaOXFjf5L2EbFfAjs/3hHyrJjc+o3psS+QPHkNp1QSfF6zahCiePi5BV628IpIWXD8WKc8y5jkdpBE800ZSuQ==,iv:UP49k4RbiqlMgUHfnw3Vf8kIffN4nJc+g9LMJNPeKSM=,tag:7xHA5eeH58pjvch61C5Lyw==,type:str]
+  - username: ENC[AES256_GCM,data:HS3UW4HUSXkhw1jJk/py+wC2PgsHZTswwYGZczhAWiFgKYmC7r1XVywyI7iettHFw7Guk0CxoV4s9V6f8dz+dw==,iv:Vb9k8VcXvAQPm/tZ1dgF2Dq8AS3CX/2CU1u7X2GWsGw=,tag:y3ShTby9BX4WP+9KyTmf0w==,type:str]
+    password: ENC[AES256_GCM,data:o7lWTA+DiwiPygJCZJoaTp/QiEBF0+7ME4msUYgZBpG1YK/GOwhsYF+GWcPe/+C5nNmNBRd6GMZsNXa+4SnVgQ==,iv:S0RKjUJ5jOJ5FAcLvXWEi6Y4BJpv/iDX3ytMxDRSkyc=,tag:XziidFAgFO6/ApLfR53bXw==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:Twg4/JHs+IW4ZvVSCU60iOLyFJA=,iv:S7w0JAV/LK5iFjqRJW0E2z7v5iiIzKZuHnispQSk0/c=,tag:MI36TK2AekiCXVeu1yt9sA==,type:str]
-      client_secret: ENC[AES256_GCM,data:1KkrWzDh6G3wnDobmWLtny1q/gtQRiMhTDjcttM0zWq3oXVLslq8Gw==,iv:AjxsUbpnTxro2+UqsAV0LnhSbuCNJJvxADlJr22i07o=,tag:PYeWI4p6DZQ/JobP95nR7g==,type:str]
+      client_id: ENC[AES256_GCM,data:zxaRqCPlG1GmVwGD0b0u+WLEc7w=,iv:LdHvyZxZ39c6WCKLGFXYzzM6/WdXyWMkteADkutaUK0=,tag:TyMouJhpRY5/GEj3Trxk+w==,type:str]
+      client_secret: ENC[AES256_GCM,data:iNqBprcb3nxvy+JEhRq15XouBZ9K+REt4QkqWve0cr9mTzL0LhG5Fg==,iv:HyDHYCY3HyJe40LWqcLCRe857M8Rq+hBYvfIt8MExPQ=,tag:kw9N/AGM5ZPxaVpvwnX86Q==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:4F0bZS+2YcqEUThplA==,iv:eE7Ebpa+SmMc6vUazPrEpXhX76OwLYHnXXsV97oFKpE=,tag:EubuTc7DOSgJhfSu5THgYg==,type:str]
+      value: ENC[AES256_GCM,data:ihDtNkMxQVIl6UL4iYF8okpq9pMmy6FLPWS3Ardc5S3om0AU6bCxTueDrWyo8jY9UokrUo/RJkuyRp/SrsBoo1umFkZZzaXSf6dvsHUBEDxulLPPiINi5R0EJoKH6ALNS9sApi3OKDFsbRYkSlwIoejmODJ2i4qs5Egcb8adkpizRm2+0KAPzLvpHTt0Jy37L2hssStwAgda4IjsVzOtmMOziQ2/QYmR+NpFYJ9+uo/PsA==,iv:El5JEDVpC1gEow+zmwvExelfBlUC4UsWRI3MUH7AY74=,tag:NGSheq3iCv+P4Sat0nuauw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:6URMgAKnqWbxsoZuWzlkdPzbqQwNiJH/b3CiO74EEZQ/BbXWl96vVXCHEVGVK5f1p4PGQAg1OIMYYyOkOTYHeA==,iv:q7NNTKYj3jhbd8kVvxxFqyZL2S7OVvSHDUgioMGZQzc=,tag:VX2SnI6pGA8hd7H9zd0wTw==,type:str]
+        password: ENC[AES256_GCM,data:p9V1/ElOFGOaTfmX40mLuR8xJx/BAA4MmI4nb2bd9/yUKFpAge8nW9zmlBQn82I9n0bfnT+HeVEuWr2nw/dF6g==,iv:33BemEOiKT2Wlbjy6gN9WV5GMkzSJIg6Io0GmyVTwr8=,tag:jZGO1aLJVo8RIMxGjSxcdQ==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        IShinge4faiyoch9Cei9yaiweithiecahsahci7aec3Moh0kahgeigh9umuaqu9a: ENC[AES256_GCM,data:2yZAK8V/kjyryizSbj6UDU/urXznDvZkm0dtAYV42fZMqTVpnr454OgXmIQjrcPKY1VPp5ilmfj2KIBR,iv:icLpvo7TtJOCWWh1dCQXVyN8j65eTCZJxDCU+k674fI=,tag:yuD+VE2O3AZ6QuV8PfM0JA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:22Z'
-    enc: CiUA4OM7eLlVbtcF53+tfg81HypbmlisHFEXhQ6PyrHqPYfS4fd5EkkAZoeZpkX+/UmxrhUToHKB85d821NZy1bpC6wfJsJx7fjwLiWa5voh+dU1NnK+Zzv1sLxwzf8TNL6wzPQWmzbocRitmqijBevS
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:22Z'
-  mac: ENC[AES256_GCM,data:KjxUm0XVxYr4b84RRCMI7mzoIZ4nBP2/URu8CZWsNRzjvWPtnt/0nQ+A+HKeCdZrLNZTyxtp2UpOzMSaWMJb9I4/Cn6FQ+wCxKukAxSD99ks9j67VZrMkKYrNPffxI+/wAgTJKWkWrmSU8UwH4BkknjGUwMP5aRo6YqDepPYLEI=,iv:F+tyr3Tp14mZXBt7UkSfbG7ZLjCAHK5UlfHE1m47Xfc=,tag:EhSXVfMayr+dIm92aaStkQ==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:34:08Z'
+    enc: CiUA4OM7eJLu+lk4ySFbC2SLfYBj2Vb2/XWDVgeTl1CwgHpVi6ohEkkAPHlbmVIehJEjGAaxSTC32rdjNThTNSokJxV+WMkvGHRWv4vXXNvCMiPzCvXzXz118N6n69aU+AdJDy98Iy86HaKHodGbLKzp
+  lastmodified: '2026-04-16T19:34:08Z'
+  mac: ENC[AES256_GCM,data:6n03FVMVOWc0pZIAAIKoJbz7zmkyEcvFfnsRu1gZQBT/fFxp1ObkBA+gLS0WVR9kVRvyRE5+jx0/869zt+jR4itt6Z+cOabuixNv3nb82iWtVHBGPmSZ3t0mc8bNc1MtZ4gOZGhGyKNnNd25ZqhD24rNsoeRDHFObejccPsTIvw=,iv:wZBQQyILmxtlglpD+LyGHRiKDo669LgaDkMsYKj4BDU=,tag:v1uzytr4Jwx+KMPtV5QIoQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/openscapeshub/enc-support.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:VFPr1jjV0yW0QaS/VBSlyrRQz8XOoRzrMefjVsMhBlyas693PPPc3lMkh0wReDzfr9G/5bBDnli3PwVjH8K4k7AuISdhlzOo3Cbp8DaWveDS1MB7s29URL/q6CyGFrJftOkbOqYaSCJvY69Dw/Aojuw1+JoxLu28MLe7BBlSyn11kWawVyamgBjuH2KeI8vUeymJEOFmp+AVuPc/,iv:g8XA0rnys16ox5dMMT8+hcX4tAFQgpSsu6DQ5zS+CmU=,tag:IMbolTLFSNcdQDsFPFTE2Q==,type:comment]
+  #ENC[AES256_GCM,data:pnSyncI2nmYbIPwHk2F2L32nHJCYM+eu4lirGFicQ7yH/4vnjJR3Jt1IUWbpeVfLcb0Vu4EP4q2Yzx9KwGFvLuxD451x8i75Yg21DzQbi7KCdpHDYH/7MGl4svDZuP5vmYh3ERi/VVwRsNC3mwqHnMrhdU6NE+agk+Nx4Tt2+anS2TgaJwm3lgwfCG+3JvmnHrmBi3IKj5kGeRrv,iv:8v+iToHeOb26p2+jpCx0DQZZ3d/kE8gkQJRBPboDy3I=,tag:F8sbegkfyA3APc+3wDq+VQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:HS3UW4HUSXkhw1jJk/py+wC2PgsHZTswwYGZczhAWiFgKYmC7r1XVywyI7iettHFw7Guk0CxoV4s9V6f8dz+dw==,iv:Vb9k8VcXvAQPm/tZ1dgF2Dq8AS3CX/2CU1u7X2GWsGw=,tag:y3ShTby9BX4WP+9KyTmf0w==,type:str]
-    password: ENC[AES256_GCM,data:o7lWTA+DiwiPygJCZJoaTp/QiEBF0+7ME4msUYgZBpG1YK/GOwhsYF+GWcPe/+C5nNmNBRd6GMZsNXa+4SnVgQ==,iv:S0RKjUJ5jOJ5FAcLvXWEi6Y4BJpv/iDX3ytMxDRSkyc=,tag:XziidFAgFO6/ApLfR53bXw==,type:str]
+  - username: ENC[AES256_GCM,data:6rrzqb4iVG4lfLbsMmd1VuYdzPjSjwnKRlZ6UmvusBvUjxA1fYxt7FjtZp2CIYXE5JIpXvuQgwO8MWugTwhjmw==,iv:z+3LXH6nM1HwLgz8n6lbGNmcjrj3xmxNpOl+L0TgKWI=,tag:6ucj6xbI/pFJGxVQrl5Qww==,type:str]
+    password: ENC[AES256_GCM,data:EgTwIRQQwGFE906AA1wmAQB3v5Ars4WGT1V2JLD9RDeRY7mPvQ6cqfqqRDcHieukNo6qNs7jkeRdSwi+BmXhOg==,iv:Iwt51xGFNWphbAI1ffoW7lcEDu59lPYoh9M7ckuTK04=,tag:goVooOce7UpakwQzypKSTw==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:zxaRqCPlG1GmVwGD0b0u+WLEc7w=,iv:LdHvyZxZ39c6WCKLGFXYzzM6/WdXyWMkteADkutaUK0=,tag:TyMouJhpRY5/GEj3Trxk+w==,type:str]
-      client_secret: ENC[AES256_GCM,data:iNqBprcb3nxvy+JEhRq15XouBZ9K+REt4QkqWve0cr9mTzL0LhG5Fg==,iv:HyDHYCY3HyJe40LWqcLCRe857M8Rq+hBYvfIt8MExPQ=,tag:kw9N/AGM5ZPxaVpvwnX86Q==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:iQ==,iv:dTad88JgrUbuqBalrepiZqiHj7D9r43BebrSaAWR274=,tag:DcGll3cWEPRaRco8LFmf+w==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:u+qOLACcX83zXQ==,iv:eVVxDsy67AFFpWekvJXchdSL0Z9QcmyGZYZDLK8qIAE=,tag:A0fH0Hyeoi/uZt/4G/Pi1g==,type:str]
+        orgId: ENC[AES256_GCM,data:GA==,iv:0lrKOPdx3Vr7gpopHqAuXdb3B+2KmPeWT7NX8z4ungQ=,tag:EnrjbtGmAAXtfjP5xqS2BA==,type:int]
+        type: ENC[AES256_GCM,data:Zegl+wZJGwf9MA==,iv:ChVby3ztZVyXFodVYlcAhaD6nZPqplnSGOADapk9XWA=,tag:tnZGDZok69YCz8msM2z6Gw==,type:str]
+        url: ENC[AES256_GCM,data:F9Uhju1RuQCwLKfy2c8UZACYG21eMA0v0uRLITzqT64=,iv:hBnAiCPgnkrzXEHad0GK4j09o8VUtC1nBsEUnrAQKDo=,tag:ch3mfdRuZjPAMTyThdWASw==,type:str]
+        access: ENC[AES256_GCM,data:sejyBoM=,iv:7P3acJYwRrUUGBoGipD6PQRwMWMhhrMGRxLBxE5F4UU=,tag:v7otaZub+65czop7Qw5Slg==,type:str]
+        isDefault: ENC[AES256_GCM,data:XpFJBVg=,iv:gByuIyzfQo0rx9xGcZlJc8+QHPEU4VDHBP3Dx/Jildo=,tag:G8IEia/1cRID0d4eX1qPzw==,type:bool]
+        editable: ENC[AES256_GCM,data:RhzFfqA=,iv:N31fLaWS5+pCLYsioATRexEyrg1HN5J7hosbwei0dtk=,tag:65iCHe3A4T4lKA0yI4av3w==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:qYdF7w==,iv:uIiZlFMJUvdH1LYvY/71hu6MGPdW40dS6w8bCqbPAyw=,tag:BOKDK+VHUkV60+aqbj7TsA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:K2bSwMeJsBIUsZAfE/zkReXpo5g+Tly+E8RexTkPOhi7ftIUT1m2vR2zx5PBzyX6jbfNuv6Z2U8UuSd+Elgp6Q==,iv:sZYrOxEzNx6fDgFfKoo8lnUTZS+P6y3qYhS68SitEgk=,tag:Ckg84MVMe+alamTwEhSyDg==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:12CrOg8vkcCoQKk2phfGGgjQxUGX7CxL3mY4b4IAknfyd2o1+Xq/3Jyv8qkMUPz1sHQuzlMwVlmiptS8ZXam4A==,iv:FlyF3rh/QjyVjEltafFFjJfQPcADCsDiLiW+AhwoDTI=,tag:wXHr7xzZ4foECIEMuaxVyA==,type:str]
+      - name: ENC[AES256_GCM,data:Kl1O/pSt+/u1tpApIGLHAtTGHmfTxq37Wiq/rDcY2w==,iv:KaRFvRABSlFGA/ltOqTwkqv+14C0R/NzmdFY/Kmzds8=,tag:7rdArL+OjiNk0LjnGt2HRg==,type:str]
+        type: ENC[AES256_GCM,data:dEo2rVuVkC70VcAKTIYvJBIUlKPIWmlB1bUVwmigsQ==,iv:aYazZUdt7agi/c9eIagbConuaKIOzaQirLWscFvBTdU=,tag:2EVGhcQrOEU4mQKf+Xlvyw==,type:str]
+        isDefault: ENC[AES256_GCM,data:ab9ZJ3g=,iv:wr7hqejMBqvx4g8V6GuAjCxA9MJhR7OYgtoC6Ic5ZNA=,tag:NFrhVIXSNV11bMAZwzPStQ==,type:bool]
+        editable: ENC[AES256_GCM,data:flUUqw==,iv:zzioB+22oS5A1j3czZjZhdmmEMi+0OnBAPAqYLah+y8=,tag:G+QX0HIH4C7aUjpqAunYPQ==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:4F0bZS+2YcqEUThplA==,iv:eE7Ebpa+SmMc6vUazPrEpXhX76OwLYHnXXsV97oFKpE=,tag:EubuTc7DOSgJhfSu5THgYg==,type:str]
-      value: ENC[AES256_GCM,data:ihDtNkMxQVIl6UL4iYF8okpq9pMmy6FLPWS3Ardc5S3om0AU6bCxTueDrWyo8jY9UokrUo/RJkuyRp/SrsBoo1umFkZZzaXSf6dvsHUBEDxulLPPiINi5R0EJoKH6ALNS9sApi3OKDFsbRYkSlwIoejmODJ2i4qs5Egcb8adkpizRm2+0KAPzLvpHTt0Jy37L2hssStwAgda4IjsVzOtmMOziQ2/QYmR+NpFYJ9+uo/PsA==,iv:El5JEDVpC1gEow+zmwvExelfBlUC4UsWRI3MUH7AY74=,tag:NGSheq3iCv+P4Sat0nuauw==,type:str]
+    - name: ENC[AES256_GCM,data:78xPi/pRDlefQ7QomA==,iv:pDSt7K4+PEOK0uUQZw0/mn9sTgYci+SAvjEmm9C4UUk=,tag:jBD1lrj78MT5TWpaxWWNdA==,type:str]
+      value: ENC[AES256_GCM,data:OsPfn532/Mi5A+nE8ntRrzbqoGJ47U7HCWpAFZd42ucyqFdHG/VWlmL0oVUkGYXak8VmZ0ec+oG6yGdkORLNjW2DfhVHLUGzEM4iSA/wZu2B0vyMIUTDCMJLn7jHVJZ1u0koEdxMLf3MoXVSaQAf/Em8Y780lsPK46E8sScDT/sF9TUfL643Epag/AnvBiaP+2/+kMQ3VnbuLQAYSUzcwTmgjuM0OYQM5Wn1b7KKMgl9Og==,iv:/Pgn+JRf0TFQrXWMVkGuG96+HsMzWg8cCKI+qZ6h03U=,tag:Rp6ceFQSCasUTwyLkLTYDw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:6URMgAKnqWbxsoZuWzlkdPzbqQwNiJH/b3CiO74EEZQ/BbXWl96vVXCHEVGVK5f1p4PGQAg1OIMYYyOkOTYHeA==,iv:q7NNTKYj3jhbd8kVvxxFqyZL2S7OVvSHDUgioMGZQzc=,tag:VX2SnI6pGA8hd7H9zd0wTw==,type:str]
-        password: ENC[AES256_GCM,data:p9V1/ElOFGOaTfmX40mLuR8xJx/BAA4MmI4nb2bd9/yUKFpAge8nW9zmlBQn82I9n0bfnT+HeVEuWr2nw/dF6g==,iv:33BemEOiKT2Wlbjy6gN9WV5GMkzSJIg6Io0GmyVTwr8=,tag:jZGO1aLJVo8RIMxGjSxcdQ==,type:str]
+        username: ENC[AES256_GCM,data:X7RP6l8yyT2HqN2CmoEgKqwPlukHQXu3U6ObCmtGxvRMmjF6+t1LwLb23eULpQaMVANZ5BUuEkb+95+eOnMOLQ==,iv:abiZjQ8lj9xk+lPjHVfP1eS0yf+dNr9D4YzrI1gcG9k=,tag:W3H74ts9cByDOvL7+eQFMw==,type:str]
+        password: ENC[AES256_GCM,data:iS4ODDPwhdLA7lHnE06xxzxbWa/u0nkPU7okkSRReRvXuiY2wvojjdG/8Qatcu0mfXA6Tdwqpkf3L36cn6JoXA==,iv:q+cRva0lvrK0AvMkODDoErnQvczq3WqtxwR5qc/+OtQ=,tag:W+5q07oROBYL4w/SIrH38g==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        IShinge4faiyoch9Cei9yaiweithiecahsahci7aec3Moh0kahgeigh9umuaqu9a: ENC[AES256_GCM,data:2yZAK8V/kjyryizSbj6UDU/urXznDvZkm0dtAYV42fZMqTVpnr454OgXmIQjrcPKY1VPp5ilmfj2KIBR,iv:icLpvo7TtJOCWWh1dCQXVyN8j65eTCZJxDCU+k674fI=,tag:yuD+VE2O3AZ6QuV8PfM0JA==,type:str]
+        IShinge4faiyoch9Cei9yaiweithiecahsahci7aec3Moh0kahgeigh9umuaqu9a: ENC[AES256_GCM,data:p5S/swY2aaOHzQFzDtRrLbi8ZVglr1XMrmyUdDqHAfIQY1BL/RAamj9ew4cyhDd0jVZM+A29vsJ7CZFf,iv:L1Ook93PrAGlapoAtSyiwzOS3PyoEXXEcYPGrD13JxU=,tag:/Vr1lhBIBbgooQuuewO3KQ==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:34:08Z'
-    enc: CiUA4OM7eJLu+lk4ySFbC2SLfYBj2Vb2/XWDVgeTl1CwgHpVi6ohEkkAPHlbmVIehJEjGAaxSTC32rdjNThTNSokJxV+WMkvGHRWv4vXXNvCMiPzCvXzXz118N6n69aU+AdJDy98Iy86HaKHodGbLKzp
-  lastmodified: '2026-04-16T19:34:08Z'
-  mac: ENC[AES256_GCM,data:6n03FVMVOWc0pZIAAIKoJbz7zmkyEcvFfnsRu1gZQBT/fFxp1ObkBA+gLS0WVR9kVRvyRE5+jx0/869zt+jR4itt6Z+cOabuixNv3nb82iWtVHBGPmSZ3t0mc8bNc1MtZ4gOZGhGyKNnNd25ZqhD24rNsoeRDHFObejccPsTIvw=,iv:wZBQQyILmxtlglpD+LyGHRiKDo669LgaDkMsYKj4BDU=,tag:v1uzytr4Jwx+KMPtV5QIoQ==,type:str]
+    created_at: '2026-04-17T08:25:32Z'
+    enc: CiUA4OM7eCke5c82s5B44DZItVvvaleJQex7tUWZXDTymdu/kPAcEkgAPHlbmQp7ego7G52RJXZGlG9QnxVyXB5n3IspPIiRaQcpnVIp3PUhcTY4WJIpj1BVRy/IVbApZFtojWKhVaCQcskMZGhAIAE=
+  lastmodified: '2026-04-17T08:25:33Z'
+  mac: ENC[AES256_GCM,data:Rk/0KFx6aHmQR0caMoasVr4YobJ1X2IfysmsM99HubpCGoQhZvL+YzbdeT6ZE8GonjHzt25xhzKSad4tMFA3d78QzQSd7g3YcaRN6n/MvuWKGvIf3QiLUSJk6qk36HHlJtdOAUVvb+JpfetESxf6SIlOtkSs/ipvWjSyj23gryA=,iv:Xgqu+v47qpdXDdQRfQpOj8Jvc8ARO3/z52GRlQC1VFU=,tag:UTSspK+GYmnK267rcDDZoQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/openscapeshub/support.values.yaml
+++ b/config/clusters/openscapeshub/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/openscapeshub/support.values.yaml
+++ b/config/clusters/openscapeshub/support.values.yaml
@@ -17,6 +17,8 @@ prometheus:
       limits:
         memory: 8Gi
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 cluster-autoscaler:
   enabled: true
   autoDiscovery:

--- a/config/clusters/opensci/enc-support.secret.values.yaml
+++ b/config/clusters/opensci/enc-support.secret.values.yaml
@@ -1,19 +1,26 @@
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:wfHbD9NGGqKlXd6eMQ==,iv:VGjxBrREYRy7md/0vxqsjynT+HSU1MocjPqUAXKQNNI=,tag:4AH+JrU/nDuHCUytwZfwjA==,type:str]
+      value: ENC[AES256_GCM,data:NN/tQLzRTZdSHolLgPuGezC1LpNcwJA5IFInYJLXQ6RwohcwLwyTLmnYnIBpoEKSANyx9NeG9yLbFXPTWDqnO3IXWYijWBJ6qeu5El/EUK91JuOzh4Vk3gh/Jwy3BMEUlyRRWW4czmZmO++xoXx55XaRD4JKi/8IpzCpM02zfcUe6nfly+LIN3lGEeUP6uY21mOUulPLvYO7nSn9ZGBWWtzLqi4KE4dbWKAhMWtS4SB3jw==,iv:/SHlmtjNtn4g3W4IsEfjQQv4eiR/Y2rNiIZhGC8jZ5E=,tag:8muW07oD9ylashmYx245yQ==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:NoDRKMJ3zLS5TkGhVgWnoFweehS/nGmaHBHESCeu87ISsuNYcvVzzGBby1NzNlI90PnHxOdd0BpvPxAE34zTug==,iv:fi8CMAMMQY7ATXA2shWDZti4oeRrKoUTLLJwRuQ2F7w=,tag:AVtk7JfUriqoe8Khi/gOsQ==,type:str]
+        password: ENC[AES256_GCM,data:YVnG3bC4AxF0MMrTIvtP6EToScHuyUFIuX5e6AODnoB9Wo+ORkeBBT5feQZd9c5dah6Sem5TuEIU8BmN7+PhOA==,iv:29VUUFYc9jWsai640NkAEV4AviUGfQ+lqww3U4jgJAU=,tag:hJQTmFWx9NNkb+E85KCt2g==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        HFSmHnxpjKCVdvLjqwD2EmZ4WZpKzb9lQ4bm1N6JArP9lx1zrLjeZx1EWl9QZM5S: ENC[AES256_GCM,data:pcQCbLExE/0YdC2AHG6BCD/Ihufeegdj3lidUcjtDDa09047skBqgQpamP0l2GamJhlwF7kz58Z9DEZ8,iv:Cyf6uWoxqGtMB9Pz9lbmST4S82dwrCVAOfxY3T3QO6Q=,tag:FMH94LKQOdG2u2r6SFgHeQ==,type:str]
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:XuQPUUzIlId5kwNxj/yRg7YC8T8JggWqqme3ZTOtGMcEYqmJGor/gzChNwqoiaLuycnUimgC+KYlKxjC31D4GJQDeGo9J5omIa7Q5TC3FRZeMwggflmmFrYJ++AtP63hQhPV3qBKpOBKFjpGEVu4pn8j9XuHBOO1ja4Te5MauDHI/P86+dEnvPz2+EhbpmMhPMxTuqSRq7o+LI88,iv:E7gGuqd0ZhIYZm8jbKnGTk/vMUaHGbsQX1d5ziQGIbU=,tag:HblAg/E2c0QQmbwwtLfrcg==,type:comment]
   users:
   - username: ENC[AES256_GCM,data:cGKPJzhDIxOwWXVVrecNSx1KJ+XnOHx6U8w1URYD789l8TCaA7F8w4iwgyqnCfYtCuLLRbyxECVtGTKLeydG2A==,iv:IkxGNrab/qsHUGapbLsqN3+M0LUBOZlG1d7PZvMcGs4=,tag:8p67bYR7w3BG4WFRCS6lNw==,type:str]
     password: ENC[AES256_GCM,data:jcXT00FChb/Yj5J8oZgs0NrYFA5MOI6lHM2ukhzGtmreJEKBOFYeo3DStWkXtOXjCOHQlJc4PcJPJNnQMey8CA==,iv:sTQB7vwOEyROnL821jEjKwBuQ4neRxgl4qlp7jEk6Pc=,tag:ouZzQZvTnwojRVZupS7FHg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2026-01-12T10:07:15Z'
     enc: CiUA4OM7eKNmo3Um3bLBklca/IZm56sG9KRwdjU/Bl3aa+PWIIyGEkkAZoeZpt22/M8rSH2VaI/eR/HX1LyZcr4hP2gD5zXz23l7VFGmdUw80jByH2iX9BIM3c8pvgkm+sCv0DCkmtuJfFYIJFmD7l16
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:15Z'
-  mac: ENC[AES256_GCM,data:2i2NO2cx7Pnm81oAYXEwTjLDo1/yeHPBLtE4/pid2kwj91n7kzY7ZQi1GC/Om2GKuJdt9vu5ccVajYfuYPRjOYp2bGq3D4Htgxhgu+Zugt0n8hp8z27Zb1uj67HLcdABibpefSzutdq8sB8EkTvueqPcow5U4FojBtrWjglLaPk=,iv:hoCGOtM4q32JXXaM42JF7ZnRqGI8vxdvhfwx7Wru/NE=,tag:h0iJ8lJB3uwQ4ss2Mowhsw==,type:str]
-  pgp: []
+  lastmodified: '2026-04-16T16:27:22Z'
+  mac: ENC[AES256_GCM,data:YPw47DDFtvNeHwAA/F/sd9y2tj5Uy5lkGL2hzZO7PAerjXDd/PhOIjQhV1tLcT5YVF7kXJpoyTtmp3JU7KP0E1g7f16Gl8woEAuSRijjzrZ+J3OqGosYwaUNtaK8/8qGqfAqspWiP5RoFFp1rDxhigQ36KmeSxCepBqLm7TaM4M=,iv:bDmqFYU5tQ447S/OXfj/2WR21NOZ3euifO/F6/bv4cc=,tag:HsDB8Q97v4KZM7EWNNqw/A==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/opensci/enc-support.secret.values.yaml
+++ b/config/clusters/opensci/enc-support.secret.values.yaml
@@ -1,26 +1,46 @@
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:fIK49Fnc1OxTitkW6Q==,iv:hjGXZICZpB0NzdReDcXzLJgbsm/9OXwKKL//Dy00mAU=,tag:isuflELGRvR8oRhG2Qjt7Q==,type:str]
-      value: ENC[AES256_GCM,data:q86xlbhaW66nhv4JdNN73P0JWIoBfgiiw946v02eWWcoXaNLr8vAWJRm9zJs/U8zYc7ehiroYP6OefXyDuIU3n8p8wfZNtARJeyQYqU0YGUh1CzA/hmB7cq8jHp1SB8gAiKOgOADCd4lll4MeyuOqziUxBQQOWloqeSgqskq6BeojKPoKKDrG1JT8Sh8CypF9Zs0+dKekw3URkL5pQ3fQVGKWQkh+9F+nVMUeaKqmL5nhQ==,iv:olBnkSqmboL/d/ly+Q4HV07eRzV5EdMAbbnBWpPMyOk=,tag:eDxGqjN1qprH0hamuWokDA==,type:str]
+    - name: ENC[AES256_GCM,data:kSeuvmrENHIAm7pDXg==,iv:Vt1PZ001jvsDWnjMQCS5bR3xYO68DmJQ4QOyADqFRsw=,tag:gLKG5Fel6x8gX9uS+y/nxg==,type:str]
+      value: ENC[AES256_GCM,data:pCWVIbHP9r0UBXivRg1Pie39mqFZ3gbwVXGPlhP6Rxmn14dh4TxKTqXuPoLq47JV1LVjThG0Ojg2hNql7ZmSmKPCdZ2AdXD9zmdUSjQyLaeSuWG5DKJCqpM1Mz0jr9ZFVYgStmpLRfOFropq97CVt0Wk65AYeU9hv64kQ33vp/RHg7GmBstPgoF9q0ZaP0V408Y/5x3PFv4RE0YqLjfgBK/OC3ZHRqTSKIDNI03er13Giw==,iv:I261Q3i65BGJqM5NGqnTVo3aOB9T8EISYtEpLYstv4c=,tag:fA1As5GIWF4p9WNzzVKJQQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:eFNr9FGemQVj4goWoU/hEKrEt1rYjtnroSrwhpmQ25Q5R6nnl2eu0LG2PywkG6d1dhVuiKJfO5YsUWkjK3oENA==,iv:zIiRMdrVgmG9korQBte4Ble1oPHYI2PlPbJZFhGAWi8=,tag:cSA7Vb80wmGkUj0dyTh3rw==,type:str]
-        password: ENC[AES256_GCM,data:uwYf7YoPaPzxORUbER+N7SdJiFDgdx8Z4VNFRvPN3EifrM1EbvbTWr0BiowzQHVl7Z9y6azglTXImG9U0ChbiQ==,iv:S3+/P7SiiKRj+/y51AZB4XTbu4icbu0BjhA4mT778l8=,tag:LRXwJRLPnBQFqq/TEspjgQ==,type:str]
+        username: ENC[AES256_GCM,data:OfpVRvMpIDecoPSZ7ytBfN8zgWwtZcvKG8ZAG6heSMLIvetP0ZkbSRavqTDdZ9zKwBtVpm+CSeZu92fppTICJA==,iv:KnfdKpSeFpimzq9Aj66wW6hp0ATBFmo11eTiu3KwvmI=,tag:iisv3I0pTpdmbzpTMmC7gw==,type:str]
+        password: ENC[AES256_GCM,data:pNxM2qREtXx1p1ZODepQ1A235FWI0hYsvlVrz2z4noIoqErKxOCDI3WQDiaNeJ7iDwYq/tGEbMKe7slVLysMvQ==,iv:pTRZy+TGWho8gEWv//i1DYtzuD5Tz6UHEamCGlLj9xs=,tag:U+3EOkSvobRYWY4srtp7HQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        HFSmHnxpjKCVdvLjqwD2EmZ4WZpKzb9lQ4bm1N6JArP9lx1zrLjeZx1EWl9QZM5S: ENC[AES256_GCM,data:DeEmXkcGndrmISul5VI3SJT2FwACXQmI9he+Gpf8gX4QhP4WsTMvEBUAyrcL94E3zs1CNXQg+AAj6HId,iv:/iLNtelcYSryVZ4iflj3NaZ0vNo/JkEJ2HazveZH+p4=,tag:DNlzaVhLIfgSohHOWnK0SA==,type:str]
+        HFSmHnxpjKCVdvLjqwD2EmZ4WZpKzb9lQ4bm1N6JArP9lx1zrLjeZx1EWl9QZM5S: ENC[AES256_GCM,data:DT+va8Gi4DEQM/711NpIR311Z9B61vYXQubZsp4tcjQ9H/05jhskxEDtDszf73sE47A1p6iCw5MM8xzl,iv:2nJbNFC2eFNftwIrwaoy0BoiePU37wekHEcP4UWa8C4=,tag:trH35SKKgfHDx8LwCAPH5g==,type:str]
 prometheusIngressAuthSecret:
   users:
-  - username: ENC[AES256_GCM,data:H9y5WDrdbYTw1LZxTbMiERLsgxtykv7oQ/1V+Yn7Szpk+swYmoDPFye9jsP272fxYFJASyItAsY+z9LZme/CYw==,iv:1RZqesfzjqC4XC9OIQ1SRpkIE3pKKxuy8Vs5GSlrOhg=,tag:R64Vc6AyBX60UOwgnyJS9A==,type:str]
-    password: ENC[AES256_GCM,data:+j/1usRZbb4Oy1719ccom5aZNgmI81OylJvUFv+5dMl+NDpwnrCY2f/Ei+OAVUu39V+NcNdHv0Z2BRQUAt+BVg==,iv:2d26O5djAyrLziyR8zr2Qxin9Mu7zCcjbTB+plOM90k=,tag:ZtExe/SXn4Wdj3NrC1faiw==,type:str]
+  - username: ENC[AES256_GCM,data:DJK6QWnqLXAKwujX14wXixibolH7wGU1wdjdwbegakrsKL2tJoonw21JQGPPjK4fWcBq+W2QwOPAMmcjTxHYkw==,iv:EQ3bsZH2U9X0qQPOww/rRMJYe/8VfufayPhBp0vDQ/Y=,tag:QxGtAN/68l87PZK+pSNYXg==,type:str]
+    password: ENC[AES256_GCM,data:zry2QCXCinOTzkvEUKnBgx/JUTEZrRF2zp0hVJTnid+bsYhA4XMjwWoiR6XuVLvi7BlzeBEvbY4NQRD3cNNDmw==,iv:CyN3dDFK/Pt9ei9NzeX1jnF3td8AvBEMkmmy0KcsecE=,tag:14N7FcVJCNYrIR9kcSvPfg==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Mg==,iv:2ynHRGtzPEJxux5SqXD+tp39JI1HQUH1n3CdHetIR58=,tag:uLg4+V5V93MOgiX3vHSE1w==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:QafsBYgJS9KwSg==,iv:RHntdaeYUQhO60sgKybamQTZwPYv/G2OlcF6RD6p9kI=,tag:8HLLYvOXyIta5kjQo3/Zvg==,type:str]
+        orgId: ENC[AES256_GCM,data:ug==,iv:+zKjKcwlziVCrqAhxrYWKGCJ+vxLEHKlwbpvMHYRY00=,tag:NnLhyfYFLPKk69p1dyPO6Q==,type:int]
+        type: ENC[AES256_GCM,data:BfDZYhjypMwAbA==,iv:wfdv5xo75TjMnumq+UnZITK8MnKwLtr4fqFpK5rWcOs=,tag:yL8Cidktn3/1sxGjkaGeRg==,type:str]
+        url: ENC[AES256_GCM,data:mSCbkNsWAi8Hizg2Ay4FPemP7CYMODa+D+6z83cjjBg=,iv:ndXYnQJ9qVpmF0ICpsttYWCDzO6Rz38tf1PEoYJA8aQ=,tag:zbxXdfvuRSQX+JMRQ/9skA==,type:str]
+        access: ENC[AES256_GCM,data:BAGWYyc=,iv:3vA5AN04CB5P1LgFvsYLwN/g0HbvRFBgi3JTXGPx86I=,tag:2v2U1gJfm+QHO+EuIm7V6A==,type:str]
+        isDefault: ENC[AES256_GCM,data:eUeDris=,iv:Wx0yoKcJTJdMnqQBzxnZmg6WoXJtpSm2cwWjK2V4FTQ=,tag:lc0T0Ki7U2AyLDAPjdPNyQ==,type:bool]
+        editable: ENC[AES256_GCM,data:KPS57Ho=,iv:F3hLSsQzAvCjuOiEMI54Xpl4mq0aQE1Za8FqH8QCx1U=,tag:WgZ39X1/iNsHpQsmFjHutg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:2SkJmQ==,iv:PV1aDWw675wiSpl/etKJSlyuigUAPO5AVJ7dn5EBDc4=,tag:xJyAK50L27f/updjcMUBig==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:NU9hV2tGPBGH/ET8ILcAGmDHypuLKScoHwK0iHY8QTRNJ3yQkAhYtPxxekUMiEmgw3nBK719mmDEmHZ3bVA7Jw==,iv:W/8Kk2gSbso9fnIeU72VtPzAFbZRzLtkPZqLZNV9FaM=,tag:JnCfnJanpKfmirMOy1bnLA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:tqtAKbf3vPYiYULSZNNcwAtL9XcTIVo3gAMcDxcYoFXtBe9rTAZCOkc0QCf3Ivs5L7f5TNoQi/lC2Csu0OKW8g==,iv:y7mmYSJSigxaP+g0Ly+wPzqtG6eW+fjAu1z5ubmzcBE=,tag:9Cln3fzoKBwlQxeeZZEp2Q==,type:str]
+      - name: ENC[AES256_GCM,data:qqESsgA39pYoOW8kzlN5wrcgVcQ7fWxUHtB3E5G4mQ==,iv:ymxLPgrTVZ8XP4kcr6CszMTnLkkUUtpXDEyIyBFblIo=,tag:XACqhL4T6TIS8dXgZNYKpQ==,type:str]
+        type: ENC[AES256_GCM,data:tqIbCuR/SuIRbeS1tgHD52ig4CnizccFSfYOzouIDg==,iv:gYoq9WRNBSJ/sXBfoba+ryqcxT0hJMne/docNRRi2Wg=,tag:QvKnC3sm/9MMyXwMU5NYyw==,type:str]
+        isDefault: ENC[AES256_GCM,data:fe3wsTQ=,iv:S99himFOybvYQeQmw7rMqFmjydzHK+KeWSg99kwqCEc=,tag:zAZOYDBDY6mVy7lSZzJWHg==,type:bool]
+        editable: ENC[AES256_GCM,data:WctYTg==,iv:lDTNgjPbJ9DGxAd02QJsf0M2B+lYcQeFXWq848MsuRo=,tag:5C0nm8Vj68CvB3D3LMw1NQ==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:39Z'
-    enc: CiUA4OM7eISduCqa5zSn8+Py9qv9vJDrH1rbM5yl/Vnml7MKGZx2EkcAPHlbmWQfZuDpTLXL+81eC80o5RNzsABsKM1o0XzmOhYf30MPZPN4AUIw7tgNeBcow/ZuBUmFdpSAxC/FIm4uDyWGG+0ouA==
-  lastmodified: '2026-04-16T19:33:39Z'
-  mac: ENC[AES256_GCM,data:8RHAGJTJu+02cceBTpAsYjN+VQX6yqGF4IMBvTWgg2LUmaU1HAwapXNQiu9Tc3IYnWtA0b+eFQxd1wrARkQgPLXSD9ZUscbQ922zRNpS2CI74Bb9bKb44BJIW7m2D5QFRg672OEfIGjyMslTk4Iq7moKn/wCGKe1UEIej89znCY=,iv:7xZogcT8pNrH+TEV/DKRCb2F7ezVKMHTnKqvnSdsFsI=,tag:E7uuuoi4F8WTdiv7XzeMQw==,type:str]
+    created_at: '2026-04-17T08:25:02Z'
+    enc: CiUA4OM7eOiA4WkYVCE6TCz9mMPBTwXfT6WCM1M1qRZI+obxPma6EkkAPHlbmUjkesN9cShDtkugHUrnpXv1N85b4tCc464WgoONgq3iyqjvJYIY/zR/hrqqLNmEJHzxolrwuBfHTDi/xhn0DcUh8diG
+  lastmodified: '2026-04-17T08:25:03Z'
+  mac: ENC[AES256_GCM,data:Eh20qOENcAgH5dzNjBcXLIQ1aQNwno0XYQdZpr0rSPu9zub+enNlE65hTVgjST3RXszEaSPAn901lpm/xuzJ5HbKgVz8Iy3EqHqHZhJXE3IujhjUSvhWj9eNbI6fy3L/I4dtZdZKx6vwpyPAMyWKckiv90YLg8tkLW1TTOGjwXc=,iv:SELvvFzixHgi57+XhX2MIEX+OHcYUePWQziYp03OYCY=,tag:eR7Rfi8mcWcUBPXvlCVrpQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/opensci/enc-support.secret.values.yaml
+++ b/config/clusters/opensci/enc-support.secret.values.yaml
@@ -1,26 +1,26 @@
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:wfHbD9NGGqKlXd6eMQ==,iv:VGjxBrREYRy7md/0vxqsjynT+HSU1MocjPqUAXKQNNI=,tag:4AH+JrU/nDuHCUytwZfwjA==,type:str]
-      value: ENC[AES256_GCM,data:NN/tQLzRTZdSHolLgPuGezC1LpNcwJA5IFInYJLXQ6RwohcwLwyTLmnYnIBpoEKSANyx9NeG9yLbFXPTWDqnO3IXWYijWBJ6qeu5El/EUK91JuOzh4Vk3gh/Jwy3BMEUlyRRWW4czmZmO++xoXx55XaRD4JKi/8IpzCpM02zfcUe6nfly+LIN3lGEeUP6uY21mOUulPLvYO7nSn9ZGBWWtzLqi4KE4dbWKAhMWtS4SB3jw==,iv:/SHlmtjNtn4g3W4IsEfjQQv4eiR/Y2rNiIZhGC8jZ5E=,tag:8muW07oD9ylashmYx245yQ==,type:str]
+    - name: ENC[AES256_GCM,data:fIK49Fnc1OxTitkW6Q==,iv:hjGXZICZpB0NzdReDcXzLJgbsm/9OXwKKL//Dy00mAU=,tag:isuflELGRvR8oRhG2Qjt7Q==,type:str]
+      value: ENC[AES256_GCM,data:q86xlbhaW66nhv4JdNN73P0JWIoBfgiiw946v02eWWcoXaNLr8vAWJRm9zJs/U8zYc7ehiroYP6OefXyDuIU3n8p8wfZNtARJeyQYqU0YGUh1CzA/hmB7cq8jHp1SB8gAiKOgOADCd4lll4MeyuOqziUxBQQOWloqeSgqskq6BeojKPoKKDrG1JT8Sh8CypF9Zs0+dKekw3URkL5pQ3fQVGKWQkh+9F+nVMUeaKqmL5nhQ==,iv:olBnkSqmboL/d/ly+Q4HV07eRzV5EdMAbbnBWpPMyOk=,tag:eDxGqjN1qprH0hamuWokDA==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:NoDRKMJ3zLS5TkGhVgWnoFweehS/nGmaHBHESCeu87ISsuNYcvVzzGBby1NzNlI90PnHxOdd0BpvPxAE34zTug==,iv:fi8CMAMMQY7ATXA2shWDZti4oeRrKoUTLLJwRuQ2F7w=,tag:AVtk7JfUriqoe8Khi/gOsQ==,type:str]
-        password: ENC[AES256_GCM,data:YVnG3bC4AxF0MMrTIvtP6EToScHuyUFIuX5e6AODnoB9Wo+ORkeBBT5feQZd9c5dah6Sem5TuEIU8BmN7+PhOA==,iv:29VUUFYc9jWsai640NkAEV4AviUGfQ+lqww3U4jgJAU=,tag:hJQTmFWx9NNkb+E85KCt2g==,type:str]
+        username: ENC[AES256_GCM,data:eFNr9FGemQVj4goWoU/hEKrEt1rYjtnroSrwhpmQ25Q5R6nnl2eu0LG2PywkG6d1dhVuiKJfO5YsUWkjK3oENA==,iv:zIiRMdrVgmG9korQBte4Ble1oPHYI2PlPbJZFhGAWi8=,tag:cSA7Vb80wmGkUj0dyTh3rw==,type:str]
+        password: ENC[AES256_GCM,data:uwYf7YoPaPzxORUbER+N7SdJiFDgdx8Z4VNFRvPN3EifrM1EbvbTWr0BiowzQHVl7Z9y6azglTXImG9U0ChbiQ==,iv:S3+/P7SiiKRj+/y51AZB4XTbu4icbu0BjhA4mT778l8=,tag:LRXwJRLPnBQFqq/TEspjgQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        HFSmHnxpjKCVdvLjqwD2EmZ4WZpKzb9lQ4bm1N6JArP9lx1zrLjeZx1EWl9QZM5S: ENC[AES256_GCM,data:pcQCbLExE/0YdC2AHG6BCD/Ihufeegdj3lidUcjtDDa09047skBqgQpamP0l2GamJhlwF7kz58Z9DEZ8,iv:Cyf6uWoxqGtMB9Pz9lbmST4S82dwrCVAOfxY3T3QO6Q=,tag:FMH94LKQOdG2u2r6SFgHeQ==,type:str]
+        HFSmHnxpjKCVdvLjqwD2EmZ4WZpKzb9lQ4bm1N6JArP9lx1zrLjeZx1EWl9QZM5S: ENC[AES256_GCM,data:DeEmXkcGndrmISul5VI3SJT2FwACXQmI9he+Gpf8gX4QhP4WsTMvEBUAyrcL94E3zs1CNXQg+AAj6HId,iv:/iLNtelcYSryVZ4iflj3NaZ0vNo/JkEJ2HazveZH+p4=,tag:DNlzaVhLIfgSohHOWnK0SA==,type:str]
 prometheusIngressAuthSecret:
   users:
-  - username: ENC[AES256_GCM,data:cGKPJzhDIxOwWXVVrecNSx1KJ+XnOHx6U8w1URYD789l8TCaA7F8w4iwgyqnCfYtCuLLRbyxECVtGTKLeydG2A==,iv:IkxGNrab/qsHUGapbLsqN3+M0LUBOZlG1d7PZvMcGs4=,tag:8p67bYR7w3BG4WFRCS6lNw==,type:str]
-    password: ENC[AES256_GCM,data:jcXT00FChb/Yj5J8oZgs0NrYFA5MOI6lHM2ukhzGtmreJEKBOFYeo3DStWkXtOXjCOHQlJc4PcJPJNnQMey8CA==,iv:sTQB7vwOEyROnL821jEjKwBuQ4neRxgl4qlp7jEk6Pc=,tag:ouZzQZvTnwojRVZupS7FHg==,type:str]
+  - username: ENC[AES256_GCM,data:H9y5WDrdbYTw1LZxTbMiERLsgxtykv7oQ/1V+Yn7Szpk+swYmoDPFye9jsP272fxYFJASyItAsY+z9LZme/CYw==,iv:1RZqesfzjqC4XC9OIQ1SRpkIE3pKKxuy8Vs5GSlrOhg=,tag:R64Vc6AyBX60UOwgnyJS9A==,type:str]
+    password: ENC[AES256_GCM,data:+j/1usRZbb4Oy1719ccom5aZNgmI81OylJvUFv+5dMl+NDpwnrCY2f/Ei+OAVUu39V+NcNdHv0Z2BRQUAt+BVg==,iv:2d26O5djAyrLziyR8zr2Qxin9Mu7zCcjbTB+plOM90k=,tag:ZtExe/SXn4Wdj3NrC1faiw==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:15Z'
-    enc: CiUA4OM7eKNmo3Um3bLBklca/IZm56sG9KRwdjU/Bl3aa+PWIIyGEkkAZoeZpt22/M8rSH2VaI/eR/HX1LyZcr4hP2gD5zXz23l7VFGmdUw80jByH2iX9BIM3c8pvgkm+sCv0DCkmtuJfFYIJFmD7l16
-  lastmodified: '2026-04-16T16:27:22Z'
-  mac: ENC[AES256_GCM,data:YPw47DDFtvNeHwAA/F/sd9y2tj5Uy5lkGL2hzZO7PAerjXDd/PhOIjQhV1tLcT5YVF7kXJpoyTtmp3JU7KP0E1g7f16Gl8woEAuSRijjzrZ+J3OqGosYwaUNtaK8/8qGqfAqspWiP5RoFFp1rDxhigQ36KmeSxCepBqLm7TaM4M=,iv:bDmqFYU5tQ447S/OXfj/2WR21NOZ3euifO/F6/bv4cc=,tag:HsDB8Q97v4KZM7EWNNqw/A==,type:str]
+    created_at: '2026-04-16T19:33:39Z'
+    enc: CiUA4OM7eISduCqa5zSn8+Py9qv9vJDrH1rbM5yl/Vnml7MKGZx2EkcAPHlbmWQfZuDpTLXL+81eC80o5RNzsABsKM1o0XzmOhYf30MPZPN4AUIw7tgNeBcow/ZuBUmFdpSAxC/FIm4uDyWGG+0ouA==
+  lastmodified: '2026-04-16T19:33:39Z'
+  mac: ENC[AES256_GCM,data:8RHAGJTJu+02cceBTpAsYjN+VQX6yqGF4IMBvTWgg2LUmaU1HAwapXNQiu9Tc3IYnWtA0b+eFQxd1wrARkQgPLXSD9ZUscbQ922zRNpS2CI74Bb9bKb44BJIW7m2D5QFRg672OEfIGjyMslTk4Iq7moKn/wCGKe1UEIej89znCY=,iv:7xZogcT8pNrH+TEV/DKRCb2F7ezVKMHTnKqvnSdsFsI=,tag:E7uuuoi4F8WTdiv7XzeMQw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/opensci/support.values.yaml
+++ b/config/clusters/opensci/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 cluster-autoscaler:
   enabled: true
@@ -17,6 +17,8 @@ prometheus:
       - secretName: prometheus-tls
         hosts:
         - prometheus.opensci.2i2c.cloud
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/projectpythia-binder/enc-support.secret.values.yaml
+++ b/config/clusters/projectpythia-binder/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:+1A2iHHmYRoenckO5aKrD/sYEwf1wH22RVQ7gzLSBdTL1XOZGcgrBKrjvmaP9Co3f+ksjsVLPKuWxeqKEiBSEaiTxXzFXhDZvCfWgUiPPyysJCJhdiOqY4SqdCgkHwFkRlZ3ArhEqKOviEpo1yYrqz9lR2RGB/2rA2UtFSsCIAL6DctcR2J3Oo7ypwzj9CT/nvciRKDn2k5LhZMM,iv:jK3lyoaDXRiVnf6XFOyp2iF9f/hySDNITXz02nRPkyE=,tag:P1bHlTKzgtNw5J5zIn2AAg==,type:comment]
+  #ENC[AES256_GCM,data:P4VBA9rVS6OX6Hnhd2bskFhMwplkxm3f6QP5c8kK4/sSOlxySBiDWfnNuNIzSO/P8Zw5yaj+mVbFHpbGKoVWjz+8MEfHn2K210a615xIqYqr1IXAuxEzVrZ0UVjJYvFF2C00bd6T16fv68cwSiEvdxXdIdsU9UBWwdc+S9MVe3hM4wTVOjItEQvoHMpCRzGRTBuHsCk957MMqJdw,iv:23m42ekIVJ3CkV6u4XShA7+p+GU1tnktA3MlbYhkSUk=,tag:1a014q/OVe6nN0Oi39zXqA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:+UuC2eDgCOi/bdm2mIkLY3cGjGailjUx1CAvPfnf4Jr65EXMJnvtTTsptvU/UMbjPVBkvdp5TD8kDJWdfgzEew==,iv:jSe71wM48SXSj007kQ2VibkZBu3wUfoVmgGR8baFF/0=,tag:rG7yojkZnhExo/7AcMPImg==,type:str]
-    password: ENC[AES256_GCM,data:yHMcnFlLIKPydx0XRqSdiMurVUxJzXAeQFyZTO39v72FYYQ+yzexBRqAppEqvOcplld87pqae9MFOAL+R1GpcA==,iv:OHVsG3kGnYT1kvYbd173rCf2FibjD/GG3D+CRK2l68M=,tag:xE8tX0iwM1tbUW1ZNxyb/w==,type:str]
+  - username: ENC[AES256_GCM,data:BcIWwHRnrY+VABVnDaYoDOZrl0SXBTbWDYTSIMFPrtB2Bvl9mkJKmHXDYKX1DXCGonwfytaHJD6sgXpy37rUzw==,iv:m4YGzpfFlAdhrxTGZizokusyv0cfOme1BPMYgzakwaU=,tag:oXJ4Wh7eAmHT2jv0ZJJZvA==,type:str]
+    password: ENC[AES256_GCM,data:HoQtFz8zlGl8zU7rxPRuNVts5QJQjmS/3IzIoyOlJW7tuNqkPkdCg3tzF4iXRigPJdxfpBXSx7NV9GmYuSW5IA==,iv:FcH+HQp5BrZNAFhdQ0mjuLafm7NEPNdAZrCaKvO9/iw=,tag:Do8/xV4f+IiNthW7C3+GcQ==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:oyPT5aI5henMeLKPxA==,iv:3u3gElAvWiwhO5v1IdPxvElHL/B5QBG2NpcBjk0FFrs=,tag:YprmYhIQzkN6EOlMbi3E0A==,type:str]
-      value: ENC[AES256_GCM,data:djaS/PvdvT4H3mjV5Pp1cSlVoyfhRgEYnCbHaSHvD2ndmvlXDqJTgPCzMDVWhEmUOy/TMrq8OJDMWQ+GMTrenJ3BVKIwhaVxZCLZDM495e/jOdhe+jGpWqPSbZKBqIIa9/U8VdRJNKK9fwMl36LzKFNDy+jixafxMCWwgM420ed40uBoYEvgF1QtJUwGEq09XgrOHKYmQtNrXjxO9ipxo+RwuKs6/xs0T7zCOn1qg+013g==,iv:Ac6LRsX1lsPsa4BcPv2lM1fJ1UdwTGK4ZoaytmcQ5fQ=,tag:TdqHwYmNWWXuDKHmMnSn+w==,type:str]
+    - name: ENC[AES256_GCM,data:84qbev33dFN1n6m+cg==,iv:myEXVmt0+qg52KEQuwcWl65dDQrozj5l7VytE7u1jhg=,tag:DHoilpou3pv4EQK8aV8MfQ==,type:str]
+      value: ENC[AES256_GCM,data:7vINU6AhFmNvTk9B3W3040MnxEWLUKghis9ZKSZgt8zj0PswVk81QT/GqXCDSZacZIcafaxPM9t8qEIxX5NXew5F66NriDpKytlxhXg6D3bzffFU/5B4gSbCM03051kTJsusOkGNux8JY6m9ZDLWrLQXBQeb1GXshqw4KxQkrdbI376V5O3ZyQhzKh5tlUZXogeP/SFwB8AwpDicuSAq8aif7cttQj9E/QXXB+1hjQsc2w==,iv:IrU2N/lMgV9JG4RbUu6+eG3rdidvZU2cyG6blbm6RRo=,tag:y9exSG1OIZiqmkdz3p8lJw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:5W9rQVQG5wc4WgSp4t8xWTZHOq/bxUGsiUviruHahtGhTmmknG/SvBKWjt9sKku3s9S5QtLN81v8iNdQz2Oa6A==,iv:OzAz+N73aLHo92OskEamE1tQkyW1w71ErYbs1LFZvwk=,tag:iTUm1kaoEpSJromrGqZaxg==,type:str]
-        password: ENC[AES256_GCM,data:fQfKv8iPMOCqZWOI7SSZEiXqb9SuOQR9zJk4MxBHDT50/3C+647GHUAJJAiUW2F9amlhv50RIIyBNIo0YeC+Dw==,iv:aoeOwff4zZbfEJHADDwROYs0G8owqJWAuFePL7x/f1k=,tag:ijSVGsetqrZHiejsg8H3+A==,type:str]
+        username: ENC[AES256_GCM,data:txSCe7rnpXndJtQynHWdC3GVrrlTeAeabTPI+o8pB5uCg2gx5yIT4ATTVYDEdEiZd2quFkRqxySzJ0PwmIbpSw==,iv:nPS8xSuVhA18ve9TXoL2FL7ChNoDcECb838DDuJMwQk=,tag:mTJrMGMzVHtwpAkzgpw5iQ==,type:str]
+        password: ENC[AES256_GCM,data:jHdU4jb8r8R8u+c6CjIhtfFpS+5wT5ScGn8JbTyhQtQgidKP18daVt6XSI+7U+K0GcFLASFP0ej7Yu089vEjtw==,iv:ug2pGXZfLRJyqu9ghuYFu1fHfUza14lq1wmYF5OLx2Q=,tag:a8efVpuATSJpDqyJnAGK/g==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        OyFZM2bRc0wzQ5pvRSKRL1ic3DPihHN2ZCt7ttt3bVkGwKvinSRGfpjEVXVh5oZs: ENC[AES256_GCM,data:OyhtVKBsyTSW/Y7aACqdlrk4g1Iqk2zSAqfNyFEWkd1nWGN6KFkdYFJ5V5T1QinPTaCa50pb9TWOANbb,iv:zhflbbblKAT23u1cMVa4FO2GfCUcyT6DXtLBNKl0xrU=,tag:v4UOrKqbyjnSjnMSjG9lMA==,type:str]
+        OyFZM2bRc0wzQ5pvRSKRL1ic3DPihHN2ZCt7ttt3bVkGwKvinSRGfpjEVXVh5oZs: ENC[AES256_GCM,data:9LcB83bRgzb58Vam8M02Ff6zC6zR+buesabQQEfWDmfRsKshFDzFuptc9qX6oW4rJjyjo7nlEcETydXq,iv:DPOetY126FwMpRZbMJzEoA0HrFs2c0fDPuEBDGBJ+YU=,tag:brbof7XY5ubcROob9qXc5g==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:EA==,iv:NEA0r8DeBLVX/wHWe8ksjeYScEFeGcAUK1TGx/jayKU=,tag:taPI3LhZL50V8XAoQwG5iA==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:LwmRcKGn+Idfmw==,iv:y06ZrrfXQT3KA/ozaGjswInFwepv9a+XLEo7jSl1r6I=,tag:+blJT1mBZsCAX0OLHb4ODQ==,type:str]
+        orgId: ENC[AES256_GCM,data:ow==,iv:kYuNhoVCXGW4gyBvVmT0JJLbdT58FlgZsxmJKX2D8lE=,tag:xMsK09GqHrqAU9WaLG5ErA==,type:int]
+        type: ENC[AES256_GCM,data:Wx6BapZtl22y2Q==,iv:xQtGe5VpxPk+69xzDHc2JFbWt50TF875deYykZcDjxc=,tag:JwlUqCaVyn0H0QTjo8tEOQ==,type:str]
+        url: ENC[AES256_GCM,data:fU/QU10UaJzplzWNzZ9EruXJZzH4bcoUnk8AO6AFORw=,iv:ir/lCEMQsatjKDrK5G+Y9SMlR5T1E5jNOem+b67V1so=,tag:2VZngRfJx1R1Z2x916QY+g==,type:str]
+        access: ENC[AES256_GCM,data:ecR6JE8=,iv:REy8TfC0lHPt26f63kQWIeNiyPC+9NlqA9wfxc9A15E=,tag:lyM91mW8ANNEh2ukPKKKag==,type:str]
+        isDefault: ENC[AES256_GCM,data:Dj+OiHU=,iv:J5YfrX3YQFlfpzA+CGvDhMXNLZ1DAFIL971SbbYyJmk=,tag:f1KWSL3Gx0IoxHeLihJewg==,type:bool]
+        editable: ENC[AES256_GCM,data:tP4wC8I=,iv:dEI+7HK2ln2xQspCJnuewhB6a1cJUQdxSKzXeK+1+FM=,tag:rWcktxWlm35pjzyTcWkRNQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:OBSKjQ==,iv:twOUHzp8JbdlRdUtHHpoBxOXd1Q5Q20Bh97lfa/1aoU=,tag:3so2YuNoymV7/RUJLDX5xw==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:MiUHkpKsM35jrC46cwYxxNXv2cLfT6IrxYa+qUP6IZtOZBbec8kLoqXTTIPezENGPBw/4nAMP+vP9v6I72+nvQ==,iv:aBlTTxvt0YAHXrvdRB0cz01yOC+GxWDx+z9TegQSTbI=,tag:pu3R9S+qdD6skQQuWlXF+A==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:qvjXL10nYA2ARoxPSETak1MJ5T7c+O2Pz+QDKPZPPGzP1tiSpiHj9GwPjaqvoeAhtO5vUrdrG6BoyCyZ9jjxNg==,iv:qS85J3KR2FNigg504Xt90guNWOnsY68x8hXCFkdDoDc=,tag:TxjfpEhWeE3QAkvBaFPvqw==,type:str]
+      - name: ENC[AES256_GCM,data:Jok+QcWpzkewn2EDpchj1RkcnrVMHYcEMxhPO00CkQ==,iv:iO5mPHgrYBKaI3N2xXKNR3JhdGGyN5yWXO+ojVzwY34=,tag:xiWsb10WLuigYDRAqeWREQ==,type:str]
+        type: ENC[AES256_GCM,data:o2EM+d4luufhkclj6JUk9zJDSAS7EgQ5C9lyBrifGQ==,iv:XPTedS0JvYt7xXPaIZ6dy6a0HIrOCUHNcLoP4up/ozw=,tag:oLez1/7o89NWsXT6TFoLtg==,type:str]
+        isDefault: ENC[AES256_GCM,data:nBf99ZA=,iv:c78PUX+uYbqAYNudzrpsDcQNJhvk4N3Njy/VPSPrDwk=,tag:ntRDtGGK6cJTrYAFcW3eqA==,type:bool]
+        editable: ENC[AES256_GCM,data:Zm/HCQ==,iv:JQUgb7H1DwFj38+qRTXBxoPyC+U08wB6AESUKoh4IcY=,tag:hVZz4JAA+luv77PFZnu8ow==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:34:02Z'
-    enc: CiUA4OM7eHu94/8cHRIe1PgHiu21WuBkJ7C2gmhTgf5WFc6QiWXgEkkAPHlbmRjjq26MuV15qusD890EAGToFLjuy2L2/wIZ53pVw0LgRMwfio8YqvGOupJtJPNzJkLXbRpunQlzwcYKPJ5l5TQXOHY1
-  lastmodified: '2026-04-16T19:34:03Z'
-  mac: ENC[AES256_GCM,data:26eEm8uSJ2uQUOWKUtnZBjBsHfLF9rOyxdm5a0MmOS3+ACnqKIH94EjYVT1lnZ8sNe0+Jh//+olmhuEVnRk/8M+loyTysy3YLBzsBo4ryrPwxpWD8klAgCzzfnpkS39DR5/HwgLO2dQGTO8KWx4UUo+yBlvJoz34LZYtegMmM7c=,iv:uazMb+V99A9UfK2eo2Z0q43sV10r1/1mRZP8fii3Bks=,tag:Xh3wYKKO6oRH42X6mvpWFg==,type:str]
+    created_at: '2026-04-17T08:25:26Z'
+    enc: CiUA4OM7eC+GFA9VAkif/QR0cBTgeOlGJmVNUJMIqd/gxcLTiAK/EkkAPHlbmf90bRYg1/Kv8MloYDFuiOivgCHGT2B2GG8Nz1ffo614xdwWMBhae3Hyv0AaFMCwk3ztplMpwiKrANjHaXEfQLV0SgLX
+  lastmodified: '2026-04-17T08:25:27Z'
+  mac: ENC[AES256_GCM,data:APLqC9klMnvdG9YjKd/hFC+dUjzLsVf93Qz0qX5YtUYv/KZDzivokIt7yomFRxnuueREY+CuYfiDL6rf7lQ1mt1Y1+fGfAOk+gfdQj6O6sq/xLgXuyMgv56Kp2IsJGh+njwuQnvCEqH5vCatnAMJYKf0NEBcpMqsjL9GejnUURg=,iv:Gj1eet3FNHWH2XiIv/EMQJc2Qz7wxsaQIY49D3MaJsM=,tag:K9RXU+al5SUYiiJ5PoJ2eg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/projectpythia-binder/enc-support.secret.values.yaml
+++ b/config/clusters/projectpythia-binder/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:yX/jY3X0OZlOL+JQcXhVpkJw6LXZVO8QC3oh0tuskZVJ2hEZL9IKTxqYe3Xdda/1RGCgKPQkSkQ0q80Fb6/XFDdmgcvv9ZAhmPZ1zMG4AH5Nb8etEUe2J9mmE+U+4aAjeZ9iyA/bntGbuhTWNOKsUMlhyUXBM58jxnqforkTDGOH1SALB+pZtneZ31AvVeJxt/WMlLCZklt9vfDU,iv:nxWu8bvtsI82e8woL69kgMRCPk9pY2QgTJcI78rZ92I=,tag:K7tzsa5JfLzlsDRq983EGA==,type:comment]
+  #ENC[AES256_GCM,data:+1A2iHHmYRoenckO5aKrD/sYEwf1wH22RVQ7gzLSBdTL1XOZGcgrBKrjvmaP9Co3f+ksjsVLPKuWxeqKEiBSEaiTxXzFXhDZvCfWgUiPPyysJCJhdiOqY4SqdCgkHwFkRlZ3ArhEqKOviEpo1yYrqz9lR2RGB/2rA2UtFSsCIAL6DctcR2J3Oo7ypwzj9CT/nvciRKDn2k5LhZMM,iv:jK3lyoaDXRiVnf6XFOyp2iF9f/hySDNITXz02nRPkyE=,tag:P1bHlTKzgtNw5J5zIn2AAg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:rOqMEUaRw9cnnk5gOdpeNfMVH+jpc78IF6JFv6j8pmetkfi2wqDNGj9dOBaxLh3AnbawyAwekU8SfmbKJ2acUg==,iv:d+HCJpo9jrJRFnqlU26JTyx5nmCVTx9u1OCFnBnMc00=,tag:MQbNuXsk67475iRziiYS2g==,type:str]
-    password: ENC[AES256_GCM,data:VUOlmwvM7HmVDcpIfMCwRtEIlgKXNpn6x6zE6Xnn0mRGZZUuEXLnaIik5yqKAb4YC6wR9a29jyY4nT0RSKEAmQ==,iv:C6XRjLvBVI0POH+Fxjtds0x3pHdMl3uKyCH2tvVjGXw=,tag:bheTptic+gOxvHU0lfQa1Q==,type:str]
+  - username: ENC[AES256_GCM,data:+UuC2eDgCOi/bdm2mIkLY3cGjGailjUx1CAvPfnf4Jr65EXMJnvtTTsptvU/UMbjPVBkvdp5TD8kDJWdfgzEew==,iv:jSe71wM48SXSj007kQ2VibkZBu3wUfoVmgGR8baFF/0=,tag:rG7yojkZnhExo/7AcMPImg==,type:str]
+    password: ENC[AES256_GCM,data:yHMcnFlLIKPydx0XRqSdiMurVUxJzXAeQFyZTO39v72FYYQ+yzexBRqAppEqvOcplld87pqae9MFOAL+R1GpcA==,iv:OHVsG3kGnYT1kvYbd173rCf2FibjD/GG3D+CRK2l68M=,tag:xE8tX0iwM1tbUW1ZNxyb/w==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:oyPT5aI5henMeLKPxA==,iv:3u3gElAvWiwhO5v1IdPxvElHL/B5QBG2NpcBjk0FFrs=,tag:YprmYhIQzkN6EOlMbi3E0A==,type:str]
+      value: ENC[AES256_GCM,data:djaS/PvdvT4H3mjV5Pp1cSlVoyfhRgEYnCbHaSHvD2ndmvlXDqJTgPCzMDVWhEmUOy/TMrq8OJDMWQ+GMTrenJ3BVKIwhaVxZCLZDM495e/jOdhe+jGpWqPSbZKBqIIa9/U8VdRJNKK9fwMl36LzKFNDy+jixafxMCWwgM420ed40uBoYEvgF1QtJUwGEq09XgrOHKYmQtNrXjxO9ipxo+RwuKs6/xs0T7zCOn1qg+013g==,iv:Ac6LRsX1lsPsa4BcPv2lM1fJ1UdwTGK4ZoaytmcQ5fQ=,tag:TdqHwYmNWWXuDKHmMnSn+w==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:5W9rQVQG5wc4WgSp4t8xWTZHOq/bxUGsiUviruHahtGhTmmknG/SvBKWjt9sKku3s9S5QtLN81v8iNdQz2Oa6A==,iv:OzAz+N73aLHo92OskEamE1tQkyW1w71ErYbs1LFZvwk=,tag:iTUm1kaoEpSJromrGqZaxg==,type:str]
+        password: ENC[AES256_GCM,data:fQfKv8iPMOCqZWOI7SSZEiXqb9SuOQR9zJk4MxBHDT50/3C+647GHUAJJAiUW2F9amlhv50RIIyBNIo0YeC+Dw==,iv:aoeOwff4zZbfEJHADDwROYs0G8owqJWAuFePL7x/f1k=,tag:ijSVGsetqrZHiejsg8H3+A==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        OyFZM2bRc0wzQ5pvRSKRL1ic3DPihHN2ZCt7ttt3bVkGwKvinSRGfpjEVXVh5oZs: ENC[AES256_GCM,data:OyhtVKBsyTSW/Y7aACqdlrk4g1Iqk2zSAqfNyFEWkd1nWGN6KFkdYFJ5V5T1QinPTaCa50pb9TWOANbb,iv:zhflbbblKAT23u1cMVa4FO2GfCUcyT6DXtLBNKl0xrU=,tag:v4UOrKqbyjnSjnMSjG9lMA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:20Z'
-    enc: CiUA4OM7eAGMXu2tlkK5c4LtFDV7M8ydWs7QQkoGYsBJnJ2hMfFxEkkAZoeZph7xrLLqjNr2qN68MfGNgkl6FeG1BA+Wfpi/tRax+N/LuByh1uwWvH3JIxxbKq2ELSFtyE/smfwWWeVUMSafnIEAYwGQ
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:21Z'
-  mac: ENC[AES256_GCM,data:96mF4BoQhmm6CvH6DobBl80319FD5DRGvSME49vQJvCystZiXksmfG1xrC1sTZdXFJsd4CnGqlYMfmETQ2Et81AvHxjx8OYpdqipap2vikvKJyw2La4Vo/pJ/T7l5CrWZMZ9RUfh8iYeDbgtYfbAdVSY05/eI7GqRDGvXc2u0xI=,iv:raUgQFlbMltEJlRKOXphtDlkhuU7oIeoI+QMHJv47wM=,tag:SOjQWQ3GjcUH2iv5tRwbJw==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:34:02Z'
+    enc: CiUA4OM7eHu94/8cHRIe1PgHiu21WuBkJ7C2gmhTgf5WFc6QiWXgEkkAPHlbmRjjq26MuV15qusD890EAGToFLjuy2L2/wIZ53pVw0LgRMwfio8YqvGOupJtJPNzJkLXbRpunQlzwcYKPJ5l5TQXOHY1
+  lastmodified: '2026-04-16T19:34:03Z'
+  mac: ENC[AES256_GCM,data:26eEm8uSJ2uQUOWKUtnZBjBsHfLF9rOyxdm5a0MmOS3+ACnqKIH94EjYVT1lnZ8sNe0+Jh//+olmhuEVnRk/8M+loyTysy3YLBzsBo4ryrPwxpWD8klAgCzzfnpkS39DR5/HwgLO2dQGTO8KWx4UUo+yBlvJoz34LZYtegMmM7c=,iv:uazMb+V99A9UfK2eo2Z0q43sV10r1/1mRZP8fii3Bks=,tag:Xh3wYKKO6oRH42X6mvpWFg==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/projectpythia-binder/support.values.yaml
+++ b/config/clusters/projectpythia-binder/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/projectpythia-binder/support.values.yaml
+++ b/config/clusters/projectpythia-binder/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.binder-pythia.jetstream2.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/projectpythia/enc-support.secret.values.yaml
+++ b/config/clusters/projectpythia/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:08K9Hg1xTkI+rxESOX7gMVoWD9blYPZg7Cw12eG7Xy2SzPzpDjO8S3whxOvtqT6JJKqwyWTPI1SRuKRp6SVKK5itN6YaICdC9VnqZ4CX6nUfUGTnxLpDcqUO8qakEZVcvk25tIB2EiP8c4felFGP97/81CN0OR6oDKySJfoLmiSjzfOaziNxeKLHWz1OdpNSRDXfFNps5RKH5krv,iv:nCCSHDgnZrznkgiBHog3JzQRGIzmOoxI5Oh+2vE2P6k=,tag:oDuo/Vn1FduCGG90KII7qg==,type:comment]
+  #ENC[AES256_GCM,data:XVxtW7UMTj3Be6nI4O5U2eJVWz+EmNvlrk6+TeABrxpsJTre35/ubAsX08HERSWygILjHb1R7iApCHDEIUb90eAGX9i+Q82jZDoe1AV1cTR8+yYds+V8xWI1hCNbZa/iFwKjAcHfvyC3XBnYxFFe2GlY+GGWWmb3L2udprAwKgIRFlELe63Oxe31ji6c11e7+7oor2l2rB0A2ldh,iv:6gGnyBazucPE8UuSt2WALHPNiUzoyrSmn3+Kh+wsZ94=,tag:B9zUJHSWPtkamMf3v1lPew==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:jHYHO6CR9i02/jXPfsakfy65gsDQLeAsXfTqIdBEDZurUBXnNhXo01enL0CajQJNq65Mu8+sP3p+xqcgGX+h1w==,iv:e2sYPlqTfqFb+6GWSW31IiXXe78nGQsfDpLBydkE5Kg=,tag:msxvPdz3tSNBymrirNdeVg==,type:str]
-    password: ENC[AES256_GCM,data:JlXfGpG4+bbsSESUuAebsMRg1mST3wAZbqe5TrQgrHI7NUIlWa+uDHNtWa7u6Niid4jIKBPLpQIvWH+DNJJ3bQ==,iv:hFBbKSsvPkzGuTFJOuXwMhGAAhZUSGgqde930++Xwrs=,tag:IX28SrDUQ3Jc+5Xiw3bOPw==,type:str]
+  - username: ENC[AES256_GCM,data:tK2JX1yxDwkbGK5/fuRNSZ0yb8haeelOanMyafj/5CmDckstjn36KnfR0boqiECnVhXA1RyyKkMBwdn0LPxEvQ==,iv:VVaHeTfSxdI+RJc0zgXetAgt2SFB8txAMQqlZdeiFj0=,tag:ko6kTsy584sotAibqg+Ibg==,type:str]
+    password: ENC[AES256_GCM,data:Sq5gjDqzVmsraSnS8YMuqSodco2RIW4MlgQ6AQZg943LazlE05bLXNpTQ/ZiAJwayv0GdHYCD/UarbvNc33ZLw==,iv:+e/i+WE7hKVyn35A43zy5pdxLZXjpCng5IY27zsRUIM=,tag:6ECIIsKXHN98xRlX1KiReA==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:/dfHdxkWBDZpP8+TZw==,iv:5gx/sRd3nOC2ODZmL0V12X1O0ssC863Q7HPfQgbaTcM=,tag:PAiizc13WA3XVA20bZi3NA==,type:str]
-      value: ENC[AES256_GCM,data:/WoQoUuvSYv4rdZWU1RQyJinsh+Qt01bga5vqzqGCncOWp8RGbAAIwB+sy0SL3by2VuYeBd0QxLOx+hNkBhaWUSfvpbyGTfhZ+SIkel1qFOWFGr5JRhagdHKEo81JXSE4srhTRZGwy0u9KLZdCNYkkKrD8QVdpimVkMbB0XEcxGcNWO71gYK21efTBuIzI4STE4j/tGVkudRiNXTSCcXyd7IC7iQVsCd5GeG15+nZ7ZJ9A==,iv:XxpeY0YZr8f8ZmM3pghieQ90UjpZ3HsJlGtneLFta38=,tag:hRrBPyl5JhobphalysNlbQ==,type:str]
+    - name: ENC[AES256_GCM,data:oY4txt1j2E2u5tiqqA==,iv:9f4MRfYbBUdOi31wWEB4BIqddeuQ3caFelZcYG3GNwA=,tag:xpw3WdFVsjqQShOO5wGPHg==,type:str]
+      value: ENC[AES256_GCM,data:5UmRGgIpnBjjHsLGjP9Mi3IZRau+gOWJs1865qpAA/w+4yzOAV7CJVxouH8msi2Bm03GwvHoQLEIj8RvkL8VYP+6L5hgDTbnIx9V/E9pnSQMgk+0hL5zx7Od7PcV4jreFUzDwSbQUMxmQSvQX4wua+Qh1T6rTvm+7nrh165S7SM8xMS0aHDZ6ahv0uAkSiUiS8BZyIpJDAF5Ry7rM5/oAZChZdZ9vcxixaLCqfmo2hWftw==,iv:RLIpn6EG3LDEFIJ+p/JJ59SFD4x68Ciax4n6jgxleEk=,tag:02ntiuuzULqMfPsDGmFj2A==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:/tUBGO03EFrGXu9ePZt7W75YrhzqxY1o+2XsDzK6yWkbV5h2lFZ946SFyYEL4vk8NNdD7nybAYIEkTO45MdyUA==,iv:FeZhcrJpel+VY1F4zJOXQKNvKetokb3A0IUXDb82AYo=,tag:OEJm5/jlc3+O7udWsLZWVA==,type:str]
-        password: ENC[AES256_GCM,data:ErReWeMb6el5EdnJNleij7k0Yz9kah3aorxZbDwt9tLF8k2Q2c7dBDLJemmuScZRLOIRKwpTbKJMvnd5nGZM6w==,iv:UUo5VRP7AMR8le42iUjs0oyVTihrHKn2VC+bPyCGtr8=,tag:Mevt6frk5cWVbRpv+eRriA==,type:str]
+        username: ENC[AES256_GCM,data:IYTOqwj1ppGqENH1h3mO/R/aQex3Uw73U4QXu0Q6M19pxCcBLwHWUxtrV2D6lVcnpWxufvBITBekXWEH5NGVqw==,iv:j5eniBiBO1nMldLNbEx81rAj1gSA0IDBwxqKHyEGDZQ=,tag:Ryv84wNYRBBaSIVe0ilS2Q==,type:str]
+        password: ENC[AES256_GCM,data:AdcTL4ZtPC7Svk9aCLwOUcjkQrMekAT7xZBWIJpX3blmGjXwl1R2WHehvsbcq3loBjbjwyIjGuGlAZg0pbeoXg==,iv:QiZTHHgYXTFQyTBl8PjH9jc8a8/WmCCi3/1ItLC24is=,tag:jnDffvSdIeDXi2fNgK6Azw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        Mo212kziLwQFZyjyGPGj76j9OEzgjXmVoAOZNQ7ckVOJy0ujANhbICirTTpWNBk5: ENC[AES256_GCM,data:JX9u1fhvMmUDB+qJCGDB/aC2gi95NCxy4YOcwnf0hKx5TBpTIQmNekewQNTK9xOVpXpZ+/x5ltDklb6Z,iv:2OcEmR+8smVFdDL4LKbeBFl41dCBw7QAlHmoVcUUwag=,tag:wh7kMfEdpADUFdzFNLm7lw==,type:str]
+        Mo212kziLwQFZyjyGPGj76j9OEzgjXmVoAOZNQ7ckVOJy0ujANhbICirTTpWNBk5: ENC[AES256_GCM,data:bqT4kvPEf+hIMia7T/Z47cnXC24bbyAtvsgp2BpIMGp6Cknn4JhLDlNKNa1DE1chjLAsYlvexn33PRpm,iv:bTfctVu2OKh6TOdpQQ18UReJ2C6ydehpfgfcLBsTK74=,tag:E3xLayd/dlD/JRZYyZCvkw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:IA==,iv:smHrChmyXbHhU41MaKaLFdPEit1wd8+MHdlcL/nJ+KA=,tag:my4Nldf8P53VVKL7WR7UFw==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:C823eLzV5wfV5A==,iv:vmFKqLAjzych5nEEFODv68UD7h1073fvo06JQbW7C/Y=,tag:CZkcPZ2MY2vKRbz/Sy1FUg==,type:str]
+        orgId: ENC[AES256_GCM,data:RQ==,iv:/CZgtXgmpyxtvRk+lBW59ae1XIBDpVmS9NstLss9YCg=,tag:Lh2wyDW9p/4/dswpQJKoxg==,type:int]
+        type: ENC[AES256_GCM,data:I6HU6x7hv1SZ3w==,iv:KfbxMZQmmsEFRRFB6q9or8lKCxjTdU6jH1eUUwuX3VQ=,tag:TGHKyDsD9I0svyX+vnWniQ==,type:str]
+        url: ENC[AES256_GCM,data:fFQxdIfR969Lgb8pFCxgPcXxUZHj0xFh3mPh9rbtxo0=,iv:ykbWtAiTNZ6iLrdEnDWaQ8ngYdIrumdjgBaENnOOxwc=,tag:l8kMhFg2DN2anzwxW0/wEA==,type:str]
+        access: ENC[AES256_GCM,data:I3iubTM=,iv:6hz08bQtZIRvEkfqF2tGahgNbO8xdSTAvAuM0oLna78=,tag:8ZtOXhwUshYxGwC81KoikQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:C9dKs1I=,iv:yJaZtSU+2DA+j1rnHgvRhFZQ30q8Mcsj88UE8Y4LosM=,tag:T9V4Sg/9+djFpASbb3OXMA==,type:bool]
+        editable: ENC[AES256_GCM,data:AnzPgmM=,iv:kdcumYpJSXJsFCDnbpphPA5WIfNFBY2Im124AcC/v0w=,tag:qN1lJwwq8P14PkXUT8U/Eg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:GX/4Tw==,iv:crQyrr4bF4c+0R0grIzHktYGgSGXG15UqXbRnITbOGc=,tag:8nAWvY3jLBhFC8BynaO92g==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:VsdEsVPZ69y1fB/D/IheneXE1DWZU0hinxHPWpli7ALAhDm9Zr1NNFRjopJD8VWh/WJFjIeADWvni3a+G++d4g==,iv:BuRoR1dcUFIHJ5dUFEsCowIrvEsbaeMN0CONSzCnnI8=,tag:yLwQWwxzHL1k2vYT1VqMKw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:3XEQuhtYBw5zXVOq8cGqpjID9lb6t4R8uKNau3e7B868rkRQwk9KhrjJrewyNEvfrNQPxbP38WeFHLdmInxeFw==,iv:pi+f4G/l9qCwi2OzRMB88VDHMXss61uN7XUZ/svFzd4=,tag:P8Jv7ZQp42cDRbW8HWR/JA==,type:str]
+      - name: ENC[AES256_GCM,data:hAu3Rhpd8fjDtua6WJuUj1yn3Tjamfu+t/ru20jbIw==,iv:dlXhW7SIAXLc3o7OQZGf4AVPUrto058rU7+w9dQ2J+w=,tag:dfL65zW/8nkSjZJ5tStGZg==,type:str]
+        type: ENC[AES256_GCM,data:7BNamGAFHQnj1ZT8pAe0nwh4JcrC4LSn1Zqh096Q5A==,iv:6XuuDcTJUQP3n8zFZDGsL0TEbj6Et1Q0GQzHPVhuJTs=,tag:xi1fTctKApX/BRpKn+kcSg==,type:str]
+        isDefault: ENC[AES256_GCM,data:8xgUixA=,iv:GlOid4H7P9cCDErvpsoIcIi4TTrTjESCuSgYW9tqNR8=,tag:o7HhJ0vNLAcfhn69K2ha4Q==,type:bool]
+        editable: ENC[AES256_GCM,data:vrVArg==,iv:BaPUuDtBz9XjmjbfmTtoRzogitjqdba7al5p0nLhz7c=,tag:hk68yDSw9tfF6l1qa4Uhlg==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:03Z'
-    enc: CiUA4OM7eEiwTcp2E/dOm0qub2dcj2XtVt4Qo17e7zIGnKNNw0i0EkkAPHlbmTbd0mNPG6rDsMwMoSN4pKF/ClgTb/YvZ4fwC0u3iKlpbXNmQ1R8NDPMzaYFw8SyoYWEjywSKs9u2JqH6v6WeN7MZ9eM
-  lastmodified: '2026-04-16T19:33:04Z'
-  mac: ENC[AES256_GCM,data:tRw2EoPbhOfzYx0V+69x4DJHejUw5oeuIqAtB5HxWEy0lFxb7hqvdyxKaWk6gys9uYc8c7QsHbqQ6lbb7bgn4ghZP54hfERDn5M3NWTlH3b7DvcPFSZiwZEIQ3sJxmK91D4py61EtfFu2SOHIZp7g6phG2PKCwxuJYXWmxLmsj8=,iv:0RWcJ2ot06za6qJZ5eOOix5loeQluilaaNXDJlDdymU=,tag:jJ+nqRYqb45AnkXSnEpvkw==,type:str]
+    created_at: '2026-04-17T08:24:27Z'
+    enc: CiUA4OM7eDMcBfqDDZw3it/qYoGKuryxTq5tGQNjRmkzkab357FPEkkAPHlbme/bpU8uLSE0PedbevC0D3DsChOZTeWZIRzFn4lOPaKzT3u0xt0DvIiozygVRzLnyiFXfv8RPy6L015s1Zfpfx+mz8ql
+  lastmodified: '2026-04-17T08:24:28Z'
+  mac: ENC[AES256_GCM,data:RXfBUyCyT3hmXbRwPN8Mw9Js/BKfYgyA2MuS2V4+slL8nO0Z6V1+vD1Bt/LHtX/Hiy4iBrJqvMk+xiShbhzLMPo0qQ11dFu6m7NWti+ZsmF7I+xtrPeTaXnS/462+YSOUw0W8mUCjJrOnHP7ITy3Gt8nQ/AuKh6MmHdXfj2g8pg=,iv:7/v7bKQLdBTJaXi7wvaMpFk+QFkqIA+PDjpm0AJLjeU=,tag:Rojt8K7F6BCLsBgBp0IKLg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/projectpythia/enc-support.secret.values.yaml
+++ b/config/clusters/projectpythia/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:AOgZL+um9yy4sIhH+vz6I35LH2Y8jryOeD0m/ebmitQIWtYGumpS9DCn8PNfGm6lEU4iaAWP6mF/6GQZuQWo2S1TYH8pYCmmcmzJf6Hdac7vkJ28BGQXpL826Xp9SHYlL+rIlj072HBqZbxNf/RLEAmEj+kgAadQAtp//UgRw3q1Bi2aLIUVKlmwUhlJF0hjy9PWPAKE+VHulW89,iv:YD+sj5rcnXe0br6w9waXIRsdnTptqg/Vm3VUht3Z+AQ=,tag:GQGTHH6BC1/l/BHVYF11Xg==,type:comment]
+  #ENC[AES256_GCM,data:08K9Hg1xTkI+rxESOX7gMVoWD9blYPZg7Cw12eG7Xy2SzPzpDjO8S3whxOvtqT6JJKqwyWTPI1SRuKRp6SVKK5itN6YaICdC9VnqZ4CX6nUfUGTnxLpDcqUO8qakEZVcvk25tIB2EiP8c4felFGP97/81CN0OR6oDKySJfoLmiSjzfOaziNxeKLHWz1OdpNSRDXfFNps5RKH5krv,iv:nCCSHDgnZrznkgiBHog3JzQRGIzmOoxI5Oh+2vE2P6k=,tag:oDuo/Vn1FduCGG90KII7qg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:RoWEYlcEctK5AOetYw6vk1uaBIlrd5jhWKvmACLCG+Ri8kzTP7fU2HYga8FmXgqLFKO647Z1x6cCU3cdrxYsfw==,iv:UqhCtVKvmlW7FMzZEiQmGVYGpXtC5hJpkz/T5j0jQfY=,tag:HPr3Q+hPfKHhMWjoSHGvvg==,type:str]
-    password: ENC[AES256_GCM,data:eagiLVIHo8iKsrV+1ZR/uA5zaHSpWuwXbfzxcM9EchkjRHw+wHP6Qj9Z3QXA6xS8tGAGODxOH7hs3C650q1m4w==,iv:/C1uFpGqeJe0jzPBA6816HWffcFCML4yYhbGNFmB228=,tag:yHF9mGOuUOc/rfH0lRDL9w==,type:str]
+  - username: ENC[AES256_GCM,data:jHYHO6CR9i02/jXPfsakfy65gsDQLeAsXfTqIdBEDZurUBXnNhXo01enL0CajQJNq65Mu8+sP3p+xqcgGX+h1w==,iv:e2sYPlqTfqFb+6GWSW31IiXXe78nGQsfDpLBydkE5Kg=,tag:msxvPdz3tSNBymrirNdeVg==,type:str]
+    password: ENC[AES256_GCM,data:JlXfGpG4+bbsSESUuAebsMRg1mST3wAZbqe5TrQgrHI7NUIlWa+uDHNtWa7u6Niid4jIKBPLpQIvWH+DNJJ3bQ==,iv:hFBbKSsvPkzGuTFJOuXwMhGAAhZUSGgqde930++Xwrs=,tag:IX28SrDUQ3Jc+5Xiw3bOPw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:/dfHdxkWBDZpP8+TZw==,iv:5gx/sRd3nOC2ODZmL0V12X1O0ssC863Q7HPfQgbaTcM=,tag:PAiizc13WA3XVA20bZi3NA==,type:str]
+      value: ENC[AES256_GCM,data:/WoQoUuvSYv4rdZWU1RQyJinsh+Qt01bga5vqzqGCncOWp8RGbAAIwB+sy0SL3by2VuYeBd0QxLOx+hNkBhaWUSfvpbyGTfhZ+SIkel1qFOWFGr5JRhagdHKEo81JXSE4srhTRZGwy0u9KLZdCNYkkKrD8QVdpimVkMbB0XEcxGcNWO71gYK21efTBuIzI4STE4j/tGVkudRiNXTSCcXyd7IC7iQVsCd5GeG15+nZ7ZJ9A==,iv:XxpeY0YZr8f8ZmM3pghieQ90UjpZ3HsJlGtneLFta38=,tag:hRrBPyl5JhobphalysNlbQ==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:/tUBGO03EFrGXu9ePZt7W75YrhzqxY1o+2XsDzK6yWkbV5h2lFZ946SFyYEL4vk8NNdD7nybAYIEkTO45MdyUA==,iv:FeZhcrJpel+VY1F4zJOXQKNvKetokb3A0IUXDb82AYo=,tag:OEJm5/jlc3+O7udWsLZWVA==,type:str]
+        password: ENC[AES256_GCM,data:ErReWeMb6el5EdnJNleij7k0Yz9kah3aorxZbDwt9tLF8k2Q2c7dBDLJemmuScZRLOIRKwpTbKJMvnd5nGZM6w==,iv:UUo5VRP7AMR8le42iUjs0oyVTihrHKn2VC+bPyCGtr8=,tag:Mevt6frk5cWVbRpv+eRriA==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        Mo212kziLwQFZyjyGPGj76j9OEzgjXmVoAOZNQ7ckVOJy0ujANhbICirTTpWNBk5: ENC[AES256_GCM,data:JX9u1fhvMmUDB+qJCGDB/aC2gi95NCxy4YOcwnf0hKx5TBpTIQmNekewQNTK9xOVpXpZ+/x5ltDklb6Z,iv:2OcEmR+8smVFdDL4LKbeBFl41dCBw7QAlHmoVcUUwag=,tag:wh7kMfEdpADUFdzFNLm7lw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:08Z'
-    enc: CiUA4OM7eDA57G7YLzXjfbAv0lUg2mD0INBswbAoIejMdiGSfV6BEkkAZoeZpjtgYhDTIQpx8NcD0+ea8U3taNZ2otBsBGUM6YFmGKRkkKtfxvNo2pLvVqax+krUNEp5hb7c+TF1UEzmSiwPZL3mJezE
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:08Z'
-  mac: ENC[AES256_GCM,data:u7DttDCoxZ//D3X5KgI04e22ZxWjKkdoQibD+e5HTCyA8RmGlx619Sy+neFP8vOyDsWq2QoIQ3WCP+Ld3X+DngWOU1hct8WYQCS5ShtUtOwmPsf3wqQSfueja8KzS2vpBfMzUPGrNWjyjJEV3Nni9ETLzeiLxBX/YWWtWKxGaUo=,iv:fKwRr9654hrIvIP9n322l7bqBwPS+gyjebGyoXGxLy0=,tag:Dxz9dSXyxQiQKdf9lwVJ5g==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:03Z'
+    enc: CiUA4OM7eEiwTcp2E/dOm0qub2dcj2XtVt4Qo17e7zIGnKNNw0i0EkkAPHlbmTbd0mNPG6rDsMwMoSN4pKF/ClgTb/YvZ4fwC0u3iKlpbXNmQ1R8NDPMzaYFw8SyoYWEjywSKs9u2JqH6v6WeN7MZ9eM
+  lastmodified: '2026-04-16T19:33:04Z'
+  mac: ENC[AES256_GCM,data:tRw2EoPbhOfzYx0V+69x4DJHejUw5oeuIqAtB5HxWEy0lFxb7hqvdyxKaWk6gys9uYc8c7QsHbqQ6lbb7bgn4ghZP54hfERDn5M3NWTlH3b7DvcPFSZiwZEIQ3sJxmK91D4py61EtfFu2SOHIZp7g6phG2PKCwxuJYXWmxLmsj8=,iv:0RWcJ2ot06za6qJZ5eOOix5loeQluilaaNXDJlDdymU=,tag:jJ+nqRYqb45AnkXSnEpvkw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/projectpythia/support.values.yaml
+++ b/config/clusters/projectpythia/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.projectpythia.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/projectpythia/support.values.yaml
+++ b/config/clusters/projectpythia/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/reflective/enc-support.secret.values.yaml
+++ b/config/clusters/reflective/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:k6jONDp3nFRi4GgqZZKbnzRCmZBmtadngYKVymEAhT19rQSbZOi+Iy7YhdeGcLicNGcioUvbCqoy2DV/SGG3e/sO5oUIg8Bdi5KRK4PG1gM+PVkJ3ES8/kArAOKtXUZPnvNU7h7tEwuTrVQu7Sshlyki4ZN+ayg3/1fKVItOKYPbIHXrwvggs3x8n60jJ1UZ9xD6k1ZrqoP7+qju,iv:LLmRHyHLVjJWrdyDEJOM0PaohgHjeSmo/xtks+eH1ac=,tag:qGKMgHzeSuKkCEXc2BfwFw==,type:comment]
+  #ENC[AES256_GCM,data:AjldhGBB1y8L2neUFp6SM8KsXt8BwHr14Jw60QB2L9bRuGkjZAKZ1Wrn+P+2VQzRupVr51JijQJGpI2w+6WyHnIAfsHmfDLS8XXoww72XiQAlANCKtbEGoByViPX62Xl/8hRm67cgZ/rUXq34nj2YjFsNPV5jVk/mIKJmczIvz6S6HjbPlW0HkFeHdyffUUuwdzW6sPIH3FIroEs,iv:Y1mgshztM9jbLUUrDgzOvoDZbHluXStRVVYJ6mOT18A=,tag:ewNDiFYRP7WUv3JA/w5TZA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:EjM/K1DMHUp8FeH3eS1d1RO/unpeBxIp6XHo2ufrWduKf7xT0YERXmYzzp7mh8RZ71+7eyfOOMVcDtjje5wpnQ==,iv:HQHwbs9a+akaN1bAnCPaM1oQAGlUC8fgnwJlhnVRYO4=,tag:QyYyitFChqZNjenNBm5cSQ==,type:str]
-    password: ENC[AES256_GCM,data:TXw1eqQZVA7+V1+0X9O7b1J797XsJtCgPAbVdZeDGLI5T2sTqr9w7ENVZeQ8pH4O1i2bAQtaaVCZn7qDLIbrLw==,iv:iQWamw3NvO0aPG/qrg7x/C+ocVAb0N08imKAd0H/ftA=,tag:a4Sw3CrbN84jdIehSDqqPg==,type:str]
+  - username: ENC[AES256_GCM,data:4Bwpvic/uCRYKogaP1M0DA6cmu9zjBSbsuDE9eGRzD8MjexEGwnIsfcVNmayEhlO9a3gSFFjbe0WXQ7BBq4CEg==,iv:MbTdkOFB75wubE+kGHGI5aBRUa2+FbDna2ldXgZJWpw=,tag:fArCUzW5JkXr8+o/n8IVIw==,type:str]
+    password: ENC[AES256_GCM,data:Uvkes9xE76qO3RxK9fZJLjlQLJf1BMaEDViOyp83BtP4tpASQwa9hNmKvV+cYXts7XVkcwx5IpT0ioAeIFmz3Q==,iv:8u8/T5Zl4thlxc3u1AHiVQMJUwn7UhvYlpJcMTHQJN4=,tag:mlHmMpt3tWkv+I/f1NLYUA==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:3G7hQ5AAmQZ1UDjFdnKGJPZw3lw=,iv:JYCtSprDdRP2mBfogpHj2wsQqZs6wg+SsxB95e7HUo4=,tag:8CMrpHEbtoBdnlhukamxVA==,type:str]
-      client_secret: ENC[AES256_GCM,data:gC+naPRDnW4Hn5eTU0kbBO5dXvxmZUaWNzggO96BfbWnKul3afBXQg==,iv:UOKLR/sifsuVMUFzah6OqtNfaDFgwOWPzOsBemhPTLk=,tag:8f6v5qcUwgQrJRTpcjRz+A==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:XA==,iv:IyCVtifr6AHrt8YJLz6Vq3DdGVSB45SsItNjtobUoxU=,tag:v9rWO9jbAUz2VYR/R2U+Pg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:HxJy3PFWUbhfeg==,iv:2HjzF2tbQHJYyY05DfYY+oxzF5Cgds+nYjMOl8nXbWg=,tag:t9gNwlqfcJvF/0VsOyV1EA==,type:str]
+        orgId: ENC[AES256_GCM,data:hQ==,iv:wDypFYGfBRdI7x9+5DPe0+xIV0/0gthJVCXLBbzRF5Y=,tag:0CGj0FdbFIjNquEC7eZPvQ==,type:int]
+        type: ENC[AES256_GCM,data:QcmFh1e1OTG2XQ==,iv:0lnbcC4658tQd2EDJxOD1R/QGYcrteg9RD03OkQcL48=,tag:8FKCAjW6OvrDUV8+5E+sQA==,type:str]
+        url: ENC[AES256_GCM,data:1TkYZa2evn+B4/INNiR3RMRVNAMGhC4Ybaj0g/IMYDA=,iv:2RFx0XwM/nlc77QIK6b4Tiv4qMCpKnSNCLM9Cr7xAMg=,tag:V517OiswgKF/hzBHutbYvg==,type:str]
+        access: ENC[AES256_GCM,data:fLWwmWY=,iv:gl7p7HfDZV5uJ3V3eH0iGL8uZjKKQKVR0i4FrQ0ezy4=,tag:DdhI7nxzrp9R+5xeR9lyaQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:G7GvAbM=,iv:H4ANVRhL0+YDAbeI+WahOWf523T81Dazx0AlCQeCyf4=,tag:2X12IjA3/wFn1J9t3oLm8A==,type:bool]
+        editable: ENC[AES256_GCM,data:YsbOQ1Y=,iv:L+PG2nvYuCPX9NPd4eCyJlZAxfVP+igryIwn2aAV80I=,tag:QXlinufGdQaNChD8dnP1Yw==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:WaORgA==,iv:6SrW3YO75poYKjC8TLyUHus5ff4ThlzUa97CFEXGCKc=,tag:7guyuy4evoOgelh+ribNbA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:3+HlnMDeo9LiUrzpeFuZK+Qqsqs7QFrfvnqMmu6MDD7Y+5UeaSMvuVJ2greWZ6srsi2FwIr+DnKOfFhJL1/IdA==,iv:Qji5fYosVlHJnJ1FNImg09foQfAmGy+V6LP/cVjbg9g=,tag:2NqJ+iflOjEU48MYRyGdbQ==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:y8EjntLUuiHjHloD1YxaeexVIMlvUnYcF6ce1zXLfNQfUzsIv8keIKuYkPxNHKOBR36SINc7/pnvjirH7uky4g==,iv:K+l3fv4wRavSKII7oMwmQz4TzUKzlzoUgwWtS/IvXsM=,tag:FZN/fTaVdONzRCleuGJQ3A==,type:str]
+      - name: ENC[AES256_GCM,data:4/5BJnWsnH9/L4p3ALQNxy1khJYr2/xoaFqWJIPnww==,iv:oA0XEFc2WFAwGzG+pfoCPsdpQzKWO577X+9bxO/N2bQ=,tag:SElpkQHbkYToCd4lxJoSLw==,type:str]
+        type: ENC[AES256_GCM,data:iJArl+BXjpIJDdhTJ5DDAjv/nTP5xbGJ9UYPywhuVA==,iv:0R/kBm7FMJrQTseYztZ5UE0ygJFo3VjhikxqS+IVU3Y=,tag:dpY4ffYLOfCnmfl86E27pg==,type:str]
+        isDefault: ENC[AES256_GCM,data:wx1nnTo=,iv:IaILwtvmVmeMSRoXy0ERnqYpYqzYGaGczuV1Ins19cw=,tag:wDPVUgdLkxuH5zp0JoewTA==,type:bool]
+        editable: ENC[AES256_GCM,data:oku/hA==,iv:bdDYJFc9EFKE9MLDF+XTowOMxjlQZM1BimXWd0HL0Nk=,tag:JIHsMnQm4eGpT9EbFbZNpA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:mteydPw7kBoSYVg1MA==,iv:PMzOJe2tM8VAyMNVfka8PupvYG6BcBKlin7kyD86PQw=,tag:W6qYM2dOyF4PH1mCdCjEnA==,type:str]
-      value: ENC[AES256_GCM,data:kgTuDzQNX8jLuij8T5VOOZwsQ9XZEIoPi0hut6GGNelePPelzcd5rRExY1SG2VQqO+DHG/aRTBB5MdrYMXgGiFCKJfv+/WTnxucgfxHzJOr/g+ut108wKPA4nymQ77JYbmvX3LiwIgpyPdw3MxcoNycGErEJsil0AQpxQXB55N9ngz9zp00hdSU8quRlGQOht7X4N1lbB7SqBpLrGtRe6LiQMUOwJ2B2pywkNyLr8tZ8lQ==,iv:HK2vgl8ujP3ufiYbC60BXOmQAb9pVzcropDwVlh4V9g=,tag:HYTQeBudK5EKbLDspBT0dQ==,type:str]
+    - name: ENC[AES256_GCM,data:orJMDFqJgqikk4cC+A==,iv:hQ4iZyJQ7ADFKbshYNh+bo32QUCdW1HRNEanQ9Jxmwk=,tag:ytniedcKv8FOy+7ctd+P4g==,type:str]
+      value: ENC[AES256_GCM,data:dkk6Dk4pIrLZAWhF7UVCj4XuyqoK4Ka54z+MnyGAEyEk5hK28xflYjYdUvVh5t6wFRcbzv37jY6xZvqtm438b4AUMkS91bO6N3bSsjen1c/juKlstGgHp2+gukXoAyGgz5wdVOfMa5JWZYnMLQu+4je7bJO9Btgq34CP3ZiBgtbNhC+y9fxEPUYDO9lMZSTec4yl3BxBMAF584UQN6Mg5f2V+hsEcKz8SNtc21yZITxhVg==,iv:KZjsdjs1xt18F1mURAX5/YBeujq9Ofu8OxDTk8jeuYU=,tag:0G+ELSZZU0iDSBJs7z8oYg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:pNCkX8g6hbSbJYHgTSBysSg9yZ8FC12XYAVBcwBc2CqxNGga93Agsmn9Feps1JTHEjquRvhsOxpeuGtT4PpQFw==,iv:tu4joehqjFcDsSaHjneb65MpeaY0Ueu939N9zH5qU84=,tag:eNs31B4Effo3QdkBtWlhUA==,type:str]
-        password: ENC[AES256_GCM,data:gm+C3BFAmCY0b3hixKpviAhxsezilrpRglHycEzR8GH7wO4iu7+3u8IW2HqZAtFLjXScZRIvy2mx7mtFDTo+Dg==,iv:JlFNeZT+iDL9HhY5l8vnlgkFuGRdmuKDKL4EO5CgEFo=,tag:6IjJHapWOPddmmTSzMCLHg==,type:str]
+        username: ENC[AES256_GCM,data:K5c9Plz435ePW9gfaelQfJxKwxS5JSuHszF6t+XWSxww6SaY8Jn3ASqCaeA9SYihZWBYITdYDreaAbDVW4mddw==,iv:JcwE98CPiKyWgrz8P8syiWji8oqR2JJBqejZXErY5Ts=,tag:FHfkeGJusFLaGlJGqLU3ww==,type:str]
+        password: ENC[AES256_GCM,data:kbX7bZpc5OugYv65gwaG9Mm87XIMWXEtPuoX6LKceAKonIYmIwAFGcWVTNHqff/cm6xiEQ85iVrhbP2sI+wbMQ==,iv:NLt9wMGWWgxmWSN9jl+DgY4Dc/sCrevcG6t+/aIqCy8=,tag:/SgPfjNz2GXzbt7xc6Rbsg==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        f1ODYMS2Ep9Jt9vlJjao5BnkX02rlTsW4JfQ1h14gFTLZbuESOuPOW5Qbo0N0KyU: ENC[AES256_GCM,data:KsG+++sLRvV09krLyuSRJYptdnc3DU7mMSMR/TdROCIAIu1exJLIX1fx1bit/1wqM8lyb9rL5lm9Pc9t,iv:awJhS/UiwHpO3agRdMVTSXRRYtBji4j4xvOVlBOp2n4=,tag:2YG7TdT5/4B9yJVAI3wqSg==,type:str]
+        f1ODYMS2Ep9Jt9vlJjao5BnkX02rlTsW4JfQ1h14gFTLZbuESOuPOW5Qbo0N0KyU: ENC[AES256_GCM,data:dV/9TufTgC9NISD32yACIOJzqmDny8ONW+VWb0cIK2kTQ+XEQPnEcbhhJSBocXC4+C0AuEF+tkvPG1XJ,iv:Vr5OY5YqnrGuXjR7Z5NjyvnK4L99d34fVpp0M2aUQlc=,tag:2NLJulJ3JJ8wUwzAiiSWnA==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:45Z'
-    enc: CiUA4OM7eLE9MEV6zdFHTzLfVKb6FZVh5A61k4TrUD1W/OzdUj1WEkkAPHlbma2HIk3EPtPEViDCVlB5AY3T4Jm+/WhJ0f4/YeKFPaml+YouHB4whm7oh7goGtWxItqP7qnXuEFGhvLS7PSVN/dI0dJE
-  lastmodified: '2026-04-16T19:33:45Z'
-  mac: ENC[AES256_GCM,data:Hdp3mAtCmjsVx1DmApPIRGk8niN9VNdJSGuuXMs0J9no4HbapRDxt0VcjPFu6eQa3w41oOD2gj5pMqD1uYLBQux2AJjEr2OGsPJRhKPyWaFRkSVrycue/15F1+f1BwBUWROv7c3EwwAQkvWvBbuM6v+9mFxC7sMx0Oj9tbrDn7s=,iv:VfBJN7tu18aTPXMS/T4dpt6wmfb6p3oBp789wgxZ35c=,tag:9pALCfS/wcjTFwzIY7vpdw==,type:str]
+    created_at: '2026-04-17T08:25:08Z'
+    enc: CiUA4OM7eOw3b/0TkyNa1jIULahlcHbGqXjGT1HvCwZk7/pPq2jpEkkAPHlbmZ/jXFRAj/gKJhbzLDW4BzkaCNq78B3x2HOmZvLWREnBkz+/paOkK6w+XQSCJnLDucCxca7XiN26uyoVu6biSjUAIovr
+  lastmodified: '2026-04-17T08:25:08Z'
+  mac: ENC[AES256_GCM,data:umPJNOD2LPW8hmSkys6ZomBKhFT63mdsrr5r3nhhv+F3tL56sypLGZ/7ccrQ/H/NsfExBxZRBPA6nlpW61cas0G+o446nWs3Ix/2RH+v75ytuc0pv4cVkWF0LQqvk50pdZIsM2rpgRT2UCTF+n7glEP+KIgkSW/55YTWisrCY+k=,iv:pDZXZbHClCUi1akVbRE30kmSNHcINgwJAj7Mu9Jkqls=,tag:KSqg/He1Zt5lhY0n4vi4MQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/reflective/enc-support.secret.values.yaml
+++ b/config/clusters/reflective/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:GsIL1kozRcF5vq6HkMNHzPmsmpkcID7CeHXUZ0ylbQVmm2xyCyUt5rk8eO6I9+aggCSRqYv70/BA79mHGtbMV8EPGPVX1o/uAIe/4HvTKdprnkvghVorsCZzA2b6PVbat2C1Q+WPX6qluROpAx9nF6n+T8XUYBxSUk9hRt/33JSrpbHtD8rDBl0JDOHEL8V2M5HFitjHxtpDX1l5,iv:GDLLc/NiXqFP0sz38Bu3namGh+RG+zTZUKBZ60o7sjw=,tag:AH7cMHvGFJPLmQrJh/UmRw==,type:comment]
+  #ENC[AES256_GCM,data:k6jONDp3nFRi4GgqZZKbnzRCmZBmtadngYKVymEAhT19rQSbZOi+Iy7YhdeGcLicNGcioUvbCqoy2DV/SGG3e/sO5oUIg8Bdi5KRK4PG1gM+PVkJ3ES8/kArAOKtXUZPnvNU7h7tEwuTrVQu7Sshlyki4ZN+ayg3/1fKVItOKYPbIHXrwvggs3x8n60jJ1UZ9xD6k1ZrqoP7+qju,iv:LLmRHyHLVjJWrdyDEJOM0PaohgHjeSmo/xtks+eH1ac=,tag:qGKMgHzeSuKkCEXc2BfwFw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Mdrvwlp+xkuHDSgHdcI+QTWap0rs7dBWo17dK2S0DYRSjX4e3j0z1i3ydXA7pCGKxcUX7D4AC8NhwyRgDeRIDg==,iv:It6JYudbtEV1/vwGrPPWvYfqn4sakoHa/nShiP1IDag=,tag:W7prvPU5DZj8F/Jv3CqjkQ==,type:str]
-    password: ENC[AES256_GCM,data:htLVHsxrygd2z0hkqnJ+MvmndJJp7XtW/T7YQOd7+7WUvBcurtLmF51NUvwzWSQsZxCqPziUCFs3q0tAIukPcA==,iv:jd1jKuyS0M+eRlRpzepBi5oSKn2TdT1MEOMp5kxRGRM=,tag:ZLLRGX0xDW5qXcDVdBNOSg==,type:str]
+  - username: ENC[AES256_GCM,data:EjM/K1DMHUp8FeH3eS1d1RO/unpeBxIp6XHo2ufrWduKf7xT0YERXmYzzp7mh8RZ71+7eyfOOMVcDtjje5wpnQ==,iv:HQHwbs9a+akaN1bAnCPaM1oQAGlUC8fgnwJlhnVRYO4=,tag:QyYyitFChqZNjenNBm5cSQ==,type:str]
+    password: ENC[AES256_GCM,data:TXw1eqQZVA7+V1+0X9O7b1J797XsJtCgPAbVdZeDGLI5T2sTqr9w7ENVZeQ8pH4O1i2bAQtaaVCZn7qDLIbrLw==,iv:iQWamw3NvO0aPG/qrg7x/C+ocVAb0N08imKAd0H/ftA=,tag:a4Sw3CrbN84jdIehSDqqPg==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:N5Py7bw2O0bPtBGN2zIrIf5Z9Wo=,iv:0sjJaB0HNb1xbo4gWeFDfa9dPcv6UTuHlnKlpmj6o1o=,tag:whLmj0tsfL6/otwg5XRILA==,type:str]
-      client_secret: ENC[AES256_GCM,data:dWLEWauN/W40ckgdlndsGwR6rEK/zfgrW7+mi9j7FDbWdRUvEVK7DA==,iv:c2EnS50MEwZ2Yyc78IIN8SJeQp6VvD3hHs5HZZykTSE=,tag:kaz2Ds2WYDU8oZJUyAPnOQ==,type:str]
+      client_id: ENC[AES256_GCM,data:3G7hQ5AAmQZ1UDjFdnKGJPZw3lw=,iv:JYCtSprDdRP2mBfogpHj2wsQqZs6wg+SsxB95e7HUo4=,tag:8CMrpHEbtoBdnlhukamxVA==,type:str]
+      client_secret: ENC[AES256_GCM,data:gC+naPRDnW4Hn5eTU0kbBO5dXvxmZUaWNzggO96BfbWnKul3afBXQg==,iv:UOKLR/sifsuVMUFzah6OqtNfaDFgwOWPzOsBemhPTLk=,tag:8f6v5qcUwgQrJRTpcjRz+A==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:mteydPw7kBoSYVg1MA==,iv:PMzOJe2tM8VAyMNVfka8PupvYG6BcBKlin7kyD86PQw=,tag:W6qYM2dOyF4PH1mCdCjEnA==,type:str]
+      value: ENC[AES256_GCM,data:kgTuDzQNX8jLuij8T5VOOZwsQ9XZEIoPi0hut6GGNelePPelzcd5rRExY1SG2VQqO+DHG/aRTBB5MdrYMXgGiFCKJfv+/WTnxucgfxHzJOr/g+ut108wKPA4nymQ77JYbmvX3LiwIgpyPdw3MxcoNycGErEJsil0AQpxQXB55N9ngz9zp00hdSU8quRlGQOht7X4N1lbB7SqBpLrGtRe6LiQMUOwJ2B2pywkNyLr8tZ8lQ==,iv:HK2vgl8ujP3ufiYbC60BXOmQAb9pVzcropDwVlh4V9g=,tag:HYTQeBudK5EKbLDspBT0dQ==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:pNCkX8g6hbSbJYHgTSBysSg9yZ8FC12XYAVBcwBc2CqxNGga93Agsmn9Feps1JTHEjquRvhsOxpeuGtT4PpQFw==,iv:tu4joehqjFcDsSaHjneb65MpeaY0Ueu939N9zH5qU84=,tag:eNs31B4Effo3QdkBtWlhUA==,type:str]
+        password: ENC[AES256_GCM,data:gm+C3BFAmCY0b3hixKpviAhxsezilrpRglHycEzR8GH7wO4iu7+3u8IW2HqZAtFLjXScZRIvy2mx7mtFDTo+Dg==,iv:JlFNeZT+iDL9HhY5l8vnlgkFuGRdmuKDKL4EO5CgEFo=,tag:6IjJHapWOPddmmTSzMCLHg==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        f1ODYMS2Ep9Jt9vlJjao5BnkX02rlTsW4JfQ1h14gFTLZbuESOuPOW5Qbo0N0KyU: ENC[AES256_GCM,data:KsG+++sLRvV09krLyuSRJYptdnc3DU7mMSMR/TdROCIAIu1exJLIX1fx1bit/1wqM8lyb9rL5lm9Pc9t,iv:awJhS/UiwHpO3agRdMVTSXRRYtBji4j4xvOVlBOp2n4=,tag:2YG7TdT5/4B9yJVAI3wqSg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:16Z'
-    enc: CiUA4OM7eAtyX+OGmyJ4Y3k1MzCYJOPPo/lGarytG/j3DE7OtI/BEkkAZoeZpqz0eaf4OeCO1NRalheh3RGnq1Fu+HClSzdprb9NR1y3ZzjAJw/2ewMrbFq9bw0QyIjiv/tNZeu1VpGGsCarVeEuhQ8l
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:16Z'
-  mac: ENC[AES256_GCM,data:vpFMrrcXmYr2jnyoTwg+5GzZpK4J/LZh83SOVqDL7DAjVy/aBFnV4dRR0WwfV0XSdIv4n/8LvWib/UIelt3yOl6CTqiMU3F9NOV1+oYqD1W29CgQgHCih/L/KtwKqRvdfBQuB0BXOT4hrPoBquBmXQiXDV8G7uZtVcxDa96bhnk=,iv:LH2Z+MP/kiox4MqHVhcFEksShNQTJTGkAGDdmfWMRQg=,tag:hMgq1mxgMP41tETQtgHolw==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:45Z'
+    enc: CiUA4OM7eLE9MEV6zdFHTzLfVKb6FZVh5A61k4TrUD1W/OzdUj1WEkkAPHlbma2HIk3EPtPEViDCVlB5AY3T4Jm+/WhJ0f4/YeKFPaml+YouHB4whm7oh7goGtWxItqP7qnXuEFGhvLS7PSVN/dI0dJE
+  lastmodified: '2026-04-16T19:33:45Z'
+  mac: ENC[AES256_GCM,data:Hdp3mAtCmjsVx1DmApPIRGk8niN9VNdJSGuuXMs0J9no4HbapRDxt0VcjPFu6eQa3w41oOD2gj5pMqD1uYLBQux2AJjEr2OGsPJRhKPyWaFRkSVrycue/15F1+f1BwBUWROv7c3EwwAQkvWvBbuM6v+9mFxC7sMx0Oj9tbrDn7s=,iv:VfBJN7tu18aTPXMS/T4dpt6wmfb6p3oBp789wgxZ35c=,tag:9pALCfS/wcjTFwzIY7vpdw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/reflective/support.values.yaml
+++ b/config/clusters/reflective/support.values.yaml
@@ -11,6 +11,8 @@ prometheus:
       - secretName: prometheus-tls
         hosts:
         - prometheus.reflective.2i2c.cloud
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/reflective/support.values.yaml
+++ b/config/clusters/reflective/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/smithsonian/enc-support.secret.values.yaml
+++ b/config/clusters/smithsonian/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:ttrbTvesDC2x9MVrIIjv39JFuPOjDxlQNuiFGHdmSLBB0pTKfFadjDnStgaanG8oPwCYR3K0m0KLJLy4BEZFztWuc8FJoXsR/psCDYzD5CA1SyWGtMWl+fDacLtnzN3x0JeINbYpKjpyY+8TLOuNAXDCx2gY5lqsCdeGi6Rcy6cE/hyH8cDl7LvJkTWZAil/1lx8F9cMLMP5rAIL,iv:cPskPZRCdYEMPwWEZcRtZShtkmUfjiUUzDdttfU8NkY=,tag:NU5+ViseDYt1+4bHsU7J1w==,type:comment]
+  #ENC[AES256_GCM,data:MHjl2VEZ+yLFpfsawpen8esflBRzaoQsLV4GeQcZBPg4kGwItCT/sVO3v4B1BsdrjfZ3wV/hr0ISaJxQCdwaxt3f6SuULbDKnMJFDZHr5ubWE0xHYIpIJYSA9BZiKzRg2wPLnMvvyAa1wVZOEE0IIPIzk8nkD2v74ZjmcLPMaMMMS1zHlktxI5wSXYWazHtp/sp14/9aF1vx7chF,iv:NvJiVgUxr5FAWDCKTeZVI0E/S95fRRVA5okWpj7O86E=,tag:n6TXwMBCcREfhrtC56LwWQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:SLptSTWdVNL6gBrevXc2GSJ2+Y0mpSf+6qz9yFTuVkHyeUPPgvIturPjKNbyQhdopcqBJol+Wc/q9dHARCPdbQ==,iv:ms7OmgVd9r9vRfrSrZ13vj3YrYKlP2RpN8pgrwxr498=,tag:myYFmAy3/ZsyC3omxzwsmQ==,type:str]
-    password: ENC[AES256_GCM,data:Njv4ZnP9IqEyoZ54dfZm2H/5xorpDnBBaV3sWMVAMVF0iFxY63mvGybWOiQ5KCrG4PitDK0I4P7Tb+YhIjoFFQ==,iv:x7gNSzfS5BeV1L7COozlsWLcB/o4IvbqTz0p2ekv37s=,tag:zRbGHqhf+PvGqMo/QVyQXw==,type:str]
+  - username: ENC[AES256_GCM,data:/Hbsi7b8BSEPLwFj6EFssEYfyyCT6c4INBwNKhA6BFI8ZTfvz/j+1LIXjJlFl7WPQALlDZ6YhKhwlA2NsDeN0w==,iv:DGDryACsNRd1RQjd164n9HvTBhFSm9OJXk/ot/8Iu08=,tag:snzteYdTK/QHDIf7BOQFOQ==,type:str]
+    password: ENC[AES256_GCM,data:gN3wWUIA74jqlSDnBylosZSHONJ7Dw3MH5NbE/1xFSPYmEUjKsQg7RuLP8FvtrCjHX/95FyGKawsY18v4p8pRQ==,iv:r33TsiY1m/zfe5aq2xI2Dye4ws27hfswvAUp2PZbCaQ=,tag:wOQCE8n5tCnxgWsee1PYIg==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:F+GyBEcYuufBFaurpBq89qSDI8I=,iv:VuynEIAdrElQUNHoeCtYJQiij6NdChUesc/k37THvlk=,tag:3shrTJAebFjsY8X/WQqttw==,type:str]
-      client_secret: ENC[AES256_GCM,data:y7xjV35P2xEaOboUr4vP9Tihp8WmJIxWHGkPzZZcnyaEzjCLjMHzgA==,iv:wYBvvxmcVsnpmFKYHKUQt7VoYdKzF81PpOV1sPF6Vq0=,tag:71A3ulDfJHy8WTbg+Izpbg==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Cg==,iv:lgf5f0TOFADZXDl8iTs1IO9zoSNPVaBFqnnH1bYdo9o=,tag:nmWxLlWuFJw1wbCELVewhg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:bdeobx7uJ6SSfA==,iv:ivwlyVRPETjk1RxHNRmxAmTP0coK+jHbEQvyB/7zU+o=,tag:MUEx+0S0ftSm+TUSDKRaPQ==,type:str]
+        orgId: ENC[AES256_GCM,data:nQ==,iv:WgfuMekUGMDe9X90TNzf9nfW0Abwz6JhWmywzJCzCnA=,tag:MsFz1HceV0TTY3ukaTpPfw==,type:int]
+        type: ENC[AES256_GCM,data:RygI/jlUl86lPQ==,iv:Nkca++mFQqEXGeiFGHGtNA7zGPXkdq0aoszU+0Bi7RI=,tag:dEyXssYbQCVS2nicOu0mKg==,type:str]
+        url: ENC[AES256_GCM,data:HOZoZLKjAzysZk69rOesoX1awmOIX69RnkdCA4lYMz0=,iv:oucdVCOG+MRjd+AiGvH8DgMEBL/d+HyC38UFj52uq7M=,tag:NcMyYcDHeldlK+vfKaFXXA==,type:str]
+        access: ENC[AES256_GCM,data:+dkCemI=,iv:RPD67YrXVjSu+qjTcCvcSLPTJbqXsyjF4JielffAw70=,tag:9gfnWWo/6mtMDKrXGbLE2w==,type:str]
+        isDefault: ENC[AES256_GCM,data:EbUUz88=,iv:abwuZTit0uRU2FiRcMfUFh/47EMKosuX/+SACexSQVw=,tag:fbW4tIGpkCLz9Mrzm7sl0Q==,type:bool]
+        editable: ENC[AES256_GCM,data:tFLCgYw=,iv:K9BbZWuoHUbRgYIRdsqKYuD54m1SJkvj9swIehQwd3Q=,tag:PC85xvZg+QQGJ3VBiHgbRA==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:bQIgFQ==,iv:tS22cEQzr5zeTE7Q/a2HTkliw/lQxrfuKfW/zpbxP4g=,tag:CPdZqdygu/h167P7C0cC1Q==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:IPp2nrTsb713rRDDSSy7WR1q6HnQypwcCnS9QO18fw5XuQ3ikDPCL3vMlpEwdffx7omsyTfCGD3XAFFW5T75bA==,iv:k4jqwV93CjXZOkc+2mwycV0sR094nCuj1HotsuSdLHU=,tag:Phk7QaREiHFon+zkJUtAXw==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:quN3mF/N1yooKyGmCRkUsEWC+TLUUhWe8I2D3Lbuc3vFooqQHW4Ly7p3Nfbt0k3r4eEuICy7QvgnnuO16nhw6g==,iv:Qiuj9PhWXBeVOVGaxP2o9X9H7eGyTClSIcWtoS8e1SE=,tag:GsbEA6UMs7K+tX/K4xcNmg==,type:str]
+      - name: ENC[AES256_GCM,data:o6WEWCEUedFjMamyEQ5hzB33ngGD39Q1uzvysLGB0w==,iv:a2lW+UotlKjQjRxgAphWb2HjqRmUkG0aJW1dpSSYB7c=,tag:quFpsBoK9Mr3pk16rCcNhg==,type:str]
+        type: ENC[AES256_GCM,data:wGG5it4ysYxrcKi+/hgYM93lhcon3N5TNCz0mP6FrA==,iv:ALVFqR4dlUG8o0fo8xiuc8Ah9YjUYMMyQDrnfF+weAg=,tag:ap9Bdr/xlB6X4e1JVLAacw==,type:str]
+        isDefault: ENC[AES256_GCM,data:Xc45qD8=,iv:6M1+OkbDMLvGhH2YH+F96OB/jl7rpWlikN+Jc0s8plc=,tag:WN5IJbpttedtgiPTBSacHg==,type:bool]
+        editable: ENC[AES256_GCM,data:7M6CeA==,iv:ETi8cQb5wz673Uho+ZFnvwre/TLoIqpT/qrw4pRu3ms=,tag:wsRbjpOPH+3GpFDTNE+TdA==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:FTndcfi2N0cljrmXCA==,iv:jEMlh7F2T0XlVWOBiHRzHoCNxN3LKsr8+CIcHUYlwH8=,tag:dbH+DXVvv9JCR+X3MgjOfA==,type:str]
-      value: ENC[AES256_GCM,data:F17z4YW0ku65g5LphwUcgc1G9/th4W+fQ2ff2faYAcFzXMEst+asXaq5l6fPnJFNGZ5WFzxQrvM8hCuamXArqXDH+DNoj1w3e/+yG1N4uQ+CtZepqMIjRmGw6xD4HuQda8dbN4lwIez2g4fn51cvDx7AICwStYcbLCQkq7y6p7WceRISpS3zOTsVcmTyyj/3rLvJAX9UrIdk+/ou7ABcGpLMVmVkWk5teyiY4zXnE40ejg==,iv:2tyxF/wF61RRpmPD9h1MF5NIERILcRGaHN7fW1/DB4s=,tag:p7a6bZgDNsOTNKdWi3azgA==,type:str]
+    - name: ENC[AES256_GCM,data:HSYwpPoev+dAOabH/A==,iv:DV1RO1kBdq16IrFvNnphZNx8JwM82CV2sURs3yD/0G0=,tag:NhVJfdI9aEpvC484j9rUbg==,type:str]
+      value: ENC[AES256_GCM,data:d6jgKwPUT+1JmKCgyxwo0cTtCVqug+ZQ1bXP6ya63Rz0uSCzqdm/61EwJAim14gObPFnoTAQpgNuQ5GZ5VhnWnFAJdAhWCUyMMHSNiBgkB1RazgjEqhpJdU39GFDUJUaC1vCqq+fQHbI8ks8i2EHEH7wPfRF+ukcpW5iEng1yO7CM0qeFEZFDmDqTa4ACg7kTx5TGZQu5I7pXJPC1vjWi+JL6dhdnx7HKVgJKPcC+2amjQ==,iv:U2EZcmSfT9ZK/sXCbblzsN5+7OSSA0qiu7iSFcUcXPc=,tag:5ykwKH7evCTfbvcUwjmizA==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:WRRJrJQf5pYMr/798+SZ+gcq3jvBKe9p6kfitXde1y4CmcT3b5aqz5qxtvDC/FGY5qeCd3DFtLw3y1mPkK1npQ==,iv:K7MbOkXcSBwmtDN0Y4DfkxZunIS4WRj3Uxhenm3Gg7o=,tag:18c1b+9SscWr3mtp/zwEKQ==,type:str]
-        password: ENC[AES256_GCM,data:8zZHRCI17h20MryQup3od5QYGWuNOrAe3D7vXrw3XQ+l6bh5/VeLBSqTY3PmGcZWbZynFo9zHax2JnKNQg2L7g==,iv:l/fILRIHPUM9f8dptCCWAjY43dNRqoIgcwL0ADiWZmg=,tag:bI+iYfWRkoGpTqnE+GQeHg==,type:str]
+        username: ENC[AES256_GCM,data:6jSBWeIvK/EjDBlbyfgUz3z8LiIaLNZpKNEIWVj1UgelAa1MymOf8sRDag60y4MZdZXVaDZ8NzIq+HFFmvUB0Q==,iv:7vd69pbOpYdA63pztYDirmEZR7KLIKpfFMAhnLfn/So=,tag:byPcTSd5S31xV4f7dyglhw==,type:str]
+        password: ENC[AES256_GCM,data:iPx8sIwRLdxEJ5q+kIh8y2BmJIRBdOI2UVl5BEGvAhACwZ9YEDRj1FxFwiC/IV/Lu/l2PyKlnLkiItN9iyR2LQ==,iv:R6jbej9RsfHqxwVxoKX39Khk2PiG9/S3/Mn/Sj9w06w=,tag:0lc41Se+wFC9MvJ696tsYQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        fXVdxJmr0ZKsp6urCavA8lDFtB4fPjxhO9V1frHwenDLtMYmaIdY49ahNk9jLPiI: ENC[AES256_GCM,data:mSYRCaKNg3sMZBESMrjc2+pQYJ5y7eOihC4o86lEQIHs4aM5apYAxbid0Mfjra3JsUq3j1pLPM01+I9A,iv:3BK7r28P7KpdoxPglUHmj2rsaPGPS5pWqkRD7hBQWu4=,tag:nZHmDftqOgyVmMNHncI4Qg==,type:str]
+        fXVdxJmr0ZKsp6urCavA8lDFtB4fPjxhO9V1frHwenDLtMYmaIdY49ahNk9jLPiI: ENC[AES256_GCM,data:IYiHz32gfVWvZZ4BRfjeTuOq7ftXXXyXRbWUzfSRgk/pNz3B5RtZuq6I+rIplUW5/q+KwwqY+5wWpp3G,iv:e1JRXU+yi8jggtOmMV60Zmqmje60431o1yA2eXFbkPQ=,tag:CVVa4eRyXxgJxvVYONEIxg==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:20Z'
-    enc: CiUA4OM7eLIG5+b1h43CirrPv9S4oo/vkdRygrNmZbAWlogquNTcEkkAPHlbmXNHI/TE+B7JcZZL/ZV6yV+Y4Vu9DeEKBKCm5UBFZM3YoM6Q1XgKmGCbp9rwObekh1SEtUqJFLTmuU8C7LSmm0OEMdgy
-  lastmodified: '2026-04-16T19:33:21Z'
-  mac: ENC[AES256_GCM,data:be572msDB01kXq/QuV3nPm/I5U9BdrI6+IHl2kseCj9sYJd4Rpd/TWAa8YpS5goGWygQh1kGlT+K9yalluVdJCDljXttU9+sgPz858cSe4w8UjIuobgffxwBfRqi7ACsxMSeie61y+E8LjfPmc5rXG0JmKNhDDbh/jbFTeNCeS4=,iv:u80X3CyGcrLRURTf2bVCadA6+6W0l16EfLvJ6hZ0HyY=,tag:IN4NRBKXNpa/UrGwPuD1zw==,type:str]
+    created_at: '2026-04-17T08:24:44Z'
+    enc: CiUA4OM7eIMjm27+enOQ1jINIU6w4o3/7QcC9Xht6NW9sEjFpsIJEkkAPHlbmT75cK/D8HkKXlELHkSntwvRO/Xpd2tUaLXu03OA04+uYznzHcXvEt5zU20zyEliqsKzvOxD7BG79o6I9e1RgGf1k5z4
+  lastmodified: '2026-04-17T08:24:44Z'
+  mac: ENC[AES256_GCM,data:fY0kJCQFLM5C1BSyFtzta+0KZzoqmoCjtxeS5cFLYBMqp7j9d5Wzlk4GAE4UyEFehVlWlpxTeH+IPRpMD8K92oLLw8tztoD2TO75M6cpkYsij6Vmv9f8fMVSRN7wuDtlwNgZybW9x6ReRViqdKolPONfdZtK/yJgdnrpHqs3UqM=,iv:888ig3FUJhrJjbLjVvhp4vrJSoCfp0POipF0LscHYE4=,tag:eZKu2ndNZdUCaCygs5mtUw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/smithsonian/enc-support.secret.values.yaml
+++ b/config/clusters/smithsonian/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:4cB3hjfQFQExa/0yBRu5r7zAlGifCVwUO30wWMjeBCFGj3/aWplBIMgsuM/0+MrwFngQljUdBobAjeoHxZ6KT0OIH69FBBfs/RRxsvm/RLgm2z6lLqEtRydvm8uFfnyvg87vCiGlTkYTc4e4oqEr+RX7yCq3e+TUzv+3Zrlu+QHeN2iXP0my4BfqVyj3a0Dxc/xgpbH3P8SQGzm4,iv:LResWWAbyNp9niF3uoXw9rQvLROpiEd32jZRTBPl1oY=,tag:GZb4Vmhd88UdNJOSyh17QA==,type:comment]
+  #ENC[AES256_GCM,data:ttrbTvesDC2x9MVrIIjv39JFuPOjDxlQNuiFGHdmSLBB0pTKfFadjDnStgaanG8oPwCYR3K0m0KLJLy4BEZFztWuc8FJoXsR/psCDYzD5CA1SyWGtMWl+fDacLtnzN3x0JeINbYpKjpyY+8TLOuNAXDCx2gY5lqsCdeGi6Rcy6cE/hyH8cDl7LvJkTWZAil/1lx8F9cMLMP5rAIL,iv:cPskPZRCdYEMPwWEZcRtZShtkmUfjiUUzDdttfU8NkY=,tag:NU5+ViseDYt1+4bHsU7J1w==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:kd8OC6FiIzlFJl3hvROOrimtqHDuboQWyY7orrCvPVN5ltnT043T7rGxyuce8Fx2x8NjK8JUFFBFGlWLp03hPQ==,iv:kn/y3uhg4rklfZRaPrA8mOzb3VNom0H834zLDRUYoeE=,tag:KRVH5Gc1itd+PjkMjMIgYA==,type:str]
-    password: ENC[AES256_GCM,data:ORhYmopXzVLFxVBpnKsSfhAwyqEtU8Jlp+UMpYl+TkderYzOfxI6vLbIB36E1OsjD+klGrFcHQUOerA9NbUjcQ==,iv:yjs00WkdHDyrG9gxEMn2DVdKv/oYzxNkmR2KmMF7Nw8=,tag:aBxVbKevZgwHPGLP8P15Tg==,type:str]
+  - username: ENC[AES256_GCM,data:SLptSTWdVNL6gBrevXc2GSJ2+Y0mpSf+6qz9yFTuVkHyeUPPgvIturPjKNbyQhdopcqBJol+Wc/q9dHARCPdbQ==,iv:ms7OmgVd9r9vRfrSrZ13vj3YrYKlP2RpN8pgrwxr498=,tag:myYFmAy3/ZsyC3omxzwsmQ==,type:str]
+    password: ENC[AES256_GCM,data:Njv4ZnP9IqEyoZ54dfZm2H/5xorpDnBBaV3sWMVAMVF0iFxY63mvGybWOiQ5KCrG4PitDK0I4P7Tb+YhIjoFFQ==,iv:x7gNSzfS5BeV1L7COozlsWLcB/o4IvbqTz0p2ekv37s=,tag:zRbGHqhf+PvGqMo/QVyQXw==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:JHYI0qgj0i1BkBSE+6HmpphswsQ=,iv:AtO6AoKw2VLOhF9rYkNzRaZxge3XmVNtOVDCmrg9IEQ=,tag:q7MPQjS2AxbxLj126pHGyw==,type:str]
-      client_secret: ENC[AES256_GCM,data:HX2IIyJIbHNNvHzwnq0Fwv1fN+kD0nDp+xb+0Psec1NjQOkjL7p7eg==,iv:ubJuKeSpATfVllNkWwSCrQE6cf85mI981vZNAdyMymE=,tag:maCotIXidcArsw+ruqutiQ==,type:str]
+      client_id: ENC[AES256_GCM,data:F+GyBEcYuufBFaurpBq89qSDI8I=,iv:VuynEIAdrElQUNHoeCtYJQiij6NdChUesc/k37THvlk=,tag:3shrTJAebFjsY8X/WQqttw==,type:str]
+      client_secret: ENC[AES256_GCM,data:y7xjV35P2xEaOboUr4vP9Tihp8WmJIxWHGkPzZZcnyaEzjCLjMHzgA==,iv:wYBvvxmcVsnpmFKYHKUQt7VoYdKzF81PpOV1sPF6Vq0=,tag:71A3ulDfJHy8WTbg+Izpbg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:FTndcfi2N0cljrmXCA==,iv:jEMlh7F2T0XlVWOBiHRzHoCNxN3LKsr8+CIcHUYlwH8=,tag:dbH+DXVvv9JCR+X3MgjOfA==,type:str]
+      value: ENC[AES256_GCM,data:F17z4YW0ku65g5LphwUcgc1G9/th4W+fQ2ff2faYAcFzXMEst+asXaq5l6fPnJFNGZ5WFzxQrvM8hCuamXArqXDH+DNoj1w3e/+yG1N4uQ+CtZepqMIjRmGw6xD4HuQda8dbN4lwIez2g4fn51cvDx7AICwStYcbLCQkq7y6p7WceRISpS3zOTsVcmTyyj/3rLvJAX9UrIdk+/ou7ABcGpLMVmVkWk5teyiY4zXnE40ejg==,iv:2tyxF/wF61RRpmPD9h1MF5NIERILcRGaHN7fW1/DB4s=,tag:p7a6bZgDNsOTNKdWi3azgA==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:WRRJrJQf5pYMr/798+SZ+gcq3jvBKe9p6kfitXde1y4CmcT3b5aqz5qxtvDC/FGY5qeCd3DFtLw3y1mPkK1npQ==,iv:K7MbOkXcSBwmtDN0Y4DfkxZunIS4WRj3Uxhenm3Gg7o=,tag:18c1b+9SscWr3mtp/zwEKQ==,type:str]
+        password: ENC[AES256_GCM,data:8zZHRCI17h20MryQup3od5QYGWuNOrAe3D7vXrw3XQ+l6bh5/VeLBSqTY3PmGcZWbZynFo9zHax2JnKNQg2L7g==,iv:l/fILRIHPUM9f8dptCCWAjY43dNRqoIgcwL0ADiWZmg=,tag:bI+iYfWRkoGpTqnE+GQeHg==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        fXVdxJmr0ZKsp6urCavA8lDFtB4fPjxhO9V1frHwenDLtMYmaIdY49ahNk9jLPiI: ENC[AES256_GCM,data:mSYRCaKNg3sMZBESMrjc2+pQYJ5y7eOihC4o86lEQIHs4aM5apYAxbid0Mfjra3JsUq3j1pLPM01+I9A,iv:3BK7r28P7KpdoxPglUHmj2rsaPGPS5pWqkRD7hBQWu4=,tag:nZHmDftqOgyVmMNHncI4Qg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:11Z'
-    enc: CiUA4OM7eFGA/b6lG2GX4fpIvSLkZEcpBgEAMqHHZgwGOF7CuJbdEkkAZoeZppBrmNFSpjQFvE6oSd4pYxBJiAMzirnzZoTPCtJ+jmPb3FgTzEKynvchIjxc9ajMnQnSPX7l5VqLkgZx1NDOvQzz1f/u
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:12Z'
-  mac: ENC[AES256_GCM,data:Q/m3BSJvQshYckyGx9kFaEaAeqx7ZQ6MrcJjzU8Jzosjk+a1MVEpyywwU8FXhXE+Df0ZdiSidG0BWCxCZk2AlBejH6HWyqd4qWVJEfYZ5xYAEtt8/6EZtMINtDM6Q0FPo2EjYShBDqlGZjt/z6mfMdr5k7QC0jBHJ8WUfBOza0Y=,iv:JYf0tSnYKX7nH4uDSbOGcTugxEW+y79iYbU/hFY+Goo=,tag:JJhTeHMiphenCMvKYBVcYA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:20Z'
+    enc: CiUA4OM7eLIG5+b1h43CirrPv9S4oo/vkdRygrNmZbAWlogquNTcEkkAPHlbmXNHI/TE+B7JcZZL/ZV6yV+Y4Vu9DeEKBKCm5UBFZM3YoM6Q1XgKmGCbp9rwObekh1SEtUqJFLTmuU8C7LSmm0OEMdgy
+  lastmodified: '2026-04-16T19:33:21Z'
+  mac: ENC[AES256_GCM,data:be572msDB01kXq/QuV3nPm/I5U9BdrI6+IHl2kseCj9sYJd4Rpd/TWAa8YpS5goGWygQh1kGlT+K9yalluVdJCDljXttU9+sgPz858cSe4w8UjIuobgffxwBfRqi7ACsxMSeie61y+E8LjfPmc5rXG0JmKNhDDbh/jbFTeNCeS4=,iv:u80X3CyGcrLRURTf2bVCadA6+6W0l16EfLvJ6hZ0HyY=,tag:IN4NRBKXNpa/UrGwPuD1zw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/smithsonian/support.values.yaml
+++ b/config/clusters/smithsonian/support.values.yaml
@@ -33,6 +33,8 @@ prometheus:
         hosts:
         - prometheus.smithsonian.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 calico:
   enabled: true
 

--- a/config/clusters/smithsonian/support.values.yaml
+++ b/config/clusters/smithsonian/support.values.yaml
@@ -5,7 +5,7 @@ cluster-autoscaler:
   awsRegion: us-east-2
 
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 grafana:
   grafana.ini:

--- a/config/clusters/strudel/enc-support.secret.values.yaml
+++ b/config/clusters/strudel/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:gGfi+cfSF5Qk+Lk8BhmDCVVxtSTdE/PVfuNaNlPG6lc7zXZR8xoEPaBGc1yBYBYTwPOPU9aMtMcPcqCbjiXP2iC0M95+aLXFsOr6nThn2iBTLBCBB9dZQ3Cymb8QcB+4fQ+1fo9OIdotAQ7C7rr2kIJ/aUiTdg1rNMxgc5kix5n9saTh/J/shZBmeyw6UyZnERzqAhrcyoX4nB2V,iv:HkPQTY4saComuVi8p/xIMkyei9k+So/xic5M94GgC94=,tag:gruQ0Z9029RWXhaYTUR72g==,type:comment]
+  #ENC[AES256_GCM,data:KUVKrtCRj1ctK4g8QeSIPYCpDguwTJBuHzDLnMd4DcbJoEaXjQAMRlXzl6Wr+5kv4Y79E37JOI1CPRNU1u8F/O0kH8A/qm0Wv5GX81VqUfYRcmmybXDnH86gZ3RE9wrvtJYxDArJNqArwAwWSiJtnS7WHw3iDIaU+/FnHs+hRZa0D4wDnAirrcCpVSLkUNBRr58YmFwVFzdbwenB,iv:7FDXUIwW3tdzDNLadZH8WujLvwB1Vn1wHjbNEaYZU6E=,tag:MYjAwUuj2oJgEiA3egswlw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:mebgZXzuT4lpUgwfplnMicJLBo28JXQ0O0M1DNyCV1SUExIHDVTFa3mggBVdsC+hcrVUORNpCUwnauVcrVsbwg==,iv:DlBkIwvUyDAXJNGmZSDTBeog2beTgYfHe8imd7uei/k=,tag:JljDkz8Cxx8IaTxzTM4y9Q==,type:str]
-    password: ENC[AES256_GCM,data:jMhrUH7EH5lN2ykrwIkj0jzetGXiAFrVTm7+QdYFERAt/gq6vSoOBmA1Gcrv5RbkE8tjldShzGRvJuIcJNHI9g==,iv:EHqj2xgwqSrevZqvqT2+cooUWQX8pGwaeeCMliMhQ1c=,tag:xUKT9C31PXEzEnxJnRHPtg==,type:str]
+  - username: ENC[AES256_GCM,data:YtT/dIKpiEXWI/xv9w9sppk4ZLbqbQilEZIrWckQtQBatM1VCZuTIZdFvIIQ5LhxcRA5f697E97r8bPx3xbr2Q==,iv:PXK40uV6sgFLetf58BoS4sdQUQy0/D3kQGcTw1wGWSc=,tag:9mOdPQCVUSCH7gp61QkboA==,type:str]
+    password: ENC[AES256_GCM,data:0o5m9Y2Z8HI+t0/Tq3SD683bKz0oSlJD1Xlq6OVKpv64nudcRiBLOMwixRnSHWn+Ej/7Hennz7qLm+EckPZadQ==,iv:IQ32VYrXHOWPWK5q6UVJjtvHi3EYHee1UpTNfX9yxfw=,tag:44nbU/1sH+hUDaYRqwaUhw==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:XJ2RopKP44mEf23XXw==,iv:2eE3EB0Y05layEighf53/z3KrBu+DO7UWMYsH2BFMiM=,tag:IN3hyMSGX4Cz56f4mHtF1Q==,type:str]
-      value: ENC[AES256_GCM,data:iIoDrHVsgFrRL6MklTy+ubZqydkE3ximkNmiMw26WVzh/ii5FPpxGGGS7ywlvTC43psLhdHY3KAQJJaBR7Hnw6Pw5Gb21NUm4J7n0e/VIZzHKGQicHxKWa2Q14KBj8pWnZPWveDBKkx1i6+YCV98we+KxvOaTWgV5CnOGZxZFfVr9A+N08JT46Ae6cxyDJ9+kv2iaFXDoOBU4uSsfj8sYPKbBdtnReQqb8NceQ3SlLodYg==,iv:Pgv0h5b22udpAWE4rf8dI+55h1FLmquma+s7NxmgA1E=,tag:pvJHaowZ3HA3tAvzkzWqiw==,type:str]
+    - name: ENC[AES256_GCM,data:2LRQd7NjFpLzFtYFqg==,iv:LZLdq10JqzJWCWKfk13yoQHgXGrDk8kKb3nK299YKRA=,tag:/x9L1GeA0Yn1KfimSjAlNA==,type:str]
+      value: ENC[AES256_GCM,data:G+c3wev7dxIrA0jQ0jdJca+8Y/LsUUoLgpWlSs6qsOvKOJ/TQo3KKjjgE+ZGZBhqtxY7InIIwDKx0cbMf8JvhVFNW1yldT3jzrhLRdlglGECa/BKmFTYKrbaor3iN2++vKrLEdACnM8mti8wh4W6OAFz1ap+bvLdPAXPWVEV6A3/ozFgkzK4prH3BbaKLLDVIB75Pm8mNmTe59eVW7FPGAiROzWu8Dg7cebYNsbgYarn0g==,iv:qSqERrjEihirtYwZfL3cmi3252Oy13yEqAE84KxWpyQ=,tag:Fx9l75G2zYOiRlORHCgbXw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:SFBxkMZ3W/MW/JkQifWkSQ/0PB122mYfAaKrKYCGdhGdBQz5/JgdETDMxw5t3xzh5S5HgLWS+We3hVZ0kzHdKQ==,iv:MyhlO3NrSTHU8hLxdp5496OQtIPoWc+1OictUdXWwGA=,tag:DpQapscic2+mcauLedlrEg==,type:str]
-        password: ENC[AES256_GCM,data:Yb4DLeKT11eFc49HiqgmaW09aK7S7zg4kRUos0fPftx98Cz4AD/SZwDEXX/mK/FWg3Zq4iwM3VtWMNFmfwo2/A==,iv:Hywul/NRkCkn7HC4jpvET/uS5to6h2at8eWdIAzi7AE=,tag:MyWddTlpMqZfu8RcMR+jQg==,type:str]
+        username: ENC[AES256_GCM,data:Z2VVZkPImRGhtF34A7Wvs1KWxzAFyM7zcUsAHQdERI4A+2XF546HTg8ICwrZtCEnYWd+C1TFVnJwEZgEy47H6A==,iv:TVk2WhUi/aRCrQrjrp9zPVprs7frq5k268wxKcRo2HU=,tag:ZDtv0AX4hhaG9gncCKIHTw==,type:str]
+        password: ENC[AES256_GCM,data:vVw0dxw9fiIsuTrCAZNLo3mNQWZHDs/CJuicc3/Q7Rprhlpn7dOHEMEWYUsuZ3iDw3npwjKtKwO4y0lM01Tzig==,iv:+xUWdTVw01KpWcwVnhWF23MWCWmLrUvODQDs3T+E7pw=,tag:lxjyIiQlRGnfSBdZCave+Q==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        TveoCKkfQGCm06D6RE3ZDWc22O4cH4SBtpwODvbXg3EqgGRJsPyOpigl5Yhj6iIq: ENC[AES256_GCM,data:GA+GMaJLnWhJ9GyRqPloWtR36DpsFBe2eKE/n4EcL6ZRhSl2WwtPnwOo2YDLwnK/BsVbDCfJjeL5gVj5,iv:IbVeFd88pAc70p76w5OCl15ZUvPYMsSfh79N3bZAJqE=,tag:UM0NeBHXUo1AscYbpHI2Hg==,type:str]
+        TveoCKkfQGCm06D6RE3ZDWc22O4cH4SBtpwODvbXg3EqgGRJsPyOpigl5Yhj6iIq: ENC[AES256_GCM,data:vDsUnbhJXVyVXawfWWEhK3mk6nOjjvOy0BK7Bqm9xWoUhc5SS5L5xST7m61V1d+pJ2LjI7Y5NQx8tjfz,iv:WR3huYjToX682A9JSo7xhoHWyZ/jWuo7pBrnwPYm7mA=,tag:tdl/kTTsfZ4Sqn3UTvR+Hw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:mg==,iv:f1z6WwfvQ6vIybkYcYW6w644K/ZEFGr68pMgXSJ1ceI=,tag:AQBZIYcbphFUYQkAefz6Kg==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:n2MPMpIHJLxNuQ==,iv:AK2aS3898kUe6leoV7f+l0dbXMhLakW9CpixEupKi+Y=,tag:+Y07PyOKat72pyZtTs1myQ==,type:str]
+        orgId: ENC[AES256_GCM,data:hw==,iv:oDYQ0NkOyvxRR3dNHZdOimtYulrPRRLEsVtXK4gxcp4=,tag:TYpp1lvD++a50GZjB9zGVw==,type:int]
+        type: ENC[AES256_GCM,data:lGjyQFlHHYr3kQ==,iv:p7h9vbb2A/F0b6pDua24RX7Juia8XZgD2BHeZpfiMNg=,tag:UlKkKkYS2LjNcyKMz/37tQ==,type:str]
+        url: ENC[AES256_GCM,data:4WykZJs7+sAHhYnPWbxVsnYPjQ4KnLZnJiUCV5SRe6I=,iv:yIM/sfjdy5WpHIvmuZrADvD67yfBL7l6BI9jl1MU4Io=,tag:NKJHUZhnaeUwbEcaBLV+6A==,type:str]
+        access: ENC[AES256_GCM,data:rCDDKyQ=,iv:1XzRIw3rkq57T1KxKko5O8bIa4cGdbGN8cwUpSTUuBA=,tag:Uq8p+ZJyQZiBa35AB+5rvw==,type:str]
+        isDefault: ENC[AES256_GCM,data:hTnjeAM=,iv:LuBrMj60eLJLkM8NyO1HMQh8E9bydgN4UM+F7IPN8xE=,tag:vsmmG/ttSnvANdPA7rG7Vg==,type:bool]
+        editable: ENC[AES256_GCM,data:7UJAl8c=,iv:NJn2S9RbnXHe4n16FdN53c6jMs49bWp/0BGG7rHGaWM=,tag:2dxEzJgfWd1W4TwU+XTUUw==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:jx7jJQ==,iv:InTbmYm6t68QkVFGYbRWEtXmoZMWs0e9PNw1mlOYCbs=,tag:cAKwvPU2rvVOQ2WNmHa84w==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:+0ju1ZifCXepajJ/h+iKTmnlzwQThJi8vr/cf+hfV0xj5VAU3X09KW1yie2Cbf0Er8elR12gBqO7nkETYhix6A==,iv:ktv4S4J9Ru6eBtFFLyZVXz82HOYLE0vTNTk4kYzDC4U=,tag:9P13dUS+NCSBoUgtYTCQ9w==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:forId/brOMC/NUhZf2hyLFm+TkWC88JeSsfoWe2Fywq4LCzFVVbHxj++gsEZNh5XeWaKkjR3vDvSjxJoeEItFQ==,iv:Lfe0TDmA9gZNIxupuGfPYGgpPcClghK83Lo44CqrUpo=,tag:6zGwPse+h8pb1JsshCXXtg==,type:str]
+      - name: ENC[AES256_GCM,data:ycMvZzuCGkvKOPMJu64VCQlCXWp1SZV1QttiFw9KUg==,iv:TmJqcu+XGB4RICshX4m9i3cfHIhBWnrOgxpSAitMHHY=,tag:ppiBovQ7uMOnOOtvU0rIGA==,type:str]
+        type: ENC[AES256_GCM,data:qJJGqn/V2Z5iLx0MpWe7y77GIVDp7WB2h1QT0QqvWA==,iv:MNnm770eCNCx/VEnPn1mi4t9uae0sK690H6V7WO4FEQ=,tag:bG2h9yfQCSIh3uQbDPQSOg==,type:str]
+        isDefault: ENC[AES256_GCM,data:DbFHN50=,iv:OxBrrYj8489/lQB6ybekeqjv/cG+SlyV9+RyaQSRSIo=,tag:m3ul1c68VYFCrxnaEsgkZA==,type:bool]
+        editable: ENC[AES256_GCM,data:+AibuQ==,iv:OuRDIMSkPZ0REfbnnLWIkIdD+RDEK0/F/IxaPsA3aIo=,tag:Doc9GcN9e5pyxDp66v+fCw==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:06Z'
-    enc: CiUA4OM7eIQOomC60KekGZ6Ng+LMH2wI0frqW7V50aRaX/nriYI/EkkAPHlbmWcNngHF+dbC8GlZcS0GsvPNMcecjNF2cGyhFzrEqfsGzqlHZKCAvnftgXmVN/+jlZcDYeg6THBmxT9MFiWlYMe41Stw
-  lastmodified: '2026-04-16T19:33:07Z'
-  mac: ENC[AES256_GCM,data:qEx9MhT+piCDKwhq4NK+RDC0RGloIZRXU+jboU7TlFrN5qjSuo5hfkwfUvFHcrDINn4w9v8P3BBY+iJzjL0dDkAwjq/j9pOWIRpvl73Fpl0HB320Ypgl2JMUjeE4DDBwWTy9SHQz6jN5Ab2tGsW5ZmS+viXzURaRh1ViDGYvQTc=,iv:InIpVV738liBOlYB5Zm7F5ppdw5qetjrg55lcclocfc=,tag:8iWUOIwpiAAbhsBRgfBFLQ==,type:str]
+    created_at: '2026-04-17T08:24:30Z'
+    enc: CiUA4OM7ePO/uHmfVMdGJTms9tN461/TkCHoZWqVqvrL1KCR4B7YEkkAPHlbmY64xk/rlPXlWjbzzQHASbjkLah+r9QPylo9rUvR494TwxEIwWA/wUusJMe1vVy7m1u1j5JC5l/FEboZYsj/jT7+kmY/
+  lastmodified: '2026-04-17T08:24:31Z'
+  mac: ENC[AES256_GCM,data:Y4SfTB1gWhwqg/q8RTt0zt3hgvdbsjdYFpxYOZS6rZIZDS1NHTi79F/KhDtOlWz42MadbN1g3FB2TxY707fXWUYlhsft/kD4Xdjg2/FoW9aLKloERmELblcGHTZcTp/wDapTG7zW8BTrGjxpL5F4dIPRbbqIBbDCll090gNwWwY=,iv:yu4K9J6XX5dEHFUZ3TB1Gxi+XRNGD8ibu8U67ob+N7I=,tag:eBhWuZPaIy81y23zmEJirg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/strudel/enc-support.secret.values.yaml
+++ b/config/clusters/strudel/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:aG3ajGh8sP5arfWstAQABLdn4opjW/Sx9QlsV6ZgZZo/4tup8UgzQg8qlN1l6RNCW/Vh9axuD+fFX6Pfm8MvCrYL9jqSPatGY+rBqc9EZ+GtMWpwpAcK7LkhhTdDPuxZwSvMKiZqciFVbmzbZQe9JRxgNQvzZYTj1BJGNaTdWjjuB9z0+jxvRR0pQQeejNSlMWZSduslX5SSEuI0,iv:ZmYyEMw3Xh0qORDmOQ2jU2328OGo11N+xw+WFjgtKm0=,tag:B176yht0HwNFDsGmGvPsyg==,type:comment]
+  #ENC[AES256_GCM,data:gGfi+cfSF5Qk+Lk8BhmDCVVxtSTdE/PVfuNaNlPG6lc7zXZR8xoEPaBGc1yBYBYTwPOPU9aMtMcPcqCbjiXP2iC0M95+aLXFsOr6nThn2iBTLBCBB9dZQ3Cymb8QcB+4fQ+1fo9OIdotAQ7C7rr2kIJ/aUiTdg1rNMxgc5kix5n9saTh/J/shZBmeyw6UyZnERzqAhrcyoX4nB2V,iv:HkPQTY4saComuVi8p/xIMkyei9k+So/xic5M94GgC94=,tag:gruQ0Z9029RWXhaYTUR72g==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:fxteSLtdbY8PW47BxADv9++A75iGBafLYjqkUBRqcZeocTiDo1EQqaq6IQFdSWkKXKFN6PINohPIFi/zJiRvLQ==,iv:hVHMPY/pSpK3ho3VhU5i4A+Od/0FMapVdjE8/GuPCUY=,tag:XvehRcfYe+fraUlgkUgS+w==,type:str]
-    password: ENC[AES256_GCM,data:X3fzuhbpz6kAiyr2fzuJcutCIQwwceecEdT8ya0LRZDVMVyL/oRqMPccnbNyJXMdEJyihlEoKanQXaP7xRcdjg==,iv:r4Jh8ScQ7Um0AMn/DxVHtRutSp9c/s7rdZIL6f6WDdk=,tag:Zah9ziSqIIuKGLTuILulGw==,type:str]
+  - username: ENC[AES256_GCM,data:mebgZXzuT4lpUgwfplnMicJLBo28JXQ0O0M1DNyCV1SUExIHDVTFa3mggBVdsC+hcrVUORNpCUwnauVcrVsbwg==,iv:DlBkIwvUyDAXJNGmZSDTBeog2beTgYfHe8imd7uei/k=,tag:JljDkz8Cxx8IaTxzTM4y9Q==,type:str]
+    password: ENC[AES256_GCM,data:jMhrUH7EH5lN2ykrwIkj0jzetGXiAFrVTm7+QdYFERAt/gq6vSoOBmA1Gcrv5RbkE8tjldShzGRvJuIcJNHI9g==,iv:EHqj2xgwqSrevZqvqT2+cooUWQX8pGwaeeCMliMhQ1c=,tag:xUKT9C31PXEzEnxJnRHPtg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:XJ2RopKP44mEf23XXw==,iv:2eE3EB0Y05layEighf53/z3KrBu+DO7UWMYsH2BFMiM=,tag:IN3hyMSGX4Cz56f4mHtF1Q==,type:str]
+      value: ENC[AES256_GCM,data:iIoDrHVsgFrRL6MklTy+ubZqydkE3ximkNmiMw26WVzh/ii5FPpxGGGS7ywlvTC43psLhdHY3KAQJJaBR7Hnw6Pw5Gb21NUm4J7n0e/VIZzHKGQicHxKWa2Q14KBj8pWnZPWveDBKkx1i6+YCV98we+KxvOaTWgV5CnOGZxZFfVr9A+N08JT46Ae6cxyDJ9+kv2iaFXDoOBU4uSsfj8sYPKbBdtnReQqb8NceQ3SlLodYg==,iv:Pgv0h5b22udpAWE4rf8dI+55h1FLmquma+s7NxmgA1E=,tag:pvJHaowZ3HA3tAvzkzWqiw==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:SFBxkMZ3W/MW/JkQifWkSQ/0PB122mYfAaKrKYCGdhGdBQz5/JgdETDMxw5t3xzh5S5HgLWS+We3hVZ0kzHdKQ==,iv:MyhlO3NrSTHU8hLxdp5496OQtIPoWc+1OictUdXWwGA=,tag:DpQapscic2+mcauLedlrEg==,type:str]
+        password: ENC[AES256_GCM,data:Yb4DLeKT11eFc49HiqgmaW09aK7S7zg4kRUos0fPftx98Cz4AD/SZwDEXX/mK/FWg3Zq4iwM3VtWMNFmfwo2/A==,iv:Hywul/NRkCkn7HC4jpvET/uS5to6h2at8eWdIAzi7AE=,tag:MyWddTlpMqZfu8RcMR+jQg==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        TveoCKkfQGCm06D6RE3ZDWc22O4cH4SBtpwODvbXg3EqgGRJsPyOpigl5Yhj6iIq: ENC[AES256_GCM,data:GA+GMaJLnWhJ9GyRqPloWtR36DpsFBe2eKE/n4EcL6ZRhSl2WwtPnwOo2YDLwnK/BsVbDCfJjeL5gVj5,iv:IbVeFd88pAc70p76w5OCl15ZUvPYMsSfh79N3bZAJqE=,tag:UM0NeBHXUo1AscYbpHI2Hg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:09Z'
-    enc: CiUA4OM7eEju90qh3CXeIGvf4tLfpBfhurqOCw5y5M5pMj71O0wWEkgAZoeZplvd6cpNM7+tFtZRxjOX4wqCcheYLUjVadVoKsLzvgxFTGk8IyyuMSps1imHOTsm1u7umS3EjbX9p6q9jIZM+9iorEE=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:09Z'
-  mac: ENC[AES256_GCM,data:dCY869uwEeoy0NONbLSr/OpFA6RYkzrtBKG8eUj0rXrUwV+uRAdJrV3+uANB5CdQQTrHx1G6ML9lQ6R+Dh7f7M4fkCHM9DYwZ0JG5QsHeZ15+N0XjDt88nkVVsw850uuYYAWQdGzEr1SKVQfyQbW5AwISf9MAFXtfC/XZ8q7dCE=,iv:N6QM5duYHMbFHLyhOWKDKeFCx5UJLgEuhPNhr8cfN3c=,tag:L2XKruRbIrRM9aus0kby1A==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:06Z'
+    enc: CiUA4OM7eIQOomC60KekGZ6Ng+LMH2wI0frqW7V50aRaX/nriYI/EkkAPHlbmWcNngHF+dbC8GlZcS0GsvPNMcecjNF2cGyhFzrEqfsGzqlHZKCAvnftgXmVN/+jlZcDYeg6THBmxT9MFiWlYMe41Stw
+  lastmodified: '2026-04-16T19:33:07Z'
+  mac: ENC[AES256_GCM,data:qEx9MhT+piCDKwhq4NK+RDC0RGloIZRXU+jboU7TlFrN5qjSuo5hfkwfUvFHcrDINn4w9v8P3BBY+iJzjL0dDkAwjq/j9pOWIRpvl73Fpl0HB320Ypgl2JMUjeE4DDBwWTy9SHQz6jN5Ab2tGsW5ZmS+viXzURaRh1ViDGYvQTc=,iv:InIpVV738liBOlYB5Zm7F5ppdw5qetjrg55lcclocfc=,tag:8iWUOIwpiAAbhsBRgfBFLQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/strudel/support.values.yaml
+++ b/config/clusters/strudel/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/strudel/support.values.yaml
+++ b/config/clusters/strudel/support.values.yaml
@@ -12,6 +12,8 @@ prometheus:
         hosts:
         - prometheus.strudel.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/temple/enc-support.secret.values.yaml
+++ b/config/clusters/temple/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:/WgI7oj5ZP3rF+3Ft54Q8T0ZJ0TXrjYl4mva8bGgbyc5ohpLsYoTK2OPd9Chc7SS+Ntwc/d0gBQ3VlUYuLPywbiXPp3C2lxsOz9Y5nlDwp29vuITLc9ykY3ldOM1OyCLRdW970YYITOOc1ahNCjqw37Vb6rhII20zjfYMdwkmAD4CGnRVCjFZ6uSyYazszAbkEX0QXmFxFUPGkzn,iv:A0d2TKaGHIAli5ymX7LIuOHAfR0l5fgmrZQ3J9SN4/c=,tag:8YLK4eNQhxV5iK9fNLW9Pg==,type:comment]
+  #ENC[AES256_GCM,data:Qe2xafuaormeUQOfaFXcfyOznClAlG6cVXsUK87aH+SdDpD0fqsw+Gsrn30pGSE9Pr+gPjJPLYavfXPIIGNPisSRW1n13WmaSu5e1BCV6SarreRCOkO6hA6VQOmd4tFWADaXbKEA5Xp8DaMMbtVQmT3kRhAaaAxF2bVKjfzUDcoBzVfvKvtZAy/vAYpaR104ZZxd+0BB2RUvFKnW,iv:xOSyitU6v7cb4bnPpA6fo/1fLay3NkuIDOhXuPlhPHU=,tag:o8C1CGEt6XIWpiN1SATktQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:2UAyBjFhTmKx3sxv4oTdGigw8Inebio5Q72f3NNZHxyKl21uBNhK7faUvFjR4Z9F1R7SnzlFQan63xU6jfHsrQ==,iv:lEds3GU3pYYrpljYjzsPzEBXwoODfrtkZVqSReHCNJU=,tag:8vnBptumdzOc5nDAWqmcww==,type:str]
-    password: ENC[AES256_GCM,data:W0bS2sguDljf1kchIhhkX3M6Ztw23eUwZHa4F/m7VZV1OX4dIkbqd3zUByO41jo5WsxrfgPl5k/SC1BjB5ghHA==,iv:2dWX+QLgx3TLBYTwPzkoFIbMVwfOiBa/bCHwrgt3Fv4=,tag:Q+/UREkmngHgA7LPkS5bgQ==,type:str]
+  - username: ENC[AES256_GCM,data:I9UJC1vZ0GB3SZehHxtTtIcpMB2KtYEi7f73tdy2WHHwB9p34PxbFQBoYlII0ioWZgf+l+wFOj4BO+YIcYIXKA==,iv:bAB2XIqg1MQYG3B0keWhkSCg/oPFkqB3gy0uMx4dg4M=,tag:/rK/UIZ/0icxB+ccHSNNzg==,type:str]
+    password: ENC[AES256_GCM,data:eQ2EOChyjRDN0sdkE7iMxqeYaXyBe0T1wL50SZcc2P4OJ/VeRzthp9QDaag46tos5Eh1HBrvKYIjw1egulQv3w==,iv:f/TaviVKaQl9Wrkwi9dgxjVx9hCN6zfQJSxp8Y1CTzs=,tag:ez55fpYcGVPqXdasGBtdnw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:a1nVWsEnPXi8in5z8w==,iv:8WYAgN73qyIOyXjbQplIYiPA9jOnXeA/ww6gCcHYwwQ=,tag:K+nqboNz9lk85YnJ0ZztPQ==,type:str]
+      value: ENC[AES256_GCM,data:TDI+rlfclslWaUOPoLGAWZEW9mG5Gtc0exwXyV+6Syk9Z/mSOqZZOnSnUpv35jS/bbE3rSkykXcB7IJaU2oY15VKLCs943cMwnLuIkZBbLSWqDuv7PN/VMqD1axUr2CD2Ym17kjZ3sbpclP9m1z6N4TUCB36IrmLYcGTti0fmGCTxa5XPWebQtZQWtGQmlrmxnLohqShkILGHVh289LWWG675ZTMkzKYQj4IqLVvRYjcbA==,iv:ifr7Lff4cNu6NCNyBZV1HYnn3YZFiq2xgMhWiFYAd3w=,tag:jPbQDz2d98niZwC1qk/Ypg==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:ssDFCpEQKWY+alrehIjFfPFl06qImSanWHXB6FllElZNmQhiGywJfE29Ts9hf0QFt1rscfHCof2iwiQh876/Fw==,iv:4+GgeAyEEKc7ua/ILeylzheSSbDCGKb8t1wYYXTbD90=,tag:6zogIVHeV6W0QAesLkrOAg==,type:str]
+        password: ENC[AES256_GCM,data:5Wm/q5jNsuVjMmMz4h6L32fQvRk1sS/OVnuO6kMJTjevysy3omW8I2h6R4X59nLTiqcF7Qnee+q5uto7Z41bvA==,iv:8zJmdmQ8FEVlYFgs6+CSGW3TWFV0if5VHw18hVi506w=,tag:2PBllqpgkArNqSZency1DA==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        Appmkqf1qmz3w3rb7eKagIu5mSRcB7MiSBE9rY1wnqcZfw1fhBqbg8A5qmAEkubd: ENC[AES256_GCM,data:wfpBPreuLWqUQCLXbm/HvFCezQ4gFhDFyL6WVu62M15nGvmpFIbQj/r1OmUWjWObgcUIZ4cjwBJkveMJ,iv:H40dOihqT4eQRzYV5qwqYSGyupcti2AMpiBV9d3w0iI=,tag:/0Kr8gPXJsIikdmu6Nf8Fg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:21Z'
-    enc: CiUA4OM7eB3rPuwlVoLBTlkoUfmY9tV8+1ekOI0PRZoHKV0U2I0UEkkAZoeZpgboa3d22t+KDSkbJWz1bkhhTLMuP6uzUdJCEhp61wyCfjbpRrQmAPoInGMMZC2HcTnGl2Df2z6Ms7ePYQ1zh1BlPeKe
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:21Z'
-  mac: ENC[AES256_GCM,data:3VmYfzuVz2mHuUoOMBmBc4BFM5/AA/MigNNMQuSVg6Y9Ynj63fTmesPVP0SQ0ivrlJaNdQQVf0Av1QjwIqO24Bgcaol1gCRe7scAKKvDfOwe3x9tIxKTtYQnmsAXw5SzPNSn3zTUuY98AexC13hL01WgU+rbxEotDYQEGgwEUxM=,iv:QdbUwx1ricqjLHbPEuC1KmN35pCLBSKNPNGKUTymtNc=,tag:cpnTFWWVZeWzB1s94x4XsA==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:34:05Z'
+    enc: CiUA4OM7eOYAnmBurQDan1VrUMhE0xog0nILjtLLTiDFqMd3cAQHEkkAPHlbmUANONNmHN+QyxWWznHM/RvREdIacFP9p4+Bmc1NJ7sKi1m6Ik+zTgBW3AkxGlvMN2n3FSbtavUlj+Y2UwN/k5IhxX3g
+  lastmodified: '2026-04-16T19:34:06Z'
+  mac: ENC[AES256_GCM,data:ol7WXOgGl7QHprquff3Q6Tc094MURdNcOApc3oh1+tz8peHaiVIQRk9gqlxJjs/rhSGDWfI1qqK4mkwQUfqVrvJeOu4bB1jPGjW7yX6jDmIgMX2Ve90Jh/V4KRCRnsaEDY4YsBx8opS9XWI7lLIUqh4pDiWymy0L7z3DPIw0+H4=,iv:ptY9sni2AhEZtPU/5vEmF5Mpm8LNFOkpu1y61mwXpM0=,tag:gpq2dQ4+UIV8rjIW+ef4UA==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/temple/enc-support.secret.values.yaml
+++ b/config/clusters/temple/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:Qe2xafuaormeUQOfaFXcfyOznClAlG6cVXsUK87aH+SdDpD0fqsw+Gsrn30pGSE9Pr+gPjJPLYavfXPIIGNPisSRW1n13WmaSu5e1BCV6SarreRCOkO6hA6VQOmd4tFWADaXbKEA5Xp8DaMMbtVQmT3kRhAaaAxF2bVKjfzUDcoBzVfvKvtZAy/vAYpaR104ZZxd+0BB2RUvFKnW,iv:xOSyitU6v7cb4bnPpA6fo/1fLay3NkuIDOhXuPlhPHU=,tag:o8C1CGEt6XIWpiN1SATktQ==,type:comment]
+  #ENC[AES256_GCM,data:mm42A2M8BHLMuh95215aARoEY1T12IpMWUU4oxX2I5/c/woq0oUf4O1f9LgN7uQWXPHD/PAEzOejDpPn7wnjV9caB2kJm8fSJeZd7YYlfVe3fzjhVjaBAbB+DUdgBdGwN6/yxtvaLC5cY3ed/MCjik+lVm+AmzMGoN0ElfXya2K1QcYGe/3PMO0hJ6nosFUjqAXzdd1Md3qH39JC,iv:7St9sCTmLJEMCkiGfXRV6Oy5kcWFNQ4d25AHkmOmsAg=,tag:6zhQeNWBEivFx0ov5VmuGA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:I9UJC1vZ0GB3SZehHxtTtIcpMB2KtYEi7f73tdy2WHHwB9p34PxbFQBoYlII0ioWZgf+l+wFOj4BO+YIcYIXKA==,iv:bAB2XIqg1MQYG3B0keWhkSCg/oPFkqB3gy0uMx4dg4M=,tag:/rK/UIZ/0icxB+ccHSNNzg==,type:str]
-    password: ENC[AES256_GCM,data:eQ2EOChyjRDN0sdkE7iMxqeYaXyBe0T1wL50SZcc2P4OJ/VeRzthp9QDaag46tos5Eh1HBrvKYIjw1egulQv3w==,iv:f/TaviVKaQl9Wrkwi9dgxjVx9hCN6zfQJSxp8Y1CTzs=,tag:ez55fpYcGVPqXdasGBtdnw==,type:str]
+  - username: ENC[AES256_GCM,data:gE0K6RSzePdGAIihUm0MmlGWRnbv/33pgRaVB6CD7W+M+cKnRsYEkVY1PvZayk1gPlI+noxCeYhDGHmLBbxEDQ==,iv:+zOguhsWPVQ9wYZ9FGrrCSD7dEfYW+nfWF2Xw76Tbkk=,tag:0qYLpRI/9TLkNp3i8t837A==,type:str]
+    password: ENC[AES256_GCM,data:YNrw6kIwi1k2CqBH4iVkBHzqKPx4+MRMauPBUmpkFsEH/JbArN96PsZVZsXc9+CJjK3gsOgT3a+Sv7UnyvdA3w==,iv:nayd6pz/W3XmtKjlhDD9LHfzWfoAhLfRuK1iaXArUhE=,tag:RbWRiL4Vjhvm7nyC/v+aEw==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:a1nVWsEnPXi8in5z8w==,iv:8WYAgN73qyIOyXjbQplIYiPA9jOnXeA/ww6gCcHYwwQ=,tag:K+nqboNz9lk85YnJ0ZztPQ==,type:str]
-      value: ENC[AES256_GCM,data:TDI+rlfclslWaUOPoLGAWZEW9mG5Gtc0exwXyV+6Syk9Z/mSOqZZOnSnUpv35jS/bbE3rSkykXcB7IJaU2oY15VKLCs943cMwnLuIkZBbLSWqDuv7PN/VMqD1axUr2CD2Ym17kjZ3sbpclP9m1z6N4TUCB36IrmLYcGTti0fmGCTxa5XPWebQtZQWtGQmlrmxnLohqShkILGHVh289LWWG675ZTMkzKYQj4IqLVvRYjcbA==,iv:ifr7Lff4cNu6NCNyBZV1HYnn3YZFiq2xgMhWiFYAd3w=,tag:jPbQDz2d98niZwC1qk/Ypg==,type:str]
+    - name: ENC[AES256_GCM,data:m3kHkA9tXMYHk6Dm6A==,iv:faFHfG6SAXzm2kkfvEaZZlWvIsuSHx8J7eH49UMYS7Y=,tag:utvQSKireXHfCdtZtyC1iA==,type:str]
+      value: ENC[AES256_GCM,data:KxDZbTyMk+ONowzM5BYn8SM93ebuLZqxMO6JBnYs0AYIVQMVBrY5nX8cp8RFcgM6j1VxLUFB3sxesPz0QucRjd27/d3ysWdgF74N2yrBd1ufuL5odxsdI5FdGptTJr82Z+SqPhCdFX0XXKKQCSOHrY0OFJUhkAX4LehVTkVYf4RJBo42DtqWacfCvUdIYQ7guje9alteBNAiup10p0O6umA4y2QqbzwUbWFYogBg5Q95qw==,iv:LvSc9ALpuLVmW4jOMWbB/MIV3qQC3/hZ/439Wh7rgvk=,tag:jt3pBOkwwVJu/UKrIOUCTw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:ssDFCpEQKWY+alrehIjFfPFl06qImSanWHXB6FllElZNmQhiGywJfE29Ts9hf0QFt1rscfHCof2iwiQh876/Fw==,iv:4+GgeAyEEKc7ua/ILeylzheSSbDCGKb8t1wYYXTbD90=,tag:6zogIVHeV6W0QAesLkrOAg==,type:str]
-        password: ENC[AES256_GCM,data:5Wm/q5jNsuVjMmMz4h6L32fQvRk1sS/OVnuO6kMJTjevysy3omW8I2h6R4X59nLTiqcF7Qnee+q5uto7Z41bvA==,iv:8zJmdmQ8FEVlYFgs6+CSGW3TWFV0if5VHw18hVi506w=,tag:2PBllqpgkArNqSZency1DA==,type:str]
+        username: ENC[AES256_GCM,data:I2KhOPHlSjgcvAlycOayb1y3VK7cNRKxUXfr6Q+Mi8bAGGNCY334YhsPbJuqgeKah8aM9ZHoyavWWLao2hJlag==,iv:+dDhpFJT/+bDrr3bnGzYmV5ilHCfdJNUZskoc9CCY8w=,tag:yKwhb1aR3ETDNVvjzKGjuQ==,type:str]
+        password: ENC[AES256_GCM,data:rTptTpSmzdPm21Xw4mK8kX7ZDLlsmi8jEOERJOM5Lat77v6m6DMDQBrrM/yhGlFA59nKyJlCY99glHxjFuDsgA==,iv:6XrOBmEJgUH6ajjDVktrwfP7uYgBncXzhIU+st3KUpY=,tag:xGzq0Nf+QzaexzyjwrdxWQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        Appmkqf1qmz3w3rb7eKagIu5mSRcB7MiSBE9rY1wnqcZfw1fhBqbg8A5qmAEkubd: ENC[AES256_GCM,data:wfpBPreuLWqUQCLXbm/HvFCezQ4gFhDFyL6WVu62M15nGvmpFIbQj/r1OmUWjWObgcUIZ4cjwBJkveMJ,iv:H40dOihqT4eQRzYV5qwqYSGyupcti2AMpiBV9d3w0iI=,tag:/0Kr8gPXJsIikdmu6Nf8Fg==,type:str]
+        Appmkqf1qmz3w3rb7eKagIu5mSRcB7MiSBE9rY1wnqcZfw1fhBqbg8A5qmAEkubd: ENC[AES256_GCM,data:dbARf39ruj6tnbHz/e43BwDDF8jQSllpY3f9JguhJ7tIR1BPXO53HlLBTzqmjBXyOlg337+y0/26Ev4E,iv:8V81hwcnL7ZiaY0diDOb5rbz4F6yk3f2sajZY/EbvhM=,tag:78ZvcMeH8BYDndUjpgLmgw==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:OA==,iv:AMgEeMG1FhCsiTK/dtMNDsWaLNcuT5sJTJNrvMWDoD8=,tag:iX2ZxAdq2LK4EqRwPwAppA==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:ofBTTXIwOfLYqg==,iv:E+tOfy6mTkuYkIoQayFARZuGL5qKY4PJcyr2DLmsyew=,tag:bUhhbw9xGD8ZyZ9X7e1vgA==,type:str]
+        orgId: ENC[AES256_GCM,data:8Q==,iv:/qg9nETi73xKKunOdi3aeG9jnDKWd+Iq8D6HJemAa3k=,tag:MD8KUZX43Y6ak9Bcz22Rsw==,type:int]
+        type: ENC[AES256_GCM,data:2wRdWyAkx97F0Q==,iv:Q3gi4CCE6KiHpSrv1OrcWMXFpUQmZvus/u2615TBeXA=,tag:E1z1+H+8OslY6PBcYP7NrQ==,type:str]
+        url: ENC[AES256_GCM,data:UJMfjlHwhdc/C7jOXGr4qpUAzWKr9CPwr6YtFLyEEuw=,iv:snQEemuzDVKJlUtyTRQMgcQYsninsST30jdrO/HPOe0=,tag:D8JK50it/BJidzCx/RP/QA==,type:str]
+        access: ENC[AES256_GCM,data:eNErb3A=,iv:Jg1vVvZQTQzJXB8lbC5+jSQ6BrGBfzdC+XYyg79rGpc=,tag:THvLTyVrGkodHQsqI3bB+A==,type:str]
+        isDefault: ENC[AES256_GCM,data:l/cgBuo=,iv:/D1rY1KJWYR3C/+jv0hPXCe7z5gBhqIf/zUfFHADQ9w=,tag:IGlr1ECdy2PFvKhMGm+FYQ==,type:bool]
+        editable: ENC[AES256_GCM,data:Bdp7T4Q=,iv:R+9d1N3nh1bXsvADXl277JGmZEJglDy6AVs5Q4Ce16E=,tag:nHNL73+4rylVxdDeTU5Y6Q==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:YGi1Hw==,iv:QxQc1P+b89afduO0RV+/xLL5wR4JGa2cchlR6eDLOGo=,tag:okqU/sUptPdaI4YI3SPFvA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:BZwmXV7kJfIXAsKZUSiY2Ejzq1HzI6wlKOfkLc9UD+pw/YZxyyL94a3dRRKi/b82zfAIZjmXwfY+OVQgV8wmgQ==,iv:3KGGLeUGjjLjVZGdBNUgBL267zQ0tFbC1VFgCY/cric=,tag:mAqX2u+wk9NCVQRQbSbYnA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:g6c2euu4Di1WjZpmIhaLdT7gbIJYwqYkm3lv1GTWF+Fputc/PMO+YOtV2iPf4OFKl7zAbj6CmMcbeZy5u08p8Q==,iv:iWV2as8oDoX3rG1YQJM1EnhgXac4hJdzgrJwAcG3rvI=,tag:to+i9hEadIZtzSPDm3jOYw==,type:str]
+      - name: ENC[AES256_GCM,data:F2AqUFsmG5Nvhxcmx+pb7J4/1dUcxWbHf9ikUbFmyA==,iv:w5XwsRyDcNRCUvNcQhm+1nk2GyoB8EIW1ElPk3dga98=,tag:8Xez5jJA8BqceZQcHhi7WA==,type:str]
+        type: ENC[AES256_GCM,data:/X30cZrQOEbyGvDVn5lghwd9r4fYXtt7SRoZXAdhnQ==,iv:toERX0GKhjW5xodcwYsZgMe2xxQv6GO7c7Ueb0nLKi4=,tag:1uBUkF+QbqZssz/FC1fZLg==,type:str]
+        isDefault: ENC[AES256_GCM,data:IimObjI=,iv:UjiqIS9OEQh383anaC0nsWUxIundKlm4EW2bl9N2Qk4=,tag:ODoGxNwEqa5k+OCfhy3hlA==,type:bool]
+        editable: ENC[AES256_GCM,data:LLQtHQ==,iv:JcLM/FUeqQ9fRl1wmUGEMO9+6qEvvB0Mk7/5QNkfefI=,tag:u5n3ychzzws6IS0LcTG1KA==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:34:05Z'
-    enc: CiUA4OM7eOYAnmBurQDan1VrUMhE0xog0nILjtLLTiDFqMd3cAQHEkkAPHlbmUANONNmHN+QyxWWznHM/RvREdIacFP9p4+Bmc1NJ7sKi1m6Ik+zTgBW3AkxGlvMN2n3FSbtavUlj+Y2UwN/k5IhxX3g
-  lastmodified: '2026-04-16T19:34:06Z'
-  mac: ENC[AES256_GCM,data:ol7WXOgGl7QHprquff3Q6Tc094MURdNcOApc3oh1+tz8peHaiVIQRk9gqlxJjs/rhSGDWfI1qqK4mkwQUfqVrvJeOu4bB1jPGjW7yX6jDmIgMX2Ve90Jh/V4KRCRnsaEDY4YsBx8opS9XWI7lLIUqh4pDiWymy0L7z3DPIw0+H4=,iv:ptY9sni2AhEZtPU/5vEmF5Mpm8LNFOkpu1y61mwXpM0=,tag:gpq2dQ4+UIV8rjIW+ef4UA==,type:str]
+    created_at: '2026-04-17T08:25:29Z'
+    enc: CiUA4OM7eBRmzX/2hii62hxDXQbD2xaZr2hpDH8DDznbQi1uAs4DEkkAPHlbmc2/jpFBTpz4ZCDjP9u+pOIZJwZiaxMr0o3dDH0rAwoA4wFbop9pduzruh6hfOIYVm8Mro7F/tiMO3ht8w/L+43novI7
+  lastmodified: '2026-04-17T08:25:30Z'
+  mac: ENC[AES256_GCM,data:CAdd4RlWX8hRRLO+BE3eIZ9r/2qiNZI5x391xYDl3f8zSDCh6xrltS4yGbtk08N4YzRcv1kdQjl1/M3kfCi8MTfVTo3D+vMmGca+yka1HPjCLDa6pw6QyIeiYNA4jX5wOuEk2MGMm1jhC+0EsTa7Eq5bdWZ2a1GA+kV4NsReshg=,iv:gsh+Zt6InBdmac2QPly2T+pr6Vd4RvnlYgzcHDb83Qg=,tag:VkvBSBBeO8sSX+rAWk9cvQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/temple/support.values.yaml
+++ b/config/clusters/temple/support.values.yaml
@@ -14,6 +14,8 @@ prometheus:
         hosts:
         - prometheus.temple.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/temple/support.values.yaml
+++ b/config/clusters/temple/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 prometheus:
   server:

--- a/config/clusters/ucmerced/enc-support.secret.values.yaml
+++ b/config/clusters/ucmerced/enc-support.secret.values.yaml
@@ -1,27 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:5BWXDn3S+qQpeh4TKntxS/kgpCygUBbmblmz5QmrYKRSEG0PjrsiNo2Iy86Ut8nndA6T48qeNukxaodf2uQUJMqtCpBdq0B6xTCYrm1qYpwGLCO/jZ0HWldpqM1kDYeCZWiAu6R0VCRI8LRw0PVfjcvV9tgsWjwnth+42SFjDKi2d3gXQlsRDL156DtxB0cH8owguDav6IEQo3rT,iv:gPflIz115i5QNJidOraT0TacrZPSXv4OjJYcpLbt7Es=,tag:pvwbSDkOlouH4ek+Cp++bw==,type:comment]
+  #ENC[AES256_GCM,data:cwEYEDwaARA6q83jRpQwn658dtDx9WKchEpP5zzExVxuu+Q+YoP3Uh/W5JThKfmS1Yk7+ZnEYY93AgfKZ4Lnm4DZa7nHjA6OJUMbSlGUG71/NjydyniiFop3B7dAgOpjuOSHfBPevxswpE8bNp1NUHcmyDvXtqeKv1I2qMayxPd/JTiwJVTD+EszZl6Fd90SfB19fKAyECTbDgdB,iv:BekNjN6I/d+BNPHvN7apCJ0BXdMRLFusPhWi5oPDw14=,tag:uaqtQzUZIuYp/EC5pwZzhQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:OvuqL4Zd83z9UNMUK5Gon/BMT9xa/pgpNy3uXAcRlMLgjCRa8UEVBp0WCv8NjsgQPwCwf5q5CWbLlR98Nxznrw==,iv:jpHk+hPmxArXhpaU6Phz0eGwwjWMdXXR7Rf9qDb5TDM=,tag:1x6fhOPpZiIx1t4CD0ePVg==,type:str]
-    password: ENC[AES256_GCM,data:6ev28XostCHVufGyz1wFp3lY8Bj7HQhL6bjFtJUWjWe5zucQJATJBd6vD9mRwPs+8YntT6CYe3cgGAYV9UTwQw==,iv:/DLly40nRlXJmJVDPCCfjDAcw/o8thM8+a65GWqzZDE=,tag:zdq7CyEAWCqMLRVFU4ADHw==,type:str]
+  - username: ENC[AES256_GCM,data:BmMtJ0IKmTyRqo88RgR74rRrx3kKvdbbjQhn6kF9jQe5+Q7IdzM/KuB6zAMkUVbdbI79pgz+7nHS2uHA2qyJCQ==,iv:2oRmP3CqL1eiboAft8YV/RD4zlJsKO+6F7PH+7h5ygM=,tag:M+IfLagqxexqgU/J3fy9Pg==,type:str]
+    password: ENC[AES256_GCM,data:Ii44aEFaRRlSdXVrS3QcEjpfRDLMirozCaG8dzHb6j4tOh/Gdzh7aYRYVv2+db679Zb2bKAfIsxmrWcMBc4yNw==,iv:AmFjQGGtdPE8EC0wSKXdakdSStablVvgpZi0fr8ns+s=,tag:0OYkqFomUjhkVYAVVEbm2Q==,type:str]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:jm3HxC/GGx0IhxSrvA==,iv:FUswduIG4NcEL7L9DlFPnHPofgcf5XHBHT+4FS/j7Vw=,tag:NXAMsyWDiHHRnuKzb10isw==,type:str]
-      value: ENC[AES256_GCM,data:vAmXQjuFa7WMIFDPwo5KxhJUX8WbPdQejY8fLd5gOw/5GfGhwMISVgdx3bv07/lciozpcWF4Ay0iSYeYUqwpYvByzCDP8t6ZP6wA+nqGZW4/vDxV096aFw2njnavG+EJUvuqEzgUhSolbULEZPwt7famJqHi1X6hNLTeeLZ5jEXajf6zqwbmmCQ1Ql1Xm3JzXIkqx6Bby61blKshapGj0Cyss6uPG7BiAJ2eBo7F1MeHPQ==,iv:gsQxppuKZ+gCEV0cq3vduHhsDXAkkk13suSaDfLNImk=,tag:pUAIjmDZyu0TeppWhq9FwA==,type:str]
+    - name: ENC[AES256_GCM,data:dJkybT1J6Eno98QsWg==,iv:CIr111BUFjg9SILclK8NuCiL1qO5YYTCPv6rjOorZW8=,tag:gzTmnfsv0G9g2INlNzwzTg==,type:str]
+      value: ENC[AES256_GCM,data:C1EqijcBY3gy4Eto2vmLdyKCJPbyNZqyolGkE9YgWaUEDHskkvD/W38F+ZLnqdU02YKPqXf98gnCM+D8KfNzVXFUhao1EOgkJTDvNiUwMs6PzmtctF3pY7uGxRB1fRx2umpuj2XsXVfpBc5m44aHf/c7B/mz8zWVyfHSD8QBCXlRfAetJyZKGdAtu2GXZ3WI6IMd4sh9sGVlAdw5cyhGdjQqbt8v0o6p6abV+RfGZs3gMg==,iv:LOA/LYnsVQ4AJIFru5usWW4BiKNztaTIp+Ygc5Mxyf8=,tag:aPnZ5l3x8zW/LUalP8KTVQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:rs2esZN1mdjwdFOzvwaq7LrztFSqTKk/Vnpv3RhDBVQn/tV4zT28G2s78etrOT3QraRJKFyBQ3X46jE6G/LXtQ==,iv:UQq5+v/EwrFwlb1OSdv4QpgFK3RC170YXtuLnSi8BRM=,tag:0npvyG1CCU9ggwVQ5Aj0WQ==,type:str]
-        password: ENC[AES256_GCM,data:Oa0EuWOMgAs4dpY920Uf2rZddea3s/NB878F5551+wJn/9u+VJHNIuGxdjnKoYJiebg+PFN++9guXxZ8Fpbx9Q==,iv:10XpoN1CFoPffz7wkbezp1Tf8SpJG3gatJkUVALCAOI=,tag:W365pkVavy3odvvQ++xEOg==,type:str]
+        username: ENC[AES256_GCM,data:BfZDcMWktp1iwKSt3W7FhCJ9J76EVahs052eXm2Tw7ye2TyGt18T+HmrnS29swfFn8EwiNXhKXpQgSFQw5V93A==,iv:muhCanPiTdW2KESXUCLoUvJ411p4xne1ZdPSKxN4yJk=,tag:wnaVBMsC1E4Dx54lVJbWxQ==,type:str]
+        password: ENC[AES256_GCM,data:5M6zRPV/FVyOXiN2z5L9LoRWTwrpk4fr54lM9q6glrflRAtM3l6eepQ+4ZYjTAhKvpIyAdmMPN7tarqirU85Wg==,iv:hz2QljMJmRMmzbYLwFwn3gTxNmZxYfT/Z7j+UufzZZg=,tag:/dvoovOiMqemwU4mj0r0Lg==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        nujsn2Khn099xNWfnILHcIKwR53lYDtMiojwCbKR54t91KqNmJQoi5YQW56sKHf1: ENC[AES256_GCM,data:Mnfos3TGdG7xkRx62bHV9DHB+Ll0uL8EUPkBaQmi97L+Jo7QCTBfSdSzOdbCf/ZrE+o+s/o8R3ixY/w+,iv:ValjCurR+MVeLsHJHDzB5YBTPceOnH+Ir2AHtAgFz9g=,tag:vcDlUxSYlO9ZCVXbKQ+QKw==,type:str]
+        nujsn2Khn099xNWfnILHcIKwR53lYDtMiojwCbKR54t91KqNmJQoi5YQW56sKHf1: ENC[AES256_GCM,data:EVhEWhvJXachU8/sEQJWFvj5FxudZRWSC+SLUCC8Il/obm3zzgQ0L65xTdvgFZjsElo3cCYTZ7GZrhhv,iv:Ot7tirZW26kAdXv7WEFIyaOV+xOAgGhFxezsKZr+eNs=,tag:NFY4ZAZYxy2eLLEE0F0maA==,type:str]
+grafana:
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Dw==,iv:m69Do7ycogUHF/aRvc5v7gI62graUqR3OattUyoL0aU=,tag:jIvG2KNwyn7FkM+iD2Ja7w==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:caZr7eUFXG7hwg==,iv:aF66EUxAnVQB5uXeUI4pJaoGfKnRv6WkwVcJBe0sTG4=,tag:4H61nk8xpDX8X2ReJUl/bw==,type:str]
+        orgId: ENC[AES256_GCM,data:ag==,iv:OoFTIvJQf1sDIGgvvoqWQKw49aEUgqQaBBmdDV4BzUY=,tag:WIfe+9iu6I3VWTqTXfGY6w==,type:int]
+        type: ENC[AES256_GCM,data:gf8Hmfwkb6bnhQ==,iv:ptU9JOKGKT9NTUqpbV/DCr60BUsrSK8gVngiWjLbyFU=,tag:QToBuFkHol+tp+A4c+iJng==,type:str]
+        url: ENC[AES256_GCM,data:I1LHeAe7avyZIOAIjNb+QYz+CSXaFXiKbYgQhp6JZK0=,iv:y+BgEiOre4CHPg5qADcqXgGsI9Aj8q16L5eazX1++sI=,tag:cIOATOG3qqzDeKVOqaQewQ==,type:str]
+        access: ENC[AES256_GCM,data:4Fy11JE=,iv:o4u1h8dDg1qEwge7djqjaqny46Qx0Sob7GRH2bJ5X5E=,tag:dEjSkSjGyFcKGGmYlOt+IQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:eQDv2G0=,iv:N2hgnzlb+/hx9AkcslehHR51SSm1y9HZAQs3wFZw3Kc=,tag:f8w8zbSPATU0eR6XBQELJg==,type:bool]
+        editable: ENC[AES256_GCM,data:bFVFJb4=,iv:b/2C3bl7LlywmLBvzzLoWj+ch7epJS/KvgIZEDtJBp4=,tag:LBjF4rWhk3xItRHGbwJ2PQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:FnlvyA==,iv:VnipEacZki+GAk30jMLa+89z3fHqQKy2jk8rgGd+O/0=,tag:S9TbOi/wgKK8UkINByD6Ig==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:C0jXD/ymlJnM7ioPb+XOTCNDOWCuYQfiTmzjBwV72tWg85xe0CARQIhRQMaX+CIaxVtDXUpe2dGIBGoVVsfa5g==,iv:cyNDxttEQSEOJDGWJYY0xoySiOrf8oK724G/4bPnJgs=,tag:jXASXOZZ2K9vbSqx8JrPFA==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:sbkCCy3I7S3pk5YWOjTJREMCFyesbKFK3f/Dzt+v+7I12WMACj2ifdEtCy5ydJqAAnxYPB87cmglzqpRa137yg==,iv:lzok6PUpIshgI+ExGOqzNU0eGedG0ZVsRNJEw6SePRM=,tag:Jd52TSDo5QKqyD0+esMxzQ==,type:str]
+      - name: ENC[AES256_GCM,data:+ARDgJscpqQkGjKeWO4OK6ZLAsRO4U3mjawG/MpiMg==,iv:sqsQDXp6PBxal2fFDJB1YAI03m2SZDbvYASxYg80VY8=,tag:7FfUufYNul3TbnKNrzNd+w==,type:str]
+        type: ENC[AES256_GCM,data:2yVsl8UA1mB3+/uXlsHRBLLWFdBDSvOMQGFgTRJ7nw==,iv:X5+l2QrLfwV/sHOiAexJmqSMwOTcfZzS4NTCZGTdsVs=,tag:vNcLqSSpcGexTetiR/Zrfg==,type:str]
+        isDefault: ENC[AES256_GCM,data:oUUPigI=,iv:9Gk6lZqYqzEJCLwKdFDNFaF8xxUWwtUMlEUT4PnClvE=,tag:TDpcri8N3WXDYJMXgnZl2w==,type:bool]
+        editable: ENC[AES256_GCM,data:ym8Lwg==,iv:hca0nWeHjq3iMu/oLRq3Rf+7WPP9zRXI0R4/MR0gedU=,tag:irSI+kGvZmTYJ8cKezymYQ==,type:bool]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:29Z'
-    enc: CiUA4OM7eONpXqqIQa+KZMVtSiq7zjdVvCbh2Ckxx7mnxzX/E7lbEkkAPHlbmTVr/TwmTYA/nHRRYgWk6PbZtY8pGJb6XKC6FkUQowX7AfBkLNvQBQITMwtulAAnfmddweJ5IHb7Bi6N3W6xrpHbvGB1
-  lastmodified: '2026-04-16T19:33:29Z'
-  mac: ENC[AES256_GCM,data:EhlczMoGWwBV4xs3zNb9pde9j+VcDhxDrmv5OcSBqM9J/hsDjc9bFN/S7XuKbhzPgoCy4xnIqW09JUrYFW/NUymsgbW44H+dL4a2NpowIJT2PI9sYik0gRWQnOfyUuG63BEEsovcRPiUd8nfPhQogQ8slVErtspoaqaktBmDgQY=,iv:Q2NMOOXLIqN+rVEzfJqzgYO1hxluCTZOV557tikdQWY=,tag:xrgm0C5SJLJM5EaeAIhA9w==,type:str]
+    created_at: '2026-04-17T08:24:53Z'
+    enc: CiUA4OM7eJlq9kj0AwnVMKD6zJyg8YWKi3TFFeIm+/BZdj3UYXJdEkkAPHlbmUm0a8yvQ9sGTFVKqCsHopq41LLid3zp4kVRBzmJ8s28qRIoB1sn8WTYa/DwlhKvxR5uVi9xSS0bij7xI9dzZ+LdpCLz
+  lastmodified: '2026-04-17T08:24:53Z'
+  mac: ENC[AES256_GCM,data:/Moekt03cp2FKIR3GdaVovJ/DJ6re5cLnFYUxeiqy03BLoiQzA+IntZZPp+I2wY0DSm4omxXspqhcIZiXkvdzQZjxqgrFbW5J09wr151O+BJsUCi1my/D+T7ze9G4Y4bHZp69Y3Jwv1fmND8drAp7MN0EChoY1ilmYgE38Gzakg=,iv:VZA9rxpA4fphiIxDER/sZMU0+kICrdG0nJiUW6iMrXU=,tag:BscdvUNqI3Gy9Xt/69XQBA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/ucmerced/enc-support.secret.values.yaml
+++ b/config/clusters/ucmerced/enc-support.secret.values.yaml
@@ -1,19 +1,27 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:zcl6F0RUTuVEE7+qmhYf/7gh3l8k+1+trsSHqKkb4LAejp9MpeJFfg0g/3LBbtPqLW1Iar+/zOVqviAEnrOkZyvsk2lNxQKrvNuec1vVOdArbZsdMgRJKp+mT6T5RbhdkVt4iVmQslk+z7gqyAOxibKuu3+1iScxhfFxln2f4ZwRufx6IpjTSjba9VrCy8GJsCKnn6EK6GVHc94S,iv:puHXZwr6SLL/7QC1VkVLZYLKVd/5V1zCXHwbKGMN2rM=,tag:ZrQMktVMxuczsR1pg/1e5w==,type:comment]
+  #ENC[AES256_GCM,data:5BWXDn3S+qQpeh4TKntxS/kgpCygUBbmblmz5QmrYKRSEG0PjrsiNo2Iy86Ut8nndA6T48qeNukxaodf2uQUJMqtCpBdq0B6xTCYrm1qYpwGLCO/jZ0HWldpqM1kDYeCZWiAu6R0VCRI8LRw0PVfjcvV9tgsWjwnth+42SFjDKi2d3gXQlsRDL156DtxB0cH8owguDav6IEQo3rT,iv:gPflIz115i5QNJidOraT0TacrZPSXv4OjJYcpLbt7Es=,tag:pvwbSDkOlouH4ek+Cp++bw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:GziHGId0CsYOhQS7ty7JMJ8eGoTBm7mjo96ZOI9xMfDZlD4Cx47j7aNdpYLN4Tu5WdVRH3zELDTaS1MuoIc+Dg==,iv:lh5FFByhBWnXIfXNeE0f0n4QnWmqXfzcsumOqV8rP+E=,tag:6eTCpx/j5h8b4nSJcRGOSQ==,type:str]
-    password: ENC[AES256_GCM,data:4GYgBmTabswrExlx1SGSYOWnJQP+qQG4oxA4LyvbqrQe0wR4XOIuVMmfopp9niochvTHUA+P+ntFKJXNAyrI3g==,iv:/l3qDl4pVJj1cglXY9Ib87kjO+SID1kchTwPIWX6fMQ=,tag:gc+wl/yB24hlYFlFrCFA6w==,type:str]
+  - username: ENC[AES256_GCM,data:OvuqL4Zd83z9UNMUK5Gon/BMT9xa/pgpNy3uXAcRlMLgjCRa8UEVBp0WCv8NjsgQPwCwf5q5CWbLlR98Nxznrw==,iv:jpHk+hPmxArXhpaU6Phz0eGwwjWMdXXR7Rf9qDb5TDM=,tag:1x6fhOPpZiIx1t4CD0ePVg==,type:str]
+    password: ENC[AES256_GCM,data:6ev28XostCHVufGyz1wFp3lY8Bj7HQhL6bjFtJUWjWe5zucQJATJBd6vD9mRwPs+8YntT6CYe3cgGAYV9UTwQw==,iv:/DLly40nRlXJmJVDPCCfjDAcw/o8thM8+a65GWqzZDE=,tag:zdq7CyEAWCqMLRVFU4ADHw==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:jm3HxC/GGx0IhxSrvA==,iv:FUswduIG4NcEL7L9DlFPnHPofgcf5XHBHT+4FS/j7Vw=,tag:NXAMsyWDiHHRnuKzb10isw==,type:str]
+      value: ENC[AES256_GCM,data:vAmXQjuFa7WMIFDPwo5KxhJUX8WbPdQejY8fLd5gOw/5GfGhwMISVgdx3bv07/lciozpcWF4Ay0iSYeYUqwpYvByzCDP8t6ZP6wA+nqGZW4/vDxV096aFw2njnavG+EJUvuqEzgUhSolbULEZPwt7famJqHi1X6hNLTeeLZ5jEXajf6zqwbmmCQ1Ql1Xm3JzXIkqx6Bby61blKshapGj0Cyss6uPG7BiAJ2eBo7F1MeHPQ==,iv:gsQxppuKZ+gCEV0cq3vduHhsDXAkkk13suSaDfLNImk=,tag:pUAIjmDZyu0TeppWhq9FwA==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:rs2esZN1mdjwdFOzvwaq7LrztFSqTKk/Vnpv3RhDBVQn/tV4zT28G2s78etrOT3QraRJKFyBQ3X46jE6G/LXtQ==,iv:UQq5+v/EwrFwlb1OSdv4QpgFK3RC170YXtuLnSi8BRM=,tag:0npvyG1CCU9ggwVQ5Aj0WQ==,type:str]
+        password: ENC[AES256_GCM,data:Oa0EuWOMgAs4dpY920Uf2rZddea3s/NB878F5551+wJn/9u+VJHNIuGxdjnKoYJiebg+PFN++9guXxZ8Fpbx9Q==,iv:10XpoN1CFoPffz7wkbezp1Tf8SpJG3gatJkUVALCAOI=,tag:W365pkVavy3odvvQ++xEOg==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        nujsn2Khn099xNWfnILHcIKwR53lYDtMiojwCbKR54t91KqNmJQoi5YQW56sKHf1: ENC[AES256_GCM,data:Mnfos3TGdG7xkRx62bHV9DHB+Ll0uL8EUPkBaQmi97L+Jo7QCTBfSdSzOdbCf/ZrE+o+s/o8R3ixY/w+,iv:ValjCurR+MVeLsHJHDzB5YBTPceOnH+Ir2AHtAgFz9g=,tag:vcDlUxSYlO9ZCVXbKQ+QKw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:13Z'
-    enc: CiUA4OM7eKPVxs2PIwo4gk8GMWh3DjQXT8l5kdVvMtCT119CePoSEkkAZoeZpk+87tV9MFS6nX+ndg0W/ir1mDGplSzfzkdA5a3pxXnP3tixXObLRwcVfvqVMF8goJwqlzplrHViYubyfPf4xl2ouB2Y
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:14Z'
-  mac: ENC[AES256_GCM,data:n3YFNbhFbvaZi0Pzw4UuB9cQ+5v/p2C3en7G3HJ3f8NVHM8CtFh5B+6K7WaQrzpi8vy3OdzllvzxT2HhICDnt1VIUJykGEApR53zv20EYPmli1nKz9+dfhX3o7C+v3YGiYI/xgtrMz+8RU9sIYzD+MpcVay+gLXVZ4buVtxW62o=,iv:Vvn0atVnZBBuTCWGwhLe1DTqBpSwZDD6N0KsGzKgVBU=,tag:qRcHV3PYhQwymmxqrqI9Sg==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:29Z'
+    enc: CiUA4OM7eONpXqqIQa+KZMVtSiq7zjdVvCbh2Ckxx7mnxzX/E7lbEkkAPHlbmTVr/TwmTYA/nHRRYgWk6PbZtY8pGJb6XKC6FkUQowX7AfBkLNvQBQITMwtulAAnfmddweJ5IHb7Bi6N3W6xrpHbvGB1
+  lastmodified: '2026-04-16T19:33:29Z'
+  mac: ENC[AES256_GCM,data:EhlczMoGWwBV4xs3zNb9pde9j+VcDhxDrmv5OcSBqM9J/hsDjc9bFN/S7XuKbhzPgoCy4xnIqW09JUrYFW/NUymsgbW44H+dL4a2NpowIJT2PI9sYik0gRWQnOfyUuG63BEEsovcRPiUd8nfPhQogQ8slVErtspoaqaktBmDgQY=,iv:Q2NMOOXLIqN+rVEzfJqzgYO1hxluCTZOV557tikdQWY=,tag:xrgm0C5SJLJM5EaeAIhA9w==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/ucmerced/support.values.yaml
+++ b/config/clusters/ucmerced/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 
 

--- a/config/clusters/ucmerced/support.values.yaml
+++ b/config/clusters/ucmerced/support.values.yaml
@@ -16,6 +16,8 @@ prometheus:
         hosts:
         - prometheus.ucmerced.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/utoronto/enc-support.secret.values.yaml
+++ b/config/clusters/utoronto/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:heliedz9McOfCuVmO50hd8hwXhnZpEdmOAb4wjg5IEp5nCtcyAc4hUMHlLe/StLj3QgtCnXzoFGh2uuOCeID0bmB+D7xfv3ioCmnSCreFhzw/PesWBKH4iXHUwaB2h+iQCHH9zmMtd7eJsvNyyAEFn2eCmAiUs48yMsqqLgRlIsmCD7WMq41PmuKk/IfIO5cdda7Y+2/VsSQ+NY3,iv:FWRz3s+INQ+Qjkyt+y9joVGb+PIL0jpsnkLPQaxv8zQ=,tag:werONNIIEt7fJUFerV8+aA==,type:comment]
+  #ENC[AES256_GCM,data:ataOo0Zw3Ahmqw6mDqsVp7+nSO8jItdH8MCZ30Nqq3CfVfWVQfpG1gmQ4BmLT5+2V91SgGJeshFiJh1CAashPnMOiSGz+dpSbrv/wwr0sWhqWpqwY8qkcg5csJ21I5HfGu2l4HUSJt73y/JLrSL4zVGJNuof0dEigh4htm2iUxubVhgjkKDek8za4rcSP0vbgA4wbhzMg9xa5T+F,iv:vQCIFYV4Vuzy9viuXF/xpfBOqmrWPjy1/TnfL5LiP9M=,tag:RStHo7Kx9ov40KaT5pEptg==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:wEGZkFbubc2islzyrRVDe+NXy5hXVRnsUQG6FrKVTsP9LnNhZ53M8QSEtZ1WwAghy9pkg1sGL7HLO36NV9xP6w==,iv:2DAnBnV3WpyR/lCOr4ED7kRqI2srJcj/eYYpaE0oe8U=,tag:bVJSfwn4kTfBBYGmYUrDVw==,type:str]
-    password: ENC[AES256_GCM,data:aceEa79zeeHt9hK4lvoV2FH32pqQrBp+mn7/3FvXo0iTcM00Cm3WenoFBSWq+dv//MSNEwTfn5VFhYSZP4ps/g==,iv:tU6c8R24CLp34tXzIPuxavsGaJ0i9ahwWIEQlf8beC0=,tag:Ct2v7dkyB66Rjdf+zQmx9w==,type:str]
+  - username: ENC[AES256_GCM,data:tEOW2VWuBJkufpdWQRidhavmESeLu+KUQ+ub4WBij5zGKgzMmIy7yQc8//x5JuuYfv0rY4oVFWyJPTVEXk6ETg==,iv:9fl4egRzdEeEsE9QpYIwA/SJHBnyxyyQrY7gyoerfuE=,tag:UYHmyHejnoR+EORVoCmeQA==,type:str]
+    password: ENC[AES256_GCM,data:e+dNfKr/+e28ozIt5+vuGWbmif++iRdqWI0JjsrHaijWi9BKIvRVSHF0ZnSJgjED4bSTJilCllLrrVf9GyPR+g==,iv:obyv37VgTFusbtJDpiMherIXbURdKcg/Vl9jYEReczM=,tag:AD5utSn403c2JdlsW6PKLw==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:MFCkkaU9Gg8O0SqyEnhDUQ673gU=,iv:FudpK+LhscgdCR0PokEPA/rSK641iWk7NcAT2hTLWkE=,tag:se6nUJQGOYDD5+t5j02/fQ==,type:str]
-      client_secret: ENC[AES256_GCM,data:eBRxF2L1eP6hMb6ZXLJDakW/LFAE5mCs6r8tJMvaG0YB17hyFPxytQ==,iv:mDsdvgpgjb0Y00QOqYDHEzF1XInXQCQPGu7wk5QoIHk=,tag:jaA8Ln+TNm0efqaYReoN9A==,type:str]
+      client_id: ENC[AES256_GCM,data:xoLGApJ1HHdMgJuBSAhBZAJnTMM=,iv:u1uejFbi7D4Dx7DAr1STH9hYUCDK0Q8urGW78i1EQRQ=,tag:9vqFxSBBEbKlRingoCnHMA==,type:str]
+      client_secret: ENC[AES256_GCM,data:CRf+WiNoQS3jPsGvgOYXTlgqkuhKvxsuQryDl7/BQeGqGywGkBkzlQ==,iv:wCcpnJBdYOdz7m6XU6E10OyHdoyN5+L0aCHZHF3/NG8=,tag:RHbKCYfUU7RcfxpiZXaZgA==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:4s1BhWcnbCNEUebvBg==,iv:2YefrsFW7Y05Fi7GuD1VYy4zIET1ohsTpY+ojcqH1EU=,tag:UOmbAoG/R0klSk1SbxhHjw==,type:str]
+      value: ENC[AES256_GCM,data:yqEy68nBOhu+vwGMjMCd9GI3950EBJKRhz1FP3JV8CxuvdSVkNdHGLLx+jvQlT6+6CpXRYLUBh8PxP7gEl+HLfq9Jo7lBB2Dn80wei/46+v7l//K2HDrF4Q5JmXoiRF59K9idJraP6tVq2SgKEzp/5vC3Czetn9UlgAe3nWPXjvD8+zRfP2lkDPjK0JN/LtR4I5Dlt/EE/zWP3gKR3UMGr5gF0nTraE/nZEm9R1KP0RtuA==,iv:on+9ehQHzIUm4pez6Y33//ixoR7YyGIf09f/ivWk6J0=,tag:sb8l9THbTkqUzvDUK6z3ug==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:LtTlbH51LGyFc42mBxsRio3NA3jxeVwbcH5tDGhLmNfPI9md7HqpibLYUTAxCVNDiqZEsHJgEmYL7ybrCi5m1A==,iv:P25Jyb8kkz4tHGde5BjtjWl+oRnPdkXDQznh8mIK+jo=,tag:iVTgnXmCHOD9edegSGttFA==,type:str]
+        password: ENC[AES256_GCM,data:n+RpFrh8Otj7hv/15UjPBmD7IzsKNxkqP0U54bjLMycLgp+VIknNaZrAswZdPH9bSFn9oqmjTYMk73BMjh2pkw==,iv:h3naLmOWTuoBPrTE44ugG4rdF3ymGBS2+4BWvs5FMB0=,tag:ujQIp+LvNvEUmwxhoanrEw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        aewahche8niw3Ier0shaiwieMaim4phixa1Yalu0sieFohdie6Ii2TaecohJo2ti: ENC[AES256_GCM,data:YxiFY/meqNzI/5oqClXJuVPVVl5s1lDADHOQG2+dHbCRcOWiBNdicxK6w/VWWWXPuI+D6Seud6lfLSa5,iv:I8ChNz0gN2b+Iwuf4Xpq2P1LUkDVAHdnlimk3O7/gKo=,tag:5yO1rsvEBYdLueIFq94XdQ==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:12Z'
-    enc: CiUA4OM7eHdHH5NoXOVp1zwGlKIvG/E0UpjjkAdSE7epjs+eVmO3EkkAZoeZps/GE9EqYov3tY9v7cZ9rdL9UeBUoNDbMM/GuU/9tqXeq0ibjuumcnkenCqOcgwyyylfnHoYIWqJ1XnVkx6glkjpgVh2
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:12Z'
-  mac: ENC[AES256_GCM,data:cKL721fPd8tIN1GbkElT+gqFkD4s7v6OksAW38b2U0fOsBXEUF13MVd4vKLpTuwO1+6+C8Q1MHNBSccj6ZrudpqyZSZ4oEb4pTS71kCSgt2JWSP5yJWyK1lcMM488xKoDf4rl/IET0ioxM7mQwpUMr2aZrf9QoSn6X7pyBuYpWc=,iv:5U9PXpYYb9W91Lu4RWRcpDBngq5UnXR9LyYGS5ELS/I=,tag:UWLjK/DwdQKK+I6cUG0uuw==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:33:22Z'
+    enc: CiUA4OM7ePJDUsSY94WhUSO+SLCp4G6XxiC56HWep3pzl2Ikpk7+EkkAPHlbmfAWEdHa3KBE6D/OlhxOCT3Tx7mekf9hrMCDirIxHSQKaH2WhZpAi4fLjtxrU4thkxOz4QE/vpqf/rPIjJCxabsGxK78
+  lastmodified: '2026-04-16T19:33:22Z'
+  mac: ENC[AES256_GCM,data:R1W5S2nEKOrwC8ilXV4tQUPrSTIQRiHEld1POFA6vcBibIp2GQrhcoglgwjtqdXcFOSqHXB/GqtaqPQJc19nzfxSu42dwsez1Dlwv0VDXbLSourSK9B6p1Dbum40toQXqyI6SOl6l/au6BigOxmGo0VUOan+dSfrfPljpDRdTm8=,iv:fHsrh+bysRY77T/Jev2BcLB27914X3GsfRgwUdcL0MY=,tag:Nk0twhH7RDjbPZc3mb7wLw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/utoronto/enc-support.secret.values.yaml
+++ b/config/clusters/utoronto/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:ataOo0Zw3Ahmqw6mDqsVp7+nSO8jItdH8MCZ30Nqq3CfVfWVQfpG1gmQ4BmLT5+2V91SgGJeshFiJh1CAashPnMOiSGz+dpSbrv/wwr0sWhqWpqwY8qkcg5csJ21I5HfGu2l4HUSJt73y/JLrSL4zVGJNuof0dEigh4htm2iUxubVhgjkKDek8za4rcSP0vbgA4wbhzMg9xa5T+F,iv:vQCIFYV4Vuzy9viuXF/xpfBOqmrWPjy1/TnfL5LiP9M=,tag:RStHo7Kx9ov40KaT5pEptg==,type:comment]
+  #ENC[AES256_GCM,data:QydHF0wC7E3Hf9pa+OxznU4FPwKAkY4E2+Bt44726l9kZykZSxN3S9xjnhNjUVaSxX27MHV3hSyDjSrflglOJ/5u16wFpXRrjar9Dq7j89yXKG+ON0Aaxv4J/8tok1io9Z8JP5imXNHuA23jWBlePNfu6KME+cZE35jASl/JtNmx+wgNmZnjAfxxA9S643Jv7utKIKmQROvcWoU1,iv:DBIhK1oujR8ZUzOSzeMVHwNRKfvQa/eVZSSJ5EHiEA8=,tag:qmf/4Tjca/E4o/2jeoGVUw==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:tEOW2VWuBJkufpdWQRidhavmESeLu+KUQ+ub4WBij5zGKgzMmIy7yQc8//x5JuuYfv0rY4oVFWyJPTVEXk6ETg==,iv:9fl4egRzdEeEsE9QpYIwA/SJHBnyxyyQrY7gyoerfuE=,tag:UYHmyHejnoR+EORVoCmeQA==,type:str]
-    password: ENC[AES256_GCM,data:e+dNfKr/+e28ozIt5+vuGWbmif++iRdqWI0JjsrHaijWi9BKIvRVSHF0ZnSJgjED4bSTJilCllLrrVf9GyPR+g==,iv:obyv37VgTFusbtJDpiMherIXbURdKcg/Vl9jYEReczM=,tag:AD5utSn403c2JdlsW6PKLw==,type:str]
+  - username: ENC[AES256_GCM,data:R0IhtAV+SYxXWQu34Z33MEB7AZIu/rgoUMTAqlOxJnP6KB84cJxYgYApm3isRH51S5D8/vyDJ4V+Fclstnp5oA==,iv:ojITeC0TDCrwPboQ1yXeVGcu7nq5+5N6ETA+V0SMq78=,tag:PqLexJOUC/uU+AqF6tt4Kg==,type:str]
+    password: ENC[AES256_GCM,data:ri0BN+UhmLanruWXVlIJVPwDQQUy+1o1feGix/WHckZD1sRmx3kbOr49t4Z2+VCHCBd9UfGG8YwGmfzd/0w1UA==,iv:TsGBUy+iPf/2vUXXpThFQgjrEfrhn243+oEtNItaDmo=,tag:QTzeuTrfCfS0zsvM0G1jkg==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:xoLGApJ1HHdMgJuBSAhBZAJnTMM=,iv:u1uejFbi7D4Dx7DAr1STH9hYUCDK0Q8urGW78i1EQRQ=,tag:9vqFxSBBEbKlRingoCnHMA==,type:str]
-      client_secret: ENC[AES256_GCM,data:CRf+WiNoQS3jPsGvgOYXTlgqkuhKvxsuQryDl7/BQeGqGywGkBkzlQ==,iv:wCcpnJBdYOdz7m6XU6E10OyHdoyN5+L0aCHZHF3/NG8=,tag:RHbKCYfUU7RcfxpiZXaZgA==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Fg==,iv:N3gewEWd6TxLL1rLJrrvxICC5m4Nnj6VnTu9AxFdfS8=,tag:FCg7F7LCYhXylFcAQFTxiw==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:xqqTkh7XVTGT6g==,iv:/QGUSDFhmCpd8APU8yK7vInX+W6m3eL5rpOKK1JaVO4=,tag:CeJpkwFVUxsJtj15gkKsag==,type:str]
+        orgId: ENC[AES256_GCM,data:NA==,iv:xbT14096R56/iHYzYvM/q/IapM/VHa9mff4mNzqy+48=,tag:tI0PnkBZpD+CZ4wUWxcnqw==,type:int]
+        type: ENC[AES256_GCM,data:eJQWyuq/cs3Dhg==,iv:ViOpDsnTwk3GOGla4yNUp+97NfbFZ+/3KBkRmMRsKhQ=,tag:x2xr+B4oHT3E3wQqyZvC2A==,type:str]
+        url: ENC[AES256_GCM,data:Vu0PjRm/19m3xvf+utfPtHkeOxB8U3PJ+1FW9v/Cris=,iv:At4BxjCnIwMY9HSCnmLJXoeITuIFgR8NsCbsbg+1DIw=,tag:8pvVS0/CpURCa18f+aJCtg==,type:str]
+        access: ENC[AES256_GCM,data:bqwtebo=,iv:svqxsQ2qQDURdfE6IcaCoP6HePtNEJaZc/8nGYxP53c=,tag:fuI1mxgVOrZk7bKJR7vCzw==,type:str]
+        isDefault: ENC[AES256_GCM,data:JKJ2RI8=,iv:oBSn40567V6Gr4753QGisAaZQpofaPZmqfQmKktf34s=,tag:AJFqCTtjdVC2FlyclhUXBQ==,type:bool]
+        editable: ENC[AES256_GCM,data:gnrgEIE=,iv:hlCYL4BY75yKFUZVHBelBxfQS/FXhIHSHNqp95uU/wg=,tag:5/ttnioVYkZv0mLwWfaxfg==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:KYJRpw==,iv:Ke/1rLjgl+B8JYM0I4C4bbaMZIhiGpL9uMj0HXYb0ic=,tag:IeC8dvdjtQZ3wGEiq2th/Q==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:mnFQVx5qFTWEHt4zFj9AiocRnAuGs3V0vNZbJzehbuAkWFgG8IRxJ68Tr2xQyBLh5NSIe7bxTbWYQjV3VBCD+g==,iv:yvO7ui2fobLXmBJSAn3bGUx7GkJLxR75Hh+PtOHp7hw=,tag:nZP8wvdn0jYBvIGyIBYMNQ==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:+LgUOiLIS/hc6xJav5tVRMSaOoAPm2ZKT1OyVZVoxlkKPqGZiPZZlyQSdsomGFWKt8dmf05EHNq9vDeDRw9FNw==,iv:bBWgxltxwgPGsgU+kx4YgXIihK8690qqE5Pte0ONM1s=,tag:onCwjVPY/GyFE7GLWX0kAQ==,type:str]
+      - name: ENC[AES256_GCM,data:d5bcS1BqL8QEpaRio1fDuqh12JgaVOyLydNDYEBg9g==,iv:nRCui/RMrpHW3fLVq5io6hAVXjjFGwKsb13W9T/nCHc=,tag:oXK0TZUciqbtTZM4Q8aGUA==,type:str]
+        type: ENC[AES256_GCM,data:od+zw4DlAPcruYhYxkExtyXIOiqbHb0WU+J5hsxQpg==,iv:9dwPTYoBmh38O7b0lwMZZ+BgHMO3wltdaFylBi6iTg0=,tag:9WAbGJoeYI4RRazlXNfQog==,type:str]
+        isDefault: ENC[AES256_GCM,data:8BDcHXQ=,iv:khJc9rL7zdbQRtrm6uj9rVTkJHch0r5FYosrd1MOg1Y=,tag:uAIDuOuFINJEcJ25vFuzZw==,type:bool]
+        editable: ENC[AES256_GCM,data:UF1zkA==,iv:37cuaPZHq300mn5Sd8gb6KMK0pzd7Dp7YFvs443UOmw=,tag:RNLN2gbZf2IT60dLcDbYGQ==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:4s1BhWcnbCNEUebvBg==,iv:2YefrsFW7Y05Fi7GuD1VYy4zIET1ohsTpY+ojcqH1EU=,tag:UOmbAoG/R0klSk1SbxhHjw==,type:str]
-      value: ENC[AES256_GCM,data:yqEy68nBOhu+vwGMjMCd9GI3950EBJKRhz1FP3JV8CxuvdSVkNdHGLLx+jvQlT6+6CpXRYLUBh8PxP7gEl+HLfq9Jo7lBB2Dn80wei/46+v7l//K2HDrF4Q5JmXoiRF59K9idJraP6tVq2SgKEzp/5vC3Czetn9UlgAe3nWPXjvD8+zRfP2lkDPjK0JN/LtR4I5Dlt/EE/zWP3gKR3UMGr5gF0nTraE/nZEm9R1KP0RtuA==,iv:on+9ehQHzIUm4pez6Y33//ixoR7YyGIf09f/ivWk6J0=,tag:sb8l9THbTkqUzvDUK6z3ug==,type:str]
+    - name: ENC[AES256_GCM,data:FefqxRHQShp6txJ2NQ==,iv:pMW+ArNtrCb7CV1DgiHMEtBXAnQDWt+mASBjf58v6lA=,tag:lgCDmNghvFYHeZRTK7IZBQ==,type:str]
+      value: ENC[AES256_GCM,data:94cV24k6AwjHFUnElZF8CH+LJ5iJUL7OSkjW5GjZpNv8Pv9ezW7HtAI8Kv7iqidnx2f2wZfiOsDY+f+HXKp5kwLPymEX2HpFxKlo/zyN8M9wcHT49mOrhurdF+JxguSo9Yvbtjf0qT3nP+Vlqc49hMzXsAxeMvQfS5bXQytH18cs6kqM9mNuOivUWzYYJJ4g32ZSiLAOCW9we10x2cGElD9l691UXfpWrJYq/p4NzTGwCg==,iv:Q7dRD4X7i6g931xDjaSE24VOhdgRkIHZP6rsk5Cbh10=,tag:56JX2MdbEWl27kaYLG1zgw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:LtTlbH51LGyFc42mBxsRio3NA3jxeVwbcH5tDGhLmNfPI9md7HqpibLYUTAxCVNDiqZEsHJgEmYL7ybrCi5m1A==,iv:P25Jyb8kkz4tHGde5BjtjWl+oRnPdkXDQznh8mIK+jo=,tag:iVTgnXmCHOD9edegSGttFA==,type:str]
-        password: ENC[AES256_GCM,data:n+RpFrh8Otj7hv/15UjPBmD7IzsKNxkqP0U54bjLMycLgp+VIknNaZrAswZdPH9bSFn9oqmjTYMk73BMjh2pkw==,iv:h3naLmOWTuoBPrTE44ugG4rdF3ymGBS2+4BWvs5FMB0=,tag:ujQIp+LvNvEUmwxhoanrEw==,type:str]
+        username: ENC[AES256_GCM,data:tV4ANGzIDUnzePEW6EGa5bvQfO4dtRX4S8rMhPMq419syeArooYVYIbegfHlnJKP4bZkc86t7T21Yu0nHSZm+Q==,iv:CisKhrFzMbzh+qX6521BICA43+Wf2fyeYFUwS1xLXtc=,tag:oWt3kUJbPJoPzj0ySgxYrw==,type:str]
+        password: ENC[AES256_GCM,data:mK5ZDam2qi80xCuWdD6JxZHB7u3UM9e2FsroLnS8dtx2pt/eFMsaJPlmHA4oI4X3/mlmqla2fapekOw2X1g12g==,iv:7RrWPuyE98d08MfRFVvySny4zv4huLYqzVSsl2z3r94=,tag:rrzmIx0ChNGjqvWTTV1dhw==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        aewahche8niw3Ier0shaiwieMaim4phixa1Yalu0sieFohdie6Ii2TaecohJo2ti: ENC[AES256_GCM,data:YxiFY/meqNzI/5oqClXJuVPVVl5s1lDADHOQG2+dHbCRcOWiBNdicxK6w/VWWWXPuI+D6Seud6lfLSa5,iv:I8ChNz0gN2b+Iwuf4Xpq2P1LUkDVAHdnlimk3O7/gKo=,tag:5yO1rsvEBYdLueIFq94XdQ==,type:str]
+        aewahche8niw3Ier0shaiwieMaim4phixa1Yalu0sieFohdie6Ii2TaecohJo2ti: ENC[AES256_GCM,data:n02YUmsxLykn8knW9QiXK3h7wIuMGKXcXEutksod+adbBD+hPLlbYnD3VeOyyPUnCV9k6ts/p8QZ+Ull,iv:bhKBNIvbl2ZyXf80vjdlwT99IAWW+s0QT64b4y48bpw=,tag:Q0qnuJcuxe50IEKOJIIiKw==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:33:22Z'
-    enc: CiUA4OM7ePJDUsSY94WhUSO+SLCp4G6XxiC56HWep3pzl2Ikpk7+EkkAPHlbmfAWEdHa3KBE6D/OlhxOCT3Tx7mekf9hrMCDirIxHSQKaH2WhZpAi4fLjtxrU4thkxOz4QE/vpqf/rPIjJCxabsGxK78
-  lastmodified: '2026-04-16T19:33:22Z'
-  mac: ENC[AES256_GCM,data:R1W5S2nEKOrwC8ilXV4tQUPrSTIQRiHEld1POFA6vcBibIp2GQrhcoglgwjtqdXcFOSqHXB/GqtaqPQJc19nzfxSu42dwsez1Dlwv0VDXbLSourSK9B6p1Dbum40toQXqyI6SOl6l/au6BigOxmGo0VUOan+dSfrfPljpDRdTm8=,iv:fHsrh+bysRY77T/Jev2BcLB27914X3GsfRgwUdcL0MY=,tag:Nk0twhH7RDjbPZc3mb7wLw==,type:str]
+    created_at: '2026-04-17T08:24:46Z'
+    enc: CiUA4OM7eFDVlMgjzL2DmfgQ58LzWtkZNcYCy8+FRm0FFdEhj16eEkkAPHlbmaoS6dKQgb8mHmAUvCzaZHAiJC4t1ND/1IaNmLW1EXRGCqzt+nuoX+qLQo+rizVk1CfK1RPFdWFOc1Gs+2btvWWU0Aeq
+  lastmodified: '2026-04-17T08:24:46Z'
+  mac: ENC[AES256_GCM,data:CXH3yTL+oATGsLQaIevPw1wwEjrBh/jNZCZKBk1W9ma/AaWgLwzcBwrRp4a1yn12C9JSH3S6QZwK4LFqGyCci/6N/MM0MRcfw5zGIImnqe4YT+gRJh7Z668scLLNXedbp8kHBgrEshZPAAcmDMKVRX/bISw9Q8tU813jVKxxaPM=,iv:ZQyWXPKWoeUnsvs+ffUweT7fzctqeJGNXfS9tKJLdrg=,tag:aCxVd4FeMZ0PSRW/S93TMQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -33,6 +33,8 @@ prometheus:
       limits:
         memory: 12Gi
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 redirects:
   rules:

--- a/config/clusters/victor/enc-support.secret.values.yaml
+++ b/config/clusters/victor/enc-support.secret.values.yaml
@@ -1,32 +1,47 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:RI5FpzCymSf9afx2uPINkGSxSUy6YJty/2Hnnfe5M/dNN9MWMpc03h8OE2DAjWQTzXlxwj5m5PtoefXRTBA5GiHbcy14wMv2efA1VmcAXOhsqewVCnYlyyWoabLQRG1DeraWM/cyDiDq/S+YF5YhEvzlV1VtZvdThgZsveJYk3BwNCNyiujeyFVe42Iv3qY3bbnUuAOGaWFu1l93,iv:VLc8rJDh7OqFOq1I65xG6aNjiXW0H9Y7LjuPZlrXdwo=,tag:/DBDF1urMUeo0URd/1VNXA==,type:comment]
+  #ENC[AES256_GCM,data:aLHu5JN9F9qFbblkd/rySa4TtlPeseTyhK95y+lP7ArKTn35yAEdvO0+QkcV9OSa5qe/l4lEWQqoeIcKyrG13KWWsItDdR/4ce4p3lezjzyXkreB1y4w/ubMW3h0hVkujAbIzzWh8kGGjZaCdfFZGwGza4M1Qsxe80hqPFC6NY3TQ4A2K+P/TjuI8eKc5UttUOlmp1zc88oy9MHH,iv:40PWEVbbfmTcqh8O57sSzrY8LPTOX449xMx0YO9OY5Q=,tag:lNiL4EeSHHv2+4x2ZNT+VA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:mJC8dHbRzULAEaure3MOcIikdSUHj08Lmua3kvNnXN12jBdOcdSBLQDckHxmBK4C0/G245dkt+bU8Q9LwxuOuw==,iv:xWBVfP+je9kylg5cjAp1LOit/zk5+R96tIh1KsMjudg=,tag:5Me+jBAkDkoZ2/z323JABw==,type:str]
-    password: ENC[AES256_GCM,data:uwbBh7k49bexh9/RykdoQJ+Vcn3DDPk/3yUkS3KNey7HZiQXqIatdUjpLfM10GBiDfJk3FWiK6ikRpQFuhJgOg==,iv:9lreooMECBcBrvQ854gWFGBn+sWxCX3QQXrgeH7xvPg=,tag:UUEuNxgcBn7WKEHqa8Tdxg==,type:str]
+  - username: ENC[AES256_GCM,data:19HbPitH2kXYc2ydyyVrtKbTpUjlY8VYenScYSoD/iIB3UDYKGYncIBLEhCulkx8frq84hXn4on01cwyzJ1sLA==,iv:J4kcAide1ftNVVsPcuUdMDpyav1qkbU4JHAu21FMlBY=,tag:29LXwlsaufbQ7odPPzc4Ig==,type:str]
+    password: ENC[AES256_GCM,data:Axks8Nz+WOEBJK7hQ9jZdJbSFZoebO8XJmAId7xJHceG2jevUgmEk8yj0Hs3FfHXykd9BhR8WrhVNu19Aa7Bmw==,iv:4ujJ5qU//nTPrUZcSk/Xp6f6efvWOvSVz6dRo6x/DBA=,tag:u4lRBkU0G0DtgjROlX8A8A==,type:str]
 grafana:
-  grafana.ini:
-    auth.github:
-      client_id: ENC[AES256_GCM,data:x2VZmJq1k4xdHdst3gMIEhPvlwc=,iv:xu8kHUb/ZXcoD7Q5slMoDdRME37DhR4Ffgy8IBZHhB0=,tag:0VP6KYvi1cjNfnN0Uox32Q==,type:str]
-      client_secret: ENC[AES256_GCM,data:+2eJHV9lkwanCFaStpip+gdEQ88GtdwOXJu3XcPx3rQj5JHjbs60Lg==,iv:STBEvogVgEZpalcGlJ9+TTduFrMNXOQa9lPPAzzBFs0=,tag:eia1YJS+uqHHgAQdnZgaeg==,type:str]
+  datasources:
+    datasources.yaml:
+      apiVersion: ENC[AES256_GCM,data:Yw==,iv:Wt36fAt5gY2iKv1N96ys7XwFwthTzxG8hvhO96v7fYA=,tag:4ED0SWDkF1WzQzgwc6Jnig==,type:int]
+      datasources:
+      - name: ENC[AES256_GCM,data:sSpEv8Rpn7XVZQ==,iv:1PGdiB+5r2bvy6HW2HsNo350cTg8gy0BoiC528dPpPQ=,tag:m7N3aIb7IGbtHERQotnaSA==,type:str]
+        orgId: ENC[AES256_GCM,data:LA==,iv:ESB9P560zRsYvB3DZQWyhTHrZNKEXNEUZAhyic8eJhY=,tag:xpySQ4cYyk1/IjK/Tk8dwA==,type:int]
+        type: ENC[AES256_GCM,data:LDk/ur9ImNuhEA==,iv:XehLgb423E/g9EydRrDjnmM4An6VWAOERyPzMnlAHx0=,tag:O1S8MP6RtUywy5SZEyZ4nA==,type:str]
+        url: ENC[AES256_GCM,data:tzGSSahbMYF2VCFkPqkxs1/NHHF2Cva/dIE+2RjgsmQ=,iv:KhdASE4VKa2N/kNinQoyoLtPtz3q69lsqlZ15Dte8cs=,tag:ffSeunYfDTMRjhbMBavm+A==,type:str]
+        access: ENC[AES256_GCM,data:iumCFtI=,iv:X/fCWKOkMX0hth4uzhXqRjKYoTYWQc4Y8MkM5PHmFAs=,tag:j0eXOK9+8BtOoQVDRz1xzw==,type:str]
+        isDefault: ENC[AES256_GCM,data:uQQho9A=,iv:mQd4qrRTSP3QlgpemQOwYsoAotGm5fpBRebiHfKWRqk=,tag:1T/zt6x/ty5q1KFT0jPABQ==,type:bool]
+        editable: ENC[AES256_GCM,data:5wD5NqE=,iv:V3ArkI3phZXW9zcal0kJFy2STRVE9Fna1lscoNR+l1Q=,tag:hn6IFB3bBFRkAtiGJeCEYw==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:l/GPBA==,iv:IEw5mCDGjHVwNqr6YrXNqRDM5US7mXVxtsqeGhckiyQ=,tag:EoxPcy3pJfR27Rb5l6Rzkg==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:xnpfYwoH+EuQ1pOZoc30Cem/Pwp9g4bRaWUtGN1VO5LYsxZdZYlnhyIRT3vnO+EJgNFnSB7MGtZVD7GLk2f4ag==,iv:JTuszIsDwDvHWoq1VcZSLOQgU5SELvLWdjhF560wRV4=,tag:rBFnJ3+EqTRLKJFXOq6/zg==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:DDG2pyqMOFCG8/vNvw5yIpXd1UkNfs1IQaDY3+BzMqZ/zHLm+dSVf5aTZa/LBP0Vtgh/T6V+dvfzg9dxu74u3w==,iv:6N4/TWBEc0kK94uELyHLaaI/7WUqJuGwhWZr2tZ2k2Y=,tag:IHnSGJtrdfBOZpEDydo0Xw==,type:str]
+      - name: ENC[AES256_GCM,data:F0BvnFNesvlhLQZrqC5/dJm66RSS2ij7jov4lkvlHg==,iv:VxdY7sNsjwdJnQAOxylElFAT7OFk4SuolyBdMCAGf1Q=,tag:6xzI0n0M8ngp83dx+Laqfg==,type:str]
+        type: ENC[AES256_GCM,data:AbbSYFn3CDCpC0kxHRz8t4+2vuFwUO6GbDB/81QJXw==,iv:8+JWtN3GS0EvvUB4ICnHBG3b+nyWSJoqZ6FbbZqmAoI=,tag:uvF1w/TcU5VzFpNpb6R2KA==,type:str]
+        isDefault: ENC[AES256_GCM,data:vapkdR4=,iv:aM8zWdsd96PNqzjAhIu1vwH/wILeLf07lW2zXo4oRdU=,tag:fRS+sNcUT2hhsg8PvYpSRg==,type:bool]
+        editable: ENC[AES256_GCM,data:rEMEeg==,iv:okqafDsq1+yt/gY+c/wJyoQ3ypX+zPSxOUe4zBU88Gs=,tag:9iqF8jJcuHBeJXOvii8ysg==,type:bool]
 prometheus:
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:vNfOnnHKOkq24e5ECg==,iv:CGnr8SxISU1R8bA7jk4OrFUHgysJR1Cj2qN8AGS4LQE=,tag:wqz01M0QhiCPsNggD26sGg==,type:str]
-      value: ENC[AES256_GCM,data:PQYkl8hImwCdU8SpHUTKKFtZVKCdd+K1dz5xAqmiUTlcO0eb0mXcRodX+39yJ0kzEy5uIZhXLPqXkEaH2ZR7DFXfY1p0hxjeINCihBTVRJmhSSHcFtwGAzZTRvYVIXIAZEWv9RgWh6QJSvXZY4BaBWw2nPgdbPCpJxOlYDxK6D9c2yYEZ3mGmztHSFHpaIUdK6EDG0uJPsQEfronh0hwRbSmMBQYCqXAIgp54k6JyfZVZw==,iv:mCSe9appYM0+eznthwDhfQv2WDorz2mgVmjrn3WaRaE=,tag:s491MFtkyyJZxaz+6aG72w==,type:str]
+    - name: ENC[AES256_GCM,data:Pd44p2ArwIgzLIP0hQ==,iv:hJQunuX8LDoYr2MbY7feJ+bldWb9hAYzS9ag+xi3OnM=,tag:HsF5qlA8yF1B6aYAH6ZEvw==,type:str]
+      value: ENC[AES256_GCM,data:Vvifr7gfqCqZNzzJYjAus59ERFFWQE4GfslRIA4AYXqo/XWc/XfqkPuiKGObsU6kA4Tqq4XmJmNQc9JK4K7mqZNd7sxDNi+rvCK7Cld44TQuHDwW1rlb3VtyS0VNEsE5jP7GgodyOubriJvSi68ZVgKymcHBizx4VpSS+Smp0biv8y1DKHWPq/G5ZSBIdY7VbVFJH0WIjTdcZ9P+tK6Z03E+fhXVZ0O6uMa0PxswQsNPNw==,iv:Uy0QMNWZJ7bBKEcg1NB9x9fJAzuoSR4W2MEm5js98rY=,tag:W1b/Daw7gn4G5vvQ0FA2Kw==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:MXz0wi1uShXdLZRgL3O9ie0NjA4n86RmaF/nw4gnDvNT7S0VIA0rMio4AsiVop/iTDVeZnpKzEyg1q0mIWSGoA==,iv:dR+qkv0OLm2T+tdb/ECv2xjUpSem63lnGNwrTJQB5+w=,tag:jjDK2f8V7Qk1r/50q/CxrA==,type:str]
-        password: ENC[AES256_GCM,data:dFdhvXrd89OdIlebNROks3+KZC5UpA0qmpkM8wlQXBbZU6Wqrrkvnhv5HbhquX6//Es7icFMAMMff9iAZXrEzQ==,iv:RhtvUjyLpPW0HTEVoWCOUHJZLc/dTtBm606qK5F31wc=,tag:v54xpbVWa1Y6jSEiencBCw==,type:str]
+        username: ENC[AES256_GCM,data:audO6+GQVyINUOt90vzN9Kh4ryFZAr4kNgCxgmuAvZ5c2p+MeBi55+6Wrx0ffjXYgYz6Rh1+1ONZZMcj+wSlkA==,iv:wKwAvxMXnLKxBl4xOnjsyLwEulGQmv3s0Ct29LfkmCE=,tag:06BFFCWbI6DajkfHPU5fQg==,type:str]
+        password: ENC[AES256_GCM,data:aLgHNfodcClnAOpDzORgAJ3AfebSi0GB4NkmpY+eSbxT1e/6v5HYNsS0GdfozHjA0Ar3aPa9YzrXpvwDHDZTNg==,iv:JQQnYOZ4E5xm0yol7YIZxgtNGDDu14IgHMTCONPutOE=,tag:8/VvCmVtmANytHViGRTprg==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        HJK2ImmQhgclS5musEdi9AsP4ISIAjn0vkpKAcpW4FELIc4pfmcv2SjP27L1eLQV: ENC[AES256_GCM,data:ApETDRMnXtk6QYdiBtqKNt2SVWuDs3Su5ezOk27GRLR1RIodzzU8oo3XYMjYiPqdAMMMAxLQVz/akzLC,iv:ZOs44rfpVkaskXmj1+LkJnNWEHQGr/a9iQngNlsjc3Y=,tag:Xz8Nnd6qRjA4y8LklU/iJg==,type:str]
+        HJK2ImmQhgclS5musEdi9AsP4ISIAjn0vkpKAcpW4FELIc4pfmcv2SjP27L1eLQV: ENC[AES256_GCM,data:u8QuaM68VSaYpshv7/eKe40QASMhiWFVpNxdZzf/+3cuXz76LbC5A2jKw2/U9aLtUls2Ut2raZzsrs83,iv:pOg39rks0cGIF29g+Py2ef5TpcYfqFj3BiW6t5Ak8oY=,tag:bgvF68O5CLSlhKmbFFif7Q==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-04-16T19:32:41Z'
-    enc: CiUA4OM7eOiFItl6iRyCxarptOnqWg8OZ66lFZ5SfSLkAwEP4nEoEkkAPHlbmWz0IFziWE3i2Fd3q49J/gNOfj+EsWQHbK+5PsCuJnkufPgTs9l3R6x96hkDgY0LCQW7pN4gw/3f1m/6mRWYSULoe9U9
-  lastmodified: '2026-04-16T19:32:42Z'
-  mac: ENC[AES256_GCM,data:T44I12zreLAmUZ74Obm61k7pLZWxk0fqVTzuLJBM25g7ojYYVfzkz2WABUmEDuGLmDtuSfDH32sSuSrg4+jWOEE2Re1i9tKkTDsVzvOYpXS32Tu97A/BbI3VsUOsiUzlDlFygDEIeaCWYA7swRzpecFXtBvCNNJTLfT5IeZNHwo=,iv:qhLlsCIa6b9yEd8vihbSakIt21RSkmPBY1TV2t6tO+0=,tag:ub71I4pjNxZeB93uoPHVZw==,type:str]
+    created_at: '2026-04-17T08:24:09Z'
+    enc: CiUA4OM7eOEB4NGIrfGPWFXH/K3AeHstYuXDMZmwTm/wKicmXFZWEkkAPHlbmf3Eo/+4FHPFWemYRx9wiPqbMqJ4MNT3+zzw9ZZSfYtaUCpy5IgAAjW+HhGWXUeXS1Bcblg9EyjM/FEcSVbFeWNquWRS
+  lastmodified: '2026-04-17T08:24:10Z'
+  mac: ENC[AES256_GCM,data:rTI6tAKAbnJ6j1z1HRYyDZrAy9ih4GCCNUZDjMGJxWqFd7cnS26f3+S7rZkfPFor3FicXqrkaJtTqhc/KBXuikuZpvVRpY0aG8jRlNcV9vbsAqVFW9i5qq2f8dGqM+3CyVF59yIaGDNTqCjNW0uYpv1Dci2eryoIDNHEMY3Fqxs=,iv:rbmR+NExw+A9OehymxM46RSFrI9vn83O+GjbT6KshsM=,tag:gKEKCqlP3SAD5GSN+MsERQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/config/clusters/victor/enc-support.secret.values.yaml
+++ b/config/clusters/victor/enc-support.secret.values.yaml
@@ -1,24 +1,32 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:YN2ASPRbs+fQ7KwCwZIixYv41D0/s0kDJM5wkuqNXvPQVVTR1pUWYss1v9jouyWPcWSy8TdOsPA6Ym5J2RTudsoxBp6vN8esNVwNk0siyDjCgwE1LK+TKFYyrlH9MKPJtZZ9UNbnn/Gw11i6jvnLfHAkMss25abToE77FTHbTsWy4/rNLs8dWgs41IWqXCUIIPMyrpugie3qui/J,iv:DtYw3V3hC+eBInpkWH2MkTYaDEg3D6wRvX8okWkJSx8=,tag:lcDhlRyeEZQDCel5dQMOfw==,type:comment]
+  #ENC[AES256_GCM,data:RI5FpzCymSf9afx2uPINkGSxSUy6YJty/2Hnnfe5M/dNN9MWMpc03h8OE2DAjWQTzXlxwj5m5PtoefXRTBA5GiHbcy14wMv2efA1VmcAXOhsqewVCnYlyyWoabLQRG1DeraWM/cyDiDq/S+YF5YhEvzlV1VtZvdThgZsveJYk3BwNCNyiujeyFVe42Iv3qY3bbnUuAOGaWFu1l93,iv:VLc8rJDh7OqFOq1I65xG6aNjiXW0H9Y7LjuPZlrXdwo=,tag:/DBDF1urMUeo0URd/1VNXA==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:Xw5kLS5Ku+VMiF2GznHyCvxiXdnP4WTRprSJyc+gzEcNDWIV+rjuXjwZIzKcEESKLQ1M4XYCkviaBnVm8HMFWg==,iv:dS06Pm6TCWazjyCjKPxagKusm0Bm7NvnNcK+hA4Qs0M=,tag:+lzq1Pa8NbUea4dT34x+hg==,type:str]
-    password: ENC[AES256_GCM,data:COCpLxMK9PjPbgNZfBaqQyvOA6ToGr0QNFAgrHNoSquiO58X0KITPeKvrzkrYBOp/NXUFHSGn97/iIONKRy2rQ==,iv:i236bB8KBSW9gwqlYDR8+pyrKpN/tSyfBK1P5lV3j8c=,tag:N5nl00qSdhRIVdFkZZvwrQ==,type:str]
+  - username: ENC[AES256_GCM,data:mJC8dHbRzULAEaure3MOcIikdSUHj08Lmua3kvNnXN12jBdOcdSBLQDckHxmBK4C0/G245dkt+bU8Q9LwxuOuw==,iv:xWBVfP+je9kylg5cjAp1LOit/zk5+R96tIh1KsMjudg=,tag:5Me+jBAkDkoZ2/z323JABw==,type:str]
+    password: ENC[AES256_GCM,data:uwbBh7k49bexh9/RykdoQJ+Vcn3DDPk/3yUkS3KNey7HZiQXqIatdUjpLfM10GBiDfJk3FWiK6ikRpQFuhJgOg==,iv:9lreooMECBcBrvQ854gWFGBn+sWxCX3QQXrgeH7xvPg=,tag:UUEuNxgcBn7WKEHqa8Tdxg==,type:str]
 grafana:
   grafana.ini:
     auth.github:
-      client_id: ENC[AES256_GCM,data:CKjCk+e1vdP6fRbje5W7tE/jn8A=,iv:Q6WrubeWQBCgLlTIMgaJzF0meqYXotN38oVcX5PbxTo=,tag:KKKOqTOLuZeUtxI9ZbwSCg==,type:str]
-      client_secret: ENC[AES256_GCM,data:3UPAWiB+TRiBeNspz2lBmg4WjnHz39koDugXvBj/JJ4XgSFy6Y4++Q==,iv://wOa3sSVp+ZgalNmC9ediBDJZLunZooCQHmR/w4uLo=,tag:fu5ZziVTF0TYUjPKyCBKYA==,type:str]
+      client_id: ENC[AES256_GCM,data:x2VZmJq1k4xdHdst3gMIEhPvlwc=,iv:xu8kHUb/ZXcoD7Q5slMoDdRME37DhR4Ffgy8IBZHhB0=,tag:0VP6KYvi1cjNfnN0Uox32Q==,type:str]
+      client_secret: ENC[AES256_GCM,data:+2eJHV9lkwanCFaStpip+gdEQ88GtdwOXJu3XcPx3rQj5JHjbs60Lg==,iv:STBEvogVgEZpalcGlJ9+TTduFrMNXOQa9lPPAzzBFs0=,tag:eia1YJS+uqHHgAQdnZgaeg==,type:str]
+prometheus:
+  server:
+    probeHeaders:
+    - name: ENC[AES256_GCM,data:vNfOnnHKOkq24e5ECg==,iv:CGnr8SxISU1R8bA7jk4OrFUHgysJR1Cj2qN8AGS4LQE=,tag:wqz01M0QhiCPsNggD26sGg==,type:str]
+      value: ENC[AES256_GCM,data:PQYkl8hImwCdU8SpHUTKKFtZVKCdd+K1dz5xAqmiUTlcO0eb0mXcRodX+39yJ0kzEy5uIZhXLPqXkEaH2ZR7DFXfY1p0hxjeINCihBTVRJmhSSHcFtwGAzZTRvYVIXIAZEWv9RgWh6QJSvXZY4BaBWw2nPgdbPCpJxOlYDxK6D9c2yYEZ3mGmztHSFHpaIUdK6EDG0uJPsQEfronh0hwRbSmMBQYCqXAIgp54k6JyfZVZw==,iv:mCSe9appYM0+eznthwDhfQv2WDorz2mgVmjrn3WaRaE=,tag:s491MFtkyyJZxaz+6aG72w==,type:str]
+    configmapReload:
+      prometheus:
+        username: ENC[AES256_GCM,data:MXz0wi1uShXdLZRgL3O9ie0NjA4n86RmaF/nw4gnDvNT7S0VIA0rMio4AsiVop/iTDVeZnpKzEyg1q0mIWSGoA==,iv:dR+qkv0OLm2T+tdb/ECv2xjUpSem63lnGNwrTJQB5+w=,tag:jjDK2f8V7Qk1r/50q/CxrA==,type:str]
+        password: ENC[AES256_GCM,data:dFdhvXrd89OdIlebNROks3+KZC5UpA0qmpkM8wlQXBbZU6Wqrrkvnhv5HbhquX6//Es7icFMAMMff9iAZXrEzQ==,iv:RhtvUjyLpPW0HTEVoWCOUHJZLc/dTtBm606qK5F31wc=,tag:v54xpbVWa1Y6jSEiencBCw==,type:str]
+  serverFiles:
+    web.yml:
+      basic_auth_users:
+        HJK2ImmQhgclS5musEdi9AsP4ISIAjn0vkpKAcpW4FELIc4pfmcv2SjP27L1eLQV: ENC[AES256_GCM,data:ApETDRMnXtk6QYdiBtqKNt2SVWuDs3Su5ezOk27GRLR1RIodzzU8oo3XYMjYiPqdAMMMAxLQVz/akzLC,iv:ZOs44rfpVkaskXmj1+LkJnNWEHQGr/a9iQngNlsjc3Y=,tag:Xz8Nnd6qRjA4y8LklU/iJg==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-01-12T10:07:03Z'
-    enc: CiUA4OM7eL57D/ZS2AKqj3tNYAPn/9n1o0PoN+0BJ1junsB54bkBEkkAZoeZpvZjJRmAiQMbTv7DhDX4YQesnBDXB4DOcqxxZskxlq6T65hIvFKV6Y352hZzXFY36+9cYbw61hI2yBdgfV5zfnuzLs+V
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-01-12T10:07:04Z'
-  mac: ENC[AES256_GCM,data:4wgpP/OOc47ni9NGAgk/WCmLL6HH1T7npEeIcNiYzzqvrnHD7RwcM18oE6aRJPgRDuJQoSVM1RmnaRc8tljg5SYyunD9y81rLUyJ/QjDmL8qiKvAjultiU8j4IBdNj4OuFt+3eFqtNCGS9zn2pt+shiRDKrBHppaqO5C2wn8ryg=,iv:e1xAN30ZHWpCdmnSQh4AXRG89G2XhVo2zVzdBTMmPMQ=,tag:a9Yt1gv87ZL0ZOm7mfdk8Q==,type:str]
-  pgp: []
+    created_at: '2026-04-16T19:32:41Z'
+    enc: CiUA4OM7eOiFItl6iRyCxarptOnqWg8OZ66lFZ5SfSLkAwEP4nEoEkkAPHlbmWz0IFziWE3i2Fd3q49J/gNOfj+EsWQHbK+5PsCuJnkufPgTs9l3R6x96hkDgY0LCQW7pN4gw/3f1m/6mRWYSULoe9U9
+  lastmodified: '2026-04-16T19:32:42Z'
+  mac: ENC[AES256_GCM,data:T44I12zreLAmUZ74Obm61k7pLZWxk0fqVTzuLJBM25g7ojYYVfzkz2WABUmEDuGLmDtuSfDH32sSuSrg4+jWOEE2Re1i9tKkTDsVzvOYpXS32Tu97A/BbI3VsUOsiUzlDlFygDEIeaCWYA7swRzpecFXtBvCNNJTLfT5IeZNHwo=,iv:qhLlsCIa6b9yEd8vihbSakIt21RSkmPBY1TV2t6tO+0=,tag:ub71I4pjNxZeB93uoPHVZw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.1
+  version: 3.12.1

--- a/config/clusters/victor/support.values.yaml
+++ b/config/clusters/victor/support.values.yaml
@@ -1,5 +1,5 @@
 prometheusIngressAuthSecret:
-  enabled: true
+  enabled: false
 
 cluster-autoscaler:
   enabled: true

--- a/config/clusters/victor/support.values.yaml
+++ b/config/clusters/victor/support.values.yaml
@@ -33,6 +33,8 @@ prometheus:
         hosts:
         - prometheus.victor.2i2c.cloud
 
+    extraArgs:
+      web.config.file: /etc/config/web.yml
 nginx-ingress:
   enabled: true
   controller:

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -168,17 +168,6 @@ prometheus:
     ingress:
       ingressClassName: nginx
       annotations:
-        # Annotations required to enable basic authentication for any ingress
-        # into prometheus server from the outside world. This secret is
-        # created via templates/prometheus-ingress-auth/secret.yaml file in the support chart,
-        # and the contents are controlled by config under prometheusIngressAuthSecret.
-        # These annotations set it up for ingress-nginx ingress controller
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: prometheus-ingress-auth-basic
-        nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
-        # These annotations set it up for the nginx-ingress controller
-        nginx.org/basic-auth-secret: prometheus-nginx-ingress-auth-basic
-        nginx.org/auth-realm: "Authentication Required"
         # If we enable external ingress into prometheus, we must secure it with HTTPS
         cert-manager.io/cluster-issuer: letsencrypt-prod
         # Increase timeout for each query made by the grafana frontend to the

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -373,24 +373,6 @@ grafana:
   plugins:
     - yesoreyeram-infinity-datasource
 
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        # Automatically add the prometheus server in the same namespace as the grafana as a datasource
-        - name: prometheus
-          orgId: 1
-          type: prometheus
-          # This is the name of the kubernetes service exposed by the prometheus server
-          url: http://support-prometheus-server
-          access: proxy
-          isDefault: false
-          editable: false
-        - name: yesoreyeram-infinity-datasource
-          type: yesoreyeram-infinity-datasource
-          isDefault: false
-          editable: true
-
 # cryptnono kills processes attempting to mine the cryptocurrency Monero in the
 # k8s cluster.
 #


### PR DESCRIPTION
Generated this with https://gist.github.com/GeorgianaElena/9f001026f990f346e55fe8435f3509be
~It excludes earthscope because it has to be treated separately due to having two pairs of credentials.~

Ref #8063 
Fixes https://github.com/2i2c-org/infrastructure/issues/8119