### PR TITLE
fix: disable X509 strict SSL verification on JS2

### DIFF
--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -1,6 +1,9 @@
 config:
   JupyterBookPubApp:
     base_url: /services/jupyterbook-pub/
+  KubernetesExecutor:
+    # Current JS2 certs are not X509 valid
+    disable_strict_ssl_verification: true
 
 extraBuilderConfig:
   name: builder_config.json


### PR DESCRIPTION
This disables strict X509 verification on projectpythia-binder's JupyterBookPub deployment. Python 3.13 introduced this strict behaviour, so our BinderHubs are technically already running this implicitly (on Python 3.11, I think).