### PR TITLE
[earthscope, prod] Bump image n quota

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -146,7 +146,7 @@ basehub:
             empty:
               resource: memory
               limit:
-                value: 2500
+                value: 5000
                 unit: GiB-hours
               window: 30
             intersection: max

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -19,7 +19,7 @@ basehub:
       image:
         # Usage quotas 0.1.2 and fancy-profiles 0.6.0
         name: quay.io/2i2c/jupyterhub-usage-quotas
-        tag: 0.1.2
+        tag: 04215347e9f05cc95b7a4eb4c87066bb7bf6f1f9
       extraConfig:
         001-username-claim: |
           import json

--- a/helm-charts/images/hub/quotas-requirements.txt
+++ b/helm-charts/images/hub/quotas-requirements.txt
@@ -1,2 +1,2 @@
-jupyterhub-usage-quotas[service]==0.1.2
+jupyterhub-usage-quotas[service] @ git+https://github.com/2i2c-org/jupyterhub-usage-quotas@04215347e9f05cc95b7a4eb4c87066bb7bf6f1f9
 jupyterhub-fancy-profiles==0.6.0


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/7552.

Updates compute quota limit from 2500 to 5000 GiB-hours because there is a user with > 4000 GiB-hours usage over the last 30 days.