### PR TITLE
Populate hubspot_deal_id for some clusters

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_new-hub_phase-1.yaml
+++ b/.github/ISSUE_TEMPLATE/03_new-hub_phase-1.yaml
@@ -34,6 +34,7 @@ body:
       | Name of cloud account | | |
       | Community Representative(s) (GitHub handles or email) | | |
       | Have the Technical Contacts been added to the [AirTable](https://airtable.com/appbjBTRIbgRiElkr/pagD3XyZjqBunYMnC)? | `Yes/No` | |
+      | Hubspot Deal URL | | |
 
       Available runbooks:
       - https://infrastructure.2i2c.org/hub-deployment-guide/runbooks/phase1/#available-runbooks

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -2,6 +2,9 @@ name: 2i2c-aws-us
 provider: aws
 # two-eye-two-see
 provider_url: https://2i2c.awsapps.com/start
+metadata:
+  2i2c:
+    hubspot_deal_id: 323519075008
 aws:
   account: 790657130469
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/2i2c-jetstream2/cluster.yaml
+++ b/config/clusters/2i2c-jetstream2/cluster.yaml
@@ -3,6 +3,9 @@ provider: kubeconfig # allocation CIS250031_IU in https://js2.jetstream-cloud.or
 provider_url: https://js2.jetstream-cloud.org/project/
 kubeconfig:
   file: enc-deployer-credentials.secret.yaml
+metadata:
+  2i2c:
+    hubspot_deal_id: 323519075008
 support:
   helm_chart_values_files:
   - support.values.yaml

--- a/config/clusters/2i2c-uk/cluster.yaml
+++ b/config/clusters/2i2c-uk/cluster.yaml
@@ -1,6 +1,9 @@
 name: 2i2c-uk
 provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/europe-west2/two-eye-two-see-uk-cluster/nodes?project=two-eye-two-see-uk
+metadata:
+  2i2c:
+    hubspot_deal_id: 128809921227
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see-uk

--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -1,7 +1,10 @@
 name: 2i2c
 provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1-b/pilot-hubs-cluster/details?project=two-eye-two-see
-tenancy: shared
+metadata:
+  2i2c:
+    # This is just for MTU, as this cluster is just for MTU now
+    hubspot_deal_id: 231111145206
 gcp:
   key: enc-deployer-credentials.secret.json
   project: two-eye-two-see

--- a/config/clusters/aimatx-2i2c-hub/cluster.yaml
+++ b/config/clusters/aimatx-2i2c-hub/cluster.yaml
@@ -1,6 +1,9 @@
 name: aimatx-2i2c-hub
 provider: aws
 provider_url: https://426578051359.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 160773736149
 aws:
   account: 426578051359
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/awi-ciroh/cluster.yaml
+++ b/config/clusters/awi-ciroh/cluster.yaml
@@ -1,6 +1,9 @@
 name: awi-ciroh
 provider: gcp
 provider_url: https://console.cloud.google.com/home/dashboard?&project=ciroh-jupyterhub-423218
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221242068
 gcp:
   key: enc-deployer-credentials.secret.json
   project: ciroh-jupyterhub-423218

--- a/config/clusters/berkeley-geojupyter/cluster.yaml
+++ b/config/clusters/berkeley-geojupyter/cluster.yaml
@@ -1,6 +1,9 @@
 name: berkeley-geojupyter
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221242070
 aws:
   account: 622703418259
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/bnext-bio/cluster.yaml
+++ b/config/clusters/bnext-bio/cluster.yaml
@@ -1,6 +1,9 @@
 name: bnext-bio
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 107252426460
 aws:
   account: 882437028641
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -8,6 +8,9 @@ gcp:
   zone: us-central1-b
   billing:
     paid_by_us: false
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236427
 support:
   helm_chart_values_files:
   - support.values.yaml

--- a/config/clusters/disasters/cluster.yaml
+++ b/config/clusters/disasters/cluster.yaml
@@ -1,6 +1,9 @@
 name: disasters
 provider: aws
 provider_url: https://smce-aws-disasters.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236464
 aws:
   account: 515966502221
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/dubois/cluster.yaml
+++ b/config/clusters/dubois/cluster.yaml
@@ -1,6 +1,9 @@
 name: dubois
 provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/dubois-cluster/observability?project=dubois-436615
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221243093
 gcp:
   key: enc-deployer-credentials.secret.json
   project: dubois-436615

--- a/config/clusters/earthscope/cluster.yaml
+++ b/config/clusters/earthscope/cluster.yaml
@@ -1,6 +1,9 @@
 name: earthscope
 provider: aws
 provider_url: https://762698921361.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 96791452357
 aws:
   account: 762698921361
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/hhmi/cluster.yaml
+++ b/config/clusters/hhmi/cluster.yaml
@@ -1,6 +1,9 @@
 name: hhmi
 provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-west2/hhmi-cluster/details?project=hhmi-398911
+metadata:
+  2i2c:
+    hubspot_deal_id: 231111145206
 gcp:
   key: enc-deployer-credentials.secret.json
   project: hhmi-398911

--- a/config/clusters/jupyter-health/cluster.yaml
+++ b/config/clusters/jupyter-health/cluster.yaml
@@ -1,6 +1,10 @@
 name: jupyter-health
 provider: aws
 provider_url: https://2i2c.awsapps.com/start/#/
+metadata:
+  2i2c:
+    # Counted as part of the BIDS contract
+    hubspot_deal_id: 86221242070
 aws:
   account: 211125465508
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/leap/cluster.yaml
+++ b/config/clusters/leap/cluster.yaml
@@ -1,6 +1,9 @@
 name: leap
 provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/leap-cluster/nodes?project=leap-pangeo
+metadata:
+  2i2c:
+    hubspot_deal_id: 96869388000
 gcp:
   key: enc-deployer-credentials.secret.json
   project: leap-pangeo

--- a/config/clusters/maap/cluster.yaml
+++ b/config/clusters/maap/cluster.yaml
@@ -1,6 +1,9 @@
 name: maap
 provider: aws
 provider_url: https://916098889494.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236464
 aws:
   account: 916098889494
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-cryo/cluster.yaml
+++ b/config/clusters/nasa-cryo/cluster.yaml
@@ -1,6 +1,9 @@
 name: nasa-cryo
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236461
 aws:
   account: 574251165169
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-ghg-hub/cluster.yaml
+++ b/config/clusters/nasa-ghg-hub/cluster.yaml
@@ -1,6 +1,9 @@
 name: nasa-ghg-hub
 provider: aws
 provider_url: https://smce-ghg-center.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236464
 aws:
   account: 597746869805
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -1,6 +1,9 @@
 name: nasa-veda
 provider: aws
 provider_url: https://smce-veda.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933236464
 aws:
   account: 444055461661
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/nmfs-openscapes/cluster.yaml
+++ b/config/clusters/nmfs-openscapes/cluster.yaml
@@ -1,6 +1,9 @@
 name: nmfs-openscapes
 provider: aws
 provider_url: https://891612562472.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 96602996427
 aws:
   account: 891612562472
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/openscapeshub/cluster.yaml
+++ b/config/clusters/openscapeshub/cluster.yaml
@@ -1,6 +1,9 @@
 name: openscapeshub
 provider: aws
 provider_url: https://783616723547.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221243106
 aws:
   account: 783616723547
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/opensci/cluster.yaml
+++ b/config/clusters/opensci/cluster.yaml
@@ -1,6 +1,9 @@
 name: opensci
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 102945995509
 aws:
   account: 211125293633
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/projectpythia-binder/cluster.yaml
+++ b/config/clusters/projectpythia-binder/cluster.yaml
@@ -1,6 +1,9 @@
 name: projectpythia-binder
 provider: kubeconfig # allocation SEE240014_IU in https://js2.jetstream-cloud.org/project/
 provider_url: https://js2.jetstream-cloud.org/project/
+metadata:
+  2i2c:
+    hubspot_deal_id: 102799509217
 kubeconfig:
   file: enc-deployer-credentials.secret.yaml
 support:

--- a/config/clusters/projectpythia/cluster.yaml
+++ b/config/clusters/projectpythia/cluster.yaml
@@ -1,6 +1,9 @@
 name: projectpythia
 provider: aws
 provider_url: https://590183926898.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 102799509217
 aws:
   account: 590183926898
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/reflective/cluster.yaml
+++ b/config/clusters/reflective/cluster.yaml
@@ -1,6 +1,9 @@
 name: reflective
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 96807259872
 aws:
   account: 916143380841
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/smithsonian/cluster.yaml
+++ b/config/clusters/smithsonian/cluster.yaml
@@ -1,6 +1,9 @@
 name: smithsonian
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 86933237434
 aws:
   account: 969396938818
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/templates/aws/cluster.yaml
+++ b/config/clusters/templates/aws/cluster.yaml
@@ -1,6 +1,9 @@
 name: {{ cluster_name }}
 provider: aws
 provider_url: {{ sign_in_url }}
+metadata:
+  2i2c:
+    hubspot_deal_id: null
 aws:
   account: {{ cluster_account_id }}
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/templates/gcp/cluster.yaml
+++ b/config/clusters/templates/gcp/cluster.yaml
@@ -1,6 +1,9 @@
 name: {{ cluster_name }}
-provider: gcp 
+provider: gcp
 provider_url: https://console.cloud.google.com/kubernetes/clusters/details/{{ cluster_region }}/{{ cluster_name }}-cluster/observability?project={{ project_id }}
+metadata:
+  2i2c:
+    hubspot_deal_id: null
 gcp:
   key: enc-deployer-credentials.secret.json
   project: {{ project_id }}

--- a/config/clusters/temple/cluster.yaml
+++ b/config/clusters/temple/cluster.yaml
@@ -1,6 +1,9 @@
 name: temple
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221243084
 aws:
   account: 324830304144
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/ucmerced/cluster.yaml
+++ b/config/clusters/ucmerced/cluster.yaml
@@ -1,6 +1,9 @@
 name: ucmerced
 provider: aws
 provider_url: https://2i2c.awsapps.com/start#/
+metadata:
+  2i2c:
+    hubspot_deal_id: 104040436473
 aws:
   account: 596308305316
   key: enc-deployer-credentials.secret.json

--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -3,6 +3,9 @@ provider: kubeconfig # azure based, cloud infra work requires a dedicated utoron
 provider_url: https://portal.azure.com/?l=en.en-gb#@utoronto.onmicrosoft.com/resource/subscriptions/ead3521a-d994-4a44-a68d-b16e35642d5b/resourceGroups/2i2c-utoronto-cluster/providers/Microsoft.ContainerService/managedClusters/hub-cluster/overview
 kubeconfig:
   file: enc-deployer-credentials.secret.yaml
+metadata:
+  2i2c:
+    hubspot_deal_id: 86221242056
 support:
   helm_chart_values_files:
   - support.values.yaml

--- a/config/clusters/victor/cluster.yaml
+++ b/config/clusters/victor/cluster.yaml
@@ -1,6 +1,9 @@
 name: victor
 provider: aws
 provider_url: https://129856558350.signin.aws.amazon.com/console
+metadata:
+  2i2c:
+    hubspot_deal_id: 128809917128
 aws:
   account: 129856558350
   key: enc-deployer-credentials.secret.json

--- a/deployer/commands/validate/cluster.schema.yaml
+++ b/deployer/commands/validate/cluster.schema.yaml
@@ -4,12 +4,34 @@ additionalProperties: false
 required:
 - name
 - provider
+- metadata
 properties:
   name:
     type: string
     description: |
       Name of the cluster, used primarily to identify it in
       the deploy script. This value should match the parent folder name.
+  metadata:
+    type: object
+    description: |
+      Various metadata about the cluster
+    required:
+    - 2i2c
+    properties:
+      2i2c:
+        type: object
+        required:
+        - hubspot_deal_id
+        properties:
+          hubspot_deal_id:
+            type: integer
+            description: |
+              Deal ID of the current contract in hubspot under which
+              this hub is being run.
+
+              If the URL of the deal looks like
+              https://app-na2.hubspot.com/contacts/242496330/record/0-3/96602996427,
+              the deal ID is the last integer, that comes after `0-3`
   support:
     type: object
     additionalProperties: false

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -355,6 +355,19 @@ An automated deployer command doesn't exist yet, these files need to be manually
 ````
 `````
 
+## Specify `hubspot_deal_id`
+
+We want to match every cluster we deploy to a particular contract that we have to run it
+for a specific time. We manage contracts on Hubspot, and each contract is associated with
+a "Deal". We specify the id of this deal for each Cluster under `metadata.2i2c.hubspot_deal_id`,
+and it must be specified when creating the cluster. The new hub request issue should have
+a Hubspot deal URL, and you can determine the deal ID by either:
+
+1. Opening the URL, logging into hubspot and looking in the sidebar
+2. Manually just look at the URL - if the URL of the deal looks like
+   https://app-na2.hubspot.com/contacts/242496330/record/0-3/96602996427,
+   the deal ID is the last integer, that comes after `0-3`.
+
 ## Add GPU nodegroup if needed
 
 If this cluster is going to have GPUs, you should edit the generated jsonnet file


### PR DESCRIPTION
Thinking about experimenting with using the hubspot API to get information about deals (https://developers.hubspot.com/docs/api-reference/latest/crm/objects/deals/get-deal). A deal is how we seem to be encoding 'current contracts', with appropriate end dates.

Nothing concrete, just an exploration.