### PR TITLE
[awi-ciroh] Enable Huge profile

### DIFF
--- a/config/clusters/awi-ciroh/workshop.values.yaml
+++ b/config/clusters/awi-ciroh/workshop.values.yaml
@@ -149,8 +149,6 @@ basehub:
       - display_name: Huge
         description: ~59 GB RAM, ~16 CPUs. Up to ~62 CPUs when available
         profile_options: *profile_options
-        allowed_groups:
-        - huge
         kubespawner_override:
           mem_guarantee: 59579456061
           mem_limit: 59579456061


### PR DESCRIPTION
This profile will force one user per node, which means they'll have exclusive benefit of the `/tmp` disk. Hyperdisks are limited by instance capability in addition to provisioning. On the n2-standard-16, that's 1200 MiB/s half-duplex.

This is a stop-gap measure until we can think more carefully about this.

We have enough IP addresses and CPU quota for ~150 people to use Huge. But, that will be very expensive, and I worry about node availability. Let's discourage this.