### PR TITLE
[earthscope, staging] configure alerts

### DIFF
--- a/config/clusters/earthscope/staging.values.yaml
+++ b/config/clusters/earthscope/staging.values.yaml
@@ -10,7 +10,7 @@ basehub:
     hub:
       image:
         name: quay.io/2i2c/jupyterhub-usage-quotas
-        tag: bfdbe0bee333610ff2163455e5da36eea9f5d893
+        tag: f2689dcd155e22e9a1f4115e78448f5393b021c6
       config:
         GenericOAuthenticator:
           token_url: https://login-dev.earthscope.org/oauth/token

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -292,7 +292,7 @@ prometheus:
             severity: action needed this week
       - name: Possible application outage
         rules:
-        - alert: At least one fail open detected by compute usage quotas system in the last 30 mins
+        - alert: Compute usage quotas - At least one fail open detected in the last 30 mins
           annotations:
             summary: Compute usage quotas - Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30m
           expr: |
@@ -303,7 +303,7 @@ prometheus:
           labels:
             namespace: hub={{ $labels.namespace }}
             severity: immediate action needed
-        - alert: At least one Prometheus error detected by compute usage quotas system in the last 30m
+        - alert: Compute usage quotas - At least one Prometheus error detected  in the last 30m
           annotations:
             summary: Compute usage quotas - At least one Prometheus error detected in cluster earthscope by compute usage quotas system in the last 30 mins
           expr: |

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -249,6 +249,14 @@ prometheus:
           labels:
             cluster: earthscope
             severity: immediate action needed
+        - alert: support-prometheus-server pod has restarted
+          annotations:
+            summary: support-prometheus-server pod has restarted on earthscope:{{ $labels.namespace }}
+          expr: "# Count total container restarts with pod name containing 'pod_name_substring'.\n# We sum by pod name (which resets after restart) and namespace, so we don't get all\n# the other labels of the metric in our alert.\n  (\n        sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~\"^support-prometheus-server.*\"})\n      -\n        sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~\"^support-prometheus-server.*\"} offset 10m)\n  ) >= 1    \n"
+          for: 5m
+          labels:
+            cluster: earthscope
+            severity: immediate action needed
       - name: Pod stuck in state for too long
         rules:
         - alert: Pod stuck in Pending for at least 30m
@@ -301,6 +309,7 @@ prometheus:
             ) by (namespace) >= 1
           for: 0m
           labels:
+            cluster: earthscope
             namespace: hub={{ $labels.namespace }}
             severity: immediate action needed
         - alert: Compute usage quotas - At least one Prometheus error detected  in the last 30m
@@ -312,6 +321,7 @@ prometheus:
             ) >= 1
           for: 0m
           labels:
+            cluster: earthscope
             severity: immediate action needed
   alertmanager:
     config:

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -290,6 +290,31 @@ prometheus:
           labels:
             cluster: earthscope
             severity: action needed this week
+      - name: Compute usage quotas - Fail open detected
+        rules:
+        - alert: At least one fail open detected by compute usage quotas system in the last 30 mins
+          annotations:
+            summary: Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30 mins
+          expr: |
+            sum(
+              changes(jupyterhub_usage_quotas_fail_open_total[30m])
+            ) by (namespace) >= 1
+          for: 0m
+          labels:
+            namespace: hub={{ $labels.namespace }}
+            severity: same day action needed
+      - name: Compute usage quotas - Prometheus error
+        rules:
+        - alert: At least one Prometheus error detected by compute usage quotas system in the last 30 mins
+          annotations:
+            summary: At least one Prometheus error detected in cluster earthscope by compute usage quotas system in the last 30 mins
+          expr: |
+            sum(
+              changes(jupyterhub_usage_quotas_prometheus_error_total[30m])
+            ) >= 1
+          for: 0m
+          labels:
+            severity: same day action needed
 grafana:
   grafana.ini:
     server:

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -302,7 +302,7 @@ prometheus:
           for: 0m
           labels:
             namespace: hub={{ $labels.namespace }}
-            severity: same day action needed
+            severity: immediate action needed
       - name: Compute usage quotas - Prometheus error
         rules:
         - alert: At least one Prometheus error detected by compute usage quotas system in the last 30m
@@ -314,7 +314,7 @@ prometheus:
             ) >= 1
           for: 0m
           labels:
-            severity: same day action needed
+            severity: immediate action needed
   alertmanager:
     config:
       route:

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -290,11 +290,11 @@ prometheus:
           labels:
             cluster: earthscope
             severity: action needed this week
-      - name: Compute usage quotas - Fail open detected
+      - name: Possible application outage
         rules:
         - alert: At least one fail open detected by compute usage quotas system in the last 30 mins
           annotations:
-            summary: Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30m
+            summary: Compute usage quotas - Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30m
           expr: |
             sum(
               changes(jupyterhub_usage_quotas_fail_open_total[30m])
@@ -303,11 +303,9 @@ prometheus:
           labels:
             namespace: hub={{ $labels.namespace }}
             severity: immediate action needed
-      - name: Compute usage quotas - Prometheus error
-        rules:
         - alert: At least one Prometheus error detected by compute usage quotas system in the last 30m
           annotations:
-            summary: At least one Prometheus error detected in cluster earthscope by compute usage quotas system in the last 30 mins
+            summary: Compute usage quotas - At least one Prometheus error detected in cluster earthscope by compute usage quotas system in the last 30 mins
           expr: |
             sum(
               changes(jupyterhub_usage_quotas_prometheus_error_total[30m])

--- a/config/clusters/earthscope/support.values.yaml
+++ b/config/clusters/earthscope/support.values.yaml
@@ -294,7 +294,7 @@ prometheus:
         rules:
         - alert: At least one fail open detected by compute usage quotas system in the last 30 mins
           annotations:
-            summary: Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30 mins
+            summary: Fail open detected on cluster earthscope, hub {{ $labels.namespace }} in the last 30m
           expr: |
             sum(
               changes(jupyterhub_usage_quotas_fail_open_total[30m])
@@ -305,7 +305,7 @@ prometheus:
             severity: same day action needed
       - name: Compute usage quotas - Prometheus error
         rules:
-        - alert: At least one Prometheus error detected by compute usage quotas system in the last 30 mins
+        - alert: At least one Prometheus error detected by compute usage quotas system in the last 30m
           annotations:
             summary: At least one Prometheus error detected in cluster earthscope by compute usage quotas system in the last 30 mins
           expr: |
@@ -315,6 +315,35 @@ prometheus:
           for: 0m
           labels:
             severity: same day action needed
+  alertmanager:
+    config:
+      route:
+        routes:
+        - continue: false
+          matchers:
+          - cluster =~ .*
+          - alertname =~ ".*has 0% of space left.*"
+          receiver: known-storage-outage-pager
+        - matchers:
+          - cluster =~ .*
+          - alertname =~ ".*space left.*"
+          receiver: persistent-storage-pager
+        - matchers:
+          - cluster =~ .*
+          - alertname =~ ".*pod has restarted"
+          receiver: pod-restarts-pager
+        - matchers:
+          - cluster =~ .*
+          - alertname =~ ".*failed to start.*"
+          receiver: server-startup-pager
+        - matchers:
+          - cluster =~ .*
+          - alertname =~ ".*stuck in state.*"
+          receiver: pod-stuck-in-state-pager
+        - matchers:
+          - cluster =~ .*
+          - alertname =~ "Compute usage quotas.*"
+          receiver: jupyterhub-usage-quotas
 grafana:
   grafana.ini:
     server:

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -146,5 +146,9 @@ Also, clicking on an alert in PagerDuty, gets you all the metadata associated wi
   - create a new Service in Pagerduty for this groups
   - get the integration key of this service and store it encrypted under a new Pagerduty receiver
   - write a matcher rule in Alert Manager that will link this group to this new receiver
-3. Test it
-4. If you know what the outage condition for this new group is, create a new Orchestration rule for it, so that outage alerts are automatically assigned P1 and shown in the status page
+4. Configure Slack notifications with the PagerDuty service integrations
+   - Go to the `#pagerduty-notifications` channel in the 2i2c Slack
+   - Make sure your PD account is linked to Slack with the shortcut command `/pd link`
+   - Use `/pd connect` to select the service to connect to the channel and select *Responder* for how you want to be notified
+5. Test it
+6. If you know what the outage condition for this new group is, create a new Orchestration rule for it, so that outage alerts are automatically assigned P1 and shown in the status page

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -140,7 +140,7 @@ Also, clicking on an alert in PagerDuty, gets you all the metadata associated wi
 ## How to add a new alert
 
 1. To add a new alert, you'll have to add it to `/helm-charts/support/values.jsonnet` first after checking out [](#topic/jsonnet).
-2. Then, if this is an alert that doesn't pertain to any of the existing alerting groups as defined in [](alerting:configuration), you'll have to:
+2. Then, if this is an alert that doesn't pertain to any of the existing alerting groups as defined in [Alerting - Configuration](alerting:jsonnet-alerts), you'll have to:
   - create a new group
   - create a new Service in Pagerduty for this groups
   - get the integration key of this service and store it encrypted under a new Pagerduty receiver

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -70,6 +70,9 @@ We monitor pod restarts for the following services:
 
 - `jupyterhub-groups-exporter`
 - `jupyterhub-home-nfs`
+- `jupyterhub-cost-monitoring`
+- `support-grafana`
+- hub proxy pod
 
 If a pod has restarted, it may indicate an issue with the service or its configuration.
 To resolve the alert:
@@ -90,6 +93,10 @@ There is additional automation that runs each time an alert like this is trigger
 - A note with the status of this run is left in the PagerDuty incident
 - In addition, if the health check succeeds, the incident is resolved and a message with this status is posted in the `#pagerduty-notifications` Slack channel
 - If the health check fails, then a message, mentioning the channel members, is posted in the `#pagerduty-notifications` Slack channel
+
+### What to do for alerts for application outages
+
+When an application is not working as expected, it is classed as a possible application outage. Similar to the server start alert above, it's best to investigate these ASAP to validate whether this is an outage or not. If it is an outage, follow the incident process as normal.
 
 #### To resolve the alert:
 1. Check if you can spawn a server on that cluster and hub. If not, then is most likely an outage an you must set the P1 priority on this alert and follow the incident response process for outages.
@@ -126,7 +133,7 @@ Example: `[FIRING:1] home-nfs has 10% of space left openscapes prod (same day ac
 - The `FIRING:n` part tracks how many times the alert has been triggered. But because we are not yet grouping alerts, it will always be 1, so it can be ignored.
 - `<disk name> has <limit>% of space left` this is the alert name and it has info about which disk the alert is about and how much space left it has
 - `<cluster-name> <hub-name>` these are labels that provide info about the cluster and hub for which the alert has triggered for
-- `same day action needed` the severity of the alert, which set the timeline when this alert should be handled 
+- `same day action needed` the severity of the alert, which set the timeline when this alert should be handled
 
 Also, clicking on an alert in PagerDuty, gets you all the metadata associated with it, where you can find extra info, like the summary.
 
@@ -138,5 +145,5 @@ Also, clicking on an alert in PagerDuty, gets you all the metadata associated wi
   - create a new Service in Pagerduty for this groups
   - get the integration key of this service and store it encrypted under a new Pagerduty receiver
   - write a matcher rule in Alert Manager that will link this group to this new receiver
-3. Test i
+3. Test it
 4. If you know what the outage condition for this new group is, create a new Orchestration rule for it, so that outage alerts are automatically assigned P1 and shown in the status page

--- a/docs/howto/manage-alerts/index.md
+++ b/docs/howto/manage-alerts/index.md
@@ -72,7 +72,8 @@ We monitor pod restarts for the following services:
 - `jupyterhub-home-nfs`
 - `jupyterhub-cost-monitoring`
 - `support-grafana`
-- hub proxy pod
+- `support-prometheus-server`
+- `proxy`
 
 If a pod has restarted, it may indicate an issue with the service or its configuration.
 To resolve the alert:

--- a/docs/topic/monitoring-alerting/alerting.md
+++ b/docs/topic/monitoring-alerting/alerting.md
@@ -75,6 +75,8 @@ At the time of writing, we have the following [alerting rules groups](https://pr
    - `jupyterhub-home-nfs` restart
    - `jupyterhub-cost-monitoring` restart
    - `support-grafana` restart
+   - `support-prometheus-server` restart
+   - `proxy` restart
 3. **Server Startup Failure**
    For when a user server has failed to start.
 4. **DiskIO saturation**

--- a/docs/topic/monitoring-alerting/alerting.md
+++ b/docs/topic/monitoring-alerting/alerting.md
@@ -53,12 +53,11 @@ If an Alert goes from P1 to another priority number or no number at all, Pagerdu
 - Correlate `to be planned in sprint planning` severity level
 - Community not necessarily affected on a specific timeline, but we must take some action into the committed column of next sprint
 
-
 (alerting:jsonnet-alerts)=
 ## Alerts configured with Jsonnet
 Certain alerts are configured in support deployments using [](#topic/jsonnet).
 
-(alerting:configuration)=
+(alerting:jsonnet:configuration)=
 ### Configuration
 We use the [Prometheus alert manager](https://prometheus.io/docs/alerting/latest/overview/) to set up alerts that are defined in the `helm-charts/support/values.jsonnet` file.
 
@@ -74,12 +73,16 @@ At the time of writing, we have the following [alerting rules groups](https://pr
    For when a pod has restarted, with the following alerts:
    - `jupyterhub-groups-exporter` restart
    - `jupyterhub-home-nfs` restart
+   - `jupyterhub-cost-monitoring` restart
+   - `support-grafana` restart
 3. **Server Startup Failure**
    For when a user server has failed to start.
 4. **DiskIO saturation**
    For when a disk is approaching IO saturation
 5. **Pods stuck in an undesirable state for too long**
    For when there's a pod that's stuck in `Pending` for more than 15m or a pod stuck in `Terminating` for more than 10m.
+6. **Possible application outage**
+   For when an application is not working as expected.
 
 Each of these alerts is integrated with a **Pagerduty Service**. And these services can then be grouped under **Pagerduty Business Services** that can be presented on the status page.
 
@@ -91,8 +94,7 @@ You can find the existing Services under [Service Directory](https://2i2c-org.pa
 ## Alerts configured with Terraform
 Some alerts are configured at the infrastructure using Terraform.
 
-
-(alerting:configuration)=
+(alerting:terraform:configuration)=
 ### Configuration
 
 1. **AWS NFS Home Directory IOPs & Throughput**

--- a/docs/topic/monitoring-alerting/escalation-policies.md
+++ b/docs/topic/monitoring-alerting/escalation-policies.md
@@ -30,6 +30,13 @@ The following escalation policies are defined [in PagerDuty](https://2i2c-org.pa
 - This policy doesn't include the Technical Lead's schedule
 - This policy assigns incidents to the on-call users in a Round Robin fashion, escalating to the next user if the incident is not acknowledged within 12h.
 
+3. **Application outage or possible outage**
+
+- This escalation policy is connected to the following services in our [Service Directory][1]:
+  - JupyterHub Usage Quotas
+- The alerts triggered under these services signal that there is potentially a P1 outage for the application
+- It makes use of all **app engineers'** schedules in a Round Robin fashion (choosing from the users that are on-call, in the moment the incident is triggered), escalating to the next user if the incident is not acknowledged within 4h.
+
 ## Paging
 **TBD**
 

--- a/helm-charts/support/enc-support.secret.values.yaml
+++ b/helm-charts/support/enc-support.secret.values.yaml
@@ -24,12 +24,15 @@ prometheus:
         - name: ENC[AES256_GCM,data:RjWjqWkpXC+jVHYm2ZzP6HsbybfnF7Ei,iv:WbjOLB2EU3LXGZcOTUOLRN9Ml79hzP8wEJb9+TYAQ/s=,tag:Sk/HCIUWKVF/hmEXmvaE+w==,type:str]
           pagerduty_configs:
             - routing_key: ENC[AES256_GCM,data:uMqLsmF0b8Fians7tPNZDO0fNKbJw9cJ5RYavOUrZNw=,iv:GSlEuJy9jyoLKiHX1/fF9FKRYRxva5uGmWJm6iv1fP8=,tag:PutTbVfAgj5ZRDXSbKpsMg==,type:str]
+        - name: ENC[AES256_GCM,data:cqbceth2f3/nxEa7UJoV4gHtKzKJT7c=,iv:WhlK45lcFrMIHLCf5FXhDv29B4rDv9xsi1uFfGO828w=,tag:N7bRE2g0D1+HJRvMd4UNJw==,type:str]
+          pagerduty_configs:
+            - routing_key: ENC[AES256_GCM,data:Vn2POZIKDfuf69Q4wRogdce6+rP+5OUrrRV4TVweDt0=,iv:A+ZxIjlEnfHHwLo3w6KzQA3YRIKPhrcPkzkn2XvBC54=,tag:yCMhR0WbTrZYkFkL3M49tA==,type:str]
 sops:
   gcp_kms:
     - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
       created_at: "2024-12-18T10:09:21Z"
       enc: CiUA4OM7eOThrN3NqDXYd4belMxUdYfF8XpeUSYfiefKkYutN2KoEkkAnGhyNqzzrXyUXTvtS4xl4IjlJpo6hwm9FVbQAyh2Vw9dcXH6h1+NNUHGPYj6KQJvvWZzgXHFLiWdqOfUgTJME0YDx/DYgXgm
-  lastmodified: "2026-03-10T12:04:22Z"
-  mac: ENC[AES256_GCM,data:+zjyjUrXx1pHZS1IH6GAciHG51NqO/DTLfUvZ0XiUUGgACJD/4Y8SXqhjHnaKQxCOtKIBFJ33FbuwQfOZVe3LCuX94nX73f+DwjqirqYH4JjumWMuGzOxmj/++bwHJiAVDC3fLGqiZ7tBdTKeR8SdPy1pxAO/thtVYMLuJgGzxc=,iv:TWaskr8JNkrmGcfU8f3Rfkddq/8774r6meHWNNnEdFk=,tag:s7M4ZF4afjEprZsICRY8tw==,type:str]
+  lastmodified: "2026-05-19T10:28:23Z"
+  mac: ENC[AES256_GCM,data:pyWby9W4I4f/1Zcj1oBOJ0X3vOsImN5eoZnbd0ES1rK6tq/pC70aDpK+phhPS6dDtfC71v15LH0+HL+N4/mg/V6MtMH4w7WjOFXzo+0RyHDJnDpGSYSzobPevJncsNjXWXgVqQLTNLSU8ehQoYm9ecy9vmBKOBFRpYqiyAECl0U=,iv:+QVaySYzu8hRxSqoM2MhDLh0uWjzHd7qT7XJPmkqieU=,tag:h/a225gvTZZfRKhjU/PM6Q==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.12.1
+  version: 3.12.2

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -330,6 +330,12 @@ local configCostMonitoring = {
                 '^proxy.*',
                 'immediate action needed'
               ),
+              makePodRestartAlert(
+                'support-prometheus-server',
+                'support-prometheus-server pod has restarted on %s:{{ $labels.namespace }}' % [cluster_name],
+                '^proxy.*',
+                'same day action needed'
+              ),
             ],
           },
           {


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/7552

- [x] Configure usage quota alerts for earthscope staging
- [x] Add pod restart alert for prometheus server, since this is now on critical path for usage quota system

Note that the alert rules are manually updated in the support values file for Earthscope for now, but the idea would be to roll this out network-wide and refactor into jsonnet pending sufficient testing of the Earthscope cluster.