### PR TITLE
Always run the report job

### DIFF
--- a/.github/workflows/pagerduty-triggered-health-check.yaml
+++ b/.github/workflows/pagerduty-triggered-health-check.yaml
@@ -45,12 +45,12 @@ jobs:
   report_status:
     needs: [get_incident_details, health_check]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
     - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Report Status
-      if: always()
       uses: ravsamhq/notify-slack-action@v2
       with:
         notify_when: success,failure


### PR DESCRIPTION
I noticed it was skipped if the health check is unsuccessful. It's entire job is to report back to slack if this happens.
So we always run the _job_ (not the step)