### PR TITLE
[awi-ciroh] Use temporary hyperdisk for HOME

### DIFF
--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -1,7 +1,14 @@
 basehub:
   jupyterhub-home-nfs:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: workshop-temp-nfs
+    tolerations:
+      - effect: NoSchedule
+        key: 2i2c.org/nfs-vm-family
+        operator: Equal
+        value: n4
     gke:
-      volumeId: projects/ciroh-jupyterhub-423218/zones/us-central1-b/disks/hub-nfs-homedirs-workshop
+      volumeId: projects/ciroh-jupyterhub-423218/zones/us-central1-b/disks/home-nfs-workshop-hyperdisk 
     quotaEnforcer:
       config:
         QuotaManager:


### PR DESCRIPTION
This PR switches the home-nfs for workshop to use a hyperdisk. The hyperdisk was created imperatively, and needs to be destroyed imperatively:

https://console.cloud.google.com/compute/disksDetail/zones/us-central1-b/disks/home-nfs-workshop-hyperdisk?project=<PROJECT-ID>

I've left the original pd-balanced SSD disk.

> [!Note]
> To revert this PR, first scale down the home-nfs replicas and dirsize replicas to 0. Then delete the two PVCs and PVs for the workshop home dirs (clearing the finalizers). Finally, deploy the reverted PR.

> [!Important]
> This PR requires an n4 node pool, also created imperatively. This node pool will need to be upgraded (replaced) with a higher-performance pool when the workshop runs.