### PR TITLE
feat: bump JB chart

### DIFF
--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -1,3 +1,6 @@
+# Manually deployed from
+# https://agoose77.github.io/jupyterbook-pub-service/
+# 0.1.0-0.dev.git.27.h91f01c4
 config:
   JupyterBookPubApp:
     base_url: /services/jupyterbook-pub/


### PR DESCRIPTION
This adds a security context to the builder container, and mounts all emptyDir volumes from the FS, not memory.