### PR TITLE
Increase throughput for earthscope homedirs to 250

### DIFF
--- a/terraform/aws/ebs-volumes.tf
+++ b/terraform/aws/ebs-volumes.tf
@@ -5,6 +5,7 @@ resource "aws_ebs_volume" "nfs_home_dirs" {
   size              = each.value.size
   type              = each.value.type
   iops              = each.value.iops
+  throughput        = each.value.throughput
   encrypted         = true
 
   tags = merge(each.value.tags, {

--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -22,8 +22,9 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 4096 # 4TiB 
+    size        = 4096 # 4TiB
     type        = "gp3"
+    throughput  = 250 # Double the default 125
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }
   },

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -272,6 +272,7 @@ variable "ebs_volumes" {
     name_suffix = optional(string, null)
     tags        = optional(map(string), {})
     iops        = optional(number, 3000)
+    throughput  = optional(number, 125)
   }))
   default     = {}
   description = <<-EOT


### PR DESCRIPTION
Doubles the default 125. Costs roughly only 5$ a month more. Based on noticing that they still have throughput spikes throughout the day.

Ref https://github.com/2i2c-org/infrastructure/issues/8128