### PR TITLE
[earthscope, prod] Apply 50GiB home storage limit with a few exceptions

### DIFF
--- a/config/clusters/earthscope/enc-prod.secret.values.yaml
+++ b/config/clusters/earthscope/enc-prod.secret.values.yaml
@@ -2,7 +2,7 @@ basehub:
   jupyterhub-home-nfs:
     quotaEnforcer:
       extraConfig:
-        secret-quota-overrides: ENC[AES256_GCM,data:2WkGpV4Y3T1Wxi+KsI4LKMJas6PIHlq+NtjatnlT9UxrZbYMHJiXxM/9Na22htgHeiqDZ8m4xoBFrUu0WoG/zpKJUCXFMOQyIccKVKF39YEXG66akVhWOCTDcWIRPlvCfrdBMc1VjnV5zECsO8sX+OtK/cDFiVBhKRhCPLn4eh6nxuQ5K5JVWC+GixrLC0y/Z3IY,iv:Vz4Z+15fyAn8LcFH6vz7c8Ul03f/mtrdl2vaVyFIx6Q=,tag:MUzJmK3aLfY84w8dbpuywg==,type:str]
+        secret-quota-overrides: ENC[AES256_GCM,data:aJ0JlZ9MLsKITfDWmQyTPcIwKEMLwb6QZztWUhK4mV5IeNi6N2axWTbEJWojEFvHW8Ax2oNCpoAJvWDggGLhG1I3Hm/B5LFjatP1HH6k7Tjop/zQMjR1EBzfMapPEo7SdxXd17xLEu+782tKrC4J7t1C5XQcoRmpsbwQatty7UD81CSM3dfglFChvaXZPW1JBy27oABgjtI0ZSCmCnllg8E9pze29/hfZRMu/CLzBBCMA7BAO+4j76HM71K54d6OVIaAq1Uzq+D/0fwAo+CJsyMI0bLr3/bkafnj2n5EEgjKwEpuBeiIa2YVkFMbsB4iCkqhpwK7AnxEk522jMpFrtW/dKgj3sykdae6LaiDLYB4bWYVfuWxAe50eqvW3tWRTAkPc6/fLScxCN/G1+4cnM3ClYrUtATJkmkK7go9VUctko7tctTI,iv:cYppXk7Fjsxkr16mD3A78BuzeuDUDxqtPJEoCtVD8J4=,tag:eWNEXfLFJMpannTy6jRiNA==,type:str]
   jupyterhub:
     hub:
       config:
@@ -31,7 +31,7 @@ sops:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2024-02-01T19:48:36Z'
     enc: CiUA4OM7eNqlXnXuPafjk2mTtwiF9Rj9YkZ3urDKx4qdhKBpmS6bEkkAjTWv+vVCb2ruGuWZED5P/YZ637VqREwUreI3ycHvsSoaAEXe8CSUZBQ+0FIi4x9xKnpnLEF9JNcwaME2Fr9iwURYVJhoDk89
-  lastmodified: '2026-05-21T13:28:36Z'
-  mac: ENC[AES256_GCM,data:ZfO8Mfjr9q5sdpTBujCT2ji7SbDt8Z5o4kwvJpkp7hbdtZAF1zfklJLyy3DNygY5EnSnx9RuNKM+u0uhJfSJzfSbbwPq7FlGfcvCa3ctZ6dWIwDsSl0Miy6445Mg2UdQA3B+VhvhGMGqJzjxIKoiRD9G3OWKROLzPDapaeUG0aA=,iv:/ZF5chARf2oMT6VNMmvmCH7mP6E46vFzoFVGbgh1KBM=,tag:yeTB2/Ik5PiSnsSVTe0Yzg==,type:str]
+  lastmodified: '2026-05-21T17:19:50Z'
+  mac: ENC[AES256_GCM,data:akFSdGGFQ4T6OV4j6KTFYptYNVfPW2FD3NIgcQELY4CEfkcvIZChHU5J1WPoUosNB6KZWa7Rt6NApVbNLlWXqZtBFhnXqP3rhtQr8xO1iQW7VNkOWjl7j3/IUGJR4MN2fQmZcmnKw7lqbl7Fx0gKZg1OC7r2PUqpGDvv5RLLtL8=,iv:ysiPJ9Aefp+KbRQSUeSXrEZfM5UAa4lqBm8KZWhJUxg=,tag:0NxIIFG1m6AVHxA7kcHaVA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.2

--- a/config/clusters/earthscope/prod.values.yaml
+++ b/config/clusters/earthscope/prod.values.yaml
@@ -30,7 +30,7 @@ basehub:
       config:
         QuotaManager:
           # Requested by community
-          hard_quota: 100 # in GiB
+          hard_quota: 50 # in GiB
     eks:
       volumeId: vol-06f3c3dc2ded0cd06
   nfs:


### PR DESCRIPTION
We learnt from [#8364](https://github.com/2i2c-org/infrastructure/issues/8364) that the expectation was 50GiB per user. Context from https://2i2c.freshdesk.com/a/tickets/3140 suggests that when the quotas were initially implemented we needed a few users who had already exceeded that limit to downsize their usage before we could actually apply it.

There are only 4 users currently over that limit, so I have applied them as exceptions and introduced the 50GiB blanket policy.

cc @sarahw-earthscope 