### PR TITLE
[awi-ciroh, workshop] Change Huge node to n2-standard-16

### DIFF
--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -160,13 +160,13 @@ basehub:
           node_selector:
             node.kubernetes.io/instance-type: n2-highmem-16
       - display_name: Huge
-        description: ~59 GB RAM, ~16 CPUs
+        description: ~59 GB RAM, ~15 CPUs
         profile_options: *profile_options
         kubespawner_override:
-          mem_guarantee: 63731921920
-          mem_limit: 63731921920
-          cpu_guarantee: 15.5745
-          cpu_limit: 62.298
+          mem_guarantee: 59579452047
+          mem_limit: 59579452047
+          cpu_guarantee: 15.109639999999999
+          cpu_limit: 15.109639999999999
           node_selector:
             node.kubernetes.io/instance-type: n2-standard-16
       extraEnv:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -168,7 +168,7 @@ basehub:
           cpu_guarantee: 15.5745
           cpu_limit: 62.298
           node_selector:
-            node.kubernetes.io/instance-type: n2-standard-64
+            node.kubernetes.io/instance-type: n2-standard-16
       extraEnv:
         SCRATCH_BUCKET: gs://awi-ciroh-scratch-workshop/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://awi-ciroh-scratch-workshop/$(JUPYTERHUB_USER)

--- a/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
@@ -142,5 +142,23 @@
             "cpu": 63.298,
             "memory": 257075171328
         }
+    },
+    "n2-standard-16": {
+        "capacity": {
+            "cpu": 16.0,
+            "memory": 67428651008
+        },
+        "allocatable": {
+            "cpu": 15.89,
+            "memory": 61481127936
+        },
+        "measured_overhead": {
+            "cpu": 0.472,
+            "memory": 685768704
+        },
+        "available": {
+            "cpu": 15.418,
+            "memory": 60795359232
+        }
     }
 }

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -77,6 +77,12 @@ notebook_nodes = {
     max : 100,
     machine_type : "n2-highmem-64",
   },
+  "n2-standard-16" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 100,
+    machine_type : "n2-standard-16",
+  },
   "n2-standard-64" : {
     min : 0,
     # Keep the numbers down, for safety!


### PR DESCRIPTION
I tried the n2-standard-64, but I struggled to acquire a node. Let's try a smaller node on the assumption (there is no information on this from Google) that these are more abundant.

See #8254 