### PR TITLE
Fix deployer exec promql

### DIFF
--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -472,13 +472,15 @@ class Cluster:
                 support_config = yaml.load(f)
 
         # Don't return the address if the prometheus instance wasn't securely exposed to the outside.
-        auth = support_config.get('prometheus', {}).get('server', {}).get('configmapReload', {}).get('prometheus')
+        auth = (
+            support_config.get("prometheus", {})
+            .get("server", {})
+            .get("configmapReload", {})
+            .get("prometheus")
+        )
         if auth is None:
             raise ValueError(
                 f"""`prometheus.configmapReload.prometheus` authentication wasn't configured for {self.spec["name"]}"""
             )
 
-        return (
-            auth["username"],
-            auth["password"]
-        )
+        return (auth["username"], auth["password"])

--- a/deployer/infra_components/cluster.py
+++ b/deployer/infra_components/cluster.py
@@ -444,14 +444,6 @@ class Cluster:
         with open(config_file) as f:
             support_config = yaml.load(f)
 
-        # Don't return the address if the prometheus instance wasn't securely exposed to the outside.
-        if not support_config.get("prometheusIngressAuthSecret", {}).get(
-            "enabled", False
-        ):
-            raise ValueError(
-                f"""`prometheusIngressAuthSecret` wasn't configured for {self.spec["name"]}"""
-            )
-
         tls_config = (
             support_config.get("prometheus", {})
             .get("server", {})
@@ -480,12 +472,13 @@ class Cluster:
                 support_config = yaml.load(f)
 
         # Don't return the address if the prometheus instance wasn't securely exposed to the outside.
-        if "prometheusIngressAuthSecret" not in support_config:
+        auth = support_config.get('prometheus', {}).get('server', {}).get('configmapReload', {}).get('prometheus')
+        if auth is None:
             raise ValueError(
-                f"""`prometheusIngressAuthSecret` wasn't configured for {self.spec["name"]}"""
+                f"""`prometheus.configmapReload.prometheus` authentication wasn't configured for {self.spec["name"]}"""
             )
 
         return (
-            support_config["prometheusIngressAuthSecret"]["users"][0]["username"],
-            support_config["prometheusIngressAuthSecret"]["users"][0]["password"],
+            auth["username"],
+            auth["password"]
         )


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/infrastructure/pull/8114, which puts credentials elsewhere