### PR TITLE
[2i2c-aws-us, staging] Add authenticated JupyterBook.pub deployment

### DIFF
--- a/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
@@ -1,20 +1,18 @@
 jupyterhub:
   hub:
+    services:
+      jupyterbook-pub:
+        api_token: ENC[AES256_GCM,data:06jVzCg6Zv6Xvd5lFR8IkSbBKiaD3GZGh4uqu8A=,iv:TlaJ1sWJnKgs4nWmkc9cvXzFXwk2VAOILl2mjN5n73M=,tag:xQ2QIb6aCVob5UxtUEM8rA==,type:str]
     config:
       GitHubOAuthenticator:
         client_id: ENC[AES256_GCM,data:cCcFsREidFJE+8mNguzsiglaDNU=,iv:8/ONoisn8fresVPcztUejV5j1njBJe1TiyTPbzsl9ag=,tag:1zUsouNBoTdAAoVwZCrXNw==,type:str]
         client_secret: ENC[AES256_GCM,data:QVmzgFYEGKPgTrj6bCrumcQp5mZreLFrw6G+zITLOSJtydDY62zD/Q==,iv:nAdsoPGHyPhFzFPU4uxRAbQOm4fuZSD4IKtZYAHx3vU=,tag:jV9OsG1sy/OyOTUp7M9pvA==,type:str]
 sops:
-  kms: []
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2023-01-05T15:13:06Z'
     enc: CiUA4OM7ePFTK8jhF1PvaNsOlsH2PwopRPJE7K+2pVikF/Brl4zPEkkA+0T9hUjgsZa2zAOVqZHOAjeg91553kP+YnHnIW2QPPnSha1dlGfrTcesxV5hsrbeqc3fxs7OnKow5KK3fr48Djf31CYGOgLY
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-01-05T15:13:06Z'
-  mac: ENC[AES256_GCM,data:tSbbwxnJEQflFUma0Ou0Faci4nypPH7UDFkPe6jyfnNEckteG9qviBk9pUbpuR404NOZp8QtVqB0Vqv3fwo1EBGrmeT0E0zhgz0RR2/k85nDnPD9mLYWq4xtestHQOdibmMAFe4D2QbVSgI4t8NiYAWLPqKaH8UGKFgiFAV9pnU=,iv:yPX35eIVYw1rh9BTmPpc3P+DzEu499Wk/GJkwN4AcUs=,tag:mWr1ieAR7bZ605gA2tHHdA==,type:str]
-  pgp: []
+  lastmodified: '2026-05-08T15:42:36Z'
+  mac: ENC[AES256_GCM,data:0BYTIrtIw5paTmBqv2x1UGOuhlIO+OYGfnpORF3epIw79xa14d0Qm8a6J+4SmO9uk8dSWT7XY48SRcB9CMPGoYY7ljai4emorsOYhJ2w6gfyv3Lo5orz/EdKZnHbR6x7TpGa3kUb0r4+DpNjuUU/m3cnm1HgNJvKjjGlyuy9OdA=,iv:m8OKmdpVGZDwkL+3cPiSN8fV/ZmLbMNy4ZEHD7p3nLI=,tag:Hydfs39bQMJNBSaaLWTwHA==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.11.0

--- a/config/clusters/2i2c-aws-us/jupyterbook-pub.yaml
+++ b/config/clusters/2i2c-aws-us/jupyterbook-pub.yaml
@@ -1,0 +1,36 @@
+# See https://agoose77.github.io/jupyterbook-pub-service/
+# Run the core service on the core nodes
+nodeSelector: &nodeSelector
+  hub.jupyter.org/node-purpose: core
+
+config:
+  JupyterBookPubApp:
+    base_url: /services/jupyterbook-pub/
+    site_subheading: |
+      Instantly render pre-built JupyterBook AST!
+  KubernetesExecutor:
+    resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 500Mi
+    node_selector: *nodeSelector
+
+extraBuilderConfig:
+  name: builder_config.json
+  json:
+    JupyterBook2Builder:
+      allow_source_builds: false
+
+volumeClaim:
+  enabled: false
+
+volume:
+  hostPath:
+    path: /var/cache/jupyterbook-pub/
+    type: DirectoryOrCreate
+
+auth:
+  enabled: true
+  # hub_api_token: <set via deploy>
+  hub_api_url: https://staging.aws.2i2c.cloud/hub/api/

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -14,6 +14,14 @@ jupyterhub-home-nfs:
       QuotaManager:
         hard_quota: 10 # in GiB
 jupyterhub:
+  hub:
+    services:
+      jupyterbook-pub:
+        # Auth
+        # api_token: <see secret>
+        oauth_client_id: service-jupyterbook-pub
+        oauth_no_confirm: true
+        url: http://jupyterbook-pub-service
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
This PR adds a deployment of JupyterBook.pub with authentication and AST-only builds to the staging 2i2c-aws-us hub. This is such that we can test authentication, and use this to test other apps that generate AST.

For now, to avoid churn etc. I'm not adding this to the base hub chart. Deployments are made, like for projectpythia-binder, imperatively via `helm upgrade`. The auth token is pulled from the `enc-staging` secret and passed in via a Helm CLI `--set` flag.

Here's the service! https://staging.aws.2i2c.cloud/services/jupyterbook-pub/