### PR TITLE
Reduce resources on '2i2c' cluster

### DIFF
--- a/config/clusters/2i2c/mtu.values.yaml
+++ b/config/clusters/2i2c/mtu.values.yaml
@@ -54,7 +54,32 @@ jupyterhub:
 jupyterhub-home-nfs:
   gke:
     volumeId: projects/two-eye-two-see/zones/us-central1-b/disks/hub-nfs-homedirs-mtu
-
+  quotaEnforcer:
+    resources:
+      requests:
+        cpu: 0.001
+        memory: 32Mi
+      limits:
+        cpu: 0.2
+        memory: 256Mi
+  nfsServer:
+    resources:
+      requests:
+        cpu: 0.02
+        memory: 512Mi
+      limits:
+        cpu: 0.1
+        memory: 1Gi
+  nodeExporter:
+    resources:
+      requests:
+        cpu: 0.001
+      limits:
+        cpu: 0.1
+  autoResizer:
+    resources:
+      requests:
+        cpu: 0.001
 nfs:
   pv:
     serverIP: storage-quota-home-nfs.mtu.svc.cluster.local

--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -7,8 +7,17 @@ prometheusStorageClass:
 
 prometheus:
   server:
+    # Tune down resources, as there's only 1 hub here now
+    resources:
+      requests:
+        cpu: 0.01
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
     persistentVolume:
-      # 100Gi filled up, and this is source of our billing data.
+      # This *used* to be the source of our shared cluster billing
+      # data, so is larger
       size: 512Gi
       storageClass: balanced-rwo-retain
     ingress:

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -17,7 +17,7 @@ k8s_versions = {
   dask_nodes_version : "1.34.1-gke.3971001",
 }
 
-core_node_machine_type = "n2-highmem-4"
+core_node_machine_type = "n2-highmem-2"
 enable_network_policy  = true
 
 # Explicitly disabling filestores in favour of persistent disks
@@ -27,10 +27,6 @@ persistent_disks = {
   "staging" = {
     size        = 5 # in GB
     name_suffix = "staging"
-  },
-  "dask-staging" = {
-    size        = 3 # in GB
-    name_suffix = "dask-staging"
   },
   "mtu" = {
     size        = 75 # in GB
@@ -85,6 +81,4 @@ hub_cloud_permissions = {
 }
 
 container_repos = [
-  "binder-staging",
-  "binderhub-ui-demo"
 ]

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -65,9 +65,9 @@ dask_nodes = {
   },
 }
 
-user_buckets = { }
+user_buckets = {}
 
 
-hub_cloud_permissions = { }
+hub_cloud_permissions = {}
 
-container_repos = [ ]
+container_repos = []

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -65,20 +65,9 @@ dask_nodes = {
   },
 }
 
-user_buckets = {
-  "scratch-dask-staging" : {
-    "delete_after" : 7,
-  },
-}
+user_buckets = { }
 
 
-hub_cloud_permissions = {
-  "dask-staging" : {
-    allow_access_to_external_requester_pays_buckets : true,
-    bucket_admin_access : ["scratch-dask-staging"],
-    hub_namespace : "dask-staging",
-  },
-}
+hub_cloud_permissions = { }
 
-container_repos = [
-]
+container_repos = [ ]


### PR DESCRIPTION
- Stop running the registries as they are not used
- Turn down the core node size
- Turn down prometheus size
- Turn down nfs server size
- Finish cleaning up dask-staging

Ref https://github.com/2i2c-org/infrastructure/issues/8196