### PR TITLE
Add brian-rose to the list of allowed GitHub orgs

### DIFF
--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -141,6 +141,7 @@ binderhub-service:
       - ^ktyle/.*$
       - ^DAES433533/.*$
       - ^binder-examples/.*
+      - ^brian-rose/.*$
     BinderHub:
       base_url: /
       hub_url: https://hub.projectpythia.org


### PR DESCRIPTION
As far as I understand, this PR should just make it possible for me to build images on the Pythia binderhub from repos in my personal GitHub domain @brian-rose.