### PR TITLE
Turn off using IPs to form XSRF tokens

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -915,6 +915,10 @@ jupyterhub:
                     title: RStudio
                     description: An IDE For R, created by the RStudio company
     extraEnv:
+      # Turn off IP checks for XSRF, as we aren't currently able to consistently
+      # get the end user IP to the JupyterHub process at all times
+      # See https://github.com/2i2c-org/infrastructure/issues/8192
+      JUPYTERHUB_XSRF_ANONYMOUS_IP_CIDRS: "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
       BASEHUB_K8S_DIST:
         valueFrom:
           configMapKeyRef:


### PR DESCRIPTION
We aren't consistently able to get the end user's IP to JupyterHub - sometimes it's the node IP instead. Let's stop including IP in calculating XSRF tokens while we figure out what's the right thing to do.

Ref https://2i2c.slack.com/archives/CKJS000F4/p1778261541857609 Ref https://github.com/2i2c-org/infrastructure/issues/8192