### PR TITLE
[ucmerced] Fix placeholder selector

### DIFF
--- a/config/clusters/ucmerced/prod.values.yaml
+++ b/config/clusters/ucmerced/prod.values.yaml
@@ -17,6 +17,9 @@ jupyterhub:
         requests:
           memory: 32Gi
   singleuser:
+    # Used by userPlaceholder (and profiles)
+    nodeSelector:
+      node.kubernetes.io/instance-type: r5.2xlarge
     profileList:
     - display_name: Python
       description: Start a Python server with JupyterLab and scientific Python stack
@@ -30,19 +33,25 @@ jupyterhub:
         requests:
           display_name: Resource Allocation
           choices:
-            mem_1:
-              display_name: 1 GB RAM
+            mem_954_mb:
+              default: true
+              display_name: ~954 MB RAM, ~0.1 CPUs
+              description: Up to ~8 CPUs when available
               kubespawner_override:
-                mem_guarantee: 995622387
-                mem_limit: 995622387
+                mem_guarantee: 999856524
+                mem_limit: 999856524
+                cpu_guarantee: 0.1176765625
+                cpu_limit: 7.5313
                 node_selector:
                   node.kubernetes.io/instance-type: r5.2xlarge
-              default: true
-            mem_2:
-              display_name: 2 GB RAM
+            mem_2_gb:
+              display_name: ~2 GB RAM, ~0.2 CPUs
+              description: Up to ~8 CPUs when available
               kubespawner_override:
-                mem_guarantee: 1991244775
-                mem_limit: 1991244775
+                mem_guarantee: 1999713049
+                mem_limit: 1999713049
+                cpu_guarantee: 0.235353125
+                cpu_limit: 7.5313
                 node_selector:
                   node.kubernetes.io/instance-type: r5.2xlarge
     - display_name: R

--- a/config/clusters/ucmerced/prod.values.yaml
+++ b/config/clusters/ucmerced/prod.values.yaml
@@ -17,6 +17,8 @@ jupyterhub:
         requests:
           memory: 32Gi
   singleuser:
+    # [CUSTOM] jupyterhub.singleuser.nodeSelector
+    #
     # Used by userPlaceholder (and profiles)
     nodeSelector:
       node.kubernetes.io/instance-type: r5.2xlarge

--- a/config/clusters/ucmerced/staging.values.yaml
+++ b/config/clusters/ucmerced/staging.values.yaml
@@ -13,19 +13,25 @@ jupyterhub:
         requests: &profile_options_resource_allocation
           display_name: Resource Allocation
           choices:
-            mem_1:
-              display_name: 1 GB RAM
+            mem_954_mb:
+              default: true
+              display_name: ~954 MB RAM, ~0.1 CPUs
+              description: Up to ~8 CPUs when available
               kubespawner_override:
-                mem_guarantee: 995622387
-                mem_limit: 995622387
+                mem_guarantee: 999856524
+                mem_limit: 999856524
+                cpu_guarantee: 0.1176765625
+                cpu_limit: 7.5313
                 node_selector:
                   node.kubernetes.io/instance-type: r5.2xlarge
-              default: true
-            mem_2:
-              display_name: 2 GB RAM
+            mem_2_gb:
+              display_name: ~2 GB RAM, ~0.2 CPUs
+              description: Up to ~8 CPUs when available
               kubespawner_override:
-                mem_guarantee: 1991244775
-                mem_limit: 1991244775
+                mem_guarantee: 1999713049
+                mem_limit: 1999713049
+                cpu_guarantee: 0.235353125
+                cpu_limit: 7.5313
                 node_selector:
                   node.kubernetes.io/instance-type: r5.2xlarge
     - display_name: R

--- a/config/clusters/ucmerced/staging.values.yaml
+++ b/config/clusters/ucmerced/staging.values.yaml
@@ -1,5 +1,10 @@
 jupyterhub:
   singleuser:
+    # [CUSTOM] jupyterhub.singleuser.nodeSelector 
+    # 
+    # Used by userPlaceholder (and profiles)
+    nodeSelector:
+      node.kubernetes.io/instance-type: r5.2xlarge
     profileList:
     - display_name: Python
       description: Start a Python server with JupyterLab and scientific Python stack

--- a/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
+++ b/deployer/dev_commands/generate/resource_allocation/node-capacity-info.json
@@ -160,5 +160,23 @@
             "cpu": 15.418,
             "memory": 60795359232
         }
+    },
+    "r5.2xlarge": {
+        "capacity": {
+            "cpu": 8.0,
+            "memory": 66681921536
+        },
+        "allocatable": {
+            "cpu": 7.91,
+            "memory": 65640685568
+        },
+        "measured_overhead": {
+            "cpu": 0.225,
+            "memory": 343932928
+        },
+        "available": {
+            "cpu": 7.685,
+            "memory": 65296752640
+        }
     }
 }


### PR DESCRIPTION
UCMerced didn't previously have `singleuser.nodeSelector`. This was added by the recent changes to the base Jsonnet #8305, but the smallest node selector on ucmerced is not the default r5.xlarge! 

This PR modifies the base selector, for consistency.