### PR TITLE
[awi-ciroh] Bump perf on n4-standard-16

### DIFF
--- a/terraform/gcp/projects/awi-ciroh.tfvars
+++ b/terraform/gcp/projects/awi-ciroh.tfvars
@@ -134,8 +134,8 @@ notebook_nodes = {
 
     # Do not compute oversubscription due to small numbers --
     # Mix of smaller-than-medium profiles would disrupt this
-    disk_iops : 5000,
-    disk_throughput : 960
+    disk_iops : 7000,
+    disk_throughput : 1200
   },
   "n4-standard-64" : {
     min : 0,


### PR DESCRIPTION
This is the maximum we can provision for this node size.