### PR TITLE
[projectpythia-binder] Add temporary jupyterbook-pub-service

### DIFF
--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -83,6 +83,9 @@ jupyterhub:
       nodeSelector:
         capi.stackhpc.com/node-group: user-m3-large
   hub:
+    services:
+      jupyterbook-pub:
+        url: http://jupyterbook-pub-service
     nodeSelector:
       capi.stackhpc.com/node-group: core
     loadRoles:

--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -1,0 +1,12 @@
+config:
+  JupyterBookPubApp:
+    base_url: /services/jupyterbook-pub/
+
+extraBuilderConfig:
+  name: builder_config.json
+  json:
+    JupyterBook2Builder:
+      allow_source_builds: false
+
+auth:
+  enabled: false


### PR DESCRIPTION
This service uses ephemeral storage for builds and repos. It doesn't use auth, because they likely don't want it authenticated for CI previews. It uses AST previewing only, to reduce the attack surface (for build poisoning).

Part of a spike for #8206 