### PR TITLE
[awi-ciroh, workshop] Bump node-sharing setup to n2-standard-64

### DIFF
--- a/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
@@ -3,13 +3,14 @@ basehub:
     hub:
       config:
         SharedPasswordAuthenticator:
+          admin_password: ENC[AES256_GCM,data:tXvBUY5Xj2suA9gCLsa5SWRhzlTo75Mk5KRVnsCbcp40Bsf7GAljnHFJq80n3HCKkXA=,iv:9NEYm8C+9LD0/xgux00wsdzJOjmdqLVXpcuS0I0MxLQ=,tag:LF09qhhkFzzZy+HAbJjdLA==,type:str]
           user_password: ENC[AES256_GCM,data:PU76mfyoala2eSZsw+SvB12uCEDmxNU0rBB3QUv27g==,iv:7ItyZGYy6MsNj+Oe9THtot6GJ2hIqmsIkgl5avMwtNE=,tag:k2vCgrdkEqNV+82qeIef2w==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2025-05-07T08:07:12Z'
     enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
-  lastmodified: '2026-05-06T20:28:12Z'
-  mac: ENC[AES256_GCM,data:HImhIeEWzQkOl0D4gaKSd8+/LtrH0NvTVKIID9y5Km9WUAAZe8IFtNUlzuV2nq6WN8KcAtE7cmOjCLMu/PRhbriS5PrIALyzFoDg776HOqbRCnvP23N0qc7kivbqdqTHHe9Z50WdXmXAPvNwDxY6oZ/vXup7dYBW1a72A4RGNe0=,iv:tqNd00AlWokZ6oDWBZzMkTsUtfs2Lt+4qZVDboAEXF4=,tag:qDTig8114RBtOpI5ZsMqMQ==,type:str]
+  lastmodified: '2026-05-11T15:19:50Z'
+  mac: ENC[AES256_GCM,data:iHLBcV/uYX5PxX+a36RbVRve7UJ7Z4ulgKhj/KRRPLwclueLLxye5hMYq42PEp2zBSYQSJiMoxinr3p/z6vC96WuamEkSf6I0t8SUeNr/q4ew47e9ORjJW6FfoEU+x9f4Ovn9EHxOJFlfF0vapmWGYFDSHRQJQ2lGjW9BLdqPbc=,iv:Mj66+yCNImjVOH5+rhauZIL0BNyh3ghuX/rOLOQYIvU=,tag:PWZItTpeROWGhHnDeNU51A==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -162,13 +162,13 @@ basehub:
           node_selector:
             node.kubernetes.io/instance-type: n2-highmem-16
       - display_name: Huge
-        description: 52GB RAM, 16 CPUs
+        description: ~59 GB RAM, ~16 CPUs
         profile_options: *profile_options
         kubespawner_override:
-          mem_limit: 60G
-          mem_guarantee: 52G
-          cpu_limit: 16
-          cpu_guarantee: 7.5
+          mem_guarantee: 63731921920
+          mem_limit: 63731921920
+          cpu_guarantee: 15.5745
+          cpu_limit: 62.298
           node_selector:
             node.kubernetes.io/instance-type: n2-standard-64
       extraEnv:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -170,7 +170,7 @@ basehub:
           cpu_limit: 16
           cpu_guarantee: 7.5
           node_selector:
-            node.kubernetes.io/instance-type: n2-highmem-16
+            node.kubernetes.io/instance-type: n2-standard-64
       extraEnv:
         SCRATCH_BUCKET: gs://awi-ciroh-scratch-workshop/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://awi-ciroh-scratch-workshop/$(JUPYTERHUB_USER)

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -14,8 +14,6 @@ basehub:
           hard_quota: 40 # in GiB
   jupyterhub:
     custom:
-      2i2c:
-        add_staff_user_ids_to_admin_users: false
       singleuserAdmin:
         extraVolumeMounts:
       homepage:

--- a/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
@@ -106,5 +106,23 @@
             "cpu": 3.45,
             "memory": 28967406928
         }
+    },
+    "n2-highmem-16": {
+        "capacity": {
+            "cpu": 16.0,
+            "memory": 135074349056
+        },
+        "allocatable": {
+            "cpu": 15.89,
+            "memory": 125132800000
+        },
+        "measured_overhead": {
+            "cpu": 0.472,
+            "memory": 685768704
+        },
+        "available": {
+            "cpu": 15.418,
+            "memory": 124447031296
+        }
     }
 }

--- a/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
@@ -124,5 +124,23 @@
             "cpu": 15.418,
             "memory": 124447031296
         }
+    },
+    "n2-standard-64": {
+        "capacity": {
+            "cpu": 64.0,
+            "memory": 270450806784
+        },
+        "allocatable": {
+            "cpu": 63.77,
+            "memory": 257760940032
+        },
+        "measured_overhead": {
+            "cpu": 0.472,
+            "memory": 685768704
+        },
+        "available": {
+            "cpu": 63.298,
+            "memory": 257075171328
+        }
     }
 }

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -67,20 +67,6 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-4",
   },
-  "n2-highmem-16" : {
-    min : 0,
-    max : 100,
-    machine_type : "n2-highmem-16",
-    node_version : "1.34.4-gke.1130000",
-    taints : [
-      # Prevent new pods from scheduling here.
-      {
-        key : "manual-phaseout"
-        value : "noop"
-        effect : "NO_SCHEDULE"
-      }
-    ],
-  },
   "n2-highmem-16-a" : {
     min : 0,
     max : 100,
@@ -90,6 +76,12 @@ notebook_nodes = {
     min : 0,
     max : 100,
     machine_type : "n2-highmem-64",
+  },
+  "n2-standard-64" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 20,
+    machine_type : "n2-standard-64",
   },
   "gpu-t4" : {
     min : 0,


### PR DESCRIPTION
This workshop needs 32 ~16vCPU ~64GiB instances. To improve startup behaviour (where we are not worried about over provisioning like we are for day-to-day scenarios), this PR adds a new profile option for packing four "Huge" instances into n2-standard-64.

I have not updated the other profile options — I think we should let the community know about that kind of change ahead of time.

Part of #8254 