### PR TITLE
Move from DummyAuthenticator to SharedPasswordAuthenticator for workshops

### DIFF
--- a/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
@@ -7,13 +7,13 @@ basehub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-05-07T08:07:12Z"
-      enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-05-07T08:07:12Z'
+    enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-27T20:26:04Z"
+  lastmodified: '2026-04-27T20:26:04Z'
   mac: ENC[AES256_GCM,data:p6QBjXJ7y7OdQZPWk0coVlHeatB7bm1Zz0cOWPiA8MRtvqT2dBN5MBwaqvWKCF3kQkvnVOOLtSvA9tdCb9U6io9tku7X3JM9ZZ6RYL3qQjzCDjkwiyINxrGr5Fk4Zh7sFUiuE7ZzP20iagYCUgPnMSjmcuIptxEJS9msNozA83A=,iv:Wq8XcceqvAGq2gsgYteMe8RPYmsAwwzTj2UmXMfGbUE=,tag:I7cKPgS//n1RErdj2/vN7Q==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
@@ -2,14 +2,19 @@ basehub:
   jupyterhub:
     hub:
       config:
-        DummyAuthenticator:
-          password: ENC[AES256_GCM,data:67m3vfLTYQane0YUDXMX3W6ZEg9uQST3GH9Bnxh+pM84k2v/4BQ=,iv:Haf+iY8OqsoItEORu1eyJhQr/Pfb17onhEfn5EBVdF4=,tag:q3ptO78RYtKK93p4C+5fPw==,type:str]
+        SharedPasswordAuthenticator:
+          user_password: ENC[AES256_GCM,data:wEGow8B/3J2lwqqmEywIOZI3NxgcIBA8+GLkNs6URA+xo+ZNZIQ=,iv:Ftz4PKOaTcHQwiVPbi95dwsCSt7kMg1Ih3wvvXQnK58=,tag:IU85YP5P1NQRfqAwFB7qGA==,type:str]
 sops:
+  kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-05-07T08:07:12Z'
-    enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
-  lastmodified: '2026-04-08T13:08:36Z'
-  mac: ENC[AES256_GCM,data:GRBDbHnAyailB9DaRCB7efLLu1o0/KGjzeaRx8AYK5oHeWlz9L2yliViolCw0ZDXQv0SFxUfvC971Macj/1Z7RrdxzMH7+OobxHzHZ2A0DtBjlKh2kfg4h4bXAQTSDkSmZy5OxDmyLyouMpvs5Mcl2Uoa1ARwTVAiKeZLH7ZFW0=,iv:J+mVv7BNvRO7VbSdHBRkUlOYJ0PdSEfVoSIDjfvNp+Q=,tag:z8bPSrBs1QwwzBnLNnnlTg==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-05-07T08:07:12Z"
+      enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-04-27T20:26:04Z"
+  mac: ENC[AES256_GCM,data:p6QBjXJ7y7OdQZPWk0coVlHeatB7bm1Zz0cOWPiA8MRtvqT2dBN5MBwaqvWKCF3kQkvnVOOLtSvA9tdCb9U6io9tku7X3JM9ZZ6RYL3qQjzCDjkwiyINxrGr5Fk4Zh7sFUiuE7ZzP20iagYCUgPnMSjmcuIptxEJS9msNozA83A=,iv:Wq8XcceqvAGq2gsgYteMe8RPYmsAwwzTj2UmXMfGbUE=,tag:I7cKPgS//n1RErdj2/vN7Q==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -175,7 +175,7 @@ basehub:
     hub:
       config:
         JupyterHub:
-          authenticator_class: dummy
+          authenticator_class: shared-password
         GitHubOAuthenticator: {}
         Authenticator:
           manage_groups: false

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -14,6 +14,8 @@ basehub:
           hard_quota: 40 # in GiB
   jupyterhub:
     custom:
+      2i2c:
+        add_staff_user_ids_to_admin_users: false
       singleuserAdmin:
         extraVolumeMounts:
       homepage:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -180,3 +180,4 @@ basehub:
         Authenticator:
           manage_groups: false
           admin_users: []
+          allow_all: True

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -180,4 +180,4 @@ basehub:
         Authenticator:
           manage_groups: false
           admin_users: []
-          allow_all: True
+          allow_all: true

--- a/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
@@ -6,18 +6,19 @@ jupyterhub:
   hub:
     config:
       SharedPasswordAuthenticator:
-        user_password: ENC[AES256_GCM,data:yi+H0x4zgw==,iv:VkIrXAYnVcRaSRyN+ubRTXNJ6qBBW6dK8N1rDW81t0U=,tag:KbgylPmJOQaO2Lbwfo9szg==,type:str]
+        user_password: ENC[AES256_GCM,data:l1AXzU8nESs=,iv:degKfJQNihBclZUS6nwyZQtoXxTPNJwdwajI0KMDmCg=,tag:ODPsnzUH+iop1IbPHi6F9Q==,type:str]
+        admin_password: ENC[AES256_GCM,data:wny6FClnUEKvyws7ryQYBbn8gukUGX2365Yps9MJGoI=,iv:wiS7aHusbxbslqqbBcO/4leZjKIEZa4nuYyTYVgAqqQ=,tag:keb7nZweG0zIDOdUDnvKcQ==,type:str]
 sops:
   kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-01-09T15:19:55Z'
-    enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-01-09T15:19:55Z"
+      enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2026-04-27T20:27:37Z'
-  mac: ENC[AES256_GCM,data:AVffSdl7lrBcIL8fHdZs0PcAMjDk/TbFmGaZFkNCjNkWglDSpkiYeV1YAFUETKQ7lHJTJvRJkhb8VB6kCuPXf+N9g4JgDwplJHyxHvwFGlQQRho6gl+u3CJhFE45GTyGHS6ACautJp77/C6FjYAXRB8x6xe5MJVRUsLBAHWo/QA=,iv:UHz5fqfiThOBnCTYfyLVNNmykRDCrE0MFtt1BM6xvCo=,tag:0pwC0bAXRMxNCU4taatf1A==,type:str]
+  lastmodified: "2026-04-28T19:44:09Z"
+  mac: ENC[AES256_GCM,data:2eUlhcNOoOe8zLcj6T5dGfD6WwINEnOC/jDBt26c+wG+N7jBW0BZaMW5NDmiTsbQk29AuhfhxaOPqmuCU5l5Z4PnPBsdQ6rkJusjFqzZnlL5tCciQ8mAvpgBS44IvY3qJhlflDGlqvc72PyGWYsyg6T82SSOCiWpRkqbm0wmmGs=,iv:vcmTFCnoWEqIn4KXwTdC6rZ8MiTpYElWKl+BmdCvQ3o=,tag:LhbPkyuI9MnfINCOgXgN0A==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
@@ -11,13 +11,13 @@ jupyterhub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-01-09T15:19:55Z"
-      enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-01-09T15:19:55Z'
+    enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-28T19:44:09Z"
+  lastmodified: '2026-04-28T19:44:09Z'
   mac: ENC[AES256_GCM,data:2eUlhcNOoOe8zLcj6T5dGfD6WwINEnOC/jDBt26c+wG+N7jBW0BZaMW5NDmiTsbQk29AuhfhxaOPqmuCU5l5Z4PnPBsdQ6rkJusjFqzZnlL5tCciQ8mAvpgBS44IvY3qJhlflDGlqvc72PyGWYsyg6T82SSOCiWpRkqbm0wmmGs=,iv:vcmTFCnoWEqIn4KXwTdC6rZ8MiTpYElWKl+BmdCvQ3o=,tag:LhbPkyuI9MnfINCOgXgN0A==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
@@ -5,14 +5,19 @@ jupyterhub-home-nfs:
 jupyterhub:
   hub:
     config:
-      DummyAuthenticator:
-        password: ENC[AES256_GCM,data:JUaPwFr/3A==,iv:qYX7ooj8M7Ssp7CH5el1yXSoOD99yqLfcZD8frDWImw=,tag:NWNIu6axD8FPDiEs2o56bw==,type:str]
+      SharedPasswordAuthenticator:
+        user_password: ENC[AES256_GCM,data:yi+H0x4zgw==,iv:VkIrXAYnVcRaSRyN+ubRTXNJ6qBBW6dK8N1rDW81t0U=,tag:KbgylPmJOQaO2Lbwfo9szg==,type:str]
 sops:
+  kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-01-09T15:19:55Z'
-    enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
-  lastmodified: '2026-01-19T16:47:01Z'
-  mac: ENC[AES256_GCM,data:AFDge+505PwfAzccXfS8LVNTOjkT2v5AUoY6IUz50sieh+Ro+i8ikCCUzCWN998bn+1XryZq0CcIjL8+xE+f7gnZczLn9jq+Z7lJpvNM+YytO4YDXlg/QUMAz+1zajJiZ4+y/+cclP5kAFE/2mlijeHjNJWx5sfJojA6HsoEBQQ=,iv:USO4qCH/IQw+Yc8vtjkDZPEedQdkKc2ue2kvKKwFbc8=,tag:Vvec06CnPRuJzisEPeSRpQ==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-01-09T15:19:55Z"
+      enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-04-27T20:27:37Z"
+  mac: ENC[AES256_GCM,data:AVffSdl7lrBcIL8fHdZs0PcAMjDk/TbFmGaZFkNCjNkWglDSpkiYeV1YAFUETKQ7lHJTJvRJkhb8VB6kCuPXf+N9g4JgDwplJHyxHvwFGlQQRho6gl+u3CJhFE45GTyGHS6ACautJp77/C6FjYAXRB8x6xe5MJVRUsLBAHWo/QA=,iv:UHz5fqfiThOBnCTYfyLVNNmykRDCrE0MFtt1BM6xvCo=,tag:0pwC0bAXRMxNCU4taatf1A==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
+++ b/config/clusters/nmfs-openscapes/enc-workshop.secret.values.yaml
@@ -10,13 +10,13 @@ jupyterhub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-01-09T15:19:55Z"
-      enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-01-09T15:19:55Z'
+    enc: CiUA4OM7eGez8KDuQZXma3aE2ZS9b3HenoeE9zJDAt9k+DMfqFVMEkkAnGhyNvSoFbF+zxcX/4id6Slvrld7haauv8LWoKhnKNroAKcT7U9aEqy80YJrXAMKJeuaWBgcTZUtpulxNqhb5FltsbNX8eY1
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-27T20:27:37Z"
+  lastmodified: '2026-04-27T20:27:37Z'
   mac: ENC[AES256_GCM,data:AVffSdl7lrBcIL8fHdZs0PcAMjDk/TbFmGaZFkNCjNkWglDSpkiYeV1YAFUETKQ7lHJTJvRJkhb8VB6kCuPXf+N9g4JgDwplJHyxHvwFGlQQRho6gl+u3CJhFE45GTyGHS6ACautJp77/C6FjYAXRB8x6xe5MJVRUsLBAHWo/QA=,iv:UHz5fqfiThOBnCTYfyLVNNmykRDCrE0MFtt1BM6xvCo=,tag:0pwC0bAXRMxNCU4taatf1A==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -32,7 +32,7 @@ jupyterhub:
     allowNamedServers: true
     config:
       JupyterHub:
-        authenticator_class: dummy
+        authenticator_class: shared-password
       Authenticator:
         manage_groups: false
         enable_auth_state: false

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -15,14 +15,10 @@ dask-gateway:
 
 jupyterhub:
   custom:
-    2i2c:
-      add_staff_user_ids_to_admin_users: false
     homepage:
       # Remove once https://github.com/2i2c-org/default-hub-homepage/pull/51
       # is merged
       gitRepoBranch: unify-logins-2
-    singleuserAdmin:
-      extraVolumeMounts:
   ingress:
     hosts: [workshop.nmfs-openscapes.2i2c.cloud]
     tls:
@@ -36,7 +32,6 @@ jupyterhub:
       Authenticator:
         manage_groups: false
         enable_auth_state: false
-        admin_users: []
         allow_all: true
   singleuser:
     storage:

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -37,6 +37,7 @@ jupyterhub:
         manage_groups: false
         enable_auth_state: false
         admin_users: []
+        allow_all: true
   singleuser:
     storage:
       extraVolumeMounts:

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -2,14 +2,19 @@ basehub:
   jupyterhub:
     hub:
       config:
-        DummyAuthenticator:
-          password: ENC[AES256_GCM,data:tweGHv0b9w==,iv:Gol8p3QohWfrR6Xc9Ekwo1wHYRVf8lN5oABuM1JTnNY=,tag:cBpNVtks681QiPjXmnxDuA==,type:str]
+        SharedPasswordAuthenticator:
+          user_password: ENC[AES256_GCM,data:mSkc0AQ0FA==,iv:sey+5Maz97nEBxg+hVW3rzMrmW87wi12H5vqjUOyxU8=,tag:Q4NWaCtucuHjUnO6Pfn7/Q==,type:str]
 sops:
+  kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-08-07T13:17:08Z'
-    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
-  lastmodified: '2026-01-06T17:47:43Z'
-  mac: ENC[AES256_GCM,data:ueofKKmU+xafe7bLWzZ3EJ+vbTjadCDa3xXNEtjnvHcDeUHfUHCO1X1DD4pNdiZXuOUoYBpluGte49bWLVPBtK1L7tIj3vkg9CxUVtqel2shiM3TQctykqHlv5DRFidnyWbe5EPJU3/2D0ORY4nfZ7vo6bsLUztva9Tgrd3VeEY=,iv:/yER8KxoMaQ+wpNwPUnWAD+PFitAJfk1l35DupUXtrY=,tag:LPxKubyVsKxvKDvPET2H1Q==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-08-07T13:17:08Z"
+      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-04-27T20:28:11Z"
+  mac: ENC[AES256_GCM,data:Fezw2Bf9H8astP5Edpv+yllHKzeClkiJsHHypAI7Zy36BTWPhByGctWGXeCXOZICW13IK+QdWIsvTFY4fYBCnulmF0Y1AstUlBbUeakk1I6Nd4aFxsrfMWzvCdGlPNAsXop3FZuwMLwQV+/bMjY3tMNka4Z4uDc8CV8TeMgfHCM=,iv:w3KWSbxiU6qxPYsO/xWqa8QZ8ncNMhL8PnAgXTVDHsg=,tag:IvWhgIDn+HKA/WkQzismnw==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -7,13 +7,13 @@ basehub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-08-07T13:17:08Z"
-      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-08-07T13:17:08Z'
+    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-27T20:28:11Z"
+  lastmodified: '2026-04-27T20:28:11Z'
   mac: ENC[AES256_GCM,data:Fezw2Bf9H8astP5Edpv+yllHKzeClkiJsHHypAI7Zy36BTWPhByGctWGXeCXOZICW13IK+QdWIsvTFY4fYBCnulmF0Y1AstUlBbUeakk1I6Nd4aFxsrfMWzvCdGlPNAsXop3FZuwMLwQV+/bMjY3tMNka4Z4uDc8CV8TeMgfHCM=,iv:w3KWSbxiU6qxPYsO/xWqa8QZ8ncNMhL8PnAgXTVDHsg=,tag:IvWhgIDn+HKA/WkQzismnw==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -3,18 +3,19 @@ basehub:
     hub:
       config:
         SharedPasswordAuthenticator:
-          user_password: ENC[AES256_GCM,data:mSkc0AQ0FA==,iv:sey+5Maz97nEBxg+hVW3rzMrmW87wi12H5vqjUOyxU8=,tag:Q4NWaCtucuHjUnO6Pfn7/Q==,type:str]
+          user_password: ENC[AES256_GCM,data:N8kNL3FuAiMZ,iv:Bel8zLH5X5NkMLM78968VdlZmTYuAe99jl0m/QePwv4=,tag:LJc3MiXz3y7OX70D5fxC5A==,type:str]
+          admin_password: ENC[AES256_GCM,data:fToycIA4LmyMoKpqqcLsq6KrjQiEr3C8bnnU/2r7j8A=,iv:8NzCzHhPrVvnqMEuDXpv5T7+qqzQb6Ka8AhN8Bqfx1g=,tag:E5gRxuIBS821RAs1C3ePCg==,type:str]
 sops:
   kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-08-07T13:17:08Z'
-    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-08-07T13:17:08Z"
+      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2026-04-27T20:28:11Z'
-  mac: ENC[AES256_GCM,data:Fezw2Bf9H8astP5Edpv+yllHKzeClkiJsHHypAI7Zy36BTWPhByGctWGXeCXOZICW13IK+QdWIsvTFY4fYBCnulmF0Y1AstUlBbUeakk1I6Nd4aFxsrfMWzvCdGlPNAsXop3FZuwMLwQV+/bMjY3tMNka4Z4uDc8CV8TeMgfHCM=,iv:w3KWSbxiU6qxPYsO/xWqa8QZ8ncNMhL8PnAgXTVDHsg=,tag:IvWhgIDn+HKA/WkQzismnw==,type:str]
+  lastmodified: "2026-04-28T19:43:43Z"
+  mac: ENC[AES256_GCM,data:8RXj1vMzHS8b13qad2aJ52FMxrpakSTIw5xsiCcfZd2G12EpfvXV2+rxBI45zO5ErpgX/zAK/aYYyqJj6LB9Yi99cI62s5BIMHHWkXMcC95FH0FSfgsMWbgXRSuYs5VzOFcXplxJiC8zyk5BTQqVaFbG+1GzhCFIlnbdaEd1cFc=,iv:Rz0o1/aUx6+Lap2tQvV/rG25kZmt7wyv0dOiyIoiJlo=,tag:6S9fiDQdNloKri1QJNXHdA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
+++ b/config/clusters/openscapeshub/enc-workshop.secret.values.yaml
@@ -8,13 +8,13 @@ basehub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-08-07T13:17:08Z"
-      enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-08-07T13:17:08Z'
+    enc: CiUA4OM7eK/VsLTEtsrCh8V+s/m56JPwDsKI3mIE2+sMDVgsZRstEkkAXpa10DqAg6p8ZMfa5mZpJHr9S+C7Nj3FEh1eb5d0a1jju6HzcHi01x0rLTa2DB2b5sVthiKLT5l4SpkKBW0iPAwl3rXOBmNB
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-28T19:43:43Z"
+  lastmodified: '2026-04-28T19:43:43Z'
   mac: ENC[AES256_GCM,data:8RXj1vMzHS8b13qad2aJ52FMxrpakSTIw5xsiCcfZd2G12EpfvXV2+rxBI45zO5ErpgX/zAK/aYYyqJj6LB9Yi99cI62s5BIMHHWkXMcC95FH0FSfgsMWbgXRSuYs5VzOFcXplxJiC8zyk5BTQqVaFbG+1GzhCFIlnbdaEd1cFc=,iv:Rz0o1/aUx6+Lap2tQvV/rG25kZmt7wyv0dOiyIoiJlo=,tag:6S9fiDQdNloKri1QJNXHdA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -26,6 +26,7 @@ basehub:
           enable_auth_state: false
           manage_groups: false
           admin_users: []
+          allow_all: true
     singleuser:
       storage:
         extraVolumeMounts:

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -4,14 +4,10 @@ basehub:
       serverIP: 10.100.130.27
   jupyterhub:
     custom:
-      2i2c:
-        add_staff_user_ids_to_admin_users: false
       homepage:
         # Remove once https://github.com/2i2c-org/default-hub-homepage/pull/51
         # is merged
         gitRepoBranch: unify-logins-2
-      singleuserAdmin:
-        extraVolumeMounts:
     ingress:
       hosts: [workshop.openscapes.2i2c.cloud]
       tls:
@@ -25,7 +21,6 @@ basehub:
         Authenticator:
           enable_auth_state: false
           manage_groups: false
-          admin_users: []
           allow_all: true
     singleuser:
       storage:

--- a/config/clusters/openscapeshub/workshop.values.yaml
+++ b/config/clusters/openscapeshub/workshop.values.yaml
@@ -21,7 +21,7 @@ basehub:
       allowNamedServers: true
       config:
         JupyterHub:
-          authenticator_class: dummy
+          authenticator_class: shared-password
         Authenticator:
           enable_auth_state: false
           manage_groups: false

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -38,6 +38,8 @@ jupyterhub:
         authenticator_class: shared-password
       Authenticator:
         admin_users: []
+        allow_all: true
+        manage_groups: false
   singleuser:
     defaultUrl: /lab/tree/climaterisk/book/Startup.ipynb
     image:

--- a/config/clusters/opensci/climaterisk.values.yaml
+++ b/config/clusters/opensci/climaterisk.values.yaml
@@ -35,7 +35,7 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: dummy
+        authenticator_class: shared-password
       Authenticator:
         admin_users: []
   singleuser:

--- a/config/clusters/opensci/enc-climaterisk.secret.values.yaml
+++ b/config/clusters/opensci/enc-climaterisk.secret.values.yaml
@@ -10,13 +10,13 @@ jupyterhub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2024-06-24T17:36:36Z"
-      enc: CiUA4OM7eBOWzH84tMOe7jjDSg2wPYXmAsw5XLCvoLipuJM8B0W6EkkAWX/fcSGMljZmaoawQPw5HvUWEzawvsgq1gRdKlZoGoc/36i3LAgVcl3Xf6uYhOpZjlVQM1SdIr+Z6cwILVX2CM3ZT4tyqgdU
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2024-06-24T17:36:36Z'
+    enc: CiUA4OM7eBOWzH84tMOe7jjDSg2wPYXmAsw5XLCvoLipuJM8B0W6EkkAWX/fcSGMljZmaoawQPw5HvUWEzawvsgq1gRdKlZoGoc/36i3LAgVcl3Xf6uYhOpZjlVQM1SdIr+Z6cwILVX2CM3ZT4tyqgdU
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-27T20:28:41Z"
+  lastmodified: '2026-04-27T20:28:41Z'
   mac: ENC[AES256_GCM,data:DoLLjCFuW3uv31FxZy3YaLEZuFOTGxoZBOrh4wphZuibNMXv2XGRqpkFyYtCFYWgFxYSRGHaXoHMYLUUOFMu5HSEC0yJkpprTyQh2XnhdOBc/A1oZjeVEkciUbw4qHCa/cXqxfV4LvWka48+Veyq4t/It46TGBKR3XPENw5A7Mc=,iv:NrY0YS+xHbZFsLXd3q6Po1xIZXAFJsOgagWuSB3dTUk=,tag:xX0iHgNuolh6Yq7kPHttyQ==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/opensci/enc-climaterisk.secret.values.yaml
+++ b/config/clusters/opensci/enc-climaterisk.secret.values.yaml
@@ -5,14 +5,19 @@ jupyterhub-home-nfs:
 jupyterhub:
   hub:
     config:
-      DummyAuthenticator:
-        password: ENC[AES256_GCM,data:FoskWC+mXyn53zQ=,iv:rRlNVFHzafzhk7XKsIULSxDTWCxiFt3bwdsuMV3gIgI=,tag:wF7gysYqwPSWqItsK+gX1Q==,type:str]
+      SharedPasswordAuthenticator:
+        password: ENC[AES256_GCM,data:4+J12pe60LmGHp8=,iv:XtXtvpLR1rbdCuBx14wFdngtos68onHMtB53LBOLybc=,tag:rqaGyF0nhDhTJbzTU6xemw==,type:str]
 sops:
+  kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2024-06-24T17:36:36Z'
-    enc: CiUA4OM7eBOWzH84tMOe7jjDSg2wPYXmAsw5XLCvoLipuJM8B0W6EkkAWX/fcSGMljZmaoawQPw5HvUWEzawvsgq1gRdKlZoGoc/36i3LAgVcl3Xf6uYhOpZjlVQM1SdIr+Z6cwILVX2CM3ZT4tyqgdU
-  lastmodified: '2025-10-20T13:02:56Z'
-  mac: ENC[AES256_GCM,data:r3wLYhefzVvx0H3gsOSv/2IN0NHEF0V9DUqhTmciUv9J0SOENqvJsaro8k8d/f0taVaob3zfIH7EZUF+8YdIqK1EQzteUYlxmhQ2yLLPYSgLs1ajgpqiz0lVlFy4VaW705NsZnzf/aFvef/FXi8pOqk99kOlRf/KSTjo9EjnvC8=,iv:bt70AC6D5lwxx7MneJSgZ9VS9aWAPHxiTIIZbpqjmOo=,tag:CoXpNXilsKLpHSKvAOcyZw==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2024-06-24T17:36:36Z"
+      enc: CiUA4OM7eBOWzH84tMOe7jjDSg2wPYXmAsw5XLCvoLipuJM8B0W6EkkAWX/fcSGMljZmaoawQPw5HvUWEzawvsgq1gRdKlZoGoc/36i3LAgVcl3Xf6uYhOpZjlVQM1SdIr+Z6cwILVX2CM3ZT4tyqgdU
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-04-27T20:28:41Z"
+  mac: ENC[AES256_GCM,data:DoLLjCFuW3uv31FxZy3YaLEZuFOTGxoZBOrh4wphZuibNMXv2XGRqpkFyYtCFYWgFxYSRGHaXoHMYLUUOFMu5HSEC0yJkpprTyQh2XnhdOBc/A1oZjeVEkciUbw4qHCa/cXqxfV4LvWka48+Veyq4t/It46TGBKR3XPENw5A7Mc=,iv:NrY0YS+xHbZFsLXd3q6Po1xIZXAFJsOgagWuSB3dTUk=,tag:xX0iHgNuolh6Yq7kPHttyQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/config/clusters/reflective/enc-workshop.secret.values.yaml
+++ b/config/clusters/reflective/enc-workshop.secret.values.yaml
@@ -1,19 +1,19 @@
 jupyterhub:
   hub:
     config:
-      DummyAuthenticator:
-        password: ENC[AES256_GCM,data:mI44ouyNut3vGoX2JtqL,iv:ZUKViNjEQFcPPX9tuTyIk6n37V1kwHC36HFWUZwXK2w=,tag:yTKIhoDVN+AOn7dcwkPJEA==,type:str]
+      SharedPasswordAuthenticator:
+        user_password: ENC[AES256_GCM,data:/mKfDzGnUHuSB/MqS3Ph,iv:RbyFsF4CVgLuAlsATlrPP/4vpP0OlpwlU4j/eyN0CvE=,tag:IrRD8s6flLQnpyrovxjRoQ==,type:str]
 sops:
   kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-04-11T09:58:17Z'
-    enc: CiUA4OM7eFlVc72nV+TuQ5lymnGxKd59TY5jUXNmbdvNP6F1cP3sEkkAWOWv8N3LmcXJNED84UAFnxpcUKcNe7/39QWFmn/Rn7GrFgzKyMVV/MR6g2jBm2jpCu8lu5tm5sh+TGOdxkUNzOhHnKuAr7C7
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2025-04-11T09:58:17Z"
+      enc: CiUA4OM7eFlVc72nV+TuQ5lymnGxKd59TY5jUXNmbdvNP6F1cP3sEkkAWOWv8N3LmcXJNED84UAFnxpcUKcNe7/39QWFmn/Rn7GrFgzKyMVV/MR6g2jBm2jpCu8lu5tm5sh+TGOdxkUNzOhHnKuAr7C7
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2025-04-22T20:19:44Z'
-  mac: ENC[AES256_GCM,data:t6A11ryZBrQ8u1efqrY+mPhGEJYU9QmmUTId3r5FeZFq5hGKyEwfKRJzN2409rL0dtT/NGfnyz8uZHp7OFd+FDFEvv4T+/DDKia0kKvhNfYil9DMjXf0LCdNQJE2psJZf01Z7kvIgc1WnDg5fVHRtsJmOQB4uuEvjwoWu4AL1+c=,iv:mhMPEmMxMc0c0FVG/0Xxnn7aOy3Q9KdiXtNq5ymVvro=,tag:zbBgPP10osOI1QsAhMVOsQ==,type:str]
+  lastmodified: "2026-04-27T20:30:52Z"
+  mac: ENC[AES256_GCM,data:VMZZMlzoLbk+RPpE8PnlxJ4SzibFxWhLLq2E8wihvQ9CXt0SLsrOoiFVpVGPoFOdDOIOuI4hdK3MyQoaJUN4erPWUBAzs1KK5cF5mXYrtALwK136m53VRIX/U3HrAbpFfHXR+vqNCQTdLOxKYjFLHXHaXzjPzTZErxio4MEnmq4=,iv:Aogkz9pwRsLgvvbRHCfsGZWTj1XeGxQ/NNuMLOpJeHM=,tag:Vp+k8vxuOLwc3lo1gXhbKg==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.1

--- a/config/clusters/reflective/enc-workshop.secret.values.yaml
+++ b/config/clusters/reflective/enc-workshop.secret.values.yaml
@@ -6,13 +6,13 @@ jupyterhub:
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2025-04-11T09:58:17Z"
-      enc: CiUA4OM7eFlVc72nV+TuQ5lymnGxKd59TY5jUXNmbdvNP6F1cP3sEkkAWOWv8N3LmcXJNED84UAFnxpcUKcNe7/39QWFmn/Rn7GrFgzKyMVV/MR6g2jBm2jpCu8lu5tm5sh+TGOdxkUNzOhHnKuAr7C7
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2025-04-11T09:58:17Z'
+    enc: CiUA4OM7eFlVc72nV+TuQ5lymnGxKd59TY5jUXNmbdvNP6F1cP3sEkkAWOWv8N3LmcXJNED84UAFnxpcUKcNe7/39QWFmn/Rn7GrFgzKyMVV/MR6g2jBm2jpCu8lu5tm5sh+TGOdxkUNzOhHnKuAr7C7
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-04-27T20:30:52Z"
+  lastmodified: '2026-04-27T20:30:52Z'
   mac: ENC[AES256_GCM,data:VMZZMlzoLbk+RPpE8PnlxJ4SzibFxWhLLq2E8wihvQ9CXt0SLsrOoiFVpVGPoFOdDOIOuI4hdK3MyQoaJUN4erPWUBAzs1KK5cF5mXYrtALwK136m53VRIX/U3HrAbpFfHXR+vqNCQTdLOxKYjFLHXHaXzjPzTZErxio4MEnmq4=,iv:Aogkz9pwRsLgvvbRHCfsGZWTj1XeGxQ/NNuMLOpJeHM=,tag:Vp+k8vxuOLwc3lo1gXhbKg==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted

--- a/config/clusters/reflective/workshop.values.yaml
+++ b/config/clusters/reflective/workshop.values.yaml
@@ -6,7 +6,8 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::916143380841:role/reflective-workshop
 jupyterhub:
   custom:
-    2i2c: {}
+    2i2c:
+      add_staff_user_ids_to_admin_users: false
     homepage:
       templateVars:
         learn_more: |

--- a/config/clusters/reflective/workshop.values.yaml
+++ b/config/clusters/reflective/workshop.values.yaml
@@ -30,6 +30,7 @@ jupyterhub:
         admin_users: []
         enable_auth_state: false
         manage_groups: false
+        allow_all: true
   singleuser:
     nodeSelector:
       2i2c/hub-name: workshop

--- a/config/clusters/reflective/workshop.values.yaml
+++ b/config/clusters/reflective/workshop.values.yaml
@@ -25,7 +25,7 @@ jupyterhub:
     config:
       GitHubOAuthenticator: {}
       JupyterHub:
-        authenticator_class: dummy
+        authenticator_class: shared-password
       Authenticator:
         admin_users: []
         enable_auth_state: false

--- a/docs/hub-deployment-guide/configure-auth/shared-password.md
+++ b/docs/hub-deployment-guide/configure-auth/shared-password.md
@@ -1,7 +1,13 @@
 # Shared Password Authentication
 
-This documentation covers setting up a hub to have a shared password for login using the [Dummy Authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#the-dummy-authenticator)
-for a hub.
+This documentation covers setting up a hub to have a shared password for login using the
+[Shared Password Authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#shared-password-authenticator)
+
+```{note}
+We used to use the
+[Dummy Authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#the-dummy-authenticator)
+instead. That is deprecated
+```
 
 For this section, it may be useful to set the following environment variables in your terminal.
 
@@ -26,99 +32,52 @@ jupyterhub:
       # Remove once https://github.com/2i2c-org/default-hub-homepage/pull/51
       # is merged
       gitRepoBranch: unify-logins-2
-      templateVars: [...]  # These values are as normal
 ```
 
-## Using a global password
+## Set a *regular* user password and an *admin* password
 
-We **only** support using a global password with this method of authentication.
-A global password is simple to distribute to a large group of people for a specific event, such as a workshop, while still locking the hub down from the public which can protect it from cryptomining abuse.
+When using the shared password method, you can have *two* passwords:
 
-Enable the Dummy Authenticator in the `${HUB_NAME}.values.yaml` file with the following config.
+1. A *regular* user password, to be distributed to all users. Anyone can login with this
+   password and an arbitrary username. This *must* be at least **8 characters** in length.
+
+2. (Optional) An *admin* user password, to be distributed *just* to admins. Anyone whose name is
+   listed as an admin user (through `Authenticator.admin_users` config) can log in when
+   using this admin password. This must be at least **32 characters** in length, as admin
+   users have additional powers (such as shared directory access, being able to list of
+   users logged in, access anyone's home directory, etc).
+
+Enable the Shared Password Authenticator in the `${HUB_NAME}.values.yaml` file with the following config.
 
 ```yaml
 jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: dummy
+        authenticator_class: shared-password
+        Authenticator:
+          # We don't use the per-group password feature of shared-passwords yet
+          manage_groups: false
+          # Allow everyone with the password to log in
+          allow_all: true
+          # List of admin users, *if* admin_password is set in the next step
+          admin_users:
+          - <admin1>
+          - <admin2>
 ```
 
-Then, in a `${HUB_NAME}.secret.values.yaml` file, include the password.
+Then, in the `sops` encrypted `enc-${HUB_NAME}.secret.values.yaml` file, include the passwords.
 
 ```yaml
 jupyterhub:
   hub:
     config:
-      DummyAuthenticator:
-        password: <password>
+      SharedPasswordAuthenticator:
+        user_password: <password>
 ```
 
-You can then encrypt the password using the below `sops` command.
-
-```bash
-sops --output config/clusters/${CLUSTER_NAME}/enc-${HUB_NAME}.secret.values.yaml -e config/clusters/${CLUSTER_NAME}/${HUB_NAME}.secret.values.yaml
-```
-
-Ensure both these files are listed in the related `cluster.yaml` file.
-
-```yaml
-[...]
-hubs:
-  - name: ...
-    display_name: ...
-    domain: ...
-    helm_chart: ...
-    helm_chart_values_files:
-      - ${HUB_NAME}.values.yaml
-      - enc-${HUB_NAME}.secret.values.yaml
-```
 
 ### How the community should request changing the password
 
-If the community wishes to change the global password, they should do so by [submitting a ticket the support team](https://docs.2i2c.org/support/).
-
-## Disabling admin users
-
-Since using the Dummy Authenticator will allow any username with the correct password to login, this opens scope for a user to login with an admin username and gain admin rights.
-Hence, we disable all admins on the hub to prevent this.
-We do this by not providing anything to `jupyterhub.hub.config.Authenticator.admin_users`.
-
-However if the hub is sharing config with another, e.g. via a `common.values.yaml` file, you may need to explicitly disable admin users with the following config in the `${HUB_NAME}.values.yaml` file.
-
-```yaml
-jupyterhub:
-  hub:
-    config:
-      Authenticator:
-        admin_users: []
-```
-
-## Disabling shared/shared-read-write directories
-
-Since there are no admin users on shared passwords hub, there's no point in having a shared directory.
-We can disable this by setting the following in the `${HUB_NAME}.values.yaml` file.
-
-```yaml
-jupyterhub:
-  custom:
-    singleuserAdmin:
-      extraVolumeMounts:
-  singleuser:
-    initContainers:
-      - name: volume-mount-ownership-fix
-        image: busybox:1.36.1
-        command:
-          - sh
-          - -c
-          - id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: home
-            mountPath: /home/jovyan
-            subPath: "{escaped_username}"
-    storage:
-      extraVolumeMounts:
-      extraVolumes:
-```
+If the community wishes to change the global password or the admin, they should
+do so by [submitting a ticket the support team](https://docs.2i2c.org/support/).


### PR DESCRIPTION
I contributed https://github.com/jupyterhub/jupyterhub/pull/5037 a while back, and it's come back to us after our latest z2jh upgrade. This lets us re-offer admin access (and eventually groups) for our workshop hubs, and is already in use for cloudbank/gpu-demo (which needed it for the shared-readwrite to work).

Ref https://github.com/2i2c-org/infrastructure/issues/7864