### PR TITLE
Bump the disks of a couple of hubs

### DIFF
--- a/terraform/aws/projects/earthscope.tfvars
+++ b/terraform/aws/projects/earthscope.tfvars
@@ -16,7 +16,7 @@ default_budget_alert = {
 
 ebs_volumes = {
   "staging" = {
-    size        = 2
+    size        = 5
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name" : "staging" }

--- a/terraform/gcp/projects/2i2c-uk.tfvars
+++ b/terraform/gcp/projects/2i2c-uk.tfvars
@@ -57,7 +57,7 @@ persistent_disks = {
     name_suffix = "staging"
   },
   "lis" = {
-    size        = 480 # in GB
+    size        = 504 # in GB
     name_suffix = "lis"
   }
 }


### PR DESCRIPTION
Per PD alerts.

I gave earthscope staging 5GB because they actively use the staging hub for testing and don't want them to run out of space again. This 3GB extra is not expensive, so let's have it.