### PR TITLE
Add new S3 ARNs for disaster management

### DIFF
--- a/terraform/aws/projects/disasters.tfvars
+++ b/terraform/aws/projects/disasters.tfvars
@@ -79,7 +79,13 @@ hub_cloud_permissions = {
               "arn:aws:s3:::csdap-iceye-delivery",
               "arn:aws:s3:::csdap-iceye-delivery/*",
               "arn:aws:s3:::naip-analytic",
-              "arn:aws:s3:::naip-analytic/*"
+              "arn:aws:s3:::naip-analytic/*",
+              "arn:aws:s3:::csdap-planet-skysat-delivery",
+              "arn:aws:s3:::csdap-planet-skysat-delivery/*",
+              "arn:aws:s3:::nasa-disasters-dev",
+              "arn:aws:s3:::nasa-disasters-dev/*",
+              "arn:aws:s3:::nasa-disasters-staging",
+              "arn:aws:s3:::nasa-disasters-staging/*"
             ]
           },
           {
@@ -153,7 +159,13 @@ hub_cloud_permissions = {
               "arn:aws:s3:::csdap-iceye-delivery",
               "arn:aws:s3:::csdap-iceye-delivery/*",
               "arn:aws:s3:::naip-analytic",
-              "arn:aws:s3:::naip-analytic/*"
+              "arn:aws:s3:::naip-analytic/*",
+              "arn:aws:s3:::csdap-planet-skysat-delivery",
+              "arn:aws:s3:::csdap-planet-skysat-delivery/*",
+              "arn:aws:s3:::nasa-disasters-dev",
+              "arn:aws:s3:::nasa-disasters-dev/*",
+              "arn:aws:s3:::nasa-disasters-staging",
+              "arn:aws:s3:::nasa-disasters-staging/*"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Add permissions for newly created buckets for `nasa-disasters-dev` and `nasa-disasters-staging` as well as adding permissions to a new CSDA bucket.