### PR TITLE
Set up cloudwatch credentials for grafana

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -173,7 +173,15 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
     },
   };
 
+
   {
+    grafana: {
+      serviceAccount: {
+        annotations: if provider_name == 'aws' then {
+          'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/jupyterhub_grafana_cloudwatch' % VARS_2I2C_AWS_ACCOUNT_ID,
+        } else {}
+      }
+    },
     prometheus: {
       alertmanager: {
         enabled: true,

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -179,8 +179,8 @@ function(VARS_2I2C_AWS_ACCOUNT_ID=null)
       serviceAccount: {
         annotations: if provider_name == 'aws' then {
           'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/jupyterhub_grafana_cloudwatch' % VARS_2I2C_AWS_ACCOUNT_ID,
-        } else {}
-      }
+        } else {},
+      },
     },
     prometheus: {
       alertmanager: {

--- a/terraform/aws/grafana.tf
+++ b/terraform/aws/grafana.tf
@@ -1,0 +1,56 @@
+// Cost monitoring resources for IAM role and cost allocation tags.
+// Note: if the name of the IAM role is changed, then update the config in helm-charts/support/values.jsonnet for the k8s service account annotation.
+
+resource "aws_iam_role" "jupyterhub_grafana_cloudwatch" {
+  name = "jupyterhub_grafana_cloudwatch"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow",
+      Action = "sts:AssumeRoleWithWebIdentity",
+      Principal = {
+        Federated = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}"
+      },
+
+      Condition = {
+        StringEquals = {
+          "${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}:sub" = "system:serviceaccount:support:support-grafana"
+        }
+      },
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "jupyterhub_grafana_cloudwatch" {
+  name  = "jupyterhub_grafana_cloudwatch"
+  role  = aws_iam_role.jupyterhub_grafana_cloudwatch.name
+  # ref: https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/configure/#iam-policy-examples
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowReadingMetricsFromCloudWatch",
+        "Effect": "Allow",
+        "Action": [
+          "CloudWatch:DescribeAlarmsForMetric",
+          "CloudWatch:DescribeAlarmHistory",
+          "CloudWatch:DescribeAlarms",
+          "CloudWatch:ListMetrics",
+          "CloudWatch:GetMetricData",
+          "CloudWatch:GetInsightRuleReport"
+        ],
+        "Resource": "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policies_exclusive" "jupyterhub_grafana_cloudwatch" {
+  role_name    = aws_iam_role.jupyterhub_grafana_cloudwatch.name
+  policy_names = [aws_iam_role_policy.jupyterhub_grafana_cloudwatch.name]
+}
+
+output "jupyterhub_grafana_cloudwatch_k8s_sa_annotation" {
+  value = "eks.amazonaws.com/role-arn: ${aws_iam_role.jupyterhub_grafana_cloudwatch.arn}"
+}

--- a/terraform/aws/grafana.tf
+++ b/terraform/aws/grafana.tf
@@ -23,16 +23,16 @@ resource "aws_iam_role" "jupyterhub_grafana_cloudwatch" {
 }
 
 resource "aws_iam_role_policy" "jupyterhub_grafana_cloudwatch" {
-  name  = "jupyterhub_grafana_cloudwatch"
-  role  = aws_iam_role.jupyterhub_grafana_cloudwatch.name
+  name = "jupyterhub_grafana_cloudwatch"
+  role = aws_iam_role.jupyterhub_grafana_cloudwatch.name
   # ref: https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/configure/#iam-policy-examples
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Sid": "AllowReadingMetricsFromCloudWatch",
-        "Effect": "Allow",
-        "Action": [
+        "Sid" : "AllowReadingMetricsFromCloudWatch",
+        "Effect" : "Allow",
+        "Action" : [
           "CloudWatch:DescribeAlarmsForMetric",
           "CloudWatch:DescribeAlarmHistory",
           "CloudWatch:DescribeAlarms",
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy" "jupyterhub_grafana_cloudwatch" {
           "CloudWatch:GetMetricData",
           "CloudWatch:GetInsightRuleReport"
         ],
-        "Resource": "*"
+        "Resource" : "*"
       }
     ]
   })


### PR DESCRIPTION
- Sets up an appropriate role for grafana to access just cloudwatch metrics, so we can make dashboards that rely on 'source of truth' for throttling (like iops / throughput on EBS volumes)
- Automatically and unconditionally sets up the appropriate grafana annotation, so this is unconditionally enabled for all clusters

Ref https://github.com/2i2c-org/infrastructure/issues/8178

To be applied to:

- [x] 2i2c-aws-us
- [x] aimatx-2i2c-hub
- [x] berkeley-geojupyter
- [x] bnext-bio
- [ ] disasters
- [x] earthscope
- [x] jupyter-health
- [x] maap
- [x] nasa-cryo
- [x] nasa-ghg-hub
- [x] nasa-veda
- [x] nmfs-openscapes
- [x] openscapeshub
- [x] opensci
- [x] projectpythia
- [x] reflective
- [x] smithsonian
- [x] template
- [x] temple
- [x] ucmerced
- [x] victor
