### PR TITLE
Update openscapes python image to use positron

### DIFF
--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -65,7 +65,7 @@ basehub:
                 display_name: Python
                 description: Python datascience environment
                 kubespawner_override:
-                  image: openscapes/python:65d6916
+                  image: openscapes/python:998fa91
               02-R:
                 display_name: R + Python Geospatial
                 description: Py-R - Geospatial + QGIS, Panoply, CWUtils - py-rocket-geospatial-2 latest


### PR DESCRIPTION
After adding the positron educational license file in #8258, this adds Positron-server to our core python image (https://github.com/NASA-Openscapes/corn/pull/59).