### PR TITLE
Bump k8s and cos image version in gke clusters

### DIFF
--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -8,16 +8,31 @@ billing_account_id = "0157F7-E3EA8C-25AC3C"
 filestores = {}
 
 k8s_versions = {
-  min_master_version : "1.34.4-gke.1130000",
-  core_nodes_version : "1.34.4-gke.1130000",
-  notebook_nodes_version : "1.34.4-gke.1130000",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
 }
 
 core_node_machine_type = "n2-highmem-4"
 enable_network_policy  = true
 
 notebook_nodes = {
+  # To be deleted when empty
   "n2-highmem-4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-4",
+    node_version : "1.34.4-gke.1130000",
+    taints : [
+      # Prevent new pods from scheduling here.
+      {
+        key : "manual-phaseout"
+        value : "noop"
+        effect : "NO_SCHEDULE"
+      }
+    ],
+  },
+  "n2-highmem-4-a" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -31,10 +31,10 @@ budget_alert_enabled = false
 billing_account_id   = ""
 
 k8s_versions = {
-  min_master_version : "1.34.4-gke.1130000",
-  core_nodes_version : "1.34.4-gke.1130000",
-  notebook_nodes_version : "1.34.4-gke.1130000",
-  dask_nodes_version : "1.34.4-gke.1130000",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
+  dask_nodes_version : "1.35.3-gke.1943000",
 }
 
 user_buckets = {
@@ -68,6 +68,20 @@ notebook_nodes = {
     machine_type : "n2-highmem-4",
   },
   "n2-highmem-16" : {
+    min : 0,
+    max : 100,
+    machine_type : "n2-highmem-16",
+    node_version : "1.34.4-gke.1130000",
+    taints : [
+      # Prevent new pods from scheduling here.
+      {
+        key : "manual-phaseout"
+        value : "noop"
+        effect : "NO_SCHEDULE"
+      }
+    ],
+  },
+  "n2-highmem-16-a" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-16",

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -321,7 +321,7 @@ notebook_nodes = {
       }
     ],
   },
-  "n2-highmem-4" : {
+  "n2-highmem-4-a" : {
     min : 2,
     max : 100,
     machine_type : "n2-highmem-4",

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -236,7 +236,7 @@ persistent_disks = {
     name_suffix = "skyline"
   }
   "sou" = {
-    size        = 25
+    size        = 100
     name_suffix = "sou"
   }
   "spelman" = {
@@ -293,10 +293,10 @@ k8s_versions = {
   # NOTE: This isn't a regional cluster / highly available cluster, when
   #       upgrading the control plane, there will be ~5 minutes of k8s not being
   #       available making new server launches error etc.
-  min_master_version : "1.34.4-gke.1193000",
-  core_nodes_version : "1.34.4-gke.1193000",
-  notebook_nodes_version : "1.34.4-gke.1193000",
-  dask_nodes_version : "1.34.4-gke.1193000",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
+  dask_nodes_version : "1.35.3-gke.1943000",
 }
 
 core_node_machine_type = "n2-highmem-2"
@@ -307,17 +307,11 @@ enable_network_policy = true
 
 notebook_nodes = {
   "n2-highmem-4-b" : {
-    min : 2,
-    max : 100,
-    machine_type : "n2-highmem-4",
-    disk_size_gb : 150,
-  },
-  "n2-highmem-4" : {
-    node_version : "1.34.1-gke.3971001",
     min : 0,
     max : 100,
     machine_type : "n2-highmem-4",
     disk_size_gb : 150,
+    node_version : "1.34.4-gke.1193000",
     taints : [
       # Prevent new pods from scheduling here.
       {
@@ -326,6 +320,12 @@ notebook_nodes = {
         effect : "NO_SCHEDULE"
       }
     ],
+  },
+  "n2-highmem-4" : {
+    min : 2,
+    max : 100,
+    machine_type : "n2-highmem-4",
+    disk_size_gb : 150,
   },
   "gpu-t4" : {
     min : 0,

--- a/terraform/gcp/projects/dubois.tfvars
+++ b/terraform/gcp/projects/dubois.tfvars
@@ -12,9 +12,9 @@ single_process_oom_kill  = false
 billing_account_id = "0157F7-E3EA8C-25AC3C"
 
 k8s_versions = {
-  min_master_version : "1.34.1-gke.3971001",
-  core_nodes_version : "1.34.1-gke.3971001",
-  notebook_nodes_version : "1.34.1-gke.3971001",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
 }
 
 notebook_nodes = {

--- a/terraform/gcp/projects/hhmi.tfvars
+++ b/terraform/gcp/projects/hhmi.tfvars
@@ -7,10 +7,10 @@ billing_account_id     = "0157F7-E3EA8C-25AC3C"
 enable_network_policy  = true
 
 k8s_versions = {
-  min_master_version : "1.34.4-gke.1130000",
-  core_nodes_version : "1.34.4-gke.1130000",
-  notebook_nodes_version : "1.34.4-gke.1130000",
-  dask_nodes_version : "1.34.4-gke.1130000",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
+  dask_nodes_version : "1.35.3-gke.1943000",
 }
 
 # Disable single centralised filestore in favour of persistent disks

--- a/terraform/gcp/projects/leap.tfvars
+++ b/terraform/gcp/projects/leap.tfvars
@@ -10,10 +10,10 @@ budget_alert_enabled = false
 billing_account_id   = ""
 
 k8s_versions = {
-  min_master_version : "1.34.4-gke.1130000",
-  core_nodes_version : "1.34.4-gke.1130000",
-  notebook_nodes_version : "1.34.4-gke.1130000",
-  dask_nodes_version : "1.34.4-gke.1130000",
+  min_master_version : "1.35.3-gke.1943000",
+  core_nodes_version : "1.35.3-gke.1943000",
+  notebook_nodes_version : "1.35.3-gke.1943000",
+  dask_nodes_version : "1.35.3-gke.1943000",
 }
 
 # GPUs not available in us-central1-b
@@ -113,22 +113,65 @@ notebook_nodes = {
     },
   }
 
-  "n2-highmem-16" : {
+  "n2-highmem-16-a" : {
     # A minimum of one is configured for LEAP to ensure quick startups at all
     # time. Cost is not a greater concern than optimizing startup times.
     min : 1,
     max : 100,
     machine_type : "n2-highmem-16",
   },
+  "n2-highmem-16" : {
+    # A minimum of one is configured for LEAP to ensure quick startups at all
+    # time. Cost is not a greater concern than optimizing startup times.
+    min : 1,
+    max : 100,
+    machine_type : "n2-highmem-16",
+    node_version : "1.34.4-gke.1130000",
+    taints : [
+      # Prevent new pods from scheduling here.
+      {
+        key : "manual-phaseout"
+        value : "noop"
+        effect : "NO_SCHEDULE"
+      }
+    ],
+  },
   "n2-highmem-64" : {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64"
   },
+  "gpu-t4" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    gpu : {
+      enabled : true,
+      type : "nvidia-tesla-t4",
+      count : 1
+    },
+    zones : [
+      # Get GPUs wherever they are available, as sometimes a single
+      # zone might be out of GPUs.
+      "us-central1-a",
+      "us-central1-b",
+      "us-central1-c",
+      "us-central1-f"
+    ]
+  },
   "gpu-t4-b" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-8",
+    node_version : "1.34.4-gke.1130000",
+    taints : [
+      # Prevent new pods from scheduling here.
+      {
+        key : "manual-phaseout"
+        value : "noop"
+        effect : "NO_SCHEDULE"
+      }
+    ],
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -54,7 +54,9 @@ variable "k8s_version_prefixes" {
     "1.32.",
     "1.33.",
     "1.34.",
-    "1.",
+    "1.35.",
+    "1.36.",
+    "1."
   ]
   description = <<-EOT
   A list of k8s version prefixes that can be evaluated to their latest version by


### PR DESCRIPTION
Comes with a security patch https://docs.cloud.google.com/kubernetes-engine/security-bulletins#gcp-2026-026