### PR TITLE
Automatically set oauth_callback_url

### DIFF
--- a/config/clusters/2i2c-aws-us/showcase.values.yaml
+++ b/config/clusters/2i2c-aws-us/showcase.values.yaml
@@ -44,7 +44,6 @@ basehub:
     hub:
       config:
         GitHubOAuthenticator:
-          oauth_callback_url: https://showcase.2i2c.cloud/hub/oauth_callback
           allowed_organizations:
           - 2i2c-community-showcase:access-2i2c-showcase
           - 2i2c-community-showcase:magiclinks-demo

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -33,10 +33,6 @@ jupyterhub:
         funded_by:
           name: 2i2c
           url: https://2i2c.org
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.aws.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/config/clusters/2i2c-jetstream2/staging.values.yaml
+++ b/config/clusters/2i2c-jetstream2/staging.values.yaml
@@ -59,8 +59,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.js.2i2c.cloud/hub/oauth_callback
   singleuser:
     defaultUrl: /lab
     nodeSelector:

--- a/config/clusters/2i2c-uk/lis.values.yaml
+++ b/config/clusters/2i2c-uk/lis.values.yaml
@@ -88,7 +88,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://ds.lis.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - lisacuk
       Authenticator:

--- a/config/clusters/2i2c-uk/staging.values.yaml
+++ b/config/clusters/2i2c-uk/staging.values.yaml
@@ -40,7 +40,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://staging.uk.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/2i2c/dask-staging.values.yaml
+++ b/config/clusters/2i2c/dask-staging.values.yaml
@@ -41,7 +41,6 @@ basehub:
         JupyterHub:
           authenticator_class: cilogon
         CILogonOAuthenticator:
-          oauth_callback_url: https://dask-staging.2i2c.cloud/hub/oauth_callback
           allowed_idps:
             http://google.com/accounts/o8/id:
               default: true

--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://mtu.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           # Allow MTU to login via Shibboleth
           https://sso.mtu.edu/idp/shibboleth:

--- a/config/clusters/2i2c/staging.values.yaml
+++ b/config/clusters/2i2c/staging.values.yaml
@@ -30,7 +30,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://staging.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/aimatx-2i2c-hub/prod.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/prod.values.yaml
@@ -12,10 +12,6 @@ jupyterhub:
     tls:
     - hosts: [aimatx.2i2c.cloud]
       secretName: https-auto-tls
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://aimatx.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: prod

--- a/config/clusters/aimatx-2i2c-hub/staging.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/staging.values.yaml
@@ -7,10 +7,6 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::426578051359:role/aimatx-2i2c-hub-staging
 
 jupyterhub:
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.aimatx.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/config/clusters/awi-ciroh/prod.values.yaml
+++ b/config/clusters/awi-ciroh/prod.values.yaml
@@ -188,7 +188,3 @@ basehub:
         SCRATCH_BUCKET: gs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://awi-ciroh-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://awi-ciroh-persistent/$(JUPYTERHUB_USER)
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://ciroh.awi.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/awi-ciroh/staging.values.yaml
+++ b/config/clusters/awi-ciroh/staging.values.yaml
@@ -137,5 +137,3 @@ basehub:
           # Requested as part of https://2i2c.freshdesk.com/a/tickets/1607, to
           # make it easier to test custom images
           image_pull_policy: Always
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.ciroh.awi.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/berkeley-geojupyter/prod.values.yaml
+++ b/config/clusters/berkeley-geojupyter/prod.values.yaml
@@ -15,8 +15,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      GitHubOAuthenticator:
-        oauth_callback_url: https://berkeley-geojupyter.2i2c.cloud/hub/oauth_callback
 
   singleuser:
     extraEnv:

--- a/config/clusters/berkeley-geojupyter/staging.values.yaml
+++ b/config/clusters/berkeley-geojupyter/staging.values.yaml
@@ -11,8 +11,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.berkeley-geojupyter.2i2c.cloud/hub/oauth_callback
   singleuser:
     extraEnv:
       SCRATCH_BUCKET: s3://berkeley-geojupyter-scratch-staging/$(JUPYTERHUB_USER)

--- a/config/clusters/bnext-bio/prod.values.yaml
+++ b/config/clusters/bnext-bio/prod.values.yaml
@@ -16,8 +16,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      GitHubOAuthenticator:
-        oauth_callback_url: https://hub.nucleus.engineering/hub/oauth_callback
   singleuser:
     image:
       name: quay.io/nucleus/nucleus-hub

--- a/config/clusters/bnext-bio/staging.values.yaml
+++ b/config/clusters/bnext-bio/staging.values.yaml
@@ -11,8 +11,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.hub.nucleus.engineering/hub/oauth_callback
   singleuser:
     profileList:
     - display_name: Choose your environment and resources

--- a/config/clusters/cloudbank/ahs.values.yaml
+++ b/config/clusters/cloudbank/ahs.values.yaml
@@ -42,7 +42,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://ahs.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/authoring.values.yaml
+++ b/config/clusters/cloudbank/authoring.values.yaml
@@ -38,7 +38,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://authoring.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - ucb-ds
         scope:

--- a/config/clusters/cloudbank/bcc.values.yaml
+++ b/config/clusters/cloudbank/bcc.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://bcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/bmcc.values.yaml
+++ b/config/clusters/cloudbank/bmcc.values.yaml
@@ -36,7 +36,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://bmcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://ccsf.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/chabot.values.yaml
+++ b/config/clusters/cloudbank/chabot.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://chabot.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/chaffey.values.yaml
+++ b/config/clusters/cloudbank/chaffey.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://chaffey.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://chaffey.ondemandlogin.com:
             default: true

--- a/config/clusters/cloudbank/chicagostate.values.yaml
+++ b/config/clusters/cloudbank/chicagostate.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://chicagostate.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/cmu.values.yaml
+++ b/config/clusters/cloudbank/cmu.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://cmu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://login.cmu.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://csm.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/csum.values.yaml
+++ b/config/clusters/cloudbank/csum.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://csum.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://cma-shibboleth.csum.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/deanza.values.yaml
+++ b/config/clusters/cloudbank/deanza.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://deanza.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/demo.values.yaml
+++ b/config/clusters/cloudbank/demo.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://demo.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - ucb-ds
         scope:

--- a/config/clusters/cloudbank/dvc.values.yaml
+++ b/config/clusters/cloudbank/dvc.values.yaml
@@ -32,7 +32,6 @@ jupyterhub:
   hub:
     config:
       CILogonOAuthenticator:
-        oauth_callback_url: https://dvc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/elac.values.yaml
+++ b/config/clusters/cloudbank/elac.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://elac.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://elcamino.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/etsu.values.yaml
+++ b/config/clusters/cloudbank/etsu.values.yaml
@@ -48,7 +48,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://etsu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/evc.values.yaml
+++ b/config/clusters/cloudbank/evc.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://evc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/foothill.values.yaml
+++ b/config/clusters/cloudbank/foothill.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://foothill.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/fresno.values.yaml
+++ b/config/clusters/cloudbank/fresno.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://fresno.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://glendale.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/golden.values.yaml
+++ b/config/clusters/cloudbank/golden.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://golden.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/gwu.values.yaml
+++ b/config/clusters/cloudbank/gwu.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://gwu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://singlesignon.gwu.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/high.values.yaml
+++ b/config/clusters/cloudbank/high.values.yaml
@@ -45,7 +45,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://high.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/hmc.values.yaml
+++ b/config/clusters/cloudbank/hmc.values.yaml
@@ -38,7 +38,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://hmc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://sso.hmc.edu/idp:
             default: true

--- a/config/clusters/cloudbank/humboldt.values.yaml
+++ b/config/clusters/cloudbank/humboldt.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://humboldt.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://sso.humboldt.edu/idp/metadata:
             default: true

--- a/config/clusters/cloudbank/kean.values.yaml
+++ b/config/clusters/cloudbank/kean.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://kean.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://sso.kean.edu/idp:
             default: true

--- a/config/clusters/cloudbank/lacc.values.yaml
+++ b/config/clusters/cloudbank/lacc.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://lacc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - LACC-Statistical-Data-Analytics
         scope:

--- a/config/clusters/cloudbank/lahc.values.yaml
+++ b/config/clusters/cloudbank/lahc.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://lahc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - LAHC-DataScience
         scope:

--- a/config/clusters/cloudbank/laney.values.yaml
+++ b/config/clusters/cloudbank/laney.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://laney.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/lavc.values.yaml
+++ b/config/clusters/cloudbank/lavc.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://lavc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - LAVC-DataScience
         scope:

--- a/config/clusters/cloudbank/lbcc.values.yaml
+++ b/config/clusters/cloudbank/lbcc.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://lbcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/mendocino.values.yaml
+++ b/config/clusters/cloudbank/mendocino.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://mendocino.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/merced.values.yaml
+++ b/config/clusters/cloudbank/merced.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://merced.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - Merced-College
         scope:

--- a/config/clusters/cloudbank/merritt.values.yaml
+++ b/config/clusters/cloudbank/merritt.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://merritt.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/miracosta.values.yaml
+++ b/config/clusters/cloudbank/miracosta.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://miracosta.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://miracosta.fedgw.com/gateway:
             default: true

--- a/config/clusters/cloudbank/mission.values.yaml
+++ b/config/clusters/cloudbank/mission.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://mission.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/mmc.values.yaml
+++ b/config/clusters/cloudbank/mmc.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://mmc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/moreno.values.yaml
+++ b/config/clusters/cloudbank/moreno.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://moreno.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/norco.values.yaml
+++ b/config/clusters/cloudbank/norco.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://norco.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/ocu.values.yaml
+++ b/config/clusters/cloudbank/ocu.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://ocu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://palomar.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://pasadena.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/redwoods.values.yaml
+++ b/config/clusters/cloudbank/redwoods.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       # JupyterHub:
       #   authenticator_class: github
       # GitHubOAuthenticator:
-      #   oauth_callback_url: https://redwoods.cloudbank.2i2c.cloud/hub/oauth_callback
       #   allowed_organizations:
       #   - redwoods-datascience
       #   scope:
@@ -47,7 +46,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://redwoods.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/reedley.values.yaml
+++ b/config/clusters/cloudbank/reedley.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://reedley.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/riohondo.values.yaml
+++ b/config/clusters/cloudbank/riohondo.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://riohondo.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - RHC-DSCI-100
         scope:

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://saddleback.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/santiago.values.yaml
+++ b/config/clusters/cloudbank/santiago.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://santiago.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/sbcc-dev.values.yaml
+++ b/config/clusters/cloudbank/sbcc-dev.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://sbcc-dev.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://sbcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/cloudbank/sierra.values.yaml
+++ b/config/clusters/cloudbank/sierra.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://sierra.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - SierraCollege-DataScience
         scope:

--- a/config/clusters/cloudbank/sjcc.values.yaml
+++ b/config/clusters/cloudbank/sjcc.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://sjcc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/sjsu.values.yaml
+++ b/config/clusters/cloudbank/sjsu.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://sjsu.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp01.sjsu.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://skyline.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://sou.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/spelman.values.yaml
+++ b/config/clusters/cloudbank/spelman.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://spelman.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/config/clusters/cloudbank/srjc.values.yaml
+++ b/config/clusters/cloudbank/srjc.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://srjc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             username_derivation:

--- a/config/clusters/cloudbank/staging.values.yaml
+++ b/config/clusters/cloudbank/staging.values.yaml
@@ -45,7 +45,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://staging.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/config/clusters/cloudbank/stanford.values.yaml
+++ b/config/clusters/cloudbank/stanford.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://stanford.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           urn:mace:incommon:stanford.edu:
             default: true

--- a/config/clusters/cloudbank/tuskegee.values.yaml
+++ b/config/clusters/cloudbank/tuskegee.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://tuskegee.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - TU-CSCI-Data8
         scope:

--- a/config/clusters/cloudbank/ucsc.values.yaml
+++ b/config/clusters/cloudbank/ucsc.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://ucsc.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           urn:mace:incommon:ucsc.edu:
             default: true

--- a/config/clusters/cloudbank/umd.values.yaml
+++ b/config/clusters/cloudbank/umd.values.yaml
@@ -36,7 +36,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://umd.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           urn:mace:incommon:umd.edu:
             default: true

--- a/config/clusters/cloudbank/und.values.yaml
+++ b/config/clusters/cloudbank/und.values.yaml
@@ -33,7 +33,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://und.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp.und.edu/idp:
             default: true

--- a/config/clusters/cloudbank/unr.values.yaml
+++ b/config/clusters/cloudbank/unr.values.yaml
@@ -34,7 +34,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://unr.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           https://idp2.unr.edu/idp/shibboleth:
             default: true

--- a/config/clusters/cloudbank/virginia.values.yaml
+++ b/config/clusters/cloudbank/virginia.values.yaml
@@ -35,7 +35,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://virginia.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           urn:mace:incommon:virginia.edu:
             default: true

--- a/config/clusters/cloudbank/wlac.values.yaml
+++ b/config/clusters/cloudbank/wlac.values.yaml
@@ -28,7 +28,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://wlac.cloudbank.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - WLAC-CS
         scope:

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -10,12 +10,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       2i2c/hub-name: prod
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://hub.disasters.2i2c.cloud/hub/oauth_callback
-      GenericOAuthenticator:
-        oauth_callback_url: https://hub.disasters.2i2c.cloud/hub/oauth_callback
   ingress:
     hosts: [hub.disasters.2i2c.cloud]
     tls:

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -11,10 +11,6 @@ jupyterhub:
       2i2c/hub-name: staging
   hub:
     config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.hub.disasters.2i2c.cloud/hub/oauth_callback
-      GenericOAuthenticator:
-        oauth_callback_url: https://staging.hub.disasters.2i2c.cloud/hub/oauth_callback
       Authenticator:
         # Disable for now the authentication token refreshing
         # https://oauthenticator.readthedocs.io/en/latest/reference/api/gen/oauthenticator.oauth2.html#oauthenticator.oauth2.OAuthenticator.auth_refresh_age

--- a/config/clusters/earthscope/binder.values.yaml
+++ b/config/clusters/earthscope/binder.values.yaml
@@ -142,7 +142,6 @@ jupyterhub:
         authorize_url: https://login.earthscope.org/authorize
         userdata_url: https://login.earthscope.org/userinfo
         logout_redirect_url: https://login.earthscope.org/v2/logout?client_id=2PbhUTbRU6e7uIaaEZIShotx15MbvsJJ
-        oauth_callback_url: https://hub.binder.geolab.earthscope.cloud/hub/oauth_callback
     redirectToServer: false
     loadRoles:
       binder:

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -19,7 +19,6 @@ basehub:
           authorize_url: https://login.earthscope.org/authorize
           userdata_url: https://login.earthscope.org/userinfo
           logout_redirect_url: https://login.earthscope.org/v2/logout?client_id=2PbhUTbRU6e7uIaaEZIShotx15MbvsJJ
-          oauth_callback_url: https://geolab.earthscope.cloud/hub/oauth_callback
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.earthscope.org

--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -21,7 +21,6 @@ basehub:
           authorize_url: https://login-dev.earthscope.org/authorize
           userdata_url: https://login-dev.earthscope.org/userinfo
           logout_redirect_url: https://login-dev.earthscope.org/v2/logout?client_id=Kn6kSKtw9TqgrSrEmDS0rlBM7Sc69BkL
-          oauth_callback_url: https://staging.geolab.earthscope.cloud/hub/oauth_callback
           extra_authorize_params:
             # This isn't an actual URL, just a string. Must not have a trailing slash
             audience: https://api.dev.earthscope.org

--- a/config/clusters/jupyter-health/prod.values.yaml
+++ b/config/clusters/jupyter-health/prod.values.yaml
@@ -18,7 +18,6 @@ jupyterhub:
   hub:
     config:
       GenericOAuthenticator:
-        oauth_callback_url: https://jupyter-health.2i2c.cloud/hub/oauth_callback
         client_id: bS8rx5PRGM3U3XQm4HBLHhqjNyKQzhKsZchYO0Bd
         authorize_url: https://berkeley-jhe-demo.jupyterhealth.org/o/authorize/
         token_url: https://berkeley-jhe-demo.jupyterhealth.org/o/token/

--- a/config/clusters/jupyter-health/staging.values.yaml
+++ b/config/clusters/jupyter-health/staging.values.yaml
@@ -13,7 +13,6 @@ jupyterhub:
   hub:
     config:
       GenericOAuthenticator:
-        oauth_callback_url: https://staging.jupyter-health.2i2c.cloud/hub/oauth_callback
         client_id: Ima7rx8D6eko0PzlU1jK28WBUT2ZweZj7mqVG2wm
         authorize_url: https://berkeley-jhe-staging.jupyterhealth.org/o/authorize/
         token_url: https://berkeley-jhe-staging.jupyterhealth.org/o/token/

--- a/config/clusters/leap/prod.values.yaml
+++ b/config/clusters/leap/prod.values.yaml
@@ -50,9 +50,6 @@ basehub:
         limits:
           cpu: 1
           memory: 1Gi
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://leap.2i2c.cloud/hub/oauth_callback
     singleuser:
       extraEnv:
         SCRATCH_BUCKET: gs://leap-scratch/$(JUPYTERHUB_USER)

--- a/config/clusters/leap/public.values.yaml
+++ b/config/clusters/leap/public.values.yaml
@@ -44,7 +44,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://public.leap.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - leap-stc:leap-pangeo-public-access
       Authenticator:

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -11,11 +11,6 @@ basehub:
         SCRATCH_BUCKET: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://leap-persistent-staging/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.leap.2i2c.cloud/hub/oauth_callback
-
   jupyterhub-home-nfs:
     gke:
       volumeId: projects/leap-pangeo/zones/us-central1-c/disks/hub-nfs-homedirs-staging

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -205,7 +205,6 @@ jupyterhub:
   hub:
     config:
       GenericOAuthenticator:
-        oauth_callback_url: https://hub.maap-project.org/hub/oauth_callback
         token_url: https://auth.openveda.cloud/realms/maap/protocol/openid-connect/token
         authorize_url: https://auth.openveda.cloud/realms/maap/protocol/openid-connect/auth
   ingress:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -230,7 +230,6 @@ jupyterhub:
         oauth_redirect_uri: https://staging.hub.maap-project.org/services/binder/oauth_callback
     config:
       GenericOAuthenticator:
-        oauth_callback_url: https://staging.hub.maap-project.org/hub/oauth_callback
         token_url: https://keycloak.delta-backend.xyz/realms/maap/protocol/openid-connect/token
         authorize_url: https://keycloak.delta-backend.xyz/realms/maap/protocol/openid-connect/auth
 

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -11,10 +11,6 @@ basehub:
       tls:
       - hosts: [hub.cryointhecloud.com]
         secretName: https-auto-tls
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://hub.cryointhecloud.com/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod

--- a/config/clusters/nasa-cryo/staging.values.yaml
+++ b/config/clusters/nasa-cryo/staging.values.yaml
@@ -6,10 +6,6 @@ basehub:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::574251165169:role/nasa-cryo-staging
   jupyterhub:
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.hub.cryointhecloud.com/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging

--- a/config/clusters/nasa-ghg-hub/prod.values.yaml
+++ b/config/clusters/nasa-ghg-hub/prod.values.yaml
@@ -13,10 +13,6 @@ basehub:
         gitRepoBranch: bootstrap5-nasa-ghg-prod
         # FIXME: use this repository again, once the changes in the bootstrap5-nasa-ghg-staging branch of 2i2c-org/default-hub-homepage have been ported to it
         # gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://hub.ghg.center/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -23,9 +23,6 @@ basehub:
       image:
         name: quay.io/2i2c/jupyterhub-usage-quotas
         tag: 1389e6181c78ec61e9c3c5e430e8840758d0854c
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.ghg.2i2c.cloud/hub/oauth_callback
       extraConfig:
         11-usage-quotas-viewer: |
           from jupyterhub_usage_quotas import setup_usage_quotas

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -22,10 +22,6 @@ basehub:
       image:
         # Temporary image with jupyterhub-fancy-profiles 0.6.0
         tag: 0.0.1-0.dev.git.15540.hbaaa997ce
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://hub.openveda.cloud/hub/oauth_callback
-
   dask-gateway:
     gateway:
       backend:

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -14,9 +14,6 @@ basehub:
         # custom image built to install jupyterhub-fancy-profiles from commit 9754f2188e337cd34cc5c533080583fe92fd47ca
         # from the PR https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/149 for testing
         tag: 0.0.1-0.dev.git.15561.hd27897dad
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.hub.openveda.cloud/hub/oauth_callback
       loadRoles:
         binder:
           services:

--- a/config/clusters/nmfs-openscapes/noaa-only.values.yaml
+++ b/config/clusters/nmfs-openscapes/noaa-only.values.yaml
@@ -273,7 +273,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://noaa.nmfs-openscapes.2i2c.cloud/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -42,7 +42,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://nmfs-openscapes.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - fish-pace:2026-hackweek-jupyterhub
         - nmfs-openscapes:longterm-access-2i2c

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -37,7 +37,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://staging.nmfs-openscapes.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - nmfs-openscapes:longterm-access-2i2c
         - nmfs-openscapes:2024-mentors

--- a/config/clusters/openscapeshub/prod.values.yaml
+++ b/config/clusters/openscapeshub/prod.values.yaml
@@ -14,12 +14,6 @@ basehub:
       extraEnv:
         SCRATCH_BUCKET: s3://openscapeshub-scratch/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: s3://openscapeshub-persistent/$(JUPYTERHUB_USER)
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://openscapes.2i2c.cloud/hub/oauth_callback
-        CILogonOAuthenticator:
-          oauth_callback_url: https://openscapes.2i2c.cloud/hub/oauth_callback
 
   dask-gateway:
     gateway:

--- a/config/clusters/openscapeshub/staging.values.yaml
+++ b/config/clusters/openscapeshub/staging.values.yaml
@@ -12,12 +12,6 @@ basehub:
       extraEnv:
         SCRATCH_BUCKET: s3://openscapeshub-scratch-staging/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: s3://openscapeshub-persistent-staging/$(JUPYTERHUB_USER)
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.openscapes.2i2c.cloud/hub/oauth_callback
-        CILogonOAuthenticator:
-          oauth_callback_url: https://staging.openscapes.2i2c.cloud/hub/oauth_callback
 
   dask-gateway:
     gateway:

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -81,7 +81,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://hub.big.binder.opensci.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - 2i2c-ephemeral-hubs:access
 

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -164,7 +164,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://sciencecore.opensci.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - 2i2c-demo-hub-access
         - ScienceCore:climaterisk-team

--- a/config/clusters/opensci/staging.values.yaml
+++ b/config/clusters/opensci/staging.values.yaml
@@ -125,7 +125,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://staging.opensci.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - 2i2c-demo-hub-access
 

--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -22,7 +22,3 @@ jupyterhub:
   singleuser:
     nodeSelector:
       2i2c/hub-name: prod
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://projectpythia.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -15,7 +15,3 @@ jupyterhub:
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.projectpythia.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/reflective/prod.values.yaml
+++ b/config/clusters/reflective/prod.values.yaml
@@ -10,10 +10,6 @@ jupyterhub:
     tls:
     - hosts: [reflective.2i2c.cloud]
       secretName: https-auto-tls
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://reflective.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: prod

--- a/config/clusters/reflective/staging.values.yaml
+++ b/config/clusters/reflective/staging.values.yaml
@@ -5,10 +5,6 @@ userServiceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::916143380841:role/reflective-staging
 jupyterhub:
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://staging.reflective.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: staging

--- a/config/clusters/smithsonian/prod.values.yaml
+++ b/config/clusters/smithsonian/prod.values.yaml
@@ -12,10 +12,6 @@ basehub:
       tls:
       - hosts: [smithsonian.2i2c.cloud]
         secretName: https-auto-tls
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://smithsonian.2i2c.cloud/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod

--- a/config/clusters/smithsonian/staging.values.yaml
+++ b/config/clusters/smithsonian/staging.values.yaml
@@ -7,10 +7,6 @@ basehub:
       volumeId: vol-0ec551895e93e4d59
 
   jupyterhub:
-    hub:
-      config:
-        GitHubOAuthenticator:
-          oauth_callback_url: https://staging.smithsonian.2i2c.cloud/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging

--- a/config/clusters/templates/common/binderhub-ui-hub.values.yaml
+++ b/config/clusters/templates/common/binderhub-ui-hub.values.yaml
@@ -92,12 +92,8 @@ jupyterhub:
         auth_enabled: true
       JupyterHub:
         authenticator_class: {{ authenticator }}
-  {% if authenticator == "github" %}
-      GitHubOAuthenticator:
-        oauth_callback_url: https://{{ jupyterhub_domain }}/hub/oauth_callback
-  {% elif authenticator == "cilogon" %}
+  {% if authenticator == "cilogon" %}
       CILogonOAuthenticator:
-        oauth_callback_url: https://{{ jupyterhub_domain }}/hub/oauth_callback
         allowed_idps:
           http://google.com/accounts/o8/id:
             username_derivation:

--- a/config/clusters/templates/common/hub.values.yaml
+++ b/config/clusters/templates/common/hub.values.yaml
@@ -1,5 +1,0 @@
-jupyterhub:
-  hub:
-    config:
-      GitHubOAuthenticator:
-        oauth_callback_url: https://{{ hub_name }}.{{ cluster_name }}.2i2c.cloud/hub/oauth_callback

--- a/config/clusters/temple/advanced.values.yaml
+++ b/config/clusters/temple/advanced.values.yaml
@@ -5,10 +5,6 @@ jupyterhub-home-nfs:
   eks:
     volumeId: vol-0b5fc915293bd5bec
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://advanced.temple.2i2c.cloud/hub/oauth_callback
   singleuser:
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23liL9VT25MVvo3RYq

--- a/config/clusters/temple/prod.values.yaml
+++ b/config/clusters/temple/prod.values.yaml
@@ -5,10 +5,6 @@ jupyterhub-home-nfs:
   eks:
     volumeId: vol-0e89a2ab60575e25a
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://temple.2i2c.cloud/hub/oauth_callback
   singleuser:
     nodeSelector:
       2i2c/hub-name: prod

--- a/config/clusters/temple/research.values.yaml
+++ b/config/clusters/temple/research.values.yaml
@@ -13,7 +13,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: github
       GitHubOAuthenticator:
-        oauth_callback_url: https://research.temple.2i2c.cloud/hub/oauth_callback
         allowed_organizations:
         - 2i2c-org:hub-access-for-2i2c-staff
         - TempleDataCompute:administrator

--- a/config/clusters/temple/staging.values.yaml
+++ b/config/clusters/temple/staging.values.yaml
@@ -5,10 +5,6 @@ jupyterhub-home-nfs:
   eks:
     volumeId: vol-09652a5540fdbd50f
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://staging.temple.2i2c.cloud/hub/oauth_callback
   singleuser:
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23libKsm2tlJzjYplj

--- a/config/clusters/ucmerced/prod.values.yaml
+++ b/config/clusters/ucmerced/prod.values.yaml
@@ -57,11 +57,6 @@ jupyterhub:
             # https://github.com/2i2c-org/infrastructure/issues/2559
         working_dir: /home/rstudio
       profile_options: *profile_options
-  hub:
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://ucmerced.2i2c.cloud/hub/oauth_callback
-
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0d9447f7288f66d1d

--- a/config/clusters/ucmerced/staging.values.yaml
+++ b/config/clusters/ucmerced/staging.values.yaml
@@ -55,10 +55,6 @@ jupyterhub:
             kubespawner_override:
               image: '{value}'
           choices: {}
-  hub:
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://staging.ucmerced.2i2c.cloud/hub/oauth_callback
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-09923c5867cea492a

--- a/config/clusters/utoronto/default-prod.values.yaml
+++ b/config/clusters/utoronto/default-prod.values.yaml
@@ -22,6 +22,3 @@ jupyterhub:
       pvc:
         # prod stores logs, so let's make it big
         storage: 60Gi
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://jupyter.utoronto.ca/hub/oauth_callback

--- a/config/clusters/utoronto/default-staging.values.yaml
+++ b/config/clusters/utoronto/default-staging.values.yaml
@@ -1,9 +1,5 @@
 jupyterhub:
   hub:
-    config:
-      GenericOAuthenticator:
-        oauth_callback_url: https://staging.utoronto.2i2c.cloud/hub/oauth_callback
-
     db:
       pvc:
         # limit was increased because of https://github.com/2i2c-org/infrastructure/issues/2288

--- a/config/clusters/utoronto/highmem.values.yaml
+++ b/config/clusters/utoronto/highmem.values.yaml
@@ -9,9 +9,6 @@ jupyterhub:
       pvc:
         # prod stores logs, so let's make it big
         storage: 60Gi
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://highmem.datatools.utoronto.ca/hub/oauth_callback
   singleuser:
     memory:
       limit: 6G

--- a/config/clusters/utoronto/r-prod.values.yaml
+++ b/config/clusters/utoronto/r-prod.values.yaml
@@ -9,6 +9,3 @@ jupyterhub:
       pvc:
         # prod stores logs, so let's make it big
         storage: 60Gi
-    config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://r.datatools.utoronto.ca/hub/oauth_callback

--- a/config/clusters/utoronto/r-staging.values.yaml
+++ b/config/clusters/utoronto/r-staging.values.yaml
@@ -14,6 +14,3 @@ jupyterhub:
       pvc:
         # prod stores logs, so let's make it big
         storage: 10Gi
-    config:
-      GenericOAuthenticator:
-        oauth_callback_url: https://r-staging.datatools.utoronto.ca/hub/oauth_callback

--- a/config/clusters/victor/prod.values.yaml
+++ b/config/clusters/victor/prod.values.yaml
@@ -29,10 +29,6 @@ basehub:
       tls:
       - hosts: [hub.victorproject.org]
         secretName: https-auto-tls
-    hub:
-      config:
-        CILogonOAuthenticator:
-          oauth_callback_url: https://hub.victorproject.org/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: prod

--- a/config/clusters/victor/staging.values.yaml
+++ b/config/clusters/victor/staging.values.yaml
@@ -24,10 +24,6 @@ basehub:
         QuotaManager:
           hard_quota: 5 # in GiB
   jupyterhub:
-    hub:
-      config:
-        CILogonOAuthenticator:
-          oauth_callback_url: https://staging.hub.victorproject.org/hub/oauth_callback
     singleuser:
       nodeSelector:
         2i2c/hub-name: staging

--- a/docs/hub-deployment-guide/configure-auth/canvas.md
+++ b/docs/hub-deployment-guide/configure-auth/canvas.md
@@ -52,17 +52,6 @@ jupyterhub:
 
 When the Hub queries the `userdata_url` endpoint to resolve information about the granted token, it needs guidance on which field to consume as the username in the response. Details of the `User` object returned by this endpoint response can be found [on the Canvas API docs](https://developerdocs.instructure.com/services/canvas/resources/users). The Student Information System (SIS) that is integrated with Canvas records its user ID in the `sis_user_id` field.
 
-Simultaneously, in the public per-hub config (of form `<hub-name>.secret.values.yaml`), we define the OAuth redirect URL for each hub:
-
-```{code-block} yaml
-:emphasize-lines: 5
-jupyterhub:
-  hub:
-    config:
-      GenericOAuthenticator:
-        oauth_callback_url: https://<hub-domain>/hub/oauth_callback
-```
-
 Although this is mostly boilerplate at this stage, later additions for things like course-based access controls (authorization) are easy to slot in with this approach.
 
 ## Define the OAuth secrets

--- a/docs/hub-deployment-guide/configure-auth/cilogon.md
+++ b/docs/hub-deployment-guide/configure-auth/cilogon.md
@@ -69,7 +69,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
         allowed_idps:
           # Community specific idp - enables community members to authenticate.
           # In this example, all authenticated users are authorized via the idp
@@ -130,7 +129,6 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
-        oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
         allowed_idps:
           http://github.com/login/oauth/authorize:
             default: true

--- a/docs/hub-deployment-guide/configure-auth/github-orgs.md
+++ b/docs/hub-deployment-guide/configure-auth/github-orgs.md
@@ -81,7 +81,6 @@ You can remove yourself from the org once you have confirmed that login is worki
           JupyterHub:
             authenticator_class: github
           GitHubOAuthenticator:
-            oauth_callback_url: https://{{ HUB_DOMAIN }}/hub/oauth_callback
             allowed_organizations:
               - ORG_NAME:TEAM_NAME
               - ORG_NAME

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -133,13 +133,13 @@ local jupyterhubConfig = {
   hub: {
     config: {
       OAuthenticator: {
-        # Always set oauth callback URL, to prevent it from being
-        # guessed 'wrong'.
-        oauth_callback_url: "https://%s/hub/oauth_callback" % [hub_domain]
-      }
+        // Always set oauth callback URL, to prevent it from being
+        // guessed 'wrong'.
+        oauth_callback_url: 'https://%s/hub/oauth_callback' % [hub_domain],
+      },
 
-    }
-  }
+    },
+  },
 };
 
 emitDaskHubCompatibleConfig({

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -130,6 +130,16 @@ local hubIngressConfig = {
 
 local jupyterhubConfig = {
   ingress: hubIngressConfig,
+  hub: {
+    config: {
+      OAuthenticator: {
+        # Always set oauth callback URL, to prevent it from being
+        # guessed 'wrong'.
+        oauth_callback_url: "https://%s/hub/oauth_callback" % [hub_domain]
+      }
+
+    }
+  }
 };
 
 emitDaskHubCompatibleConfig({


### PR DESCRIPTION
We have run into multiple issues with automatic guessing of oauth_callback_url (https://github.com/2i2c-org/infrastructure/issues/8184). We could manually set it each time, however that adds noise to the per-hub configs. Since oauth_callback_url is well known and always the same, we just unconditionally set it here. By setting it on the base `OAuthenticator` class, it's set up for every class that inherits from it.

Ref https://github.com/2i2c-org/infrastructure/issues/8157