### PR TITLE
Add post-auth webhook to notify MAAP API on user login

### DIFF
--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -116,18 +116,12 @@ jupyterhub:
 
         c.Spawner.auth_state_hook = populate_token
       002-post-auth-webhook: |
+        import asyncio
         from tornado.httpclient import AsyncHTTPClient
         from z2jh import get_config
 
-        async def maap_post_auth_hook(authenticator, handler, authentication):
-            """Notify MAAP REST API after successful login."""
-            base_url = get_config("custom.maapApiBaseUrl", "")
-            if not base_url:
-                return authentication
-
-            auth_state = authentication.get("auth_state", {})
-            pgt = f"jwt:{auth_state.get('id_token', '')}"
-
+        async def _notify_maap_api(authenticator, base_url, pgt):
+            """Fire-and-forget call to MAAP REST API."""
             http_client = AsyncHTTPClient()
             try:
                 await http_client.fetch(
@@ -138,6 +132,17 @@ jupyterhub:
                 )
             except Exception as e:
                 authenticator.log.warning("MAAP post-auth webhook failed: %s", e)
+
+        async def maap_post_auth_hook(authenticator, handler, authentication):
+            """Notify MAAP REST API after successful login (non-blocking)."""
+            base_url = get_config("custom.maapApiBaseUrl", "")
+            if not base_url:
+                return authentication
+
+            auth_state = authentication.get("auth_state", {})
+            pgt = f"jwt:{auth_state.get('id_token', '')}"
+
+            asyncio.ensure_future(_notify_maap_api(authenticator, base_url, pgt))
 
             return authentication
 

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -107,6 +107,7 @@ jupyterhub:
                 })
 
         c.Spawner.auth_state_hook = populate_token
+      # Post auth API endpoint maintained by the MAAP Platform team
       002-post-auth-webhook: |
         import asyncio
         from tornado.httpclient import AsyncHTTPClient
@@ -123,7 +124,7 @@ jupyterhub:
                     request_timeout=5.0,
                 )
             except Exception as e:
-                authenticator.log.warning("MAAP post-auth webhook failed: %s", e)
+                authenticator.log.exception("MAAP post-auth webhook failed: %s", e)
 
         async def maap_post_auth_hook(authenticator, handler, authentication):
             """Notify MAAP REST API after successful login (non-blocking)."""

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -115,33 +115,33 @@ jupyterhub:
                 })
 
         c.Spawner.auth_state_hook = populate_token
-    002-post-auth-webhook: |
-      from tornado.httpclient import AsyncHTTPClient
-      from z2jh import get_config
+      002-post-auth-webhook: |
+        from tornado.httpclient import AsyncHTTPClient
+        from z2jh import get_config
 
-      async def maap_post_auth_hook(authenticator, handler, authentication):
-          """Notify MAAP REST API after successful login."""
-          base_url = get_config("custom.maapApiBaseUrl", "")
-          if not base_url:
-              return authentication
+        async def maap_post_auth_hook(authenticator, handler, authentication):
+            """Notify MAAP REST API after successful login."""
+            base_url = get_config("custom.maapApiBaseUrl", "")
+            if not base_url:
+                return authentication
 
-          auth_state = authentication.get("auth_state", {})
-          pgt = f"jwt:{auth_state.get('id_token', '')}"
+            auth_state = authentication.get("auth_state", {})
+            pgt = f"jwt:{auth_state.get('id_token', '')}"
 
-          http_client = AsyncHTTPClient()
-          try:
-              await http_client.fetch(
-                  f"{base_url}/api/members/self",
-                  method="GET",
-                  headers={"Authorization": f"Bearer {pgt}"},
-                  request_timeout=5.0,
-              )
-          except Exception as e:
-              authenticator.log.warning("MAAP post-auth webhook failed: %s", e)
+            http_client = AsyncHTTPClient()
+            try:
+                await http_client.fetch(
+                    f"{base_url}/api/members/self",
+                    method="GET",
+                    headers={"Authorization": f"Bearer {pgt}"},
+                    request_timeout=5.0,
+                )
+            except Exception as e:
+                authenticator.log.warning("MAAP post-auth webhook failed: %s", e)
 
-          return authentication
+            return authentication
 
-      c.GenericOAuthenticator.post_auth_hook = maap_post_auth_hook
+        c.GenericOAuthenticator.post_auth_hook = maap_post_auth_hook
   singleuser:
     extraFiles:
       jupyter_server_config.json:

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -128,7 +128,7 @@ jupyterhub:
 
         async def maap_post_auth_hook(authenticator, handler, authentication):
             """Notify MAAP REST API after successful login (non-blocking)."""
-            base_url = get_config("custom.maapApiBaseUrl", "")
+            base_url = get_config("custom.maap.apiBaseUrl", "")
             if not base_url:
                 return authentication
 

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -115,6 +115,33 @@ jupyterhub:
                 })
 
         c.Spawner.auth_state_hook = populate_token
+    002-post-auth-webhook: |
+      from tornado.httpclient import AsyncHTTPClient
+      from z2jh import get_config
+
+      async def maap_post_auth_hook(authenticator, handler, authentication):
+          """Notify MAAP REST API after successful login."""
+          base_url = get_config("custom.maapApiBaseUrl", "")
+          if not base_url:
+              return authentication
+
+          auth_state = authentication.get("auth_state", {})
+          pgt = f"jwt:{auth_state.get('id_token', '')}"
+
+          http_client = AsyncHTTPClient()
+          try:
+              await http_client.fetch(
+                  f"{base_url}/api/members/self",
+                  method="GET",
+                  headers={"Authorization": f"Bearer {pgt}"},
+                  request_timeout=5.0,
+              )
+          except Exception as e:
+              authenticator.log.warning("MAAP post-auth webhook failed: %s", e)
+
+          return authentication
+
+      c.GenericOAuthenticator.post_auth_hook = maap_post_auth_hook
   singleuser:
     extraFiles:
       jupyter_server_config.json:

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -3,7 +3,8 @@ nfs:
     serverIP: 10.100.56.44
 jupyterhub:
   custom:
-    maapApiBaseUrl: https://api.maap-project.org
+    maap:
+      apiBaseUrl: https://api.maap-project.org
     2i2c:
       add_staff_user_ids_to_admin_users: false
     homepage:

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -6,6 +6,7 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::916098889494:role/maap-prod
 jupyterhub:
   custom:
+    maapApiBaseUrl: https://api.maap-project.org
     2i2c:
       add_staff_user_ids_to_admin_users: false
     homepage:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -3,7 +3,8 @@ nfs:
     serverIP: 10.100.129.224
 jupyterhub:
   custom:
-    maapApiBaseUrl: https://api.uat.maap-project.org
+    maap:
+      apiBaseUrl: https://api.uat.maap-project.org
     2i2c:
       add_staff_user_ids_to_admin_users: false
     homepage:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -6,6 +6,7 @@ userServiceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::916098889494:role/maap-staging
 jupyterhub:
   custom:
+    maapApiBaseUrl: https://api.uat.maap-project.org
     2i2c:
       add_staff_user_ids_to_admin_users: false
     homepage:


### PR DESCRIPTION
### Summary

- Adds a post_auth_hook to the MAAP hub that calls GET /api/members/self on the MAAP REST API after a user authenticates via Keycloak
- Authenticates the request using the same jwt:{id_token} format used by the spawner's existing auth_state_hook
- Adds a per-environment maapApiBaseUrl custom config value (staging: api.uat.maap-project.org, prod: api.maap-project.org)
- The webhook is non-blocking — failures are logged but do not prevent login