### PR TITLE
[earthscope, prod] Remove individual home storage quota exceptions

### DIFF
--- a/config/clusters/earthscope/enc-prod.secret.values.yaml
+++ b/config/clusters/earthscope/enc-prod.secret.values.yaml
@@ -2,7 +2,7 @@ basehub:
   jupyterhub-home-nfs:
     quotaEnforcer:
       extraConfig:
-        secret-quota-overrides: ENC[AES256_GCM,data:aJ0JlZ9MLsKITfDWmQyTPcIwKEMLwb6QZztWUhK4mV5IeNi6N2axWTbEJWojEFvHW8Ax2oNCpoAJvWDggGLhG1I3Hm/B5LFjatP1HH6k7Tjop/zQMjR1EBzfMapPEo7SdxXd17xLEu+782tKrC4J7t1C5XQcoRmpsbwQatty7UD81CSM3dfglFChvaXZPW1JBy27oABgjtI0ZSCmCnllg8E9pze29/hfZRMu/CLzBBCMA7BAO+4j76HM71K54d6OVIaAq1Uzq+D/0fwAo+CJsyMI0bLr3/bkafnj2n5EEgjKwEpuBeiIa2YVkFMbsB4iCkqhpwK7AnxEk522jMpFrtW/dKgj3sykdae6LaiDLYB4bWYVfuWxAe50eqvW3tWRTAkPc6/fLScxCN/G1+4cnM3ClYrUtATJkmkK7go9VUctko7tctTI,iv:cYppXk7Fjsxkr16mD3A78BuzeuDUDxqtPJEoCtVD8J4=,tag:eWNEXfLFJMpannTy6jRiNA==,type:str]
+        secret-quota-overrides: ENC[AES256_GCM,data:kdh4hxbFbwapXNrLQli6jTRXtt41KQNFBt490Q+iR5YskCUesbxzwSxaP7vmDoW661MsfeLzkQ==,iv:avnZANFJWuJ8HtQ1yisw4y0hCK/2dkhKuG651OZOojI=,tag:rLy7irVLJBSLeZT1AhvMLw==,type:str]
   jupyterhub:
     hub:
       config:
@@ -31,7 +31,7 @@ sops:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2024-02-01T19:48:36Z'
     enc: CiUA4OM7eNqlXnXuPafjk2mTtwiF9Rj9YkZ3urDKx4qdhKBpmS6bEkkAjTWv+vVCb2ruGuWZED5P/YZ637VqREwUreI3ycHvsSoaAEXe8CSUZBQ+0FIi4x9xKnpnLEF9JNcwaME2Fr9iwURYVJhoDk89
-  lastmodified: '2026-05-21T17:19:50Z'
-  mac: ENC[AES256_GCM,data:akFSdGGFQ4T6OV4j6KTFYptYNVfPW2FD3NIgcQELY4CEfkcvIZChHU5J1WPoUosNB6KZWa7Rt6NApVbNLlWXqZtBFhnXqP3rhtQr8xO1iQW7VNkOWjl7j3/IUGJR4MN2fQmZcmnKw7lqbl7Fx0gKZg1OC7r2PUqpGDvv5RLLtL8=,iv:ysiPJ9Aefp+KbRQSUeSXrEZfM5UAa4lqBm8KZWhJUxg=,tag:0NxIIFG1m6AVHxA7kcHaVA==,type:str]
+  lastmodified: '2026-05-22T08:47:25Z'
+  mac: ENC[AES256_GCM,data:Ts+R/L9k7NOPHfTHm4m0pHp8c1rJAfpManEJdp8XVFZqwWjHxozQJuQn1WHBjzH0kIgCX7VhS2Zjh07mjlMUsN2tuEslvoYPzE1kqWhmnlxPb5IVh3kM8BhGtHFdmlBH775Wx3njO2fVjAhiHbxnGq9uWgQ0H+HTqrwIcIKeHb8=,iv:mrzpYZFsj3ovA4wVlU5mbXDEZFakSNwRzxrrIHaEGYg=,tag:e4e0EGm7rLe9NjlX//jBAA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.2


### PR DESCRIPTION
Follow up to https://github.com/2i2c-org/infrastructure/pull/8373

Individual users are now all under 50GiB so we can leave just the blanket limit in place now.