### PR TITLE
Increase alert threshold for pods stuck in 'pending'

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -125,11 +125,11 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
     summary,
     severity,
                                                ) {
-    alert: 'Pod stuck in Pending for at least 15m',
+    alert: 'Pod stuck in Pending for at least 30m',
     expr: |||
       max by (namespace, pod) (kube_pod_status_phase{phase="Pending"}) > 0
     |||,
-    'for': '15m',
+    'for': '30m',
     labels: {
       cluster: cluster_name,
       severity: severity,


### PR DESCRIPTION
It's been firing constantly for continuous pre-pullers, as they may pull in heavy and big images.

See also https://github.com/2i2c-org/infrastructure/pull/8082

Ref https://github.com/2i2c-org/infrastructure/issues/8148