### PR TITLE
AWI-CIROH: Spruce up workshop display names

### DIFF
--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -74,43 +74,43 @@ basehub:
                   image: quay.io/2i2c/awi-ciroh-image:symfluence-v0.8.3
                   image_pull_policy: Always
               devcon1:
-                display_name: Inflect
+                display_name: INFLECT FIM
                 slug: devcon1
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-inflect
                   image_pull_policy: Always
               devcon2:
-                display_name: Hydroserver
+                display_name: HydroServer
                 slug: devcon2
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-hydroserver
                   image_pull_policy: Always
               devcon3:
-                display_name: Hillslope
+                display_name: Hillslope Water Quality Prediction
                 slug: devcon3
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-hillslope
                   image_pull_policy: Always
               devcon4:
-                display_name: Emulator
+                display_name: ML Emulator Models
                 slug: devcon4
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-emulator
                   image_pull_policy: Always
               devcon5:
-                display_name: Satellite
+                display_name: Satellite Data Projection
                 slug: devcon5
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-satellite
                   image_pull_policy: Always
               devcon6:
-                display_name: Cuahsi
+                display_name: CUAHSI Hydroinformatics
                 slug: devcon6
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-cuahsi
                   image_pull_policy: Always
               devcon9:
-                display_name: Foundations
+                display_name: Foundations of ML
                 slug: devcon9
                 kubespawner_override:
                   image: quay.io/awiciroh/devcon26:devcon26-foundations


### PR DESCRIPTION
Hello! This PR is just a request to change some image names in the Workshop Hub to look a little more polished. No functional changes beyond that are included.

Current | Requested | Rationale
-- | -- | --
Foundations | Foundations of ML | Clarity of purpose
Inflect | INFLECT FIM | Brand consistency; clarity
Hydroserver | HydroServer | Brand consistency
Hillslope | Hillslope Water Quality Prediction | Clarity of purpose
Emulator | ML Emulator Models | Clarity of purpose
Satellite | Satellite Data Projection | Clarity of purpose
Cuahsi | CUAHSI Hydroinformatics | Brand consistency; clarity