### PR TITLE
feat: Helm-managed node placeholders

### DIFF
--- a/.github/workflows/scale-placeholders.yaml
+++ b/.github/workflows/scale-placeholders.yaml
@@ -1,4 +1,4 @@
-name: Scale user placeholders
+name: Scale node placeholders
 on:
   workflow_dispatch:
     inputs:
@@ -42,7 +42,7 @@ jobs:
         go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
     - name: Apply scale-change
       run: |
-        deployer generate replicas ${{ github.event.inputs.cluster }} ${{ github.event.inputs.hub }} ${{ github.event.inputs.replicas }}
+        deployer generate node-replicas ${{ github.event.inputs.cluster }} ${{ github.event.inputs.hub }} ${{ github.event.inputs.replicas }}
     - name: Commit change
       run: |
         # Store branch name
@@ -53,7 +53,7 @@ jobs:
 
         # Add changes in config/clusters of existing tracked files
         git add -u config/clusters
-        git commit -m "Scale placeholders to ${{ github.event.inputs.replicas }} for ${{ github.event.inputs.cluster }}/${{ github.event.inputs.hub }}"
+        git commit -m "Scale node placeholders to ${{ github.event.inputs.replicas }} for ${{ github.event.inputs.cluster }}/${{ github.event.inputs.hub }}"
 
         # Push upstream
         git push --set-upstream origin "${branch_name}"

--- a/deployer/dev_commands/generate/placeholders.py
+++ b/deployer/dev_commands/generate/placeholders.py
@@ -2,6 +2,8 @@
 Commands for reserving placeholders
 """
 
+from typing import Literal
+
 import typer
 from ruamel.yaml import YAML
 
@@ -23,38 +25,7 @@ def user_replicas(
     """
     Scale up user placeholders to reserve capacity via N user placeholders
     """
-    cluster = Cluster.from_name(cluster_name)
-
-    if replicas < 0:
-        raise ValueError(f"Replicas must not be less than zero: {replicas}")
-
-    # Make sure that hub exists!
-    try:
-        next(h for h in cluster.hubs if h.spec["name"] == hub_name)
-    except StopIteration:
-        raise ValueError(f"No hub with name {hub_name} found in {cluster_name} cluster")
-
-    # Expect <hub_name>.values.yaml. We could also look for `<hub_name>-placeholders.values.yaml` for a more systematic approach
-    # This expectation meanwhile imposes constraints on hub value file names.
-    expected_config_path = cluster.config_dir / f"{hub_name}.values.yaml"
-    if not expected_config_path.exists():
-        raise FileNotFoundError(
-            f"Could not find values file for {hub_name} hub in expected location ({expected_config_path})"
-        )
-
-    hub_config = yaml.load(expected_config_path)
-    basehub_config = hub_config.get("basehub", hub_config)
-
-    try:
-        placeholders = basehub_config["jupyterhub"]["scheduling"]["userPlaceholder"]
-    except KeyError as exc:
-        exc.add_note("Could not find userPlaceholders section in hub configuration")
-        raise
-
-    # Scale repliacs
-    placeholders["replicas"] = replicas
-
-    yaml.dump(hub_config, expected_config_path)
+    patch_replicas(cluster_name, hub_name, replicas, "user")
 
 
 @generate_app.command()
@@ -69,6 +40,15 @@ def node_replicas(
     """
     Scale up node placeholders to reserve capacity via N node placeholders
     """
+    patch_replicas(cluster_name, hub_name, replicas, "node")
+
+
+def patch_replicas(
+    cluster_name: str,
+    hub_name: str,
+    replicas: int,
+    kind: Literal["node", "user"],
+):
     cluster = Cluster.from_name(cluster_name)
 
     if replicas < 0:
@@ -92,9 +72,12 @@ def node_replicas(
     basehub_config = hub_config.get("basehub", hub_config)
 
     try:
-        placeholders = basehub_config["nodePlaceholder"]
+        if kind == "node":
+            placeholders = basehub_config["nodePlaceholder"]
+        else:
+            placeholders = basehub_config["jupyterhub"]["scheduling"]["userPlaceholder"]
     except KeyError as exc:
-        exc.add_note("Could not find nodePlaceholders section in hub configuration")
+        exc.add_note(f"Could not find {kind} placeholders section in hub configuration")
         raise
 
     # Scale repliacs

--- a/deployer/dev_commands/generate/placeholders.py
+++ b/deployer/dev_commands/generate/placeholders.py
@@ -12,7 +12,7 @@ yaml = YAML(typ="rt", pure=True)
 
 
 @generate_app.command()
-def replicas(
+def user_replicas(
     cluster_name: str = typer.Argument(
         "2i2c",
         help="Name of cluster for which to reserve capacity",
@@ -49,6 +49,52 @@ def replicas(
         placeholders = basehub_config["jupyterhub"]["scheduling"]["userPlaceholder"]
     except KeyError as exc:
         exc.add_note("Could not find userPlaceholders section in hub configuration")
+        raise
+
+    # Scale repliacs
+    placeholders["replicas"] = replicas
+
+    yaml.dump(hub_config, expected_config_path)
+
+
+@generate_app.command()
+def node_replicas(
+    cluster_name: str = typer.Argument(
+        "2i2c",
+        help="Name of cluster for which to reserve capacity",
+    ),
+    hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
+    replicas: int = typer.Argument(...),
+):
+    """
+    Scale up node placeholders to reserve capacity via N node placeholders
+    """
+    cluster = Cluster.from_name(cluster_name)
+
+    if replicas < 0:
+        raise ValueError(f"Replicas must not be less than zero: {replicas}")
+
+    # Make sure that hub exists!
+    try:
+        next(h for h in cluster.hubs if h.spec["name"] == hub_name)
+    except StopIteration:
+        raise ValueError(f"No hub with name {hub_name} found in {cluster_name} cluster")
+
+    # Expect <hub_name>.values.yaml. We could also look for `<hub_name>-placeholders.values.yaml` for a more systematic approach
+    # This expectation meanwhile imposes constraints on hub value file names.
+    expected_config_path = cluster.config_dir / f"{hub_name}.values.yaml"
+    if not expected_config_path.exists():
+        raise FileNotFoundError(
+            f"Could not find values file for {hub_name} hub in expected location ({expected_config_path})"
+        )
+
+    hub_config = yaml.load(expected_config_path)
+    basehub_config = hub_config.get("basehub", hub_config)
+
+    try:
+        placeholders = basehub_config["nodePlaceholder"]
+    except KeyError as exc:
+        exc.add_note("Could not find nodePlaceholders section in hub configuration")
         raise
 
     # Scale repliacs

--- a/helm-charts/basehub/templates/deployment-node-placeholder.yaml
+++ b/helm-charts/basehub/templates/deployment-node-placeholder.yaml
@@ -12,6 +12,11 @@ spec:
     matchLabels:
       app: jupyterhub
       component: node-placeholder
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 0
   template:
     metadata:
       labels:

--- a/helm-charts/basehub/templates/deployment-node-placeholder.yaml
+++ b/helm-charts/basehub/templates/deployment-node-placeholder.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.nodePlaceholder.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-placeholder
+  labels:
+    app: jupyterhub
+    component: node-placeholder
+spec:
+  replicas: {{ .Values.nodePlaceholder.replicas }}
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: node-placeholder
+  template:
+    metadata:
+      labels:
+        app: jupyterhub
+        component: node-placeholder
+    spec:
+      {{- with .Values.nodePlaceholder.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with concat .Values.nodePlaceholder.tolerations .Values.nodePlaceholder.extraTolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      # Don't schedule pods on same node
+      affinity:
+        # Require that pods should not run in the same topology
+        podAntiAffinity:
+          # Enforce this at scheduling time
+          requiredDuringSchedulingIgnoredDuringExecution:
+            # Nodes with same host name are considered part of the same topology
+          - topologyKey: kubernetes.io/hostname
+              # Find matching pods to determine multiplicity per topology domain
+              labelSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: node-placeholder
+
+      containers:
+      - name: pause
+        image: {{ .Values.nodePlaceholder.pauseContainer.image}}
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+{{- end }}

--- a/helm-charts/basehub/templates/deployment-node-placeholder.yaml
+++ b/helm-charts/basehub/templates/deployment-node-placeholder.yaml
@@ -26,19 +26,26 @@ spec:
       tolerations:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
-      # Don't schedule pods on same node
       affinity:
+        # Require that pods run on user nodes only
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: hub.jupyter.org/node-purpose
+                  operator: In
+                  values: [user]
         # Require that pods should not run in the same topology
         podAntiAffinity:
           # Enforce this at scheduling time
           requiredDuringSchedulingIgnoredDuringExecution:
             # Nodes with same host name are considered part of the same topology
           - topologyKey: kubernetes.io/hostname
-              # Find matching pods to determine multiplicity per topology domain
-              labelSelector:
-                matchLabels:
-                  app: jupyterhub
-                  component: node-placeholder
+            # Find matching pods to determine multiplicity per topology domain
+            labelSelector:
+              matchLabels:
+                app: jupyterhub
+                component: node-placeholder
 
       containers:
       - name: pause

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -12,6 +12,7 @@ type: object
 additionalProperties: false
 required:
   - nfs
+  - nodePlaceholder
   - inClusterNFS
   - global
   - jupyterhub
@@ -116,6 +117,40 @@ properties:
             description: |
               Optional string to use as the name of the share - defaults to name of the
               hub specified in the cluster.yaml file.
+  nodePlaceholder:
+    type: object
+    additionalProperties: false
+    required:
+      - enabled
+      - replicas
+      - nodeSelector
+      - tolerations
+      - extraTolerations
+      - pauseContainer
+    properties:
+      enabled:
+        type: boolean
+      replicas:
+        type: integer
+        minimum: 0
+      pauseContainer:
+        type: object
+        additionalProperties: false
+        required:
+          - image
+        properties:
+          image:
+            type: string
+      nodeSelector:
+        type: object
+        additionalProperties: true
+        description: |
+          An object with key value pairs representing labels.
+      tolerations: &tolerations-spec
+        type: array
+        description: |
+          Tolerations allow a pod to be scheduled on nodes with taints.
+      extraTolerations: *tolerations-spec
   inClusterNFS:
     type: object
     additionalProperties: false

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -341,6 +341,23 @@ nfs:
       - vers=4.2
     baseShareName: /
 
+nodePlaceholder:
+  enabled: false
+  replicas: 0
+  pauseContainer:
+    image: registry.k8s.io/pause:3.10.1
+  nodeSelector:
+    hub.jupyter.org/node-purpose: user
+  tolerations:
+    # Tolerate tainted jupyterhub user nodes
+    - key: hub.jupyter.org_dedicated
+      value: user
+      effect: NoSchedule
+    - key: hub.jupyter.org/dedicated
+      value: user
+      effect: NoSchedule
+  extraTolerations: []
+
 # Use NFS provided by an in cluster server with the nfs-external-provisioner chart
 inClusterNFS:
   enabled: false
@@ -863,7 +880,7 @@ jupyterhub:
         manage_groups: true
         populate_teams_in_auth_state: true
         scope:
-        - read:org
+          - read:org
       Authenticator:
         # Don't allow test username to login into the hub
         # The test service will still be able to create this hub username
@@ -881,7 +898,7 @@ jupyterhub:
             KubeSpawner.image:
               type: string
               title: User docker image
-              description: Determines languages, libraries and interfaces 
+              description: Determines languages, libraries and interfaces
                 available
               help: Leave this blank to use the default
             Spawner.default_url:
@@ -1041,10 +1058,10 @@ jupyterhub:
     loadRoles:
       jupyterhub-groups-exporter:
         services:
-        - jupyterhub-groups-exporter
+          - jupyterhub-groups-exporter
         scopes:
-        - users
-        - groups
+          - users
+          - groups
     image:
       name: quay.io/2i2c/pilot-hub
       tag: "0.0.1-0.dev.git.15467.h0cadc91ad"


### PR DESCRIPTION
## Motivation
2i2c runs workshops, and we sometimes get requests to pre-warm the infrastructure. It would be nice to make this quicker / easier to manage.

We have an initiative https://github.com/2i2c-org/initiatives/issues/51 that tracks the need to reserve nodes ahead of time.

That initiative aims to implement cloud-specific backends to solve the problem. The proposal is a robust approach, but in the meantime we still would benefit from some system of scaling up hubs in a way that reduces toil.

## Implementation
This PR replaces previous work to use user placeholders (which fails for >1 node) in favour of using node placeholders. These placeholders just ensure that $N$ nodes are available, and do not respond to load i.e. do not scale up as nodes become used. This differs from user placeholders, which attempt to ensure `$N$` replicas are always available.

This can be combined with the `userScheduler` to ensure that user nodes are densely packed, rather than spread out, making scale-down less disruptive.