### PR TITLE
Change trade-offs for MAAP server startup

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -14,6 +14,13 @@ nfs:
 dask-gateway:
   enabled: true
 jupyterhub:
+
+  prePuller:
+    # Pre-pull all explicitly specified images in our profiles on all nodes
+    # when they start up
+    continuous:
+      enabled: true
+
   custom:
     daskhubSetup:
       enabled: true
@@ -190,182 +197,6 @@ jupyterhub:
         mountPath: /my-team-buckets
         subPath: my-team-buckets
         mountPropagation: Bidirectional
-    profileList:
-    - display_name: Choose your environment and resources
-      default: true
-      profile_options:
-        image:
-          display_name: Environment
-          dynamic_image_building:
-            enabled: true
-          unlisted_choice:
-            enabled: true
-            display_name: Custom image
-            validation_regex: ^.+:.+$
-            validation_message: Must be a publicly available docker image, of form <image-name>:<tag>
-            kubespawner_override:
-              image: '{value}'
-          choices:
-            01-modify-pangeo:
-              display_name: Modified Pangeo Notebook
-              description: Pangeo based notebook with a Python environment
-              kubespawner_override:
-                image: public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:2025.12.30-v1
-                init_containers:
-                # this container uses nbgitpuller to mount https://github.com/NASA-IMPACT/veda-docs/ for user pods
-                # image source: https://github.com/NASA-IMPACT/jupyterhub-gitpuller-init
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
-            02-rocker:
-              display_name: Rocker Geospatial with RStudio
-              description: R environment with many geospatial libraries pre-installed
-              kubespawner_override:
-                image: rocker/binder:4.4
-                image_pull_policy: Always
-                  # Launch RStudio after the user logs in
-                default_url: /rstudio
-                  # Ensures container working dir is homedir
-                  # https://github.com/2i2c-org/infrastructure/issues/2559
-                working_dir: /home/rstudio
-            03-qgis:
-              display_name: QGIS on Linux Desktop
-              description: Linux desktop in the browser, with qgis installed
-              kubespawner_override:
-                  # Launch people directly into the Linux desktop when they start
-                default_url: /desktop
-                  # Built from https://github.com/2i2c-org/nasa-qgis-image
-                image: quay.io/2i2c/nasa-qgis-image:2725f26348ba
-        resource_allocation:
-          display_name: Resource Allocation
-          choices:
-            # [[[cog
-            # from deployer.dev_commands.generate.resource_allocation.generate_choices import choices
-            # choices(["r5.xlarge:5", "r5.4xlarge:2"], "proportional-memory-strategy", default=True)
-            # ]]]
-            mem_2_gb:
-              display_name: ~2 GB RAM, ~0.2 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 1951419879
-                mem_limit: 1951419879
-                cpu_guarantee: 0.22815625
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-              default: true
-            mem_4_gb:
-              display_name: ~4 GB RAM, ~0.5 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 3902839759
-                mem_limit: 3902839759
-                cpu_guarantee: 0.4563125
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-            mem_7_gb:
-              display_name: ~7 GB RAM, ~0.9 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 7805679519
-                mem_limit: 7805679519
-                cpu_guarantee: 0.912625
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-            mem_15_gb:
-              display_name: ~15 GB RAM, ~1.8 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 15611359038
-                mem_limit: 15611359038
-                cpu_guarantee: 1.82525
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-            mem_29_gb:
-              display_name: ~29 GB RAM, ~4 CPUs
-              description: ~4 CPUs always available
-              kubespawner_override:
-                mem_guarantee: 31222718077
-                mem_limit: 31222718077
-                cpu_guarantee: 3.6505
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-            mem_60_gb:
-              display_name: ~60 GB RAM, ~8 CPUs
-              description: Up to ~15 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 64020707016
-                mem_limit: 64020707016
-                cpu_guarantee: 7.69055
-                cpu_limit: 15.3811
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.4xlarge
-            mem_119_gb:
-              display_name: ~119 GB RAM, ~15 CPUs
-              description: ~15 CPUs always available
-              kubespawner_override:
-                mem_guarantee: 128041414033
-                mem_limit: 128041414033
-                cpu_guarantee: 15.3811
-                cpu_limit: 15.3811
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.4xlarge
-            # [[[end]]]
-    - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
-      description: Start a container on a dedicated node with a GPU
-      slug: gpu
-      allowed_groups:
-      - 2i2c-org:hub-access-for-2i2c-staff
-      - MAAP-Project:gpu
-      profile_options:
-        image:
-          display_name: Environment
-          dynamic_image_building:
-            enabled: true
-          unlisted_choice:
-            enabled: true
-            display_name: Custom image
-            validation_regex: ^.+:.+$
-            validation_message: Must be a publicly available docker image of form <image-name>:<tag>
-            kubespawner_override:
-              image: '{value}'
-          choices:
-            pytorch:
-              display_name: Pangeo PyTorch ML Notebook
-              default: false
-              slug: pytorch
-              kubespawner_override:
-                image: quay.io/pangeo/pytorch-notebook:2025.12.30
-            tensorflow2:
-              display_name: Pangeo Tensorflow2 ML Notebook
-              default: true
-              slug: tensorflow2
-              kubespawner_override:
-                image: quay.io/pangeo/ml-notebook:2025.12.30
-      kubespawner_override:
-        environment:
-          NVIDIA_DRIVER_CAPABILITIES: compute,utility
-        mem_limit:
-        mem_guarantee: 14G
-        node_selector:
-          node.kubernetes.io/instance-type: g4dn.xlarge
-        extra_resource_limits:
-          nvidia.com/gpu: '1'
 
   scheduling:
     userScheduler:

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -110,11 +110,6 @@ jupyterhub:
         resource_allocation:
           display_name: Resource Allocation
           choices:
-              # [[[cog
-              # import os; assert "IGNORE_COG_WARNING" in os.environ, "SET IGNORE_COG_WARNING and modify after running"
-              # from deployer.dev_commands.generate.resource_allocation.generate_choices import choices
-              # choices(["r5.xlarge:5", "r5.4xlarge:2"], "proportional-memory-strategy", default=True)
-              # ]]]
             mem_2_gb:
               display_name: ~2 GB RAM, ~0.2 CPUs
               allowed_groups:
@@ -152,35 +147,36 @@ jupyterhub:
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
             mem_15_gb:
-              display_name: ~15 GB RAM, ~1.8 CPUs
+              display_name: ~15 GB RAM, ~1.9 CPUs
+              description: Up to ~15 CPUs when available
+              default: true
               allowed_groups:
               - CPU:L
-              description: Up to ~4 CPUs when available
               kubespawner_override:
-                mem_guarantee: 15611359038
-                mem_limit: 15611359038
-                cpu_guarantee: 1.82525
-                cpu_limit: 3.6505
+                mem_guarantee: 16005176754
+                mem_limit: 16005176754
+                cpu_guarantee: 1.9226375
+                cpu_limit: 15.3811
                 node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-              default: true
-            mem_29_gb:
-              display_name: ~29 GB RAM, ~4 CPUs
+                  node.kubernetes.io/instance-type: r5.4xlarge
+            mem_30_gb:
+              display_name: ~30 GB RAM, ~4 CPUs
+              description: Up to ~15 CPUs when available
               allowed_groups:
               - CPU:XL
-              description: ~4 CPUs always available
               kubespawner_override:
-                mem_guarantee: 31222718077
-                mem_limit: 31222718077
-                cpu_guarantee: 3.6505
-                cpu_limit: 3.6505
+                mem_guarantee: 32010353508
+                mem_limit: 32010353508
+                cpu_guarantee: 3.845275
+                cpu_limit: 15.3811
                 node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
+                  node.kubernetes.io/instance-type: r5.4xlarge
             mem_60_gb:
               display_name: ~60 GB RAM, ~8 CPUs
+              description: Up to ~15 CPUs when available
+
               allowed_groups:
               - CPU:XXL
-              description: Up to ~15 CPUs when available
               kubespawner_override:
                 mem_guarantee: 64020707016
                 mem_limit: 64020707016
@@ -190,9 +186,9 @@ jupyterhub:
                   node.kubernetes.io/instance-type: r5.4xlarge
             mem_119_gb:
               display_name: ~119 GB RAM, ~15 CPUs
+              description: ~15 CPUs always available
               allowed_groups:
               - CPU:XXXL
-              description: ~15 CPUs always available
               kubespawner_override:
                 mem_guarantee: 128041414033
                 mem_limit: 128041414033
@@ -200,7 +196,6 @@ jupyterhub:
                 cpu_limit: 15.3811
                 node_selector:
                   node.kubernetes.io/instance-type: r5.4xlarge
-                # [[[end]]]
     - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
       description: Start a container on a dedicated node with a GPU
       slug: gpu

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -113,11 +113,6 @@ jupyterhub:
         resource_allocation:
           display_name: Resource Allocation
           choices:
-            # [[[cog
-            # import os; assert "IGNORE_COG_WARNING" in os.environ, "SET IGNORE_COG_WARNING and modify after running"
-            # from deployer.dev_commands.generate.resource_allocation.generate_choices import choices
-            # choices(["r5.xlarge:5", "r5.4xlarge:2"], "proportional-memory-strategy", default=True)
-            # ]]]
             mem_2_gb:
               display_name: ~2 GB RAM, ~0.2 CPUs
               allowed_groups:
@@ -155,35 +150,36 @@ jupyterhub:
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
             mem_15_gb:
-              display_name: ~15 GB RAM, ~1.8 CPUs
+              display_name: ~15 GB RAM, ~1.9 CPUs
+              description: Up to ~15 CPUs when available
+              default: true
               allowed_groups:
               - CPU:L
-              description: Up to ~4 CPUs when available
               kubespawner_override:
-                mem_guarantee: 15611359038
-                mem_limit: 15611359038
-                cpu_guarantee: 1.82525
-                cpu_limit: 3.6505
+                mem_guarantee: 16005176754
+                mem_limit: 16005176754
+                cpu_guarantee: 1.9226375
+                cpu_limit: 15.3811
                 node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-              default: true
-            mem_29_gb:
-              display_name: ~29 GB RAM, ~4 CPUs
+                  node.kubernetes.io/instance-type: r5.4xlarge
+            mem_30_gb:
+              display_name: ~30 GB RAM, ~4 CPUs
+              description: Up to ~15 CPUs when available
               allowed_groups:
               - CPU:XL
-              description: ~4 CPUs always available
               kubespawner_override:
-                mem_guarantee: 31222718077
-                mem_limit: 31222718077
-                cpu_guarantee: 3.6505
-                cpu_limit: 3.6505
+                mem_guarantee: 32010353508
+                mem_limit: 32010353508
+                cpu_guarantee: 3.845275
+                cpu_limit: 15.3811
                 node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
+                  node.kubernetes.io/instance-type: r5.4xlarge
             mem_60_gb:
               display_name: ~60 GB RAM, ~8 CPUs
+              description: Up to ~15 CPUs when available
+
               allowed_groups:
               - CPU:XXL
-              description: Up to ~15 CPUs when available
               kubespawner_override:
                 mem_guarantee: 64020707016
                 mem_limit: 64020707016
@@ -193,9 +189,9 @@ jupyterhub:
                   node.kubernetes.io/instance-type: r5.4xlarge
             mem_119_gb:
               display_name: ~119 GB RAM, ~15 CPUs
+              description: ~15 CPUs always available
               allowed_groups:
               - CPU:XXXL
-              description: ~15 CPUs always available
               kubespawner_override:
                 mem_guarantee: 128041414033
                 mem_limit: 128041414033
@@ -203,7 +199,6 @@ jupyterhub:
                 cpu_limit: 15.3811
                 node_selector:
                   node.kubernetes.io/instance-type: r5.4xlarge
-            # [[[end]]]
     - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
       description: Start a container on a dedicated node with a GPU
       slug: gpu


### PR DESCRIPTION
- Put default user resource allocation on larger nodes (r5.4xlarge) than smaller nodes (r5.xlarge) so more users fit on a single node. This leads to faster startup times, as fewer node spin-ups need to happen. This is at the cost of higher cloud spend, which will need to be monitored
- Enable continuous image pre-pulling, so all images in our profile list are pulled on all nodes as they come in. This means new images don't need to be pulled, at the cost of it taking up more disk space (that would otherwise be used for tmp or logs etc) - so we may need to increase disk space too.

Ref https://github.com/2i2c-org/initiatives/issues/50
Ref https://github.com/2i2c-org/infrastructure/issues/8148