### PR TITLE
prometheus: Fix node exporter scrape timeout

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -165,6 +165,11 @@ prometheus:
   server:
     retention: 1098d # Keep data for at least 3 years
 
+    global:
+      # node_exporter on some nodes can take upto 15s, so let's increase
+      # the timeout for each scrape
+      scrape_timeout: 30s
+
     ingress:
       ingressClassName: nginx
       annotations:


### PR DESCRIPTION
On cloudbank, we noticed that node exporter metrics were missing, even though the node exporter itself was running. The error was:

> time=2026-04-24T10:41:05.704Z level=ERROR source=http.go:231 msg="error encoding and sending metric family: write tcp 10.128.0.115:9100->10.0.132.95:55334: write: broken pipe"

Looking at those IPs, 10.128.0.115 was the node exporter, and 10.0.132.95 was the prometheus server. The directional arrow in the error message meant that after prometheus server requested info, as the node exporter was responding, the prometheus server cut off the connection, resulting in the 'broken pipe'. This immediately made me think of a timeout on the server.

I exec'd into the node exporter, and timed how long scrapes take, with `time wget 127.0.0.1:9200/metrics -O -`. It was roughly 15s. I then looked at the scrape timeout for prometheus server, and noticed the default is 10s! This explained the problem.

I don't know why prometheus node exporter takes 15s to respond to a simple metrics request on GCP, but that's ok. I've increased the timeout to 30s, and that seems to be bringing the metrics back. On
utoronto, some of these seem to take upto 25s.

Ref https://github.com/2i2c-org/infrastructure/issues/8162