### PR TITLE
Automatically set hub domain name in ingress config for staging hubs

### DIFF
--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -14,11 +14,6 @@ jupyterhub-home-nfs:
       QuotaManager:
         hard_quota: 10 # in GiB
 jupyterhub:
-  ingress:
-    hosts: [staging.aws.2i2c.cloud]
-    tls:
-    - hosts: [staging.aws.2i2c.cloud]
-      secretName: https-auto-tls
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-jetstream2/staging.values.yaml
+++ b/config/clusters/2i2c-jetstream2/staging.values.yaml
@@ -34,11 +34,6 @@ jupyterhub:
     hook:
       nodeSelector:
         capi.stackhpc.com/node-group: user-m3-quad
-  ingress:
-    hosts: [staging.js.2i2c.cloud]
-    tls:
-    - hosts: [staging.js.2i2c.cloud]
-      secretName: https-auto-tls
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -11,11 +11,6 @@ jupyterhub-home-nfs:
     volumeId: projects/two-eye-two-see-uk/zones/europe-west2-b/disks/hub-nfs-homedirs-staging
 
 jupyterhub:
-  ingress:
-    hosts: [staging.uk.2i2c.cloud]
-    tls:
-    - hosts: [staging.uk.2i2c.cloud]
-      secretName: https-auto-tls
   singleuser:
     image:
       name: pangeo/pangeo-notebook

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -6,13 +6,6 @@ jupyterhub:
       resources:
         requests:
           memory: 16Gi
-  ingress:
-    hosts:
-    - staging.2i2c.cloud
-    tls:
-    - secretName: https-auto-tls
-      hosts:
-      - staging.2i2c.cloud
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/aimatx-2i2c-hub/staging.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/staging.values.yaml
@@ -7,11 +7,6 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::426578051359:role/aimatx-2i2c-hub-staging
 
 jupyterhub:
-  ingress:
-    hosts: [staging.aimatx.2i2c.cloud]
-    tls:
-    - hosts: [staging.aimatx.2i2c.cloud]
-      secretName: https-auto-tls
   hub:
     config:
       GitHubOAuthenticator:

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -13,11 +13,6 @@ basehub:
         QuotaManager:
           hard_quota: 20 # in GiB
   jupyterhub:
-    ingress:
-      hosts: [staging.ciroh.awi.2i2c.cloud]
-      tls:
-      - hosts: [staging.ciroh.awi.2i2c.cloud]
-        secretName: https-auto-tls
     singleuser:
       profileList:
         # The mem-guarantees are here so k8s doesn't schedule other pods

--- a/config/clusters/berkeley-geojupyter/staging.values.yaml
+++ b/config/clusters/berkeley-geojupyter/staging.values.yaml
@@ -7,11 +7,6 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::622703418259:role/berkeley-geojupyter-staging
 
 jupyterhub:
-  ingress:
-    hosts: [staging.berkeley-geojupyter.2i2c.cloud]
-    tls:
-    - hosts: [staging.berkeley-geojupyter.2i2c.cloud]
-      secretName: https-auto-tls
   hub:
     config:
       JupyterHub:

--- a/config/clusters/bnext-bio/staging.values.yaml
+++ b/config/clusters/bnext-bio/staging.values.yaml
@@ -7,11 +7,6 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::882437028641:role/bnext-bio-staging
 
 jupyterhub:
-  ingress:
-    hosts: [staging.hub.nucleus.engineering]
-    tls:
-    - hosts: [staging.hub.nucleus.engineering]
-      secretName: https-auto-tls
   hub:
     config:
       JupyterHub:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -1,9 +1,4 @@
 jupyterhub:
-  ingress:
-    hosts: [staging.cloudbank.2i2c.cloud]
-    tls:
-    - hosts: [staging.cloudbank.2i2c.cloud]
-      secretName: https-auto-tls
   singleuser:
     defaultUrl: /lab
     memory:

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -19,12 +19,6 @@ jupyterhub:
         # Disable for now the authentication token refreshing
         # https://oauthenticator.readthedocs.io/en/latest/reference/api/gen/oauthenticator.oauth2.html#oauthenticator.oauth2.OAuthenticator.auth_refresh_age
         auth_refresh_age: 0
-  ingress:
-    hosts: [staging.hub.disasters.2i2c.cloud]
-    tls:
-    - hosts: [staging.hub.disasters.2i2c.cloud]
-      secretName: https-auto-tls
-
 dask-gateway:
   gateway:
     backend:

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -4,12 +4,6 @@ basehub:
       eks.amazonaws.com/role-arn: arn:aws:iam::762698921361:role/earthscope-staging
 
   jupyterhub:
-    ingress:
-      hosts:
-      - staging.geolab.earthscope.cloud
-      tls:
-      - hosts: [staging.geolab.earthscope.cloud]
-        secretName: https-auto-tls
     custom:
       homepage:
         templateVars:

--- a/config/clusters/hhmi/staging.values.yaml
+++ b/config/clusters/hhmi/staging.values.yaml
@@ -11,13 +11,6 @@ nfs:
     shareNameOverride: spyglass
 
 jupyterhub:
-  ingress:
-    hosts:
-    - staging.hhmi.2i2c.cloud
-    tls:
-    - secretName: https-auto-tls
-      hosts:
-      - staging.hhmi.2i2c.cloud
   custom:
     singleuserAdmin:
       # Turn off trying to mount shared-readwrite folder for admins

--- a/config/clusters/jupyter-health/staging.values.yaml
+++ b/config/clusters/jupyter-health/staging.values.yaml
@@ -10,11 +10,6 @@ jupyterhub-home-nfs:
     volumeId: vol-097e117991afc3759
 
 jupyterhub:
-  ingress:
-    hosts: [staging.jupyter-health.2i2c.cloud]
-    tls:
-    - hosts: [staging.jupyter-health.2i2c.cloud]
-      secretName: https-auto-tls
   hub:
     config:
       GenericOAuthenticator:

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -6,11 +6,6 @@ basehub:
     annotations:
       iam.gke.io/gcp-service-account: leap-staging@leap-pangeo.iam.gserviceaccount.com
   jupyterhub:
-    ingress:
-      hosts: [staging.leap.2i2c.cloud]
-      tls:
-      - hosts: [staging.leap.2i2c.cloud]
-        secretName: https-auto-tls
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://leap-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -233,11 +233,6 @@ jupyterhub:
         oauth_callback_url: https://staging.hub.maap-project.org/hub/oauth_callback
         token_url: https://keycloak.delta-backend.xyz/realms/maap/protocol/openid-connect/token
         authorize_url: https://keycloak.delta-backend.xyz/realms/maap/protocol/openid-connect/auth
-  ingress:
-    hosts: [staging.hub.maap-project.org]
-    tls:
-    - hosts: [staging.hub.maap-project.org]
-      secretName: https-auto-tls
 
 dask-gateway:
   gateway:

--- a/config/clusters/nasa-cryo/staging.values.yaml
+++ b/config/clusters/nasa-cryo/staging.values.yaml
@@ -6,11 +6,6 @@ basehub:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::574251165169:role/nasa-cryo-staging
   jupyterhub:
-    ingress:
-      hosts: [staging.hub.cryointhecloud.com]
-      tls:
-      - hosts: [staging.hub.cryointhecloud.com]
-        secretName: https-auto-tls
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -15,11 +15,6 @@ basehub:
               2i2c/hub-name: staging
 
   jupyterhub:
-    ingress:
-      hosts: [staging.ghg.2i2c.cloud]
-      tls:
-      - hosts: [staging.ghg.2i2c.cloud]
-        secretName: https-auto-tls
     custom:
       homepage:
         gitRepoBranch: staging

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -33,11 +33,6 @@ basehub:
           oauth_client_id: service-binderhub
           oauth_no_confirm: true
           oauth_redirect_uri: https://staging.hub.openveda.cloud/services/binder/oauth_callback
-    ingress:
-      hosts: [staging.hub.openveda.cloud]
-      tls:
-      - hosts: [staging.hub.openveda.cloud]
-        secretName: https-auto-tls
     custom:
       homepage:
         gitRepoBranch: staging

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -18,11 +18,6 @@ dask-gateway:
             2i2c/hub-name: staging
 
 jupyterhub:
-  ingress:
-    hosts: [staging.nmfs-openscapes.2i2c.cloud]
-    tls:
-    - hosts: [staging.nmfs-openscapes.2i2c.cloud]
-      secretName: https-auto-tls
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/config/clusters/openscapeshub/staging.values.yaml
+++ b/config/clusters/openscapeshub/staging.values.yaml
@@ -6,11 +6,6 @@ basehub:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::783616723547:role/openscapeshub-staging
   jupyterhub:
-    ingress:
-      hosts: [staging.openscapes.2i2c.cloud]
-      tls:
-      - hosts: [staging.openscapes.2i2c.cloud]
-        secretName: https-auto-tls
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -7,13 +7,6 @@ jupyterhub-home-nfs:
 
 
 jupyterhub:
-  ingress:
-    hosts:
-    - staging.opensci.2i2c.cloud
-    tls:
-    - secretName: https-auto-tls
-      hosts:
-      - staging.opensci.2i2c.cloud
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -7,11 +7,6 @@ jupyterhub-home-nfs:
 
 
 jupyterhub:
-  ingress:
-    hosts: [staging.projectpythia.2i2c.cloud]
-    tls:
-    - hosts: [staging.projectpythia.2i2c.cloud]
-      secretName: https-auto-tls
   custom:
     homepage:
       templateVars:

--- a/config/clusters/reflective/staging.values.yaml
+++ b/config/clusters/reflective/staging.values.yaml
@@ -5,11 +5,6 @@ userServiceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::916143380841:role/reflective-staging
 jupyterhub:
-  ingress:
-    hosts: [staging.reflective.2i2c.cloud]
-    tls:
-    - hosts: [staging.reflective.2i2c.cloud]
-      secretName: https-auto-tls
   hub:
     config:
       GitHubOAuthenticator:

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -7,11 +7,6 @@ basehub:
       volumeId: vol-0ec551895e93e4d59
 
   jupyterhub:
-    ingress:
-      hosts: [staging.smithsonian.2i2c.cloud]
-      tls:
-      - hosts: [staging.smithsonian.2i2c.cloud]
-        secretName: https-auto-tls
     hub:
       config:
         GitHubOAuthenticator:

--- a/config/clusters/templates/common/hub.values.yaml
+++ b/config/clusters/templates/common/hub.values.yaml
@@ -1,9 +1,4 @@
 jupyterhub:
-  ingress:
-    hosts: [{{ hub_name }}.{{ cluster_name }}.2i2c.cloud]
-    tls:
-      - hosts: [{{ hub_name }}.{{ cluster_name }}.2i2c.cloud]
-        secretName: https-auto-tls
   hub:
     config:
       GitHubOAuthenticator:

--- a/config/clusters/temple/staging.values.yaml
+++ b/config/clusters/temple/staging.values.yaml
@@ -15,11 +15,6 @@ jupyterhub:
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/temple-advanced-staging-push
     nodeSelector:
       2i2c/hub-name: staging
-  ingress:
-    hosts: [staging.temple.2i2c.cloud]
-    tls:
-    - hosts: [staging.temple.2i2c.cloud]
-      secretName: https-auto-tls
 binderhub-service:
   dockerApi:
     nodeSelector:

--- a/config/clusters/ucmerced/staging.values.yaml
+++ b/config/clusters/ucmerced/staging.values.yaml
@@ -1,11 +1,4 @@
 jupyterhub:
-  ingress:
-    hosts:
-    - staging.ucmerced.2i2c.cloud
-    tls:
-    - secretName: https-auto-tls
-      hosts:
-      - staging.ucmerced.2i2c.cloud
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -1,9 +1,4 @@
 jupyterhub:
-  ingress:
-    hosts: [staging.utoronto.2i2c.cloud]
-    tls:
-    - hosts: [staging.utoronto.2i2c.cloud]
-      secretName: https-auto-tls
   hub:
     config:
       GenericOAuthenticator:

--- a/config/clusters/victor/staging.values.yaml
+++ b/config/clusters/victor/staging.values.yaml
@@ -24,11 +24,6 @@ basehub:
         QuotaManager:
           hard_quota: 5 # in GiB
   jupyterhub:
-    ingress:
-      hosts: [staging.hub.victorproject.org]
-      tls:
-      - hosts: [staging.hub.victorproject.org]
-        secretName: https-auto-tls
     hub:
       config:
         CILogonOAuthenticator:

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -79,7 +79,7 @@ def _prepare_hub_helm_charts_dependencies_and_schema(hub_chart_dir, legacy_dasku
 def validate_hub_config(
     cluster_name,
     hub_name,
-    helm_chart_dir="",
+    helm_chart_dir: Path,
     skip_refresh=False,
     debug=False,
 ):
@@ -90,8 +90,6 @@ def validate_hub_config(
     cluster = Cluster.from_name(cluster_name)
     hub = next((h for h in cluster.hubs if h.spec["name"] == hub_name), None)
 
-    if not helm_chart_dir:
-        helm_chart_dir = HELM_CHARTS_DIR / hub.spec["helm_chart"]
     if not skip_refresh:
         _prepare_hub_helm_charts_dependencies_and_schema(
             helm_chart_dir, hub.legacy_daskhub
@@ -106,6 +104,20 @@ def validate_hub_config(
         cmd.append("--debug")
 
     with ExitStack() as jsonnet_stack:
+
+        # Add on rendered jsonnet values.yaml file for the chart
+        rendered_values_path = jsonnet_stack.enter_context(
+            render_jsonnet(
+                helm_chart_dir / "values.jsonnet",
+                cluster.spec["name"],
+                hub.spec["name"],
+                cluster.spec["provider"],
+                hub_domain=hub.spec["domain"]
+            )
+        )
+
+        cmd += ["--values", rendered_values_path]
+
         for values_file in hub.spec["helm_chart_values_files"]:
             # FIXME: The logic here for figuring out non secret files is not correct
             if values_file.endswith(".jsonnet"):
@@ -115,6 +127,7 @@ def validate_hub_config(
                         cluster_name,
                         hub_name,
                         cluster.spec["provider"],
+                        hub_domain=hub.spec["domain"]
                     )
                 )
                 cmd.append(f"--values={rendered_file}")
@@ -271,6 +284,7 @@ def support_config(
                             cluster_name,
                             None,
                             cluster.spec["provider"],
+                            hub_domain=None
                         )
                     )
                     cmd.append(f"--values={rendered_file}")

--- a/deployer/commands/validate/config.py
+++ b/deployer/commands/validate/config.py
@@ -112,7 +112,7 @@ def validate_hub_config(
                 cluster.spec["name"],
                 hub.spec["name"],
                 cluster.spec["provider"],
-                hub_domain=hub.spec["domain"]
+                hub_domain=hub.spec["domain"],
             )
         )
 
@@ -127,7 +127,7 @@ def validate_hub_config(
                         cluster_name,
                         hub_name,
                         cluster.spec["provider"],
-                        hub_domain=hub.spec["domain"]
+                        hub_domain=hub.spec["domain"],
                     )
                 )
                 cmd.append(f"--values={rendered_file}")
@@ -284,7 +284,7 @@ def support_config(
                             cluster_name,
                             None,
                             cluster.spec["provider"],
-                            hub_domain=None
+                            hub_domain=None,
                         )
                     )
                     cmd.append(f"--values={rendered_file}")

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -192,7 +192,7 @@ class Cluster:
                             else self.spec["name"]
                         ),
                         "hub_name": None,
-                        "hub_domain": None
+                        "hub_domain": None,
                     }
                     if self.spec["provider"] == "aws":
                         render_args["aws_account_id"] = self.spec["aws"]["account"]

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -192,6 +192,7 @@ class Cluster:
                             else self.spec["name"]
                         ),
                         "hub_name": None,
+                        "hub_domain": None
                     }
                     if self.spec["provider"] == "aws":
                         render_args["aws_account_id"] = self.spec["aws"]["account"]

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -165,6 +165,7 @@ class Hub:
                     self.cluster.spec["name"],
                     self.spec["name"],
                     self.cluster.spec["provider"],
+                    hub_domain=self.spec["domain"]
                 )
             )
 
@@ -186,6 +187,7 @@ class Hub:
                             self.cluster.spec["name"],
                             self.spec["name"],
                             self.cluster.spec["provider"],
+                            hub_domain=self.spec["domain"]
                         )
                     )
                     cmd.append(f"--values={rendered_path}")

--- a/deployer/infra_components/hub.py
+++ b/deployer/infra_components/hub.py
@@ -165,7 +165,7 @@ class Hub:
                     self.cluster.spec["name"],
                     self.spec["name"],
                     self.cluster.spec["provider"],
-                    hub_domain=self.spec["domain"]
+                    hub_domain=self.spec["domain"],
                 )
             )
 
@@ -187,7 +187,7 @@ class Hub:
                             self.cluster.spec["name"],
                             self.spec["name"],
                             self.cluster.spec["provider"],
-                            hub_domain=self.spec["domain"]
+                            hub_domain=self.spec["domain"],
                         )
                     )
                     cmd.append(f"--values={rendered_path}")

--- a/deployer/utils/jsonnet.py
+++ b/deployer/utils/jsonnet.py
@@ -43,6 +43,7 @@ def render_jsonnet(
         - cluster_name
         - provider
         - hub_name (optional)
+        - hub_domain (optional)
 
     Top-level arguments can be referenced in jsonnet even if they are undefined.
     The following variables are passed as top-level arguments to jsonnet:

--- a/deployer/utils/jsonnet.py
+++ b/deployer/utils/jsonnet.py
@@ -33,6 +33,7 @@ def render_jsonnet(
     cluster_name: str,
     hub_name: str | None,
     provider: str,
+    hub_domain: str | None,
     aws_account_id: str | None = None,
 ):
     """
@@ -58,6 +59,8 @@ def render_jsonnet(
     ]
     if hub_name is not None:
         command += ["--ext-str", f"VARS_2I2C_HUB_NAME={hub_name}"]
+    if hub_domain is not None:
+        command += ["--ext-str", f"VARS_2I2C_HUB_DOMAIN={hub_domain}"]
     if provider is not None:
         command += ["--ext-str", f"VARS_2I2C_PROVIDER={provider}"]
     if aws_account_id is not None:

--- a/docs/topic/jsonnet.md
+++ b/docs/topic/jsonnet.md
@@ -44,8 +44,11 @@ of those directories and avoid repetition.
 
 Two external variables (accessible via `std.extVar` in jsonnet files) are injected:
 
-1. `2I2C_VARS.CLUSTER_NAME` - Name of the cluster we are deploying.
-2. `2I2C_VARS.HUB_NAME` - Name of the hub we are deploying. Unset for support deploys.
+1. `VARS_2I2C_CLUSTER_NAME` - Name of the cluster we are deploying.
+2. `VARS_2I2C_HUB_NAME` - Name of the hub we are deploying. Unset for support deploys.
+3. `VARS_2I2C_HUB_DOMAIN` - Domain of the hub we are deploying. Unset for support deploys.
+4. `VARS_2I2C_PROVIDER` - Provider the current hub is being deployed on (aws, gcp, etc)
+5. `VARS_2I2C_AWS_ACCOUNT_ID` - AWS Account ID for hubs on AWS
 
 We want to keep this set of variables *super minimal*, to prevent right to replicate related
 issues. A community that wants to replicate our code should be able to convert the jsonnet

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -123,18 +123,18 @@ local hubIngressConfig = {
   tls: [
     {
       hosts: [hub_domain],
-      secretName: "https-auto-tls"
-    }
-  ]
+      secretName: 'https-auto-tls',
+    },
+  ],
 };
 
 local jupyterhubConfig = {
-  ingress: hubIngressConfig
+  ingress: hubIngressConfig,
 };
 
 emitDaskHubCompatibleConfig({
   nfs: nfsConfig,
   'jupyterhub-home-nfs': jupyterhubHomeNFSConfig,
   'jupyterhub-groups-exporter': jupyterhubGroupsExporterConfig,
-  jupyterhub: jupyterhubConfig
+  jupyterhub: jupyterhubConfig,
 })

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -1,5 +1,6 @@
 local hub_name = std.extVar('VARS_2I2C_HUB_NAME');
 local provider = std.extVar('VARS_2I2C_PROVIDER');
+local hub_domain = std.extVar('VARS_2I2C_HUB_DOMAIN');
 
 // Assume we are a staging hub if the word 'staging' is in the
 // name of the hub.
@@ -117,8 +118,23 @@ local nfsConfig = {
   },
 };
 
+local hubIngressConfig = {
+  hosts: [hub_domain],
+  tls: [
+    {
+      hosts: [hub_domain],
+      secretName: "https-auto-tls"
+    }
+  ]
+};
+
+local jupyterhubConfig = {
+  ingress: hubIngressConfig
+};
+
 emitDaskHubCompatibleConfig({
   nfs: nfsConfig,
   'jupyterhub-home-nfs': jupyterhubHomeNFSConfig,
   'jupyterhub-groups-exporter': jupyterhubGroupsExporterConfig,
+  jupyterhub: jupyterhubConfig
 })


### PR DESCRIPTION
This has been a persistent source of copy paste repetition,
and should be fixed. It also helps us as we deploy the binderhub
auth change (https://github.com/2i2c-org/infrastructure/pull/8139)
so we don't have to copy paste the auth callback url everywhere.