### PR TITLE
Revert "[awi-ciroh, workshop] Setup groups via shared password"

### DIFF
--- a/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
+++ b/config/clusters/awi-ciroh/enc-workshop.secret.values.yaml
@@ -5,15 +5,12 @@ basehub:
         SharedPasswordAuthenticator:
           admin_password: ENC[AES256_GCM,data:tXvBUY5Xj2suA9gCLsa5SWRhzlTo75Mk5KRVnsCbcp40Bsf7GAljnHFJq80n3HCKkXA=,iv:9NEYm8C+9LD0/xgux00wsdzJOjmdqLVXpcuS0I0MxLQ=,tag:LF09qhhkFzzZy+HAbJjdLA==,type:str]
           user_password: ENC[AES256_GCM,data:PU76mfyoala2eSZsw+SvB12uCEDmxNU0rBB3QUv27g==,iv:7ItyZGYy6MsNj+Oe9THtot6GJ2hIqmsIkgl5avMwtNE=,tag:k2vCgrdkEqNV+82qeIef2w==,type:str]
-          password_groups:
-            music-breeze-simple-law-pen:
-            - ENC[AES256_GCM,data:RGTY,iv:Jk1aQzds7s+/WrcbRqqos53q5uewi43V8s8+QFajnxs=,tag:hreYD5a/LARZ357oZg6mng==,type:str]
 sops:
   gcp_kms:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2025-05-07T08:07:12Z'
     enc: CiUA4OM7eIHDivZcDvslLg3elkX0T4pYR0gVADUKsPLIdE9tM0IOEkkAWOWv8DPVHy3QKWEx9fdZ4KRPWJMSG8CKO+gfeqYiy+AOSoLZZpF4r3PXiCOkQIImX3yZbe2IrxHN0asSXzsJop8A2JMaTAkn
-  lastmodified: '2026-05-20T09:05:02Z'
-  mac: ENC[AES256_GCM,data:7kiK0x5SIrUXHDRVjjmknEyl87VoVTDheiLOBH9BJsh8UKc7/5YUdw49Ip5P2YHMhxA9C8FfxRCX7yeSUo5CunW1LjSFGMINJzic+HGtqnTcP5Ftu4DIShfkzKmDJszmBeC+Y1hhxcUdTlN4Vg3jD9pd9uAK9UgTnPvIrq5l8hI=,iv:a7WKx12Y/XqJ/vPHZkwIrhGDDCHVZwwQud3N/Qm32Xw=,tag:r2mU4DKjKL/e/ZG2cWPbvQ==,type:str]
+  lastmodified: '2026-05-11T15:19:50Z'
+  mac: ENC[AES256_GCM,data:iHLBcV/uYX5PxX+a36RbVRve7UJ7Z4ulgKhj/KRRPLwclueLLxye5hMYq42PEp2zBSYQSJiMoxinr3p/z6vC96WuamEkSf6I0t8SUeNr/q4ew47e9ORjJW6FfoEU+x9f4Ovn9EHxOJFlfF0vapmWGYFDSHRQJQ2lGjW9BLdqPbc=,iv:Mj66+yCNImjVOH5+rhauZIL0BNyh3ghuX/rOLOQYIvU=,tag:PWZItTpeROWGhHnDeNU51A==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -183,6 +183,7 @@ basehub:
       config:
         JupyterHub:
           authenticator_class: shared-password
-        SharedPasswordAuthenticator:
-          manage_groups: true
+        GitHubOAuthenticator: {}
+        Authenticator:
+          manage_groups: false
           allow_all: true


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#8358

The functionality isn't actually deployed in JupyterHub v5 yet.