### PR TITLE
[earthscope, staging] Grow homes disk

### DIFF
--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -16,7 +16,7 @@ default_budget_alert = {
 
 ebs_volumes = {
   "staging" = {
-    size        = 1
+    size        = 2
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name" : "staging" }


### PR DESCRIPTION
We don't normally have a larger than 1GiB staging disk (with some exceptions). I'm taking the prerogative to do this to minimise disruption for ES.