### PR TITLE
Bump version of prometheus

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   # cost. If we ever have multiple prometheii on the same cluster, we can
   # reconsider using the operator.
   - name: prometheus
-    version: 28.13.0
+    version: 29.2.1
     repository: https://prometheus-community.github.io/helm-charts
 
   # Grafana for dashboarding of metrics.


### PR DESCRIPTION
This brings new node_exporter I believe, which perhaps helps with performance trouble.

Ref https://github.com/2i2c-org/infrastructure/issues/8167