### PR TITLE
Remove extra hardcoded '2i2c' datasource

### DIFF
--- a/config/clusters/2i2c/support.values.yaml
+++ b/config/clusters/2i2c/support.values.yaml
@@ -40,24 +40,6 @@ grafana:
       allowed_organizations: 2i2c-org
     feature_toggles:
       enable: exploreMixedDatasource
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        # Add the prometheus server as a datasource in the same namespace as grafana.
-        # This is called "prometheus" in all other clusters, except of the 2i2c one,
-        # which is the central Grafana, where all clusters' prometheus instances
-        # are also linked as datasources.
-        # Having "2i2c" as the name, instead of the more generic "prometheus"
-        # will help to more easily know what cluster the datasource is mapping.
-      - name: 2i2c
-        orgId: 1
-        type: prometheus
-          # This is the name of the kubernetes service exposed by the prometheus server
-        url: http://support-prometheus-server
-        access: proxy
-        isDefault: false
-        editable: false
   ingress:
     hosts:
     - grafana.pilot.2i2c.cloud


### PR DESCRIPTION
We had 'special cased' the 2i2c prometheus in our config, and that wasn't updated to account for the basic auth work we have added. Removing config created datasources requires:

1. Removing the datasource
2. Adding the datasource to `deleteDatasources` list.

So I:

1. Removed the datasource
2. Changed the config to:
```
   datasources: 
     datasources.yaml: 
       deleteDatasources: 
       - name: 2i2c 
```
3. Re-deployed

That successfully removed the existing one.

Then I ran the `deployer grafana central-ds add 2i2c` command, to add an appropriately authenticated `2i2c` datasource.

That seems to have fixed the issue.

Ref https://github.com/grafana/grafana/issues/18848 for info about how to remove the existing datasource

Fixes https://github.com/2i2c-org/infrastructure/issues/8256