### PR TITLE
Increase disk throughput for a few more hubs

### DIFF
--- a/terraform/aws/projects/maap.tfvars
+++ b/terraform/aws/projects/maap.tfvars
@@ -222,6 +222,7 @@ ebs_volumes = {
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" },
     iops        = 5000
+    throughput  = 250 # Double the throughput, as we kept getting alerts for throughput consistently
   }
 }
 

--- a/terraform/aws/projects/nasa-cryo.tfvars
+++ b/terraform/aws/projects/nasa-cryo.tfvars
@@ -14,7 +14,7 @@ ebs_volumes = {
   "prod" = {
     size        = 5600
     type        = "gp3"
-    throughput  = 250 # Double the throughput, handling alerts for exceeding throughput consistently
+    throughput  = 375 # Triple the throughput, handling alerts for exceeding throughput consistently
     name_suffix = "prod"
     tags        = { "2i2c:hub-name" : "prod" }
   }

--- a/terraform/aws/projects/reflective.tfvars
+++ b/terraform/aws/projects/reflective.tfvars
@@ -17,6 +17,7 @@ ebs_volumes = {
     size        = 235 # in GB
     type        = "gp3"
     name_suffix = "prod"
+    throughput  = 250 # Double the throughput, as we kept getting alerts for throughput consistently
     tags        = { "2i2c:hub-name" : "prod" }
   },
   "workshop" = {

--- a/terraform/aws/projects/victor.tfvars
+++ b/terraform/aws/projects/victor.tfvars
@@ -36,6 +36,7 @@ ebs_volumes = {
     size        = 1450 # in GB
     type        = "gp3"
     name_suffix = "prod"
+    throughput  = 250 # Double the throughput, as we kept getting alerts for throughput consistently
     tags        = { "2i2c:hub-name" : "prod" }
   }
 }


### PR DESCRIPTION
To handle alerts about throughput being exceeded.

- Increase for cryo again, as we were still getting alerts after yesterday's increases
- Increase for victor, maap and reflective after alerts yesterday

Follow-up to https://github.com/2i2c-org/infrastructure/pull/8355 
Ref https://github.com/NASA-IMPACT/veda-jupyterhub/issues/115