### PR TITLE
Add dirtyfrag daemonset & harden copyfail

### DIFF
--- a/config/clusters/2i2c-aws-us/support.values.yaml
+++ b/config/clusters/2i2c-aws-us/support.values.yaml
@@ -67,3 +67,6 @@ calico:
 nvidiaDevicePlugin:
   aws:
     enabled: true
+
+dirtyfrag:
+  enabled: true

--- a/config/clusters/2i2c-jetstream2/support.values.yaml
+++ b/config/clusters/2i2c-jetstream2/support.values.yaml
@@ -26,3 +26,6 @@ grafana:
     - secretName: grafana-tls
       hosts:
       - grafana.staging.js.2i2c.cloud
+
+dirtyfrag:
+  enabled: true

--- a/config/clusters/berkeley-geojupyter/support.values.yaml
+++ b/config/clusters/berkeley-geojupyter/support.values.yaml
@@ -57,3 +57,7 @@ cluster-autoscaler:
 
 calico:
   enabled: true
+
+
+dirtyfrag:
+  enabled: true

--- a/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
+++ b/config/clusters/projectpythia-binder/jupyterbook-pub.yaml
@@ -25,9 +25,9 @@ volumeClaim:
   enabled: false
 
 volume:
-    hostPath:
-      path: /var/cache/jupyterbook-pub/
-      type: DirectoryOrCreate
+  hostPath:
+    path: /var/cache/jupyterbook-pub/
+    type: DirectoryOrCreate
 
 auth:
   enabled: false

--- a/config/clusters/victor/support.values.yaml
+++ b/config/clusters/victor/support.values.yaml
@@ -67,3 +67,7 @@ calico:
 nvidiaDevicePlugin:
   aws:
     enabled: true
+
+
+dirtyfrag:
+  enabled: true

--- a/helm-charts/support/templates/copyfail-ebpf.yaml
+++ b/helm-charts/support/templates/copyfail-ebpf.yaml
@@ -54,10 +54,14 @@ spec:
         - name: bpffs
           hostPath:
             path: /sys/fs/bpf
+            type: Directory
         - name: securityfs
           hostPath:
             path: /sys/kernel/security
+            type: Directory
         - name: debugfs
           hostPath:
             path: /sys/kernel/debug
+           type: Directory
+      priorityClassName: system-node-critical
 {{- end }}

--- a/helm-charts/support/templates/copyfail-ebpf.yaml
+++ b/helm-charts/support/templates/copyfail-ebpf.yaml
@@ -62,6 +62,6 @@ spec:
         - name: debugfs
           hostPath:
             path: /sys/kernel/debug
-           type: Directory
+            type: Directory
       priorityClassName: system-node-critical
 {{- end }}

--- a/helm-charts/support/templates/dirtyfrag-ebfp.yaml
+++ b/helm-charts/support/templates/dirtyfrag-ebfp.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.dirtyfrag.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dirtyfrag-ebpf
+  namespace: kube-system
+  labels:
+    app: dirtyfrag-ebpf
+spec:
+  selector:
+    matchLabels:
+      app: dirtyfrag-ebpf
+  template:
+    metadata:
+      labels:
+        app: dirtyfrag-ebpf
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: mitigation
+        image: {{ .Values.dirtyfrag.image.repository }}:{{ .Values.dirtyfrag.image.tag }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bpf
+          mountPath: /sys/fs/bpf
+        - name: btf
+          mountPath: /sys/kernel/btf/vmlinux
+          readOnly: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+      volumes:
+      - name: bpf
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory
+      - name: btf
+        hostPath:
+          path: /sys/kernel/btf/vmlinux
+          type: File
+      terminationGracePeriodSeconds: 5
+      priorityClassName: system-node-critical
+{{- end }}

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -61,6 +61,22 @@ properties:
             type: string
           tag:
             type: string
+  dirtyfrag:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+    properties:
+      enabled:
+        type: boolean
+      image:
+        type: object
+        additionalProperties: false
+        properties:
+          repository:
+            type: string
+          tag:
+            type: string
   redirects:
     type: object
     additionalProperties: false

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -17,14 +17,14 @@ cluster-autoscaler:
 copyfail:
   enabled: true
   image:
-    repository: ghcr.io/iwanhae/copyfail-ebpf
-    tag: latest@sha256:7cb17a6e6d734da1b1b0946f4a2157734297dce990f969320163f79671f0ccc0
+    repository: quay.io/2i2c/copyfail-mitigation
+    tag: main@sha256:8b16afdd1bd74b3aad006d695020408f47966609ff0225c5c666312d7e8e1a9e
 
 dirtyfrag:
   enabled: true
   image:
-    repository: quay.io/mrunalp/block-dirtyfrag
-    tag: latest@sha256:87bfa255fddb21991de42f962da181d15dc25e75bb7c73044cee832fcd306fd9
+    repository: quay.io/2i2c/dirtyfrag-mitigation
+    tag: main@sha256:e1510268a125ea3d17663e11f63d4dcfded3e361c5bfccf2cc3d689f0fd0984b
 
 clusterEntrypoint:
   enabled: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -20,6 +20,12 @@ copyfail:
     repository: ghcr.io/iwanhae/copyfail-ebpf
     tag: latest@sha256:7cb17a6e6d734da1b1b0946f4a2157734297dce990f969320163f79671f0ccc0
 
+dirtyfrag:
+  enabled: true
+  image:
+    repository: quay.io/mrunalp/block-dirtyfrag
+    tag: latest@sha256:87bfa255fddb21991de42f962da181d15dc25e75bb7c73044cee832fcd306fd9
+
 clusterEntrypoint:
   enabled: true
   targetController: ingress-nginx

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -18,7 +18,7 @@ copyfail:
   enabled: true
   image:
     repository: ghcr.io/iwanhae/copyfail-ebpf
-    tag: latest
+    tag: latest@sha256:7cb17a6e6d734da1b1b0946f4a2157734297dce990f969320163f79671f0ccc0
 
 clusterEntrypoint:
   enabled: true

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -21,7 +21,7 @@ copyfail:
     tag: main@sha256:8b16afdd1bd74b3aad006d695020408f47966609ff0225c5c666312d7e8e1a9e
 
 dirtyfrag:
-  enabled: true
+  enabled: false
   image:
     repository: quay.io/2i2c/dirtyfrag-mitigation
     tag: main@sha256:e1510268a125ea3d17663e11f63d4dcfded3e361c5bfccf2cc3d689f0fd0984b


### PR DESCRIPTION
This PR adds a dirtyfrag daemonset for patching the dirtyfrag vulnerability & tweaks our copyfail mitigation. It does the following:

- Adds a new eBPF filter for dirtyfrag
- Uses a 2i2c-forked repo for copyfail with SHA (to guarantee provenance)
- Uses a 2i2c-forked repo for dirtyfrag with SHA (to guarantee provenance)
- Matches the copyfail daemonset with the dirtyfrag for ease of visual comparison
- Rolls out `dirtyfrag` filters for a few clusters:
  - 2i2c-aws-us
  - 2i2c-jetstream2
  - berkeley-geojupyter
  - victor

The ground truth for the daemonsets is in:
- https://github.com/iwanhae/copyfail-ebpf-k8s
- https://github.com/mrunalp/block-dirtyfrag/