### PR TITLE
[nasa-cryo] Provide browser token with sufficient scopes for sharing UI

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -48,6 +48,15 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: github
+        Spawner:
+          # Scopes granted to the server for the *browser* token
+          # This list was taken from https://jupyterhub.readthedocs.io/en/stable/tutorial/sharing.html#grant-servers-permission-to-share-themselves-admin
+          # and then reduced to _only_ the current server
+          oauth_client_allowed_scopes:
+            - shares!server
+            - servers!server
+            - read:users:name
+            - list:users
         GitHubOAuthenticator:
           # We are restricting profiles based on GitHub Team membership and
           # so need to populate the teams in the auth state
@@ -71,8 +80,11 @@ basehub:
       loadRoles:
         user:
           scopes:
-          - self
-          - shares!user
+            - self
+            # Sharing scopes
+            - shares!user
+            - read:users:name
+            - list:users
     singleuser:
       cloudMetadata:
         blockWithIptables: false

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -53,10 +53,10 @@ basehub:
           # This list was taken from https://jupyterhub.readthedocs.io/en/stable/tutorial/sharing.html#grant-servers-permission-to-share-themselves-admin
           # and then reduced to _only_ the current server
           oauth_client_allowed_scopes:
-            - shares!server
-            - servers!server
-            - read:users:name
-            - list:users
+          - shares!server
+          - servers!server
+          - read:users:name
+          - list:users
         GitHubOAuthenticator:
           # We are restricting profiles based on GitHub Team membership and
           # so need to populate the teams in the auth state
@@ -80,11 +80,11 @@ basehub:
       loadRoles:
         user:
           scopes:
-            - self
+          - self
             # Sharing scopes
-            - shares!user
-            - read:users:name
-            - list:users
+          - shares!user
+          - read:users:name
+          - list:users
     singleuser:
       cloudMetadata:
         blockWithIptables: false


### PR DESCRIPTION
This will require an upgrade to the singleuser image, in order to bring in JupyterHub 5. We should do this anyway — it's not good to trail the singleuser behind the main hub too much.