### PR TITLE
internaltools: Collect annotations about pods

### DIFF
--- a/terraform/internaltools/variables.tf
+++ b/terraform/internaltools/variables.tf
@@ -17,6 +17,11 @@ variable "federated_metrics_allowlist" {
       name         = "active-users"
       metric_regex = "jupyterhub_active_users"
       labels_regex = "period|namespace"
+    },
+    {
+      name         = "pod-annotations"
+      metric_regex = "kube_pod_annotations"
+      labels_regex = "annotation_hub_jupyter_org_username|pod|namespace"
     }
   ]
   description = <<-EOT


### PR DESCRIPTION
This collects `kube_pod_annotations` metric, which is potentially useful for doing billing related MAU calculations

- closes https://github.com/2i2c-org/meta/issues/3209