### PR TITLE
Allow accessing GCP metrics from Grafana

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -180,7 +180,7 @@ local configCostMonitoring = {
       annotations: if provider_name == 'aws' then {
         'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/jupyterhub_grafana_cloudwatch' % account_id,
       } else if provider_name == 'gcp' then {
-        'iam.gke.io/gcp-service-account': 'grafana-2i2c-sa@%s.iam.gserviceaccount.com' % account_id
+        'iam.gke.io/gcp-service-account': 'grafana-2i2c-sa@%s.iam.gserviceaccount.com' % account_id,
       } else {},
     },
   },

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -179,6 +179,8 @@ local configCostMonitoring = {
     serviceAccount: {
       annotations: if provider_name == 'aws' then {
         'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/jupyterhub_grafana_cloudwatch' % account_id,
+      } else if provider_name == 'gcp' then {
+        'iam.gke.io/gcp-service-account': 'grafana-2i2c-sa@%s.iam.gserviceaccount.com' % account_id
       } else {},
     },
   },

--- a/terraform/gcp/grafana.tf
+++ b/terraform/gcp/grafana.tf
@@ -1,0 +1,20 @@
+# Service account for Grafana, so it can access Google Cloud Stackdriver
+resource "google_service_account" "grafana_sa" {
+  account_id   = "grafana-2i2c-sa"
+  display_name = "Service account for Grafana run by 2i2c"
+  project      = var.project_id
+}
+
+resource "google_service_account_iam_binding" "grafana_sa_binding" {
+  service_account_id = google_service_account.grafana_sa.id
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[support/support-grafana]"
+  ]
+}
+
+resource "google_project_iam_member" "grafana_sa_membership" {
+  project  = var.project_id
+  role     = "roles/monitoring.viewer"
+  member   = "serviceAccount:${google_service_account.grafana_sa.email}"
+}

--- a/terraform/gcp/grafana.tf
+++ b/terraform/gcp/grafana.tf
@@ -14,7 +14,7 @@ resource "google_service_account_iam_binding" "grafana_sa_binding" {
 }
 
 resource "google_project_iam_member" "grafana_sa_membership" {
-  project  = var.project_id
-  role     = "roles/monitoring.viewer"
-  member   = "serviceAccount:${google_service_account.grafana_sa.email}"
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.grafana_sa.email}"
 }


### PR DESCRIPTION
GCP equivalent of https://github.com/2i2c-org/infrastructure/pull/8179,
to allow us to pull in 'official' info about disk throughput and
iops.

Sample dashboard at https://grafana.ciroh.awi.2i2c.cloud/d/adg97ck/workshop-prep-dashboard?orgId=1&from=now-7d&to=now&timezone=browser&var-hub_name=prod&var-user_name=arpita0911patel&var-PROMETHEUS_DS=P1809F7CD0C75ACF3

Ref https://github.com/2i2c-org/infrastructure/issues/8244
Ref https://github.com/2i2c-org/infrastructure/issues/8178