### PR TITLE
Preserve client IPs for JupyterHub

### DIFF
--- a/helm-charts/support/templates/traffic-entrypoint.yaml
+++ b/helm-charts/support/templates/traffic-entrypoint.yaml
@@ -7,6 +7,9 @@ metadata:
     app: cluster-entrypoint
 spec:
   type: LoadBalancer
+  # Avoid extra hop and preserve client IP, as JupyterHub
+  # uses that as part of its XSRF check.
+  externalTrafficPolicy: Local
   ports:
     - name: http
       port: 80


### PR DESCRIPTION
JupyterHub uses client IPs as part of its XSRF calculation, and while we aren't sure, preserving client IP is a good idea here regardless.

Ref https://github.com/2i2c-org/infrastructure/issues/8192