### PR TITLE
Improve JupyterBook.pub resources and FS usage

### DIFF
--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -1,9 +1,15 @@
+# See https://agoose77.github.io/jupyterbook-pub-service/
 config:
   JupyterBookPubApp:
     base_url: /services/jupyterbook-pub/
   KubernetesExecutor:
     # Current JS2 certs are not X509 valid
     disable_strict_ssl_verification: true
+    builder_resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 500Mi
 
 extraBuilderConfig:
   name: builder_config.json
@@ -15,3 +21,7 @@ volumeClaim:
   - ReadWriteMany
 auth:
   enabled: false
+
+# Run the core service on the core nodes
+nodeSelector:
+  capi.stackhpc.com/node-group: core

--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -1,4 +1,8 @@
 # See https://agoose77.github.io/jupyterbook-pub-service/
+# Run the core service on the core nodes
+nodeSelector: &nodeSelector
+  capi.stackhpc.com/node-group: core
+
 config:
   JupyterBookPubApp:
     base_url: /services/jupyterbook-pub/
@@ -10,6 +14,7 @@ config:
         memory: 128Mi
       limits:
         memory: 500Mi
+    builder_node_selector: *nodeSelector
 
 extraBuilderConfig:
   name: builder_config.json
@@ -21,7 +26,3 @@ volumeClaim:
   - ReadWriteMany
 auth:
   enabled: false
-
-# Run the core service on the core nodes
-nodeSelector:
-  capi.stackhpc.com/node-group: core

--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -10,6 +10,8 @@ extraBuilderConfig:
   json:
     JupyterBook2Builder:
       allow_source_builds: false
-
+volumeClaim:
+  accessModes:
+  - ReadWriteMany
 auth:
   enabled: false


### PR DESCRIPTION
This rounds of some final pieces to ensure that the service has some limits in place on builds to avoid core node disruption.