### PR TITLE
Revert "Add alert for missing kubelet volume stats"

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -2,29 +2,6 @@ local cluster_name = std.extVar('VARS_2I2C_CLUSTER_NAME');
 local provider_name = std.extVar('VARS_2I2C_PROVIDER');
 
 function(VARS_2I2C_AWS_ACCOUNT_ID=null)
-  local sameDayAction = 'same day action needed';
-  local sameWeekAction = 'action needed this week';
-  local immediateAction = 'take immediate action';
-  local makeMissingKubeletVolumeMetricsAlert = function(
-    summary,
-    severity,
-    forInterval='5m',
-                                               ) {
-    alert: 'Kubelet volume metrics are missing',
-    expr: |||
-      # Detect when the kubelet PVC metrics are missing
-      absent(kubelet_volume_stats_available_bytes) == 1
-    |||,
-    'for': forInterval,
-    labels: {
-      cluster: cluster_name,
-      severity: severity,
-    } + labels,
-    annotations: {
-      summary: summary,
-    },
-  };
-
   local makePVCApproachingFullAlert = function(
     summary,
     persistentvolumeclaim,
@@ -266,38 +243,38 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
                   'Home Directory Disk very close to full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'home-nfs',
                   10,
-                  sameDayAction,
+                  'same day action needed',
                 ),
                 makePVCApproachingFullAlert(
                   'Home Directory Disk is full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'home-nfs',
                   0,
-                  immediateAction,
+                  'take immediate action',
                   '1m',
                 ),
                 makePVCApproachingFullAlert(
                   'Hub Database Disk about to be full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'hub-db-dir',
                   10,
-                  sameDayAction
+                  'same day action needed'
                 ),
                 makePVCApproachingFullAlert(
                   'Hub Database Disk is full: cluster:%s hub:{{ $labels.namespace }}' % [cluster_name],
                   'hub-db-dir',
                   0,
-                  immediateAction
+                  'take immediate action'
                 ),
                 makePVCApproachingFullAlert(
                   'Prometheus Disk about to be full: cluster:%s' % [cluster_name],
                   'support-prometheus-server',
                   10,
-                  sameDayAction
+                  'same day action needed'
                 ),
                 makePVCApproachingFullAlert(
                   'Prometheus Disk is full: cluster:%s' % [cluster_name],
                   'support-prometheus-server',
                   0,
-                  immediateAction
+                  'take immediate action'
                 ),
               ],
             },
@@ -306,7 +283,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 makeTwoServersStartupFailureAlert(
                   'At least two servers have failed to start in the last 30m: cluster %s hub:{{ $labels.namespace }}' % [cluster_name],
-                  immediateAction,
+                  'immediate action needed',
                 ),
               ],
             },
@@ -317,31 +294,31 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
                   'jupyterhub-cost-monitoring',
                   'jupyterhub-cost-monitoring pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '.*cost-monitoring.*',
-                  sameWeekAction
+                  'action needed this week'
                 ),
                 makePodRestartAlert(
                   'jupyterhub-groups-exporter',
                   'jupyterhub-groups-exporter pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '.*groups-exporter.*',
-                  sameWeekAction
+                  'action needed this week'
                 ),
                 makePodRestartAlert(
                   'jupyterhub-home-nfs',
                   'jupyterhub-home-nfs pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^storage-quota-home-nfs.*',
-                  sameDayAction
+                  'same day action needed'
                 ),
                 makePodRestartAlert(
                   'support-grafana',
                   'support-grafana pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^support-grafana.*',
-                  sameWeekAction
+                  'action needed this week'
                 ),
                 makePodRestartAlert(
                   'proxy',
                   'proxy pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
                   '^proxy.*',
-                  immediateAction
+                  'immediate action needed'
                 ),
               ],
             },
@@ -350,11 +327,11 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 makePodStuckInPendingForTooLongAlert(
                   'Pod is stuck in Pending state for a suspicious long time',
-                  sameWeekAction
+                  'action needed this week'
                 ),
                 makePodStuckInTerminatingForTooLongAlert(
                   'Pod is stuck in Terminating state for a suspicious long time',
-                  sameWeekAction
+                  'action needed this week'
                 ),
               ],
             },
@@ -363,17 +340,7 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
               rules: [
                 diskIOApproachingSaturation(
                   'Disk IO approaching saturation',
-                  sameWeekAction
-                ),
-              ],
-            },
-            {
-              name: 'Infrastructure Integrity',
-              rules: [
-                makeMissingKubeletVolumeMetricsAlert(
-                  'Kubelet volume metrics are not being reported',
-                  sameDayAction,
-                  '30m'
+                  'action needed this week'
                 ),
               ],
             },


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#8155

This failed jsonnet validation, due to missing `labels` key (see https://github.com/2i2c-org/infrastructure/actions/runs/24895352862)