### PR TITLE
Explicitly set the binder callback url

### DIFF
--- a/config/clusters/earthscope/binder.values.yaml
+++ b/config/clusters/earthscope/binder.values.yaml
@@ -142,6 +142,7 @@ jupyterhub:
         authorize_url: https://login.earthscope.org/authorize
         userdata_url: https://login.earthscope.org/userinfo
         logout_redirect_url: https://login.earthscope.org/v2/logout?client_id=2PbhUTbRU6e7uIaaEZIShotx15MbvsJJ
+        oauth_callback_url: https://hub.binder.geolab.earthscope.cloud/hub/oauth_callback
     redirectToServer: false
     loadRoles:
       binder:


### PR DESCRIPTION
Follow-up to #8053 
Fixes https://github.com/2i2c-org/infrastructure/issues/8184