### PR TITLE
earthscope: add auth info to prometheus config reload url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
   hooks:
   - id: sops-encryption
     # Add files here if they contain the word 'secret' but should not be encrypted
-    exclude: secrets\.md|helm-charts/support/templates/prometheus-ingres-auth/secret\.yaml|helm-charts/basehub/templates/dex/secret\.yaml|helm-charts/basehub/templates/static/secret\.yaml|config/clusters/templates/common/support\.secret\.values\.yaml|helm-charts/basehub/templates/ingress-auth/secret\.yaml|helm-charts/aws-ce-grafana-backend/templates/secret\.yaml
+    exclude: secrets\.md|helm-charts/support/templates/prometheus-auth/secret\.yaml|helm-charts/support/templates/prometheus-ingres-auth/secret\.yaml|helm-charts/basehub/templates/dex/secret\.yaml|helm-charts/basehub/templates/static/secret\.yaml|config/clusters/templates/common/support\.secret\.values\.yaml|helm-charts/basehub/templates/ingress-auth/secret\.yaml|helm-charts/aws-ce-grafana-backend/templates/secret\.yaml
 
   # Prevent known typos from being committed
 - repo: https://github.com/codespell-project/codespell

--- a/config/clusters/earthscope/enc-support.secret.values.yaml
+++ b/config/clusters/earthscope/enc-support.secret.values.yaml
@@ -1,59 +1,60 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:gXrLyea9v/a3DTUzq/MVDzVeYjf3OCGVFVRZPPoKW5zA2MjuIpw1s/4QtVzXDtrtC7StvWEV+4U4MMKOv0Zz5SQZYj3sKCTF58YzxV3pKT74OMCyhQyEaR0S7gOAsrfmL3ZhiDCbwvBii9cDbahC6/l0AUsbOI0F6Cu4yD0CbaaGJreeMvfIMWQWeR9pDQoWwqg2u4/ibhrXkHk3,iv:MBpHoDumdZTam/rPy77mIa/yT3hHN6PMNdOI/95hx/o=,tag:wfUZsPTxmq9dJJ5kZEzISA==,type:comment]
+  #ENC[AES256_GCM,data:o32QTCgJGDodA3XY/Ct7TT7y724b2qM5Z8/astIC2bXH4pCFA5zVEaDysz86Fd0NNczMo3E7H9+PzNQ9TTmGF7DKUo3m6JoDDhbxaOiA7Iy6Ylt4dC2AyLg3dJbDBbC7wh7Whe4STiDtk3eYFYV67J4l70QdAOrIbEEuFSeXQ9+sk5hvTg4m3ypu6l1njjpM06fZpJvVa+ZaFuX4,iv:L2V/8XdQ4LC97tRXnWnxSDvFtIjCpkaEiG5cx6zlWxQ=,tag:U5b4WXmULoHT1L6EbwMooQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:KEm/ZoAaV03AioPqPyFLmbKBYyCLkmz8KIbNVGrTGSIT8iDdfWGwdV7t1nselXVG5v1eWgUUV13PPUFWyK3y5Q==,iv:kysdXA9kpZB/wONCnEwkmRHYUmE41sHSj3jq7Ib480o=,tag:RLzmsJ4Uw6fxNjinR/vMgQ==,type:str]
-    password: ENC[AES256_GCM,data:O7K1xzXATH6V0zKia4WNbFQIKp5gl+Ccxsdc58E5VCSyFpCM7S9xOQKKK3ri1miZRQpQLVByDEXy9VAC64HwRw==,iv:KPGg6Q3HKVLFXhYxDc7k5caPDGQfQvdvzEqIpruJ4rI=,tag:FFQkg6LWTYJUCbd1SyNRvA==,type:str]
+  - username: ENC[AES256_GCM,data:UBYbZamFcbWkZ9WSxVXc/kSO6Kf1OAUKBj+zqkPm1O2wTIC0aRQZe3BKdfHlywm1poi1hDMl6LkCm4WaIYM4Mg==,iv:LlAHXKs+TJwBELUg2rxs/olCH0P71vMKZT0h8tgZCQ8=,tag:WjZs2cA2gV/x1UEbYtW+6A==,type:str]
+    password: ENC[AES256_GCM,data:nn/qCmdmAXCMLkoRDSW4V/aVV0PBNTBV9IJ4Ue2y7QnQwXXeo17rcnw/iBGMJayKRxL/uV0HcJyVNnxkDQydXA==,iv:HTnOhcfkI5OIs8+ERpV9dLKY01aqKFyZue/9BEalcS8=,tag:YcUGO1pKlCmoaLyiOVZ2oA==,type:str]
+prometheusAuthSecret:
+  username: ENC[AES256_GCM,data:aCeGgWfwuSpXvDlwHHnjVWIwcfTee1SGMEH6fSFtI/gk+R0uDTKE0PxzjRy8VpZHIUE2MzzlpbKDaQgmONmohQ==,iv:U0IEkcla7TuLf25RnbGylajb4uQddUiHPE6yvHfmw7s=,tag:4fxWHlpySXg9ClXrAHHvSw==,type:str]
+  password: ENC[AES256_GCM,data:Chr7FNijWn6crEOTK35VgxsBqHXYgGhOm7/r6IC8gHKhcpQPiasMH/XBDjPpQmxQXuk8xCG3Tpeb1/WeqCWVEw==,iv:xngimDuZx2U2+AqLjjSId2T2ABvaMC92TF3pPsZAwf4=,tag:aELIjNuGq8aq6w+gDBfGtg==,type:str]
 prometheus:
-  configmapReload:
-    reloadUrl: ENC[AES256_GCM,data:EF2yw3vpbhd8qCcE794Gax5kSmdOQGqBj3bfd11qUEpLBhntYhfauu/++jqm1v2fP3+1wSs32c+DU0nKdtQC/qD69aiK24Wyth7OpgxNpYu5ko7Zqs4a2lbQgCYUSexB7UMZWaUaQLh6TZ7fz6Ywekbh4X1Z+WiXdWpCCXqlFmXHmFwux+3gcHKk4Tvq4lAoLVV6Q9Uy1waXXjHHr4vj8A==,iv:RtHrwPTW5UsrF0+EX91ZdJPjHg5ky+4aO5nxYERpAV8=,tag:uFgu1po9qESx9sMRcwiR2Q==,type:str]
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:JfPCCOEsafvIw6QQow==,iv:obPJBW2qsuJfGWQRaXphY4CsdvHOgN6LF7/EdaQ1T34=,tag:f+YZE2Vubhb476aFfWvgwg==,type:str]
-      value: ENC[AES256_GCM,data:xbVQKVnzInyrI/Rm2GQWhK02CSFh5NOOgmAgHi4MUzxpX4k54Hg9I4ZltYkMMTbO7tIGwa6MXfgQ4BEvKLNia9RPH2pY7R13AKTXm7HavmrffEwzeDPCvrsSkpiuY3fuesM/owJ0ukXBjCpDOCbWhPf4RO9eCzylu4KJTvgtSgQ1fMQj4WnwjTIu+bCzDzUzHWhqZ21TGNfEhhHqpTy3MoYHQm6GGKzYnyeI6KbWmddpeA==,iv:396+CTgW5WchwKTAEfL7krjSGG/nqhveKPjOYWhZsaU=,tag:mNdBQDZqiXP15kGIaj3/Dg==,type:str]
+    - name: ENC[AES256_GCM,data:1eA2yeGqGd2e/KVWHQ==,iv:R0m4/SDrraazNlpQP65bRIlOy5wHisTlhansPBCsPec=,tag:x/IPYK3LNBV9m1vJooAq3Q==,type:str]
+      value: ENC[AES256_GCM,data:JvVpyuuoZGyOXxm4AggQTwXbUbtR+O5Dj7061AVtqybn0Ofsnn1tyXUb++/YWOw0+4lTHGb+BpYZjRIpeT/naVgHiCwlCIR+QMK3jvN7cTvy9y9nK2OLIyO4BN4DOr/HsocjfEZoyizAXyxDkbFdW+m/K42zzM+lYMlAKALrxFkPldCvbDW+mmxZpdmd2BfbsLAHvsFtoBROrtrybvEiuGtDyKk293AlnoDssbqkc9w0IQ==,iv:WjfEsmftd7n1I6kX8KxaZjGjqYBPLkA9Wwd65dHCyfM=,tag:2LT8jt/mPOGjIopEjC1NlQ==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:KG/uHVTgG0Nbi19PI4FYyCNh8//zGmLAmVFfW4k6IBYxODHlouCRt+fr0LVspRg/xoDysiZAfzcKQ4Y/asGC6Q==,iv:EAr3k7XD5GRH2HRSH07KL9DzheARX7I0KYUIbqJ/o2k=,tag:9S1+bmqxA+/2Q18Dp7eOyA==,type:str]
-        password: ENC[AES256_GCM,data:JnuivlJymOGxtWF38E4pUvzK41HdoBBMwPQ96Ll3bddGPyuHt6S81gNIA+jP5fKN/9Xz71sW6nPag1troL5zKw==,iv:FKmEx7X+EtTFPku90nkf38qLybmOv8ppJPLsU0pVE+E=,tag:dD58iTgYAzNsIO8gXOVQbQ==,type:str]
+        username: ENC[AES256_GCM,data:oiWdQu2D0Gs6A1PTMm4/RBLE2GQXbhmFbk6rHd58MF8SFgkxONKUmyQ5KIwEgL456WNsk8NEjlYC4mCvvIUCcw==,iv:wSff02qOJm170jiuNMpmgDSC6Ft/orQiBnjgmOHnFSc=,tag:YbhvfblhycQOJqLlMLcXXA==,type:str]
+        password: ENC[AES256_GCM,data:DTw6/HYzqQRyDwJtOxGGt7Zv/TO9nOPmoBs7jfQzpBb5bd9RAgWdrC0HbwBB6PIGHKMEn+1XdR2/aFP8Gn52aQ==,iv:DJc3c4LDdN5gb/uSUPcPV7oYL8cCPtGQtEC/1tXWdhM=,tag:6UQNEo9cwTN3u9sIZRhuug==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:jIkgO0AJ1D27akbYsh9c7aInoT5OIwLyyaTc04dt1pxebckXdOVd+DHudAweUSOSGGJqAii95LnQmXir,iv:ef67DPMTFdUQtLg6JZemOK2GL3UM5i4dk+y8G4WN3vU=,tag:e0s4z5IJHfvDkL5SSCho7A==,type:str]
+        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:K5Ts7IPiFTQugmKYHZD9Zn7LPAmZNL3YkQch87nG8md7KT1g884G/mQw+bqpoduTE/MkDg/Rp4SpGVhH,iv:5soLZvXF/7aV4lbkCmauE6+FLOiTraD6otg0sm5oFdo=,tag:cRS9sadKikox2LTCKNZrDw==,type:str]
 grafana:
   datasources:
     datasources.yaml:
-      apiVersion: ENC[AES256_GCM,data:hQ==,iv:5lquLyLYOSSIzcB7geSZswgeDhv4V+8/rRiYD/krzAA=,tag:pQLOLpsbc+yIhCGZaLO/2A==,type:int]
+      apiVersion: ENC[AES256_GCM,data:WQ==,iv:YpZxC5fH/UGzxSiKWFd+wFS6VlGs6KKT/MgbQYm+H+Q=,tag:B7qpAqwqG/j1WZm4h0w+eA==,type:int]
       datasources:
-      - name: ENC[AES256_GCM,data:7JfXKj2YQCSbRA==,iv:pTClvhuBiOuzj+26xkSiaRErsUr/9pj51tzGuGHdNQU=,tag:DBy0BBnuM0abnUr7Edovrg==,type:str]
-        orgId: ENC[AES256_GCM,data:WQ==,iv:qHgU8si7Nu51bmwcsPrWFD4S3av4KocBjmHOS9CbHrE=,tag:JRGu67IlpUn5X95xy3MhFw==,type:int]
-        type: ENC[AES256_GCM,data:AxfZ4hx2kE49Cw==,iv:I6ATTBNmFDlnAolq5IGBm6w6w0S2GFm/rLTI9vRrb1I=,tag:A7Q4PhpTZVW4vBICOXupbA==,type:str]
-        url: ENC[AES256_GCM,data:YN5t8MEZn12DGYVsJICrOySQC0+vWz8cnPpPngBH5tI=,iv:oqfxeeVCjya0tn6o8XiiJyIHFdTIKMvfP3xn1LThN5c=,tag:dnwY508MmxhAaB8DMpoF/A==,type:str]
-        access: ENC[AES256_GCM,data:qa1/qdE=,iv:GW7IHr7rz8QQ3n4BRPaZLleXgt8rRWoPzZyTtSxemPI=,tag:Hpok629kb7aNCkymGJDJeQ==,type:str]
-        isDefault: ENC[AES256_GCM,data:FKcuVik=,iv:RqrniGpsXIRqytc92hKOQSquVngNTlkRc5lyE4WDpew=,tag:npdMG82eZNKDgHNuIK/BzQ==,type:bool]
-        editable: ENC[AES256_GCM,data:o+fE6r8=,iv:IuGtKlsNk1/lIYpUDNGHxAX6aMzCLnh2xTunu5d4mBs=,tag:RvQ2ZAAOXEUq3ejYVlOcYQ==,type:bool]
-        basicAuth: ENC[AES256_GCM,data:RgrNog==,iv:Te7AX/m94xsa9RlBCtqH9uoUso3xiauM+jjX/eBxsXk=,tag:6SaxM+/MyeF3bxJppoCGSQ==,type:bool]
-        basicAuthUser: ENC[AES256_GCM,data:oeUnp2iA/WxeHz8k14Ny/vYZBq4qyaAg7JOB+e9Vjy4w1+hIFfR1MM8UIJAMoXB1+0JOAYSYC8wSWYYigmLrMA==,iv:329iSMl/IImMEbVfeupjuhX1dSXSzb3STR9dPDodlRw=,tag:InEQ6LXirgo1J0cVr0aVKg==,type:str]
+      - name: ENC[AES256_GCM,data:fPyvXU2/U+0uKA==,iv:iWyOT/N8kdfno6HJf/mXaRP0A9Jk94XxBVwlGGkO1Nk=,tag:9PSEg3kK0RCX+LZobrrRLQ==,type:str]
+        orgId: ENC[AES256_GCM,data:CQ==,iv:BBhxRiKvIrZfgB9qgHA8n55drdapBOR382zHmdCNdrM=,tag:KpAxOX5c8tFZD42ZwH1c1w==,type:int]
+        type: ENC[AES256_GCM,data:yF6c+XvXJtxY5w==,iv:QsD6EZfgrU91DQQ85H46UGc+m1nG1UuxEeANGdQArKM=,tag:pd14fIbhOKEScadO/n6nug==,type:str]
+        url: ENC[AES256_GCM,data:zm8VzpSGbSqdObZG4VwLm2/gsluoF7I6sNMB/gEsVcg=,iv:rwZjmXWXDSPDGUr412ZyyaNC03mDpCsrjDZ92o2GFaI=,tag:Fe4MwdQeBmM1dIDzRhuE+Q==,type:str]
+        access: ENC[AES256_GCM,data:Wzjr87Q=,iv:bAqjJi8W7+Cs3aARDAzTPFQVIU2Jd0HFcGPpBA1sUAc=,tag:rJbJw4myUV1+hBF4+gepiA==,type:str]
+        isDefault: ENC[AES256_GCM,data:0Y+7+W4=,iv:64ZTucyr+v4X3icFggle3+V8Z2s1kEZlakOyVh8r+Rg=,tag:73eh7J684ZQ8grZu2lPoDA==,type:bool]
+        editable: ENC[AES256_GCM,data:JG+A850=,iv:XVzTxcu4irRO/taARrn8t5Ly0yl27RE6PQU9LlNGZwc=,tag:iDn0L9UuaLZqWSUhw9PU4w==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:hSDkfQ==,iv:N8JJnoEDqCnDY5Nn4Fp0mv723x2wXtQjHqjQYOvXo4U=,tag:ii9uvFt3bNFEFJ54YzMVLA==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:QQ+UasIk5TvUQHbK9juPpz72Ob/Hw19zq3Ju8aw+9OQSyTUtmXTW3i8q7OH5n0lLMs8FNHAWJis3WRcxzPVNjA==,iv:Wuw1MLglW7jMZr8y+UJLF1WVx6TNmP8+XKsIOyc/W/I=,tag:4avybiIhkfzM2dzgfQRhgQ==,type:str]
         secureJsonData:
-          basicAuthPassword: ENC[AES256_GCM,data:fDvVCPY9q9VVjhy0YqrwYV6rbE+yrhbafVB2TyQeQTAKtaBV5PBFs5z0KnNDK522IfQlEPC6MgyWjNwftcyiAQ==,iv:8RWPbzSsNaco66dI7RzWGIkdux7gIBbYYzkJZMKqcRE=,tag:phxrt5Mvao+hSHozuuM1Kg==,type:str]
-      - name: ENC[AES256_GCM,data:fKQA+9EJYn6t5fBwO416nTq3cXzaG/aF42G6ELQJPw==,iv:BpNKZhWIvBzdYFQDfW4ivpNPR4wI4czWPy0BPJEnt+A=,tag:MbYmrsqGIs/nekpKc4IrOA==,type:str]
-        type: ENC[AES256_GCM,data:6YXpHzO3SX6/bFlIOu4Ncm33ufND1WWxp6F6OLvkPw==,iv:9zmW8OFkAJ88cVTZ/nXzp+F0ZTw+3Ug3KJLryYRx4RI=,tag:hj2EAvNc/U6j8WQ2RHjmsw==,type:str]
-        isDefault: ENC[AES256_GCM,data:BAvJWpw=,iv:ZADzfWPg2OxdT3rf1/YxCodwkI+jiW/+qpLM7ALJMFc=,tag:zhZvb06H5EGHFfgnYhYi7g==,type:bool]
-        editable: ENC[AES256_GCM,data:DRkpVg==,iv:PfYhRtU2/2v7WUaaSlXzSdA91fB1IHvbMjNTwATq0b4=,tag:Obi77LAFDcjRxw4/bQe5TA==,type:bool]
+          basicAuthPassword: ENC[AES256_GCM,data:rDFt+DeSApf+qnUMYgHhA1zcmx1VdKv6jw2sO2inEgom0rlxW7tY9jxmh/3Wpm3pVw38DhJn+/7vGTKfVa+E1A==,iv:fTtoPdrbqcvSOW94yzPpLmuYEtK5XjRaMeyPZPyQMos=,tag:7HhBwKX56prfjTVcFN/mFw==,type:str]
+      - name: ENC[AES256_GCM,data:L46tfUlXCkH7X2n6LrkQ5L27gqdW7wYjYNUqIR8VIg==,iv:4mXMjwt4jpJ15on5/pRot5Pgfl5i+/VdtiTw8WLGN6E=,tag:BsQQKvyrcut3IzwKoECGCQ==,type:str]
+        type: ENC[AES256_GCM,data:Q2pVBRXGDCcbcncXOS0HTjo04Yq0sorg9I+WuBlBvA==,iv:WMB8YDo8oL0g58qQc1H6Vjp8wIkLwNK9J197VvgoaAI=,tag:1n6s1kLZDnaq60jW5JmAqg==,type:str]
+        isDefault: ENC[AES256_GCM,data:4k4meK8=,iv:1Ce14Olbz7DUx+ltbmArLQE9IG0DGWQJyotiEwK3ryU=,tag:ZTpB6ogi0fu+CedYB6YRmg==,type:bool]
+        editable: ENC[AES256_GCM,data:l0oYgg==,iv:foOlU3uvObWsKUArMBTI3wY1ppzF/hqll9tvaVNEgqA=,tag:P5tdNxZ93ot4pMlTDk8xbA==,type:bool]
 jupyterhub-cost-monitoring:
   prometheusAuth:
-    enabled: ENC[AES256_GCM,data:D16PYQ==,iv:ai/CSkugcl6jIbutKVmHY4y0lDcxmTpnviIDMkPGT+I=,tag:QktJyLVTYr6qTBiIJ67ezQ==,type:bool]
-    username: ENC[AES256_GCM,data:fMIJrw/WVvG6+4k8D7jht7FgwL1ZYfBanEUHmn3eyPIhFulUeGltB2Nuj2Z8gDJLjPZ6CekYl/9sP1YKvNjE9w==,iv:a6dF2Bf8WdvD7wOhx73WQ/P4r3hf+6tDaGKXBw0cy/c=,tag:4xQEOGQV8t9YK1b6BMROBg==,type:str]
-    password: ENC[AES256_GCM,data:d0liNTmT0f1ETMOT72Wf1L0vVQPaRB8BMEacbyUtODVvSgMPCtI4mJ96Fsyrsu1mxCLg+ES/WW3aCoKfkX8Mdg==,iv:py6R44hIJfGXFBNXfPiulB2orNOXdot7ZC8SwGg/9R4=,tag:sTzV6Fe3zhO0pQ8Ekx6uWQ==,type:str]
+    enabled: ENC[AES256_GCM,data:uBi3pg==,iv:hlXxs7sfxKbpwe9Bd8hha6GshLqEvKt7AmbYMmSOGzA=,tag:mlvkg2Y2wmb7g7YdNFJLrA==,type:bool]
+    username: ENC[AES256_GCM,data:/wh2gxjsjAwId7VYqXIMdsCV0JanFu1YiUT421apMOdOLFeXS2XrLKjJyMGZLPtOfcQh6FAxE20b6Wd998Wxtg==,iv:nfmBE9sx5xWS+Wqs+BYquwCfRlH9W3DtGtl1Y/1YRi4=,tag:eT5qlknGgAh5SHQhOArMkw==,type:str]
+    password: ENC[AES256_GCM,data:yB1n/HTWydclIbglwg5Ohwyoyo+DNDrynFWRx4luba/0E3z2CAhqCzOJZ/9XOC2vwjhCKT8Dm05Wv9/BMrEqtQ==,iv:+GnFOAeoHJv0Xe+mGhAMqVPD8ZPQS3r9KEL2mcF3zCQ=,tag:iuk7qy3Kmcq4klhTCW7RbQ==,type:str]
 sops:
   kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-05-08T09:19:06Z'
-    enc: CiUA4OM7eNIs8YZ4OVTnHyeLqYSy6xhomswhVtyrZ+fH/6xGAjHcEkkAmy+ekqA9OElyAvgoSkqDX62JWbk8HYWepYBbyWruyflyXhujIMsPLTVrmSGoVYyEGRW2oe/qqV3ATqd13mQne0pxQscziXK7
+    created_at: '2026-05-11T07:36:44Z'
+    enc: CiUA4OM7eL5BTyD6u6+W6UECOfD5t8/n8WTvxvJaF7DKO1gk8+XIEkgAmy+eknknFRkQtor/h0oMJhVcgoA1nNhqSEBOtJViKorlm5jO57/nvICMoDKWOW7ctJZha6wDMz6bsky/LeMZYYqN7QeiDno=
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2026-05-08T09:19:07Z'
-  mac: ENC[AES256_GCM,data:2uz5nZojfMmpIcG0kgmXmBg1iLcn/3oKt9sGJpLSEWDtFWyT6iHr97eeBjsW8yWwOnSOCI5uE6XWjGn4bQQ6cBNysbC86HaxvgNED+WxtONLrKG8A9l/B/vkzCb863hiRqLF9LbE1+XKQhLVj969+AdaPhf81cRa73EVu2Z9nVk=,iv:4+x+J8vgWSvD5TxKKLaXHB8LpbUZ6+cGfKI6E8bXDcw=,tag:I6cFIA6YbGKg2T2g4Um2WQ==,type:str]
+  lastmodified: '2026-05-11T07:36:45Z'
+  mac: ENC[AES256_GCM,data:747MBFIZzEY/hKj0SSqAEjoOG0RMknBi3S9leT4h7WtyVBkYqmeQFuT2TErnmDNYDkt3U2Vh3WbVNjgZS17OBRUqe43bTVaYClXG+1qEO4SGFQkVwbgNtCtCXkoKz9W92RRbFiKXuwc2QLAgqNReH3bLy+NxYRzDTwzFnwFjLq8=,iv:HfpRUkBJlJwvuV5jaXpyOxGDXDNAOVkdUKWvn22IB2A=,tag:egtu0vyhrj87AO+/M9KQWg==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.0

--- a/config/clusters/earthscope/enc-support.secret.values.yaml
+++ b/config/clusters/earthscope/enc-support.secret.values.yaml
@@ -1,59 +1,59 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:/Ee2+Ho2mKhZng/AZ3ThrxRKryArV1a0r1LUOv8SdKFpueF2QcJ0jrmOdEwjc4Hw5j5OmPALNDyST9OX0DNf221GwyORWXeIxUfjT52p6eJ1gIrMVo51mA4KIMglCk5w5Z+7FHUruJZ8D0Ljls/5Wzn1nXNCv3ezDA1va0mWJ8OVLrS0riGHrBy6+Ij+PboykmxlYihS0zR76MR1,iv:xYkCyrp/mC60Ctn17kskBbQjK0gGGHi4LnEo0krfSK0=,tag:jKyiUcVTpi41m4TEFXHIkQ==,type:comment]
+  #ENC[AES256_GCM,data:gXrLyea9v/a3DTUzq/MVDzVeYjf3OCGVFVRZPPoKW5zA2MjuIpw1s/4QtVzXDtrtC7StvWEV+4U4MMKOv0Zz5SQZYj3sKCTF58YzxV3pKT74OMCyhQyEaR0S7gOAsrfmL3ZhiDCbwvBii9cDbahC6/l0AUsbOI0F6Cu4yD0CbaaGJreeMvfIMWQWeR9pDQoWwqg2u4/ibhrXkHk3,iv:MBpHoDumdZTam/rPy77mIa/yT3hHN6PMNdOI/95hx/o=,tag:wfUZsPTxmq9dJJ5kZEzISA==,type:comment]
   users:
-    - username: ENC[AES256_GCM,data:akWiIqGyFogf6aTQr0/mSSciNpPYnAhmpZ7kap/UM1RMYTUqwxsnukEl8KRq0W0F8FiKG22EoR9pPDfHcSvAPA==,iv:SYJES24wy6kkUW4vM25JFyVEtSWYRnUyFVqIhJkdgPw=,tag:Lt9og0GK7zxCy+bLzcGTFw==,type:str]
-      password: ENC[AES256_GCM,data:BwK3eHJ1goRCHXqlYNvdRWXSevptBQOfasA8AkOUShJu2avSZ9zsxoxpoZW+Zd4+3kFbqhFOJqaaLP20afbcTQ==,iv:CDNw7mUSluhLZHvyBerDYjdb0YwEd4AB+tqr7B28n+0=,tag:qPTYnUDmg1uV5Dgv7+U7EA==,type:str]
+  - username: ENC[AES256_GCM,data:KEm/ZoAaV03AioPqPyFLmbKBYyCLkmz8KIbNVGrTGSIT8iDdfWGwdV7t1nselXVG5v1eWgUUV13PPUFWyK3y5Q==,iv:kysdXA9kpZB/wONCnEwkmRHYUmE41sHSj3jq7Ib480o=,tag:RLzmsJ4Uw6fxNjinR/vMgQ==,type:str]
+    password: ENC[AES256_GCM,data:O7K1xzXATH6V0zKia4WNbFQIKp5gl+Ccxsdc58E5VCSyFpCM7S9xOQKKK3ri1miZRQpQLVByDEXy9VAC64HwRw==,iv:KPGg6Q3HKVLFXhYxDc7k5caPDGQfQvdvzEqIpruJ4rI=,tag:FFQkg6LWTYJUCbd1SyNRvA==,type:str]
 prometheus:
   configmapReload:
-    reloadUrl: ENC[AES256_GCM,data:UfiB/c8Gqv1PuhwgkonYuBoj9Bm8YxxE5gyp8TrlHGzR71Q+QtjPEkNFEPhHXnvL/l5KTgnRK6lcdykEegwGQhzgNXMjaHHFTI6ATN3awrWZG6uQCZvYzcCokXHdUdwnqQ7IV8+5qg/oZyUiC5wOwvHehG8QTEWUxu9ga5RU8SfcmMFvJa+WW4HoXL1IsWroyDm6HFmhWzWuLItli4GR4w==,iv:JOtExo1BnUnl8q9zUq5jKzuG3bnwkkPTPSP2M5HuX/s=,tag:kRjzK1TSEi5B95RsA+E++w==,type:str]
+    reloadUrl: ENC[AES256_GCM,data:EF2yw3vpbhd8qCcE794Gax5kSmdOQGqBj3bfd11qUEpLBhntYhfauu/++jqm1v2fP3+1wSs32c+DU0nKdtQC/qD69aiK24Wyth7OpgxNpYu5ko7Zqs4a2lbQgCYUSexB7UMZWaUaQLh6TZ7fz6Ywekbh4X1Z+WiXdWpCCXqlFmXHmFwux+3gcHKk4Tvq4lAoLVV6Q9Uy1waXXjHHr4vj8A==,iv:RtHrwPTW5UsrF0+EX91ZdJPjHg5ky+4aO5nxYERpAV8=,tag:uFgu1po9qESx9sMRcwiR2Q==,type:str]
   server:
     probeHeaders:
-      - name: ENC[AES256_GCM,data:VPakQ2lJuC99EhIgcQ==,iv:B8xNK2JkQ2wNJlI41gQyykp6Xu8q1cPzO/JjecV2Vps=,tag:U1QJ9sK20cKcfrPaB5htRg==,type:str]
-        value: ENC[AES256_GCM,data:T6TvEjqGDZ/InlO0vEmkep+kcZ2ZSRQrA+7HMapMDrwbLQ+Hh23LTtbvQ+jgrWiM9uESaYgEtSv2oYwli+J/nlAho0HDhHEAWKG/bVed36LeH6cBtBaMrtmYOAvpbiTSW3XZkOPfbPRJrDJSx5AGF/N9VNyvBoKiSkgJOYHFR2JPo/DxyfDemeWjBhHNZHkwUR8CEL4QEcLx6GT/NP0pJ+vsWVa5uxIN0tDBqHL/1MxOJw==,iv:nAqFejHSlJiK8DHJ/KhcXaHhEgUVjXTQL7Qs4XOQc9M=,tag:lp+cy3xbyxz21j+IqyXk7w==,type:str]
+    - name: ENC[AES256_GCM,data:JfPCCOEsafvIw6QQow==,iv:obPJBW2qsuJfGWQRaXphY4CsdvHOgN6LF7/EdaQ1T34=,tag:f+YZE2Vubhb476aFfWvgwg==,type:str]
+      value: ENC[AES256_GCM,data:xbVQKVnzInyrI/Rm2GQWhK02CSFh5NOOgmAgHi4MUzxpX4k54Hg9I4ZltYkMMTbO7tIGwa6MXfgQ4BEvKLNia9RPH2pY7R13AKTXm7HavmrffEwzeDPCvrsSkpiuY3fuesM/owJ0ukXBjCpDOCbWhPf4RO9eCzylu4KJTvgtSgQ1fMQj4WnwjTIu+bCzDzUzHWhqZ21TGNfEhhHqpTy3MoYHQm6GGKzYnyeI6KbWmddpeA==,iv:396+CTgW5WchwKTAEfL7krjSGG/nqhveKPjOYWhZsaU=,tag:mNdBQDZqiXP15kGIaj3/Dg==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:ejrYp8MrOoGvzyM9qlsbtJT2D9q3oU08EnbuBmxLf2oEeY6n6B+JYyNZrhtlBjQSwSfL2jz9db2E/F7tDJXMgQ==,iv:vLUxKMXWIl4evn7tx61mMtQhL45S7AFnENYqVHydWvw=,tag:0wYunPg43VZLGFhB2Bo8ow==,type:str]
-        password: ENC[AES256_GCM,data:kZOcmvL8KGUZ6X3X88arADC7g6Kq5YQ+IX+IibyUl9s6rCsxt+EVo7UwjVkKiW5GlczVmI444ML3kFpHGcYiHg==,iv:2mJ13RKv4J8yy+SgBoxscF+ddrlpRKrWkonGirYMMF8=,tag:a7vR7UonPUW2zaAuvvHMZQ==,type:str]
+        username: ENC[AES256_GCM,data:KG/uHVTgG0Nbi19PI4FYyCNh8//zGmLAmVFfW4k6IBYxODHlouCRt+fr0LVspRg/xoDysiZAfzcKQ4Y/asGC6Q==,iv:EAr3k7XD5GRH2HRSH07KL9DzheARX7I0KYUIbqJ/o2k=,tag:9S1+bmqxA+/2Q18Dp7eOyA==,type:str]
+        password: ENC[AES256_GCM,data:JnuivlJymOGxtWF38E4pUvzK41HdoBBMwPQ96Ll3bddGPyuHt6S81gNIA+jP5fKN/9Xz71sW6nPag1troL5zKw==,iv:FKmEx7X+EtTFPku90nkf38qLybmOv8ppJPLsU0pVE+E=,tag:dD58iTgYAzNsIO8gXOVQbQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:TaZh4s2VYyNZrsBJ48ujgSmLpUQvqO2Wix8iwvExk74JhzE3ZssjwzK2Mpz3fVhYa3c3f4P9QUNDSRcU,iv:GEEvew8QIXVlfNJgQFQoAtQv0sanT/myrXJwl8a+k/k=,tag:EAcSxeesqyqIM8pYPeweXQ==,type:str]
+        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:jIkgO0AJ1D27akbYsh9c7aInoT5OIwLyyaTc04dt1pxebckXdOVd+DHudAweUSOSGGJqAii95LnQmXir,iv:ef67DPMTFdUQtLg6JZemOK2GL3UM5i4dk+y8G4WN3vU=,tag:e0s4z5IJHfvDkL5SSCho7A==,type:str]
 grafana:
   datasources:
     datasources.yaml:
-      apiVersion: ENC[AES256_GCM,data:Ng==,iv:B4jNeGsKpKUlVU83fLz5aZQV4thYuoeOMc/qkA0SIUs=,tag:jB/29MkNCYalTuYrk3T1qw==,type:int]
+      apiVersion: ENC[AES256_GCM,data:hQ==,iv:5lquLyLYOSSIzcB7geSZswgeDhv4V+8/rRiYD/krzAA=,tag:pQLOLpsbc+yIhCGZaLO/2A==,type:int]
       datasources:
-        - name: ENC[AES256_GCM,data:S0mEGvIDumYUAA==,iv:UGj2e7YbHDzyznJBeQq6fLa3hCUbzmtl+wRtM6yz8CU=,tag:8y0bLfgPcuZHkspxdM61lw==,type:str]
-          orgId: ENC[AES256_GCM,data:nQ==,iv:W3Y6rDzy9RBdn4ABVt0Mqo9T1fU8SQ0kJhCrhWrIpzI=,tag:oJ3nq+qNFZ6tDd+k1W/PWg==,type:int]
-          type: ENC[AES256_GCM,data:5Rnm9EC7/YrQPw==,iv:Y7G2AOW5OculmMkMpKkFRQiTEEiwIDlLmYXZTUOyfEo=,tag:vQKk08QstQ6cEnImv/wjYw==,type:str]
-          url: ENC[AES256_GCM,data:zhZMecpCYRlnM/21ZMeyUcQoWsWlEouZRxm7YCh2KZo=,iv:SlBZ2pHaKiDSsTkf0X27w2QENXZT0RTLauuoepVI3y8=,tag:Bv4s5tn/J4G+a+ACz9jU1g==,type:str]
-          access: ENC[AES256_GCM,data:D6kNN8s=,iv:qlXeE4CABiaQI8t6COVWH2d+D3v0bVtT++NjVYLXgBs=,tag:eS21GmHtf5bBG5f1RsZ1Jw==,type:str]
-          isDefault: ENC[AES256_GCM,data:4YBVV9A=,iv:UmefDmg1Rj2Vpa7T+RwAR9/8T85NhufkW9d059g8ycI=,tag:aYhltnDSzbg06TIzKfd8XA==,type:bool]
-          editable: ENC[AES256_GCM,data:wWCIBf8=,iv:JU3XXG9q/MA8pd3mDoOVvkRa1PrfHot9TXRorG5TepM=,tag:E7uoS6XdTOYvQxSx4QSPLg==,type:bool]
-          basicAuth: ENC[AES256_GCM,data:iuu98Q==,iv:PuQ6fwnLqkR0UxwjN8/5z0qokXGc9AWXjTYLzvqKdnk=,tag:0BiEdo4+bh3OO9kPvYCQGg==,type:bool]
-          basicAuthUser: ENC[AES256_GCM,data:xHiduGvf4kQchxmZFuDg17y59kz+2Tw0l9Dc3caR4d3N4PL6Vcc4ezY1JCzTGJqOGoLKscXAudiXjMeaPjkr2w==,iv:sAJ8WwK85LT/0My4fycr3ng8zPDRhtWLLPdChfa+OyU=,tag:Pd61Pab7sXBOCexoSy3GMQ==,type:str]
-          secureJsonData:
-            basicAuthPassword: ENC[AES256_GCM,data:OfCJKn497C9VvAuLao4DWmEE0yW01htPXxIUOLJOSmSVASGX+6zIo1lnumL2GlyyMt8nyFalp0AdE1pKVHXL5A==,iv:xEtESHTKhtRwEr7nbHtUAZ6gWAMr9zWz/i0eOqjNoWk=,tag:zrXzCl+M6aDhbEjapbNmcQ==,type:str]
-        - name: ENC[AES256_GCM,data:Q1Qy3flNf8dNtSY3xC49FYIcGLjeVgI12wJmyFiaeg==,iv:ku+GHUCxPvg9j6vzEMCqeLOjifvysTXK34vu0HCMU14=,tag:97cf7KEU3xpuECwVRRDWCA==,type:str]
-          type: ENC[AES256_GCM,data:gMRnye14yz7sGEAD0tL5BDKrXrnxfnu+vd5dUEz/Ag==,iv:oH7a0C4937bC34juDbPfdZvjGJoXRCUt5mKs9v/8eaY=,tag:Qg4I1Trto8pUMx2IpsUJzg==,type:str]
-          isDefault: ENC[AES256_GCM,data:tHKwagI=,iv:Eon1hLPq6ta+SHwGYLVSo28STOaY4Mjj2UT5UR3Rg+g=,tag:AvG03dfRNPFlmLk8SFeYww==,type:bool]
-          editable: ENC[AES256_GCM,data:HQlqYw==,iv:9CGWlgYrmW5FGL0AJxF4NgqKlVjv7sz0xPmcvH4REYI=,tag:rxF4qTC0N43mw/hQNll8SQ==,type:bool]
+      - name: ENC[AES256_GCM,data:7JfXKj2YQCSbRA==,iv:pTClvhuBiOuzj+26xkSiaRErsUr/9pj51tzGuGHdNQU=,tag:DBy0BBnuM0abnUr7Edovrg==,type:str]
+        orgId: ENC[AES256_GCM,data:WQ==,iv:qHgU8si7Nu51bmwcsPrWFD4S3av4KocBjmHOS9CbHrE=,tag:JRGu67IlpUn5X95xy3MhFw==,type:int]
+        type: ENC[AES256_GCM,data:AxfZ4hx2kE49Cw==,iv:I6ATTBNmFDlnAolq5IGBm6w6w0S2GFm/rLTI9vRrb1I=,tag:A7Q4PhpTZVW4vBICOXupbA==,type:str]
+        url: ENC[AES256_GCM,data:YN5t8MEZn12DGYVsJICrOySQC0+vWz8cnPpPngBH5tI=,iv:oqfxeeVCjya0tn6o8XiiJyIHFdTIKMvfP3xn1LThN5c=,tag:dnwY508MmxhAaB8DMpoF/A==,type:str]
+        access: ENC[AES256_GCM,data:qa1/qdE=,iv:GW7IHr7rz8QQ3n4BRPaZLleXgt8rRWoPzZyTtSxemPI=,tag:Hpok629kb7aNCkymGJDJeQ==,type:str]
+        isDefault: ENC[AES256_GCM,data:FKcuVik=,iv:RqrniGpsXIRqytc92hKOQSquVngNTlkRc5lyE4WDpew=,tag:npdMG82eZNKDgHNuIK/BzQ==,type:bool]
+        editable: ENC[AES256_GCM,data:o+fE6r8=,iv:IuGtKlsNk1/lIYpUDNGHxAX6aMzCLnh2xTunu5d4mBs=,tag:RvQ2ZAAOXEUq3ejYVlOcYQ==,type:bool]
+        basicAuth: ENC[AES256_GCM,data:RgrNog==,iv:Te7AX/m94xsa9RlBCtqH9uoUso3xiauM+jjX/eBxsXk=,tag:6SaxM+/MyeF3bxJppoCGSQ==,type:bool]
+        basicAuthUser: ENC[AES256_GCM,data:oeUnp2iA/WxeHz8k14Ny/vYZBq4qyaAg7JOB+e9Vjy4w1+hIFfR1MM8UIJAMoXB1+0JOAYSYC8wSWYYigmLrMA==,iv:329iSMl/IImMEbVfeupjuhX1dSXSzb3STR9dPDodlRw=,tag:InEQ6LXirgo1J0cVr0aVKg==,type:str]
+        secureJsonData:
+          basicAuthPassword: ENC[AES256_GCM,data:fDvVCPY9q9VVjhy0YqrwYV6rbE+yrhbafVB2TyQeQTAKtaBV5PBFs5z0KnNDK522IfQlEPC6MgyWjNwftcyiAQ==,iv:8RWPbzSsNaco66dI7RzWGIkdux7gIBbYYzkJZMKqcRE=,tag:phxrt5Mvao+hSHozuuM1Kg==,type:str]
+      - name: ENC[AES256_GCM,data:fKQA+9EJYn6t5fBwO416nTq3cXzaG/aF42G6ELQJPw==,iv:BpNKZhWIvBzdYFQDfW4ivpNPR4wI4czWPy0BPJEnt+A=,tag:MbYmrsqGIs/nekpKc4IrOA==,type:str]
+        type: ENC[AES256_GCM,data:6YXpHzO3SX6/bFlIOu4Ncm33ufND1WWxp6F6OLvkPw==,iv:9zmW8OFkAJ88cVTZ/nXzp+F0ZTw+3Ug3KJLryYRx4RI=,tag:hj2EAvNc/U6j8WQ2RHjmsw==,type:str]
+        isDefault: ENC[AES256_GCM,data:BAvJWpw=,iv:ZADzfWPg2OxdT3rf1/YxCodwkI+jiW/+qpLM7ALJMFc=,tag:zhZvb06H5EGHFfgnYhYi7g==,type:bool]
+        editable: ENC[AES256_GCM,data:DRkpVg==,iv:PfYhRtU2/2v7WUaaSlXzSdA91fB1IHvbMjNTwATq0b4=,tag:Obi77LAFDcjRxw4/bQe5TA==,type:bool]
 jupyterhub-cost-monitoring:
   prometheusAuth:
-    enabled: ENC[AES256_GCM,data:pNK9Og==,iv:iKy5MlD/1WA94KLSar5jldutiR+przARH3PrJGFMq70=,tag:/vffe4sGRLl/lArfn61JGQ==,type:bool]
-    username: ENC[AES256_GCM,data:kXjBXZO+q+yDEUKw+j/OYhYoxfPhKp+4CNpST30Lgw52DUtHZJW0V4VEnay7vsSETEMNL8CG0fqrlsa3ajt1Mw==,iv:rg5gihL7+3Cgjc94z+xnMozHMuIzEt0y0M+92TPwdq0=,tag:+rwLD8Y4lyqqSQRPOSm3vg==,type:str]
-    password: ENC[AES256_GCM,data:oLKNB470pUb5UxTKCbCKVHsH7dkF2yLlq0qeVvcIjYWJzhU33vnUnMKSmqwAO7mhtWZG7+G4p3oSluBXavEjcA==,iv:b5Qd1bVr0l1RFvpRkYwmNrTcfw4PKJVxBzFHat15kic=,tag:U68vS+jvYhGY+bS0qDOX6A==,type:str]
+    enabled: ENC[AES256_GCM,data:D16PYQ==,iv:ai/CSkugcl6jIbutKVmHY4y0lDcxmTpnviIDMkPGT+I=,tag:QktJyLVTYr6qTBiIJ67ezQ==,type:bool]
+    username: ENC[AES256_GCM,data:fMIJrw/WVvG6+4k8D7jht7FgwL1ZYfBanEUHmn3eyPIhFulUeGltB2Nuj2Z8gDJLjPZ6CekYl/9sP1YKvNjE9w==,iv:a6dF2Bf8WdvD7wOhx73WQ/P4r3hf+6tDaGKXBw0cy/c=,tag:4xQEOGQV8t9YK1b6BMROBg==,type:str]
+    password: ENC[AES256_GCM,data:d0liNTmT0f1ETMOT72Wf1L0vVQPaRB8BMEacbyUtODVvSgMPCtI4mJ96Fsyrsu1mxCLg+ES/WW3aCoKfkX8Mdg==,iv:py6R44hIJfGXFBNXfPiulB2orNOXdot7ZC8SwGg/9R4=,tag:sTzV6Fe3zhO0pQ8Ekx6uWQ==,type:str]
 sops:
   kms: []
   gcp_kms:
-    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-      created_at: "2026-05-08T08:57:57Z"
-      enc: CiUA4OM7eLIkao+TFS5UyL3WZEDg+MM+oAqdaWXaOKKPJrVfpZiREkkAmy+eksE5fKQlYY5nwzCXpGuCluEe/2blS8HSFIV94H8I0ZFlJnKcd2+EVacvkmojQJk8AtvLjiTioeymsiE5UXe7FrvHRGC/
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-05-08T09:19:06Z'
+    enc: CiUA4OM7eNIs8YZ4OVTnHyeLqYSy6xhomswhVtyrZ+fH/6xGAjHcEkkAmy+ekqA9OElyAvgoSkqDX62JWbk8HYWepYBbyWruyflyXhujIMsPLTVrmSGoVYyEGRW2oe/qqV3ATqd13mQne0pxQscziXK7
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-05-08T08:57:58Z"
-  mac: ENC[AES256_GCM,data:osTriHCSiyVylmQ4XhaRwj0PKxEk7qfpnVweO6fROQwcU24AwgRRVdyzs15w1q4rcN+mhB1JrQhFx3tPdYoZzSP4MPFpqk+KQ8M1go/8pGLHofXYRhwOD+6pLK5QvFfeTbvJfYPPCUL+j0o1euzpSVFNZIaSKyhqzeabiV5hcSY=,iv:afEV1YzHn2H5JmB+Lx/TTACbxZV17jV5FtRFPA/w5VY=,tag:XFWpuLe3qsm2jKYqbCqgbQ==,type:str]
+  lastmodified: '2026-05-08T09:19:07Z'
+  mac: ENC[AES256_GCM,data:2uz5nZojfMmpIcG0kgmXmBg1iLcn/3oKt9sGJpLSEWDtFWyT6iHr97eeBjsW8yWwOnSOCI5uE6XWjGn4bQQ6cBNysbC86HaxvgNED+WxtONLrKG8A9l/B/vkzCb863hiRqLF9LbE1+XKQhLVj969+AdaPhf81cRa73EVu2Z9nVk=,iv:4+x+J8vgWSvD5TxKKLaXHB8LpbUZ6+cGfKI6E8bXDcw=,tag:I6cFIA6YbGKg2T2g4Um2WQ==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.9.0

--- a/config/clusters/earthscope/enc-support.secret.values.yaml
+++ b/config/clusters/earthscope/enc-support.secret.values.yaml
@@ -1,52 +1,59 @@
 prometheusIngressAuthSecret:
-  #ENC[AES256_GCM,data:f+KcBDOKzjCkg4nRdbiZte6nAU4bRRLNXTsoqjVgNKJB4UNjAjX4PdxWXHglTGl7grW9dV/GwihFuS9OJok8bYENBUXT90JREnETAzVwoLmYY8qZEove68G4s/Q9rJbXnVfaCEKavC8ku2FPbMMiWmNHmHczCYG2im4WIy7guUhKUdSwZOzsgw9GgLGNuYdcOb9nMXQFhYHoOTwT,iv:QDtb8RP1Lh0btvWy5FDrMTPswE0i0NK9r0XICY2SKMw=,tag:UBIuaMdet45mxeiJFeLV6A==,type:comment]
+  #ENC[AES256_GCM,data:/Ee2+Ho2mKhZng/AZ3ThrxRKryArV1a0r1LUOv8SdKFpueF2QcJ0jrmOdEwjc4Hw5j5OmPALNDyST9OX0DNf221GwyORWXeIxUfjT52p6eJ1gIrMVo51mA4KIMglCk5w5Z+7FHUruJZ8D0Ljls/5Wzn1nXNCv3ezDA1va0mWJ8OVLrS0riGHrBy6+Ij+PboykmxlYihS0zR76MR1,iv:xYkCyrp/mC60Ctn17kskBbQjK0gGGHi4LnEo0krfSK0=,tag:jKyiUcVTpi41m4TEFXHIkQ==,type:comment]
   users:
-  - username: ENC[AES256_GCM,data:N+oqXZrEbOX5rcYuNM7THBC8nm+rn7kNsFEiO3G7GPu46iXww6rd1sWDJZCICxSpsISsLCyVP66T4mXCANcgng==,iv:NZzxyNs6vkvNnrW79Fai3dV7U6a/Cs3O07tck3CuZ2E=,tag:LVgDm3w+ogmJs19T0C4mAg==,type:str]
-    password: ENC[AES256_GCM,data:UhBdyhORIi1I2lRAlfL2T6hFyr3k8lxtzGN+I7GmBTgiiPQNZ6cR4mTTSxy2vhMNnwH+PlxGrzIkkT6eEF08DQ==,iv:Vm1qZmUJJyH1G9qAt6ydmRJQLqmcfyOrKlejYBNOWZU=,tag:V9PgrpMpPShd6wQaoT/cKw==,type:str]
+    - username: ENC[AES256_GCM,data:akWiIqGyFogf6aTQr0/mSSciNpPYnAhmpZ7kap/UM1RMYTUqwxsnukEl8KRq0W0F8FiKG22EoR9pPDfHcSvAPA==,iv:SYJES24wy6kkUW4vM25JFyVEtSWYRnUyFVqIhJkdgPw=,tag:Lt9og0GK7zxCy+bLzcGTFw==,type:str]
+      password: ENC[AES256_GCM,data:BwK3eHJ1goRCHXqlYNvdRWXSevptBQOfasA8AkOUShJu2avSZ9zsxoxpoZW+Zd4+3kFbqhFOJqaaLP20afbcTQ==,iv:CDNw7mUSluhLZHvyBerDYjdb0YwEd4AB+tqr7B28n+0=,tag:qPTYnUDmg1uV5Dgv7+U7EA==,type:str]
 prometheus:
+  configmapReload:
+    reloadUrl: ENC[AES256_GCM,data:UfiB/c8Gqv1PuhwgkonYuBoj9Bm8YxxE5gyp8TrlHGzR71Q+QtjPEkNFEPhHXnvL/l5KTgnRK6lcdykEegwGQhzgNXMjaHHFTI6ATN3awrWZG6uQCZvYzcCokXHdUdwnqQ7IV8+5qg/oZyUiC5wOwvHehG8QTEWUxu9ga5RU8SfcmMFvJa+WW4HoXL1IsWroyDm6HFmhWzWuLItli4GR4w==,iv:JOtExo1BnUnl8q9zUq5jKzuG3bnwkkPTPSP2M5HuX/s=,tag:kRjzK1TSEi5B95RsA+E++w==,type:str]
   server:
     probeHeaders:
-    - name: ENC[AES256_GCM,data:PZOhb6FwvlrS2Ya2yw==,iv:FkaMTsVQgvkJ8XkedFJ6z0cr1HgN1Qz4KfoK+303Svg=,tag:WQPo6Q3pRS22xSgkA3arKw==,type:str]
-      value: ENC[AES256_GCM,data:+Jp+lMKHTy7zQuay4ZQtmyqpQ8/38gHctwKgPS0JAkj3xf0ge1vkNIfeYaFfn/Tp7yZQpd/gJBnb006WNSPutwagMa4NTnrz/3ceBrrzlVe8pBlXqPzdATWSc05i94LNZt2ptLBN4ZjNUpwR0tTxyPaq/d6QBrCmti35h3KKwsNyCzjMxGUA8N0QbQPdLzTHM+hiqb35qAUkFHaiDQCEk/j9EvXHsLwTzLHwc2LZVPt+Xw==,iv:5i9dWrTQxXUtjuIh/dW+Wp/Bh5ZnyMVgDapW5RyYhQ4=,tag:EmvNnievehmFrBlMp7XJ4A==,type:str]
+      - name: ENC[AES256_GCM,data:VPakQ2lJuC99EhIgcQ==,iv:B8xNK2JkQ2wNJlI41gQyykp6Xu8q1cPzO/JjecV2Vps=,tag:U1QJ9sK20cKcfrPaB5htRg==,type:str]
+        value: ENC[AES256_GCM,data:T6TvEjqGDZ/InlO0vEmkep+kcZ2ZSRQrA+7HMapMDrwbLQ+Hh23LTtbvQ+jgrWiM9uESaYgEtSv2oYwli+J/nlAho0HDhHEAWKG/bVed36LeH6cBtBaMrtmYOAvpbiTSW3XZkOPfbPRJrDJSx5AGF/N9VNyvBoKiSkgJOYHFR2JPo/DxyfDemeWjBhHNZHkwUR8CEL4QEcLx6GT/NP0pJ+vsWVa5uxIN0tDBqHL/1MxOJw==,iv:nAqFejHSlJiK8DHJ/KhcXaHhEgUVjXTQL7Qs4XOQc9M=,tag:lp+cy3xbyxz21j+IqyXk7w==,type:str]
     configmapReload:
       prometheus:
-        username: ENC[AES256_GCM,data:lcWRj7HChsB6B89CWM+Ig54vTIWyjAc7EUxa1P7xvEZDHMMHRpRjwfHjOuLJwZp2o0j7rPNjTKOT6jSJigeQqQ==,iv:rR24YwsC7QilIZ5ZFUz7rHn8fBSmHBhKebsp+y137KI=,tag:fUuoWhZwV8+N3jUSS3jKLw==,type:str]
-        password: ENC[AES256_GCM,data:O8jAwx6IwaS673hst+6x4IWMRB5N7SixOYoLPt9Ax/XbfnOPkjABuD7fTxgwKQVA7LRlmPvZDN9DL1F/0j3aRw==,iv:10PqGIUBqGMNIue7pXIz36pvUZBhFE+WVhK1rWcbKUQ=,tag:Pv+Gwq2fdpeV6Gh79aqStg==,type:str]
+        username: ENC[AES256_GCM,data:ejrYp8MrOoGvzyM9qlsbtJT2D9q3oU08EnbuBmxLf2oEeY6n6B+JYyNZrhtlBjQSwSfL2jz9db2E/F7tDJXMgQ==,iv:vLUxKMXWIl4evn7tx61mMtQhL45S7AFnENYqVHydWvw=,tag:0wYunPg43VZLGFhB2Bo8ow==,type:str]
+        password: ENC[AES256_GCM,data:kZOcmvL8KGUZ6X3X88arADC7g6Kq5YQ+IX+IibyUl9s6rCsxt+EVo7UwjVkKiW5GlczVmI444ML3kFpHGcYiHg==,iv:2mJ13RKv4J8yy+SgBoxscF+ddrlpRKrWkonGirYMMF8=,tag:a7vR7UonPUW2zaAuvvHMZQ==,type:str]
   serverFiles:
     web.yml:
       basic_auth_users:
-        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:IKXvhhoX6z+uEgnrMXisXmUYAODamGFDOvaGM6NikYPNgFxC/2bz9qqYzxf60Jfw1UJtosCA5PIqIjIE,iv:poV/CTX/UX5+aF4v+tvthdYvCqj+wOtEUYWVnDa9EY4=,tag:DgC+DMVxOXxX+WNajNxNoQ==,type:str]
+        cD17A7Pe8kfJqUoXTDrD4aGhcplTA8YHEE1YnhBB0ZtUOnJqWPsL8Q4KrqjTHsZB: ENC[AES256_GCM,data:TaZh4s2VYyNZrsBJ48ujgSmLpUQvqO2Wix8iwvExk74JhzE3ZssjwzK2Mpz3fVhYa3c3f4P9QUNDSRcU,iv:GEEvew8QIXVlfNJgQFQoAtQv0sanT/myrXJwl8a+k/k=,tag:EAcSxeesqyqIM8pYPeweXQ==,type:str]
 grafana:
   datasources:
     datasources.yaml:
-      apiVersion: ENC[AES256_GCM,data:qQ==,iv:/WE7whoaf6Qj+EVwhXwmdYth44Vquod1pCCUn0MnpKY=,tag:dPOmxfN4mW72qUMMvRKlhQ==,type:int]
+      apiVersion: ENC[AES256_GCM,data:Ng==,iv:B4jNeGsKpKUlVU83fLz5aZQV4thYuoeOMc/qkA0SIUs=,tag:jB/29MkNCYalTuYrk3T1qw==,type:int]
       datasources:
-      - name: ENC[AES256_GCM,data:AvYq9vb1ocaR5g==,iv:+D4vmWOKTAvHts4Y51+nBSnh9eQj9pS75/A5PwPSTHk=,tag:Azm/cXqaeOmFXtwNf969eQ==,type:str]
-        orgId: ENC[AES256_GCM,data:0A==,iv:gkXzre7WHVAnuH7qImtWwBBsxg6HI1aP0IXYmVpavF4=,tag:wnxVV3g1f9BhN49CA1zevw==,type:int]
-        type: ENC[AES256_GCM,data:pIslnyJyjpfNVQ==,iv:HhkeL6d5+hIl3NVO6hiJHXHQu2ZvlUO84czCK0HeCgk=,tag:VYGCns5+O9gvIXgz4kjTuw==,type:str]
-        url: ENC[AES256_GCM,data:3paSGhM8WIKNQ/P0ftOpkIWViOhmziDeIVKPlec53WM=,iv:9fdYj9Ymn8W9HZspO/wDjZPHdl2fUjjTjhW4Ng+88fA=,tag:cGefRAH2L1h8a2DRhorZbA==,type:str]
-        access: ENC[AES256_GCM,data:0bFMX4I=,iv:+5gYW2p7xrNvzSNUjnREYwF5mu82MoLYtvsF6lVC5bY=,tag:alaBiXKlZ9w70rbEgiIMEQ==,type:str]
-        isDefault: ENC[AES256_GCM,data:5Vqtfe8=,iv:eXsZIHIcGZa6Op70ikQYMOJiXtAU87+brmU1CTg3iqU=,tag:kFxh1mb6dz4uKoIKA1e3WA==,type:bool]
-        editable: ENC[AES256_GCM,data:Bi6IroA=,iv:hCEk4Qh4bURmrZSvJZqurd+QBTHP0q0vpqaCRsoY7tU=,tag:4TQ7FzPRm48ISoQCy+txyw==,type:bool]
-        basicAuth: ENC[AES256_GCM,data:odROYQ==,iv:VY3vrlMdIyq4Ccd+zV8Bxew1biap6DGLLBpIweCW+h0=,tag:DqhA9OiKwEHCA+FDVQDUzQ==,type:bool]
-        basicAuthUser: ENC[AES256_GCM,data:KM0C0oKcWSJXchbpgESIzcpj3peni/uDOCVB1N4+Qr42rLBDjgyXXYFzOnCjj004uYZ/BqwpFROuKdF3URyqXw==,iv:AYu+SVhDQ0mCb+IW94rk4V5bXS8608GkBIEOlSASNVA=,tag:WWf2/nvVFrV/mwA5yLSUFQ==,type:str]
-        secureJsonData:
-          basicAuthPassword: ENC[AES256_GCM,data:QcLW/IO6m3i7jua+mV++pMTw3sqnBwfDLB3OjF3JEOnBDq6CmFNME6M5srNIOuQDySbvHdOxFJS6d0UqhWBH+w==,iv:K/D/OePX72W3nnG7egcj/9qBvcsSuTTHEY0+vKjS0QA=,tag:ItJ1Ssmn85ScUcnOlaDt6w==,type:str]
-      - name: ENC[AES256_GCM,data:NwQdyo9S0Z0x146hmALkJHxw5yBFEXaP83+uZblZOQ==,iv:fGILW9KvCe3PALq1PnEH0JZPo5hDEom/ccS9JH11DFQ=,tag:Ea+hkEI4yrsBZeHaFlnPRg==,type:str]
-        type: ENC[AES256_GCM,data:ABeX9HRpTYn8FtikXg7DMI+twd3hvJ9yY6YEXHAvnA==,iv:v+cETxolQTIt/DxbbdbhLhFs1iSjrvYrilMcFdM2ZGw=,tag:OwFgx1EAiXjROCXAbRMUzQ==,type:str]
-        isDefault: ENC[AES256_GCM,data:PWCkY8k=,iv:wX6dkPUg1UUO2JxczakzbchlUa97U6a7sIoOp3jeahU=,tag:FmYgIgnICrEer+b4DTb+mQ==,type:bool]
-        editable: ENC[AES256_GCM,data:NV41qA==,iv:DYo9pHz+z3HNyYhwYKYre0I4XKyoK1FMTOpuG+bLgKE=,tag:+EUPFHo0Mzr3KNZGlWwTQQ==,type:bool]
+        - name: ENC[AES256_GCM,data:S0mEGvIDumYUAA==,iv:UGj2e7YbHDzyznJBeQq6fLa3hCUbzmtl+wRtM6yz8CU=,tag:8y0bLfgPcuZHkspxdM61lw==,type:str]
+          orgId: ENC[AES256_GCM,data:nQ==,iv:W3Y6rDzy9RBdn4ABVt0Mqo9T1fU8SQ0kJhCrhWrIpzI=,tag:oJ3nq+qNFZ6tDd+k1W/PWg==,type:int]
+          type: ENC[AES256_GCM,data:5Rnm9EC7/YrQPw==,iv:Y7G2AOW5OculmMkMpKkFRQiTEEiwIDlLmYXZTUOyfEo=,tag:vQKk08QstQ6cEnImv/wjYw==,type:str]
+          url: ENC[AES256_GCM,data:zhZMecpCYRlnM/21ZMeyUcQoWsWlEouZRxm7YCh2KZo=,iv:SlBZ2pHaKiDSsTkf0X27w2QENXZT0RTLauuoepVI3y8=,tag:Bv4s5tn/J4G+a+ACz9jU1g==,type:str]
+          access: ENC[AES256_GCM,data:D6kNN8s=,iv:qlXeE4CABiaQI8t6COVWH2d+D3v0bVtT++NjVYLXgBs=,tag:eS21GmHtf5bBG5f1RsZ1Jw==,type:str]
+          isDefault: ENC[AES256_GCM,data:4YBVV9A=,iv:UmefDmg1Rj2Vpa7T+RwAR9/8T85NhufkW9d059g8ycI=,tag:aYhltnDSzbg06TIzKfd8XA==,type:bool]
+          editable: ENC[AES256_GCM,data:wWCIBf8=,iv:JU3XXG9q/MA8pd3mDoOVvkRa1PrfHot9TXRorG5TepM=,tag:E7uoS6XdTOYvQxSx4QSPLg==,type:bool]
+          basicAuth: ENC[AES256_GCM,data:iuu98Q==,iv:PuQ6fwnLqkR0UxwjN8/5z0qokXGc9AWXjTYLzvqKdnk=,tag:0BiEdo4+bh3OO9kPvYCQGg==,type:bool]
+          basicAuthUser: ENC[AES256_GCM,data:xHiduGvf4kQchxmZFuDg17y59kz+2Tw0l9Dc3caR4d3N4PL6Vcc4ezY1JCzTGJqOGoLKscXAudiXjMeaPjkr2w==,iv:sAJ8WwK85LT/0My4fycr3ng8zPDRhtWLLPdChfa+OyU=,tag:Pd61Pab7sXBOCexoSy3GMQ==,type:str]
+          secureJsonData:
+            basicAuthPassword: ENC[AES256_GCM,data:OfCJKn497C9VvAuLao4DWmEE0yW01htPXxIUOLJOSmSVASGX+6zIo1lnumL2GlyyMt8nyFalp0AdE1pKVHXL5A==,iv:xEtESHTKhtRwEr7nbHtUAZ6gWAMr9zWz/i0eOqjNoWk=,tag:zrXzCl+M6aDhbEjapbNmcQ==,type:str]
+        - name: ENC[AES256_GCM,data:Q1Qy3flNf8dNtSY3xC49FYIcGLjeVgI12wJmyFiaeg==,iv:ku+GHUCxPvg9j6vzEMCqeLOjifvysTXK34vu0HCMU14=,tag:97cf7KEU3xpuECwVRRDWCA==,type:str]
+          type: ENC[AES256_GCM,data:gMRnye14yz7sGEAD0tL5BDKrXrnxfnu+vd5dUEz/Ag==,iv:oH7a0C4937bC34juDbPfdZvjGJoXRCUt5mKs9v/8eaY=,tag:Qg4I1Trto8pUMx2IpsUJzg==,type:str]
+          isDefault: ENC[AES256_GCM,data:tHKwagI=,iv:Eon1hLPq6ta+SHwGYLVSo28STOaY4Mjj2UT5UR3Rg+g=,tag:AvG03dfRNPFlmLk8SFeYww==,type:bool]
+          editable: ENC[AES256_GCM,data:HQlqYw==,iv:9CGWlgYrmW5FGL0AJxF4NgqKlVjv7sz0xPmcvH4REYI=,tag:rxF4qTC0N43mw/hQNll8SQ==,type:bool]
 jupyterhub-cost-monitoring:
   prometheusAuth:
-    enabled: ENC[AES256_GCM,data:V/epJA==,iv:m8y8p8QW0XgNdtl1ejZAagzfsr3eR/lwP2sfiuUVvac=,tag:lNWEop8BgBphJhNUnUDF6Q==,type:bool]
-    username: ENC[AES256_GCM,data:/CDehRnSfkUUZVBjNyX3f/SwR7llEupgpBmR+KL/P2WP74K+3InXU/7gV8G5wszsSQH2MMsA0lzSLCThTSCtUQ==,iv:odyDEOUXhEhpZTFfKKiOpHL4DN8qnabKoqw2LfJLn1Y=,tag:dJ3cLHb8p0JslUlyz/VKEg==,type:str]
-    password: ENC[AES256_GCM,data:YASqFAQuhezeyM5tr2mtlYWvdMlbLT6sifq9YUYN8R0M4UmMSSx6+7umhHkn/jlLVpBeojKeUu8l7ReK693q9g==,iv:sZKQjKSLUEuXz85PMGU5U6gLnHHVQHt1C9I7QN/l7ME=,tag:4YbEHHn+XbUrCPzQOBu2TA==,type:str]
+    enabled: ENC[AES256_GCM,data:pNK9Og==,iv:iKy5MlD/1WA94KLSar5jldutiR+przARH3PrJGFMq70=,tag:/vffe4sGRLl/lArfn61JGQ==,type:bool]
+    username: ENC[AES256_GCM,data:kXjBXZO+q+yDEUKw+j/OYhYoxfPhKp+4CNpST30Lgw52DUtHZJW0V4VEnay7vsSETEMNL8CG0fqrlsa3ajt1Mw==,iv:rg5gihL7+3Cgjc94z+xnMozHMuIzEt0y0M+92TPwdq0=,tag:+rwLD8Y4lyqqSQRPOSm3vg==,type:str]
+    password: ENC[AES256_GCM,data:oLKNB470pUb5UxTKCbCKVHsH7dkF2yLlq0qeVvcIjYWJzhU33vnUnMKSmqwAO7mhtWZG7+G4p3oSluBXavEjcA==,iv:b5Qd1bVr0l1RFvpRkYwmNrTcfw4PKJVxBzFHat15kic=,tag:U68vS+jvYhGY+bS0qDOX6A==,type:str]
 sops:
+  kms: []
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-05-01T14:41:01Z'
-    enc: CiUA4OM7eMpON9w4aJU+06UvlzzqpDHuVEMftRsT1CzIEGemGJ+rEkgAPHlbmR3Ksm3Yhu16yTfa1lKZ51+lwA4jUbjdOk15N2C2uZJH2VyK3hn4FGsVgyyrCMlCwlIcm7ZmFdlzF/Qs13V3TVzjwNw=
-  lastmodified: '2026-05-01T14:41:01Z'
-  mac: ENC[AES256_GCM,data:22FIs00/bpuhNDODF1a9S11//Hzc+Gmfku/dxQbQwj0YwQTqnxasKpsbZsLh1yEvB3tsOx6GzZLa8ieB2TpbOg30+NPgtLF/DMuyLj3tmyIB3aNloa6vYr+KLomnnaqdaL0QpZsEdmPPzzwhrs9IL+XEUXrju5IVdF6Mlgra7yc=,iv:Sm5zLq98KRrJGRdPWr5BvWJbiO9SyxxzoVQdcnpnuws=,tag:M3QwBJTnEMf2plQwwcFa6w==,type:str]
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2026-05-08T08:57:57Z"
+      enc: CiUA4OM7eLIkao+TFS5UyL3WZEDg+MM+oAqdaWXaOKKPJrVfpZiREkkAmy+eksE5fKQlYY5nwzCXpGuCluEe/2blS8HSFIV94H8I0ZFlJnKcd2+EVacvkmojQJk8AtvLjiTioeymsiE5UXe7FrvHRGC/
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-05-08T08:57:58Z"
+  mac: ENC[AES256_GCM,data:osTriHCSiyVylmQ4XhaRwj0PKxEk7qfpnVweO6fROQwcU24AwgRRVdyzs15w1q4rcN+mhB1JrQhFx3tPdYoZzSP4MPFpqk+KQ8M1go/8pGLHofXYRhwOD+6pLK5QvFfeTbvJfYPPCUL+j0o1euzpSVFNZIaSKyhqzeabiV5hcSY=,iv:afEV1YzHn2H5JmB+Lx/TTACbxZV17jV5FtRFPA/w5VY=,tag:XFWpuLe3qsm2jKYqbCqgbQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
-  version: 3.12.2
+  version: 3.9.0

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -1,6 +1,9 @@
 prometheusIngressAuthSecret:
   enabled: false
 
+prometheusAuthSecret:
+  enabled: true
+
 redirects:
   rules:
   - from: staging.earthscope.2i2c.cloud
@@ -13,6 +16,21 @@ redirects:
     to: hub.binder.geolab.earthscope.cloud
 
 prometheus:
+  configmapReload:
+    reloadUrl: http://$(PROMETHEUS_USERNAME):$(PROMETHEUS_PASSWORD)@127.0.0.1:9090/-/reload
+    env:
+    - name: PROMETHEUS_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: prometheus-auth
+          key: password
+          optional: false
+    - name: PROMETHEUS_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: prometheus-auth
+          key: username
+          optional: false
   server:
     ingress:
       enabled: true

--- a/helm-charts/support/templates/prometheus-auth/secret.yaml
+++ b/helm-charts/support/templates/prometheus-auth/secret.yaml
@@ -1,0 +1,11 @@
+{{/* Used by internal services to authenticate with Prometheus */}}
+{{- if .Values.prometheusAuthSecret.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-auth
+type: Opaque
+stringData:
+  username: {{ .Values.prometheusAuthSecret.username }}
+  password: {{ .Values.prometheusAuthSecret.password }}
+{{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -11,6 +11,7 @@ required:
   - grafana
   - nvidiaDevicePlugin
   - prometheusIngressAuthSecret
+  - prometheusAuthSecret
   - cryptnono
   - redirects
   - jupyterhub-cost-monitoring
@@ -215,6 +216,26 @@ properties:
           required:
             - username
             - password
+
+  prometheusAuthSecret:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          When enabled, creates a Kubernetes Secret with prometheus
+          username and password credentials.
+      username:
+        type: string
+        description: |
+          Username for prometheus authentication.
+      password:
+        type: string
+        description: |
+          Password for prometheus authentication.
 
   prometheusStorageClass:
     type: object

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -473,6 +473,11 @@ prometheusIngressAuthSecret:
   enabled: false
   users: []
 
+prometheusAuthSecret:
+  enabled: false
+  username: ""
+  password: ""
+
 redirects:
   rules: []
 


### PR DESCRIPTION
related to https://github.com/2i2c-org/infrastructure/pull/8249.

Appends credentials to the Prometheus config reload URL in the form `http://username:password@127.0.0.1:9090/-/reload` to prevent config reload failures caused by 401 authentication errors.

cc @jnywong 

Update: adds a secret to the support chart to store prometheus auth values. the config-map reload URL references auth credentials from that secret.