### PR TITLE
[awi-ciroh] Prepare for scratch upgrades

### DIFF
--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -52,14 +52,11 @@ basehub:
               # Limit total size, to prevent pod being evicted
               # with over use by any one user. This can be increased,
               # but may need to increase the size of the node disk
-              sizeLimit: 5Gi
+              sizeLimit: 10Gi
         extraVolumeMounts:
-          002-scratch-session-jovyan:
+          002-scratch-session:
             name: scratch-session
-            mountPath: /home/jovyan/scratch-session
-          002-scratch-session-rstudio:
-            name: scratch-session
-            mountPath: /home/rstudio/scratch-session
+            mountPath: /tmp
     hub:
       config:
         JupyterHub:

--- a/config/clusters/awi-ciroh/common.values.yaml
+++ b/config/clusters/awi-ciroh/common.values.yaml
@@ -44,6 +44,22 @@ basehub:
       defaultUrl: /lab
       cloudMetadata:
         blockWithIptables: false
+      storage:
+        extraVolumes:
+          002-scratch-session:
+            name: scratch-session
+            emptyDir:
+              # Limit total size, to prevent pod being evicted
+              # with over use by any one user. This can be increased,
+              # but may need to increase the size of the node disk
+              sizeLimit: 5Gi
+        extraVolumeMounts:
+          002-scratch-session-jovyan:
+            name: scratch-session
+            mountPath: /home/jovyan/scratch-session
+          002-scratch-session-rstudio:
+            name: scratch-session
+            mountPath: /home/rstudio/scratch-session
     hub:
       config:
         JupyterHub:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -121,7 +121,7 @@ basehub:
           cpu_guarantee: 1.8887049999999999
           cpu_limit: 15.109639999999999
           node_selector:
-            node.kubernetes.io/instance-type: n2-standard-16
+            node.kubernetes.io/instance-type: n4-standard-16
       - display_name: Medium
         description: ~14 GB RAM, ~4 CPUs. Up to ~15 CPUs when available
         profile_options: *profile_options
@@ -131,7 +131,7 @@ basehub:
           cpu_guarantee: 3.7774099999999997
           cpu_limit: 15.109639999999999
           node_selector:
-            node.kubernetes.io/instance-type: n2-standard-16
+            node.kubernetes.io/instance-type: n4-standard-16
       - display_name: Large
         description: ~30 GB RAM, ~8 CPUs .Up to ~62 CPUs when available
         profile_options: *profile_options
@@ -141,17 +141,19 @@ basehub:
           cpu_guarantee: 7.78725
           cpu_limit: 62.298
           node_selector:
-            node.kubernetes.io/instance-type: n2-standard-64
+            node.kubernetes.io/instance-type: n4-standard-16
       - display_name: Huge
         description: ~59 GB RAM, ~16 CPUs. Up to ~62 CPUs when available
         profile_options: *profile_options
+        allowed_groups:
+        - huge
         kubespawner_override:
           mem_guarantee: 63731921920
           mem_limit: 63731921920
           cpu_guarantee: 15.5745
           cpu_limit: 62.298
           node_selector:
-            node.kubernetes.io/instance-type: n2-standard-64
+            node.kubernetes.io/instance-type: n4-standard-16
       - display_name: Small (2i2c testing)
         profile_options: *profile_options
         allowed_groups:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -155,7 +155,7 @@ basehub:
       - display_name: Small (2i2c testing)
         profile_options: *profile_options
         allowed_groups:
-        - 2i2c-org:hub-access-for-2i2c-staff
+        - 2i2c
         kubespawner_override:
           mem_guarantee: 7447431505
           mem_limit: 7447431505
@@ -166,7 +166,6 @@ basehub:
       - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
         description: Start a container on a dedicated node with a GPU
         allowed_groups:
-        - 2i2c-org:hub-access-for-2i2c-staff
         - gpu
         profile_options:
           image:

--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -152,6 +152,17 @@ basehub:
           cpu_limit: 62.298
           node_selector:
             node.kubernetes.io/instance-type: n2-standard-64
+      - display_name: Small (2i2c testing)
+        profile_options: *profile_options
+        allowed_groups:
+        - 2i2c-org:hub-access-for-2i2c-staff
+        kubespawner_override:
+          mem_guarantee: 7447431505
+          mem_limit: 7447431505
+          cpu_guarantee: 1.8887049999999999
+          cpu_limit: 15.109639999999999
+          node_selector:
+            node.kubernetes.io/instance-type: n4-standard-4
       - display_name: NVIDIA Tesla T4, ~16 GB, ~4 CPUs
         description: Start a container on a dedicated node with a GPU
         allowed_groups:

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -283,8 +283,10 @@ resource "google_container_node_pool" "notebook" {
 
   node_config {
     boot_disk {
-      disk_type = each.value.disk_type
-      size_gb   = each.value.disk_size_gb
+      disk_type              = each.value.disk_type
+      size_gb                = each.value.disk_size_gb
+      provisioned_iops       = each.value.disk_iops
+      provisioned_throughput = each.value.disk_throughput
     }
 
     dynamic "guest_accelerator" {

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -193,7 +193,22 @@ resource "google_container_node_pool" "core" {
     # than SSD disks. It contributes heavily to how fast new nodes spin up,
     # as images being pulled takes up a lot of new node spin up time.
     # Faster disks provide faster image pulls!
-    disk_type = "pd-balanced"
+
+    # Hyperdisks can be customised further, but only work with certain nodes
+    # And updating existing nodepools with the boot_disk block will force a recreation.
+    disk_type    = var.core_node_boot_disk.type == null ? "pd-balanced" : null
+    disk_size_gb = var.core_node_boot_disk.type == null ? 30 : null
+
+    dynamic "boot_disk" {
+      # pd-balanced disks can't be tuned, and they were the default
+      for_each = var.core_node_boot_disk.type == null ? [] : [var.core_node_boot_disk]
+      content {
+        disk_type              = boot_disk.value.type
+        size_gb                = boot_disk.value.size_gb
+        provisioned_iops       = boot_disk.value.iops
+        provisioned_throughput = boot_disk.value.throughput
+      }
+    }
 
     resource_labels = {
       "node-purpose" : "core"
@@ -204,7 +219,6 @@ resource "google_container_node_pool" "core" {
       "k8s.dask.org/node-purpose"    = "core"
     }
     machine_type = var.core_node_machine_type
-    disk_size_gb = 30
 
     # Our service account gets all OAuth scopes so it can access
     # all APIs, but only fine grained permissions + roles are

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -96,7 +96,9 @@ notebook_nodes = {
   },
 
   # Workshop N4 nodes
-  # Designed around "huge" node configuration
+  # Designed around n4-standard-16 node configuration
+  # These are optimal for supporting even huge instances whilst 
+  # Having better perf on hyperdisks than 64
   # Model this on Medium profiles
   # Assuming 10GiB scratch per user, 240MiB/s, 1250 IOPS
   "n4-standard-4" : {
@@ -113,8 +115,10 @@ notebook_nodes = {
     # Bump these relative to scaling from 64, as the law of large numbers is worse for smaller samples
     # And the pathological best-case is objectively worse (one person using IO can only hit disk limit)
     # than the n4-standard-64 case
-    disk_iops : 2500,
-    disk_throughput : 480
+    # Minimum 3000  
+    disk_iops : 3000,
+    # Limit of n4-standard-4
+    disk_throughput : 240
   },
   "n4-standard-16" : {
     min : 0,
@@ -123,11 +127,15 @@ notebook_nodes = {
     machine_type : "n4-standard-16",
 
     disk_type : "hyperdisk-balanced",
+
+    # Allow for 50% oversubscription (small + medium) and 100GiB for images
+    # i.e. X = (X_user * N_user * 1.5) + 100
     disk_size_gb : 160,
 
-    # Same rationale as above
-    disk_iops : 4500,
-    disk_throughput : 950
+    # Do not compute oversubscription due to small numbers --
+    # Mix of smaller-than-medium profiles would disrupt this
+    disk_iops : 5000,
+    disk_throughput : 960
   },
   "n4-standard-64" : {
     min : 0,
@@ -136,14 +144,11 @@ notebook_nodes = {
     machine_type : "n4-standard-64",
 
     disk_type : "hyperdisk-balanced",
-    # Allow for 50% oversubscription (small + medium) and 100GiB for images
-    # i.e. X = (X_user * N_user * 1.5) + 100
     disk_size_gb : 340,
 
-    # Assume 25% aren't using scratch at any time
-    # i.e. X = X_user * N_user * 0.75
+    # Limit of n4-standard-64 is 2400 MiB/s
     disk_iops : 15000,
-    disk_throughput : 2880,
+    disk_throughput : 2400,
   },
 
   "gpu-t4" : {

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -94,6 +94,12 @@ notebook_nodes = {
     max : 20,
     machine_type : "n2-standard-64",
   },
+  "n4-standard-4" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 100,
+    machine_type : "n4-standard-4"
+  },
   "n4-standard-64" : {
     min : 0,
     # Keep the numbers down, for safety!

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -98,13 +98,11 @@ notebook_nodes = {
     min : 0,
     # Keep the numbers down, for safety!
     max : 100,
-    machine_type : "n4-standard-4"
-  },
-  "n4-standard-64" : {
-    min : 0,
-    # Keep the numbers down, for safety!
-    max : 20,
-    machine_type : "n4-standard-64"
+    machine_type : "n4-standard-4",
+    disk_type : "hyperdisk-balanced",
+    disk_size_gb : 100,
+    disk_iops : 10000,
+    disk_throughput : 2000,
   },
   "gpu-t4" : {
     min : 0,

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -3,8 +3,13 @@ project_id             = "ciroh-jupyterhub-423218"
 zone                   = "us-central1-b"
 region                 = "us-central1"
 core_node_machine_type = "n2-highmem-4"
-enable_network_policy  = true
-enable_logging         = false
+#core_node_machine_type = "n4-highmem-4"
+enable_network_policy = true
+enable_logging        = false
+
+core_node_boot_disk = {
+  #type = "hyperdisk-balanced"
+}
 
 enable_filestore_backups = true
 filestores               = {}
@@ -88,6 +93,12 @@ notebook_nodes = {
     # Keep the numbers down, for safety!
     max : 20,
     machine_type : "n2-standard-64",
+  },
+  "n4-standard-64" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 20,
+    machine_type : "n4-standard-64"
   },
   "gpu-t4" : {
     min : 0,

--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -94,20 +94,68 @@ notebook_nodes = {
     max : 20,
     machine_type : "n2-standard-64",
   },
+
+  # Workshop N4 nodes
+  # Designed around "huge" node configuration
+  # Model this on Medium profiles
+  # Assuming 10GiB scratch per user, 240MiB/s, 1250 IOPS
   "n4-standard-4" : {
     min : 0,
     # Keep the numbers down, for safety!
     max : 100,
     machine_type : "n4-standard-4",
+
     disk_type : "hyperdisk-balanced",
-    disk_size_gb : 100,
-    disk_iops : 10000,
-    disk_throughput : 2000,
+
+    # Prefer large disks as cheap and safer
+    disk_size_gb : 130,
+
+    # Bump these relative to scaling from 64, as the law of large numbers is worse for smaller samples
+    # And the pathological best-case is objectively worse (one person using IO can only hit disk limit)
+    # than the n4-standard-64 case
+    disk_iops : 2500,
+    disk_throughput : 480
   },
+  "n4-standard-16" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 100,
+    machine_type : "n4-standard-16",
+
+    disk_type : "hyperdisk-balanced",
+    disk_size_gb : 160,
+
+    # Same rationale as above
+    disk_iops : 4500,
+    disk_throughput : 950
+  },
+  "n4-standard-64" : {
+    min : 0,
+    # Keep the numbers down, for safety!
+    max : 30,
+    machine_type : "n4-standard-64",
+
+    disk_type : "hyperdisk-balanced",
+    # Allow for 50% oversubscription (small + medium) and 100GiB for images
+    # i.e. X = (X_user * N_user * 1.5) + 100
+    disk_size_gb : 340,
+
+    # Assume 25% aren't using scratch at any time
+    # i.e. X = X_user * N_user * 0.75
+    disk_iops : 15000,
+    disk_throughput : 2880,
+  },
+
   "gpu-t4" : {
     min : 0,
     max : 20,
     machine_type : "n1-highmem-8",
+
+    # Use regular storage for scratch
+    # As this is an n1 node
+    disk_type : "pd-ssd",
+    disk_size_gb : 100,
+
     gpu : {
       enabled : true,
       type : "nvidia-tesla-t4",

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -100,6 +100,8 @@ variable "notebook_nodes" {
     # Faster disks provide faster image pulls!
     disk_type : optional(string, "pd-balanced"),
     disk_size_gb : optional(number, 100),
+    disk_throughput : optional(number, null),
+    disk_iops : optional(number, null),
     gpu : optional(
       object({
         enabled : optional(bool, false),

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -215,6 +215,19 @@ variable "zone" {
   EOT
 }
 
+variable "core_node_boot_disk" {
+  type = object({
+    type       = optional(string, null)
+    size_gb    = optional(number, 30)
+    iops       = optional(number, 3000)
+    throughput = optional(number, 140)
+  })
+  default     = {}
+  description = <<-EOT
+  Configure core node boot disk type.
+  EOT
+}
+
 variable "core_node_machine_type" {
   type        = string
   description = <<-EOT


### PR DESCRIPTION
This PR switches the user nodes to n4 instances on CIROH, and mounts ephemeral storage under `/tmp`.

We want good hyperdisk performance for scratch. The hyperdisk instance limits are defined as a diminishing series. This puts smaller instances at higher relative performance per core.

For workshops, using huge instances is preferable, because probability of everyone needing scratch simultaneously is more well defined. For smaller packing, we need to be more careful and not underprovision.

`n4-highmem-16` is the sweet spot:
1. Can fit single huge instances
2. Can fit a good number (4) medium instances

This PR also adds scaffolding for migrating core nodes, although this is more work and isn't done here.

## Quotas
I have also bumped the following quotas:
- CPUs (1600) (not needed, I mistakenly thought this was needed)
- N2 CPUS (1600)
- IP addresses (128)

I have not touched the Hyperdisk quotas (40,960 GB is enough). Nor have I touched the CPUS_PER_VM_FAMILY which is sufficient (3000)