### PR TITLE
Add alert for HTTPS Certificate Renewal failures

### DIFF
--- a/terraform/uptime-checks/checks.tf
+++ b/terraform/uptime-checks/checks.tf
@@ -92,6 +92,42 @@ resource "google_monitoring_alert_policy" "hub_simple_uptime_alert" {
   notification_channels = [google_monitoring_notification_channel.pagerduty_hubs.name]
 }
 
+resource "google_monitoring_alert_policy" "hub_https_certificate_expiry_alert" {
+  display_name = "HTTPS Certificate expiry alert"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "HTTPS Certificate expiry alert"
+    condition_threshold {
+      filter = <<-EOT
+      resource.type = "uptime_url"
+      AND metric.type = "monitoring.googleapis.com/uptime_check/time_until_ssl_cert_expires"
+      EOT
+      # Alert if we have a failure condition for 31 minutes - given we do checks
+      # every 15 minutes, this means we alert if two checks have failed. This shoulod
+      # prevent alerts if the hub is momentarily down during a deployment. All alerts
+      # *must* be actionable, so we trade-off some latency here for resiliency.
+      duration        = "1860s"
+      threshold_value = 24 # This is 3 weeks, so we alert if this is less than 3 weeks
+      comparison      = "COMPARISON_LT"
+      aggregations {
+        group_by_fields = ["resource.label.host"]
+        # https://cloud.google.com/monitoring/alerts/concepts-indepth#duration has
+        # more info on alignment
+        alignment_period   = "900s"
+        per_series_aligner = "ALIGN_NEXT_OLDER"
+        # Count each failure as a "1"
+        cross_series_reducer = "REDUCE_MEAN"
+      }
+    }
+  }
+
+  project = var.project_id
+
+  # Send a notification to our PagerDuty channel when this is triggered
+  notification_channels = [google_monitoring_notification_channel.pagerduty_hubs.name]
+}
+
 resource "google_monitoring_uptime_check_config" "prometheus_simple_uptime_check" {
   for_each = { for p in local.prometheuses : p.domain => p }
 

--- a/terraform/uptime-checks/checks.tf
+++ b/terraform/uptime-checks/checks.tf
@@ -125,7 +125,7 @@ resource "google_monitoring_alert_policy" "hub_https_certificate_expiry_alert" {
   project = var.project_id
 
   # Send a notification to our PagerDuty channel when this is triggered
-  notification_channels = [google_monitoring_notification_channel.pagerduty_hubs.name]
+  notification_channels = [google_monitoring_notification_channel.pagerduty_certificates.name]
 }
 
 resource "google_monitoring_uptime_check_config" "prometheus_simple_uptime_check" {

--- a/terraform/uptime-checks/pagerduty.tf
+++ b/terraform/uptime-checks/pagerduty.tf
@@ -12,6 +12,15 @@ resource "google_monitoring_notification_channel" "pagerduty_hubs" {
   }
 }
 
+resource "google_monitoring_notification_channel" "pagerduty_certificates" {
+  project      = var.project_id
+  display_name = "PagerDuty Certificate Renewals service"
+  type         = "pagerduty"
+  sensitive_labels {
+    service_key = data.sops_file.pagerduty_integration_key.data["pagerduty.certificates"]
+  }
+}
+
 resource "google_monitoring_notification_channel" "pagerduty_prometheus" {
   project      = var.project_id
   display_name = "PagerDuty Prometheus services"

--- a/terraform/uptime-checks/secret/enc-pagerduty-service-key.secret.yaml
+++ b/terraform/uptime-checks/secret/enc-pagerduty-service-key.secret.yaml
@@ -1,19 +1,16 @@
 pagerduty:
-    #ENC[AES256_GCM,data:ZgYIf+WYREbcqPbcm1Iv/XcDT0BSrCjJfHYPpSgg5mwz6dEHTNfGIgIdEJOAcAI6avey7eMf5wU+YGVYve/18Zgv8TX8vYGkB++KDN40eSzEwx4=,iv:kBrsrr5V8/H+XFtyE7cuDaZELG+V93pmbajyk6+Y5nI=,tag:R7S1e+7YBmB4yl/Twpry1g==,type:comment]
+  #ENC[AES256_GCM,data:ZgYIf+WYREbcqPbcm1Iv/XcDT0BSrCjJfHYPpSgg5mwz6dEHTNfGIgIdEJOAcAI6avey7eMf5wU+YGVYve/18Zgv8TX8vYGkB++KDN40eSzEwx4=,iv:kBrsrr5V8/H+XFtyE7cuDaZELG+V93pmbajyk6+Y5nI=,tag:R7S1e+7YBmB4yl/Twpry1g==,type:comment]
   hubs: ENC[AES256_GCM,data:zzK2Q/KGnx2Ue3QDXg+gixv1J/5G0ZOnxUWBJ+OiZZY=,iv:Le/9zJmCOzjxlqjhJAjkBJocLH/KSnmpQFMeA8M0U6o=,tag:ez40LxQnJuDAs/17fX572A==,type:str]
-    #ENC[AES256_GCM,data:F6MPBM4UKLXIEVrhKXgQInR5covSlQt53iAOZniONbwywT20UnaTwkePgttePkZdchiD1vLmucH8p4Blv8SzhQyCYC7rI0qc+tU03ZAnnxQmKGhaeKUtb2Z+excN2Hs=,iv:jjHfAqUtGV2g+kHw/OMQZD6l+EbKvm6aeiyTsfn8DL8=,tag:ktnPB1ecTpzLQsHN3N07eg==,type:comment]
+  #ENC[AES256_GCM,data:F6MPBM4UKLXIEVrhKXgQInR5covSlQt53iAOZniONbwywT20UnaTwkePgttePkZdchiD1vLmucH8p4Blv8SzhQyCYC7rI0qc+tU03ZAnnxQmKGhaeKUtb2Z+excN2Hs=,iv:jjHfAqUtGV2g+kHw/OMQZD6l+EbKvm6aeiyTsfn8DL8=,tag:ktnPB1ecTpzLQsHN3N07eg==,type:comment]
   prometheus: ENC[AES256_GCM,data:T+XEkXSZCx9cUCJna+48SgtGbFGFT4eOeHVbRdFg5eg=,iv:qfnRMqCjufHn4qVA8kE5yf5AdMTc++nod54w5fpsdYU=,tag:ErKzIez40OB8K5qWAOtwhA==,type:str]
+  #ENC[AES256_GCM,data:BgOOqnbmMrbyKpl6HBADMtJHvAerBd0377lopwOFk83q9K85GqvPqlFxvXpNzQP6RKFctjco1Q3qB32bQPkEUWV9hI9rveuOfLsi0/EPN6zqzJcuRFMldF7aMBoDeA==,iv:GwmvXFrP5Lyfzfb62PZiqBPq4dKdRnMAfredeeAZry4=,tag:cW4Ag/eYphmGuIcqw8kgNg==,type:comment]
+  certificates: ENC[AES256_GCM,data:62Bs7q3ZDyuYAG1r8iNJhb0s++ZmL6lpAoLI4IBIDCw=,iv:E277kbdvnU0ZIspl58MVYJcIeZam8wlH82aTYx/uFms=,tag:h0iQmmlXO4OMR4Uuo4Agrw==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2022-10-11T02:23:40Z'
     enc: CiQA4OM7eEfqyWjWWT5NNrbnfQ6simFNukOJuvNDdbPb8nBC0z4SSQDuy/p8wWK8SisznvEym2nJ0WnwcAvSuorPFWartNPq58qBkIog6D7mtv8nmh3MEWbdW4+XpDQeM7v97NvZwJXYxWO2NpQ/KKw=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2022-10-15T03:34:40Z'
-  mac: ENC[AES256_GCM,data:WGwAVMilsscvuzfBD1gLpWiozN9qx+ecWX5XfT3gDQ4xTz2KizWut05Tf/KDmZxx9DbT3Bn1NGh0+6kNpEwYNFV4jkKbbJvI8QFyDBR5LgnPe2Cp6flz5K4RRYkRna2lJp6nT5sdOHjbItaqltO/O3VkgiBOEnCHVC8hvD1f6+k=,iv:WklZNo9m/lcIPRUgnAvM7kZWk5d5xQwRDaF8NDUSLQY=,tag:fXP/d/JV+WiZ/al6JmVU8A==,type:str]
-  pgp: []
+  lastmodified: '2026-04-29T09:52:00Z'
+  mac: ENC[AES256_GCM,data:J7ST1fRXMlf0DCqPQpNj1QSLtkUEYuC3D7H01ohTVsUsMsoSOAE0foRWtIWsh4JlzjBoQOm7prlOK6ZB/+4UCnJvhx/RkZ76d8+1vFI+qe5lK6WopIzvCpHwmxDkH/QKacnD18DOoXJGl3l8P/y4G9W7O0r/qKPkRyd9kO55nrM=,iv:HjAKTYWOPQ+Ud3kIoyhy4rK7e/3UOobUohoec/lmmR4=,tag:INpceTYrHgD46HVabqa83A==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.12.1


### PR DESCRIPTION
If a certificate is less than 24 days from expiry, we get an alert. cert-manager should've renewed it before that, so this is a failure. We use a single check for *all* of our uptime checks, so we don't use too many uptime check resources. This also covers our prometheus instances, and in the future, grafana when we set them up

Fixes https://github.com/2i2c-org/infrastructure/issues/3278