### PR TITLE
Add alert for missing kubelet volume stats

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -2,9 +2,29 @@ local cluster_name = std.extVar('VARS_2I2C_CLUSTER_NAME');
 local provider_name = std.extVar('VARS_2I2C_PROVIDER');
 
 function(VARS_2I2C_AWS_ACCOUNT_ID=null)
-  local sameDayAction = 'same day action needed',
-  local sameWeekAction = 'action needed this week',
-  local immediateAction = 'take immediate action',
+  local sameDayAction = 'same day action needed';
+  local sameWeekAction = 'action needed this week';
+  local immediateAction = 'take immediate action';
+  local makeMissingKubeletVolumeMetricsAlert = function(
+    summary,
+    severity,
+    forInterval='5m',
+                                               ) {
+    alert: 'Kubelet volume metrics are missing',
+    expr: |||
+      # Detect when the kubelet PVC metrics are missing
+      absent(kubelet_volume_stats_available_bytes) == 1
+    |||,
+    'for': forInterval,
+    labels: {
+      cluster: cluster_name,
+      severity: severity,
+    } + labels,
+    annotations: {
+      summary: summary,
+    },
+  };
+
   local makePVCApproachingFullAlert = function(
     summary,
     persistentvolumeclaim,
@@ -344,6 +364,16 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
                 diskIOApproachingSaturation(
                   'Disk IO approaching saturation',
                   sameWeekAction
+                ),
+              ],
+            },
+            {
+              name: 'Infrastructure Integrity',
+              rules: [
+                makeMissingKubeletVolumeMetricsAlert(
+                  'Kubelet volume metrics are not being reported',
+                  sameDayAction,
+                  '30m'
                 ),
               ],
             },

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -2,6 +2,9 @@ local cluster_name = std.extVar('VARS_2I2C_CLUSTER_NAME');
 local provider_name = std.extVar('VARS_2I2C_PROVIDER');
 
 function(VARS_2I2C_AWS_ACCOUNT_ID=null)
+  local sameDayAction = 'same day action needed',
+  local sameWeekAction = 'action needed this week',
+  local immediateAction = 'take immediate action',
   local makePVCApproachingFullAlert = function(
     summary,
     persistentvolumeclaim,
@@ -243,38 +246,38 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
                   'Home Directory Disk very close to full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'home-nfs',
                   10,
-                  'same day action needed',
+                  sameDayAction,
                 ),
                 makePVCApproachingFullAlert(
                   'Home Directory Disk is full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'home-nfs',
                   0,
-                  'take immediate action',
+                  immediateAction,
                   '1m',
                 ),
                 makePVCApproachingFullAlert(
                   'Hub Database Disk about to be full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'hub-db-dir',
                   10,
-                  'same day action needed'
+                  sameDayAction
                 ),
                 makePVCApproachingFullAlert(
                   'Hub Database Disk is full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'hub-db-dir',
                   0,
-                  'take immediate action'
+                  immediateAction
                 ),
                 makePVCApproachingFullAlert(
                   'Prometheus Disk about to be full: cluster:%s' % [cluster_name],
                   'support-prometheus-server',
                   10,
-                  'same day action needed'
+                  sameDayAction
                 ),
                 makePVCApproachingFullAlert(
                   'Prometheus Disk is full: cluster:%s' % [cluster_name],
                   'support-prometheus-server',
                   0,
-                  'take immediate action'
+                  immediateAction
                 ),
               ],
             },
@@ -283,7 +286,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 makeTwoServersStartupFailureAlert(
                   'At least two servers have failed to start in the last 30m: cluster %s hub:{{ $labels.namespace }}' % [cluster_name],
-                  'immediate action needed',
+                  immediateAction,
                 ),
               ],
             },
@@ -294,31 +297,31 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
                   'jupyterhub-cost-monitoring',
                   'jupyterhub-cost-monitoring pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '.*cost-monitoring.*',
-                  'action needed this week'
+                  sameWeekAction
                 ),
                 makePodRestartAlert(
                   'jupyterhub-groups-exporter',
                   'jupyterhub-groups-exporter pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '.*groups-exporter.*',
-                  'action needed this week'
+                  sameWeekAction
                 ),
                 makePodRestartAlert(
                   'jupyterhub-home-nfs',
                   'jupyterhub-home-nfs pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^storage-quota-home-nfs.*',
-                  'same day action needed'
+                  sameDayAction
                 ),
                 makePodRestartAlert(
                   'support-grafana',
                   'support-grafana pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^support-grafana.*',
-                  'action needed this week'
+                  sameWeekAction
                 ),
                 makePodRestartAlert(
                   'proxy',
                   'proxy pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^proxy.*',
-                  'immediate action needed'
+                  immediateAction
                 ),
               ],
             },
@@ -327,11 +330,11 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 makePodStuckInPendingForTooLongAlert(
                   'Pod is stuck in Pending state for a suspicious long time',
-                  'action needed this week'
+                  sameWeekAction
                 ),
                 makePodStuckInTerminatingForTooLongAlert(
                   'Pod is stuck in Terminating state for a suspicious long time',
-                  'action needed this week'
+                  sameWeekAction
                 ),
               ],
             },
@@ -340,7 +343,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 diskIOApproachingSaturation(
                   'Disk IO approaching saturation',
-                  'action needed this week'
+                  sameWeekAction
                 ),
               ],
             },


### PR DESCRIPTION
Several clusters, due to k8s bugs, are missing these metrics. Whilst it's not super likely that we'll run into this again, it seems prudent to check for "missing" for things that we alert on. For now, only the volume metrics.