### PR TITLE
cloudbank: Reduce enforce-xfs-quota requests

### DIFF
--- a/config/clusters/cloudbank/common.values.yaml
+++ b/config/clusters/cloudbank/common.values.yaml
@@ -30,10 +30,10 @@ jupyterhub-home-nfs:
     resources:
       requests:
         cpu: 0.001
-        memory: 256M
+        memory: 32Mi
       limits:
         cpu: 0.2
-        memory: 1G
+        memory: 256Mi
     config:
       QuotaManager:
         hard_quota: 5 # in GiB


### PR DESCRIPTION
Max usage seems to be roughly 32Mi, and requesting 256Mi is a little too high.

Follow-up to https://github.com/2i2c-org/infrastructure/pull/8059

<img width="1789" height="805" alt="image" src="https://github.com/user-attachments/assets/5e43542c-5fc6-4bf3-8193-5eaadf74ef73" />

