### PR TITLE
[2i2c-aws-us] Update token and sa account

### DIFF
--- a/config/clusters/2i2c-aws-us/enc-grafana-token.secret.yaml
+++ b/config/clusters/2i2c-aws-us/enc-grafana-token.secret.yaml
@@ -1,15 +1,10 @@
-grafana_token: ENC[AES256_GCM,data:t2qk7Ze8CPLm04pnwFDpqhoXv430t1wBH+o4H3KxGLLPZXeeBfMgHNTjOFeX0xABJ8eZw8yRi/TRXHfil9QQ+OKoTIMJ9olTr++YdBEVBRqQijlFJTc5IVRQQXNR9LhG,iv:9vVNYHRyCOexYjx49JMHqxD8RbYSs4OaU2RsDFjW1N4=,tag:Wgnr/0UIGJiCuQPULCfgbA==,type:str]
+grafana_token: ENC[AES256_GCM,data:0UUAVco8fej9Mzjc7KqNKuycIju8erXsMYkRrTcAUsCugicHj0Q8yu/wU/0m8g==,iv:vFdANmJV/wCTz3aQPp8QUVr6k6wRkN5uMHNzukd97Ik=,tag:mCq/5dKIh37fARY44pfHWA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2022-12-02T17:06:57Z'
-    enc: CiUA4OM7eE9zAnsvqqZ1DkU29yZuDSdm7AoElAMABbgu9/p8tLGkEkkA+0T9hXy+VFXSo6A4H8d8HFNwQBsm67tqAGBBUQ7SlIoWIz28wMPTIez5sNPBziRv9VrsXuIFJozC+Z2oqwexcy6Wy6663t9I
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2022-12-02T17:06:58Z'
-  mac: ENC[AES256_GCM,data:NHmFKLI8yUkZW+lhh9+rZl0LhTjBFbVgAua1M4E2+5DcDY+tA1tO87T1QcPcX+PPAPIXTO41eofFB01MbfG1FbsXjPYQE3235pmA2WNEIaeY2fTAdKylrUfbiICV/2doex/eXLdQwIrXJeyyrIYXA0Sjj1hDBkuV6DCU8HbKQ+s=,iv:1XrSnJHntEpQ9qx0MbOEfHpzpeFiIIoK0eCsEQCVI40=,tag:4+9qqk4LXBriUpPMSbTlew==,type:str]
-  pgp: []
+    created_at: '2026-05-01T10:31:59Z'
+    enc: CiUA4OM7eM3cFpLARar7wSefGE14Qp8BwekhuymYnlSzCGTz/WBEEkkAPHlbmVkzqr0PDZhQ7UZ4YXeav0Yrf7DVS3VIahVoG/468y/Ptf80fsuxFjj4wlAlZQp3NZPBtZ9QUvP3EYnps0f6iAvpEdDT
+  lastmodified: '2026-05-01T10:31:59Z'
+  mac: ENC[AES256_GCM,data:ge3G6uESpXsUc8HtuxJpqlqLiQqDcAVNJlB2JJ4XeyH8YJJa4KIhRCxXZaSt0q7mDK3M0kYoh41/3Dklidb2Ukm/+L/I8Phm6uQwF9oWnHTkLKd9oHICw4r/BIJOd1l7jB2xqejQjp3FSsAs4Erv79TbIBqs9L7KDBAAc5kZqyI=,iv:FvqOjgOj3ebAXor1ZzyJIxwgMJbMFPHkLKw/Ojqz130=,tag:WTExOBz79GTsinnLY12gig==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.11.0


### PR DESCRIPTION
Noticed that dashboard deploy for `2i2c-aws-us` was [failing CI/CD](https://github.com/2i2c-org/infrastructure/actions/runs/25204384880/job/73901873646#step:8:78). Checked Grafana and there was a missing service account. Ran `deployer grafana new-token $CLUSTER_NAME` to restore.

Ref https://github.com/2i2c-org/infrastructure/issues/8123