### PR TITLE
MAAP: Pre-pull s3fs & git-puller images

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -21,6 +21,16 @@ jupyterhub:
     continuous:
       enabled: true
 
+    extraImages:
+      # Keep up to date with the init container used for pulling in docs, under initContainers
+      nbgitpuller:
+        name: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init
+        tag: 97eb45f9d23b128aff810e45911857d5cffd05c2
+      # Keep up to date with s3fs sidecar
+      s3fs:
+        name: mas.dit.maap-project.org/root/che-sidecar-s3fs
+        tag: 2i2c # This is a mutable tag, so may trigger re-pulls
+
   custom:
     daskhubSetup:
       enabled: true
@@ -161,6 +171,22 @@ jupyterhub:
           subPath: my-team-buckets
           mountPropagation: HostToContainer
           readOnly: false
+    initContainers:
+    - name: jupyterhub-gitpuller-init
+      # Keep this up to date with `prePuller.extraImages`
+      image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
+      env:
+      - name: TARGET_PATH
+        value: veda-docs
+      - name: SOURCE_REPO
+        value: https://github.com/NASA-IMPACT/veda-docs
+      volumeMounts:
+      - name: home
+        mountPath: /home/jovyan
+        subPath: '{escaped_username}'
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
     extraContainers:
     - name: s3fs
       image: mas.dit.maap-project.org/root/che-sidecar-s3fs:2i2c

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -44,61 +44,16 @@ jupyterhub:
               description: Pangeo based notebook with a Python environment
               kubespawner_override:
                 image: mas.maap-project.org/root/maap-workspaces/2i2c/pangeo:v5.1.0
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             02-rocker:
               display_name: Rocker Geospatial v5.1.0
               description: JupyterHub environment with many R geospatial libraries pre-installed
               kubespawner_override:
                 image: mas.maap-project.org/root/maap-workspaces/2i2c/r:v5.1.0
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             03-isce3:
               display_name: isce3 v5.1.0
               description: Pangeo based notebook with a Python environment and isce3
               kubespawner_override:
                 image: mas.maap-project.org/root/maap-workspaces/2i2c/isce3:v5.1.0
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             04-qgis:
               display_name: QGIS on Linux Desktop
               description: Linux desktop in the browser, with qgis installed

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -45,63 +45,18 @@ jupyterhub:
               kubespawner_override:
                 image: mas.dit.maap-project.org/root/maap-workspaces/2i2c/pangeo:develop
                 image_pull_policy: Always
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             02-rocker:
               display_name: Rocker Geospatial
               description: JupyterHub environment with many R geospatial libraries pre-installed
               kubespawner_override:
                 image: mas.dit.maap-project.org/root/maap-workspaces/2i2c/r:develop
                 image_pull_policy: Always
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             03-isce3:
               display_name: isce3
               description: Pangeo based notebook with a Python environment and isce3
               kubespawner_override:
                 image: mas.dit.maap-project.org/root/maap-workspaces/2i2c/isce3:develop
                 image_pull_policy: Always
-                init_containers:
-                - name: jupyterhub-gitpuller-init
-                  image: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2
-                  env:
-                  - name: TARGET_PATH
-                    value: veda-docs
-                  - name: SOURCE_REPO
-                    value: https://github.com/NASA-IMPACT/veda-docs
-                  volumeMounts:
-                  - name: home
-                    mountPath: /home/jovyan
-                    subPath: '{escaped_username}'
-                  securityContext:
-                    runAsUser: 1000
-                    runAsGroup: 1000
             04-qgis:
               display_name: QGIS on Linux Desktop
               description: Linux desktop in the browser, with qgis installed


### PR DESCRIPTION
- Centralize initContainer config, as we want veda-docs to be pulled in regardless of the image being used. This also avoids repetition
- Pre-pull the s3fs image

Ref https://github.com/2i2c-org/infrastructure/issues/8148