### PR TITLE
feat: grow volume size

### DIFF
--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -22,6 +22,7 @@ extraBuilderConfig:
     JupyterBook2Builder:
       allow_source_builds: false
 volumeClaim:
+  size: 20G
   accessModes:
   - ReadWriteMany
 auth:


### PR DESCRIPTION
This grows the JupyterBookPub size on Pythia. They have lots of spare storage resources, so this is fine.