### PR TITLE
[CloudBank] gpu-demo rotate admin password

### DIFF
--- a/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
@@ -1,22 +1,22 @@
 jupyterhub:
-    hub:
-        config:
-            DummyAuthenticator:
-                password: ENC[AES256_GCM,data:KiYl/rs+H6GtJOlF162NQvNtQzF1WXtHIQ==,iv:lcdmDg/KhzFNBgi1IEsdsU0yyJq2/CABn4DDdAIzzbY=,tag:CqLWCmAMcCHbtEfvfjEkWg==,type:str]
-            SharedPasswordAuthenticator:
-                user_password: ENC[AES256_GCM,data:B/grfBdAFQxid3K0PpFjdhpOmSQuKs5HvQ==,iv:+Jzii/4TEsvTzsMkLp1VDyHnK3n697jsakS3Yrj2XC4=,tag:zCIBHSAbdwzUMcW0L+fV/w==,type:str]
-                admin_password: ENC[AES256_GCM,data:KkchEgzxMsCZ1oS3yjsWfZQ04AS+oPIOABo6pg9Oi/HlMjJB5Vm3mGUa+bWIUNNS,iv:sfDuod6U3/3JG9IOec+QCAhrpUdpjuQIt4FcJ1y7wCA=,tag:lkO0OviJ0ceYQeehKE/Dhw==,type:str]
+  hub:
+    config:
+      DummyAuthenticator:
+        password: ENC[AES256_GCM,data:KiYl/rs+H6GtJOlF162NQvNtQzF1WXtHIQ==,iv:lcdmDg/KhzFNBgi1IEsdsU0yyJq2/CABn4DDdAIzzbY=,tag:CqLWCmAMcCHbtEfvfjEkWg==,type:str]
+      SharedPasswordAuthenticator:
+        user_password: ENC[AES256_GCM,data:B/grfBdAFQxid3K0PpFjdhpOmSQuKs5HvQ==,iv:+Jzii/4TEsvTzsMkLp1VDyHnK3n697jsakS3Yrj2XC4=,tag:zCIBHSAbdwzUMcW0L+fV/w==,type:str]
+        admin_password: ENC[AES256_GCM,data:KkchEgzxMsCZ1oS3yjsWfZQ04AS+oPIOABo6pg9Oi/HlMjJB5Vm3mGUa+bWIUNNS,iv:sfDuod6U3/3JG9IOec+QCAhrpUdpjuQIt4FcJ1y7wCA=,tag:lkO0OviJ0ceYQeehKE/Dhw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-05-30T01:35:15Z"
-          enc: CiUA4OM7eMzLxcRdc0ceXelctF7OH/Ga1unGaxxXjwPAhHNxgi17EkkAmy+ektwqZhWp6H0cTojm4tbVwN0hZwDHXN8FMVbilnkiu3w0jjvekKPMtrm4eZfcxVTxuoCkzriLopB+zyMIDJAPnhDzL9sT
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-05-30T01:35:16Z"
-    mac: ENC[AES256_GCM,data:d36akKvLn5+f4BXMmmTzV0ZJOzhVc+L26tLwRZ2M7Zg7Dil/G1eQTjBdNu02uwd9j3U8nBkP4BX0lnsnMArRrLbz5lopRxOlIYOFqRp/YTY+MCJXCPba61ORrMUXYSkvB41soEc5LsrbGlw6HrQm/NO9FbCpS8qEts7O0E6RYUg=,iv:NRIywQD8HP5yEUGMT0chRD81Ylm0WKA/UJDG/S69jR0=,tag:RsTjMcBP9hHg7SIdtazU8w==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-05-30T01:35:15Z'
+    enc: CiUA4OM7eMzLxcRdc0ceXelctF7OH/Ga1unGaxxXjwPAhHNxgi17EkkAmy+ektwqZhWp6H0cTojm4tbVwN0hZwDHXN8FMVbilnkiu3w0jjvekKPMtrm4eZfcxVTxuoCkzriLopB+zyMIDJAPnhDzL9sT
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-05-30T01:35:16Z'
+  mac: ENC[AES256_GCM,data:d36akKvLn5+f4BXMmmTzV0ZJOzhVc+L26tLwRZ2M7Zg7Dil/G1eQTjBdNu02uwd9j3U8nBkP4BX0lnsnMArRrLbz5lopRxOlIYOFqRp/YTY+MCJXCPba61ORrMUXYSkvB41soEc5LsrbGlw6HrQm/NO9FbCpS8qEts7O0E6RYUg=,iv:NRIywQD8HP5yEUGMT0chRD81Ylm0WKA/UJDG/S69jR0=,tag:RsTjMcBP9hHg7SIdtazU8w==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-gpu-demo.secret.values.yaml
@@ -1,22 +1,22 @@
 jupyterhub:
-  hub:
-    config:
-      DummyAuthenticator:
-        password: ENC[AES256_GCM,data:V1vEDjEG+7wxMgoF7yniAV9AcxOZv0BiQA==,iv:DvKLtYzGuaRmBbku3VtUPiNawZeLzOSw1pHcfeeaSnU=,tag:GLfcm95cIs1Pd9rs+MtTpg==,type:str]
-      SharedPasswordAuthenticator:
-        user_password: ENC[AES256_GCM,data:8XOETiaGDcju86gVHnZ04LWYDfTyqV1gxQ==,iv:s+6XAuBgRinwesC6MfUdU1fYDTzkExaMRUwwIpgK7/M=,tag:Ej0y2b6la/Gej1Gfh4817Q==,type:str]
-        admin_password: ENC[AES256_GCM,data:hfYb/k51bpUo7Ug5iafr1sqY1Wmih3JXlxSescIp,iv:shnFT6nuBMfVk33k2uxr3i1sbLfonDiVCLXmm7TF4ys=,tag:taRYS6APiN7xqOesQ/0g9g==,type:str]
+    hub:
+        config:
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:KiYl/rs+H6GtJOlF162NQvNtQzF1WXtHIQ==,iv:lcdmDg/KhzFNBgi1IEsdsU0yyJq2/CABn4DDdAIzzbY=,tag:CqLWCmAMcCHbtEfvfjEkWg==,type:str]
+            SharedPasswordAuthenticator:
+                user_password: ENC[AES256_GCM,data:B/grfBdAFQxid3K0PpFjdhpOmSQuKs5HvQ==,iv:+Jzii/4TEsvTzsMkLp1VDyHnK3n697jsakS3Yrj2XC4=,tag:zCIBHSAbdwzUMcW0L+fV/w==,type:str]
+                admin_password: ENC[AES256_GCM,data:KkchEgzxMsCZ1oS3yjsWfZQ04AS+oPIOABo6pg9Oi/HlMjJB5Vm3mGUa+bWIUNNS,iv:sfDuod6U3/3JG9IOec+QCAhrpUdpjuQIt4FcJ1y7wCA=,tag:lkO0OviJ0ceYQeehKE/Dhw==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-05-30T00:49:25Z'
-    enc: CiUA4OM7eKnlhNhknMSfmN5r6izWbVTJ1E636TyFKnd0UOCUcWfWEkkAmy+ekuWMKlr3+lYYWDFrr7iCxf7utq70IYEXntWIsZIUk+kbtiY7CeWHI5hMaWahA4HLdYkeUcPetq9mhYwLd7qwcj6gYZst
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-05-30T00:49:25Z'
-  mac: ENC[AES256_GCM,data:it/mMK7/Kvca54Qvcqsz3HO8uFuidJUFJLxbCD4MeYOJaI4ch9npXIWLMyz2vl+sJZ/5I2Rsmd40yLMV2wfrZZvPgShs6jhqKodOZquyz0Bih/mPjS8S/07X/pOYYPciM1hDvy89qfyjT6k60itZVMbZWkj5wM4v7kE/K3n6tzQ=,iv:6t7C80c3/TwBAM7PpIXtziYdHgykNKhWKCPOVPr8g6o=,tag:2FOWZavUyQlCeqw1enXFhg==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.8.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-05-30T01:35:15Z"
+          enc: CiUA4OM7eMzLxcRdc0ceXelctF7OH/Ga1unGaxxXjwPAhHNxgi17EkkAmy+ektwqZhWp6H0cTojm4tbVwN0hZwDHXN8FMVbilnkiu3w0jjvekKPMtrm4eZfcxVTxuoCkzriLopB+zyMIDJAPnhDzL9sT
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-05-30T01:35:16Z"
+    mac: ENC[AES256_GCM,data:d36akKvLn5+f4BXMmmTzV0ZJOzhVc+L26tLwRZ2M7Zg7Dil/G1eQTjBdNu02uwd9j3U8nBkP4BX0lnsnMArRrLbz5lopRxOlIYOFqRp/YTY+MCJXCPba61ORrMUXYSkvB41soEc5LsrbGlw6HrQm/NO9FbCpS8qEts7O0E6RYUg=,iv:NRIywQD8HP5yEUGMT0chRD81Ylm0WKA/UJDG/S69jR0=,tag:RsTjMcBP9hHg7SIdtazU8w==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
## Summary
- Rotates the gpu-demo SharedPasswordAuthenticator admin password to satisfy JupyterHub's 32 character minimum
- Keeps the decrypted gpu-demo.secret.values.yaml local/ignored and commits only the encrypted secret file

## Validation
- Decrypted enc-gpu-demo.secret.values.yaml locally and verified SharedPasswordAuthenticator.admin_password length is 48 characters