### PR TITLE
Reduce baseline cost of hhmi cluster

### DIFF
--- a/config/clusters/hhmi/spyglass.values.yaml
+++ b/config/clusters/hhmi/spyglass.values.yaml
@@ -13,10 +13,36 @@ nfs:
 jupyterhub-home-nfs:
   gke:
     volumeId: projects/hhmi-398911/zones/us-west2-b/disks/hub-nfs-homedirs-spyglass
+  # Reduce quota, as this hub isn't heavily used
   quotaEnforcer:
+    resources:
+      requests:
+        cpu: 0.001
+        memory: 32Mi
+      limits:
+        cpu: 0.2
+        memory: 256Mi
     config:
       QuotaManager:
         hard_quota: 100 # in GiB
+  nfsServer:
+    resources:
+      requests:
+        cpu: 0.02
+        memory: 128M
+      limits:
+        cpu: 0.1
+        memory: 512M
+  nodeExporter:
+    resources:
+      requests:
+        cpu: 0.001
+      limits:
+        cpu: 0.1
+  autoResizer:
+    resources:
+      requests:
+        cpu: 0.001
 
 jupyterhub:
   ingress:

--- a/config/clusters/hhmi/support.values.yaml
+++ b/config/clusters/hhmi/support.values.yaml
@@ -3,6 +3,12 @@ prometheusIngressAuthSecret:
 
 prometheus:
   server:
+    resources:
+      requests:
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
     ingress:
       enabled: true
       hosts:

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -2,7 +2,7 @@ prefix                 = "hhmi"
 project_id             = "hhmi-398911"
 zone                   = "us-west2-b"
 region                 = "us-west2"
-core_node_machine_type = "n2-highmem-4"
+core_node_machine_type = "n2-highmem-2"
 billing_account_id     = "0157F7-E3EA8C-25AC3C"
 enable_network_policy  = true
 


### PR DESCRIPTION
- Switch from n2-highmem-4 nodes to n2-highmem-2 nodes
- Reduce the resources allocated to nfs server, as this sees very light use
- Reduce the prometheus server allocation too

Ref https://github.com/2i2c-org/meta/issues/3097