### PR TITLE
Rollout fancy profiles 0.6.0 to prod veda hubs

### DIFF
--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -2,7 +2,11 @@ nfs:
   pv:
     serverIP: 10.100.150.169
 
-jupyterhub: {}
+jupyterhub:
+  hub:
+    image:
+      # Temporary image with jupyterhub-fancy-profiles 0.6.0
+      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
 dask-gateway:
   gateway:
     backend:
@@ -20,4 +24,3 @@ jupyterhub-home-nfs:
     config:
       QuotaManager:
         hard_quota: 100 # in GiB
-

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -197,6 +197,9 @@ jupyterhub:
         extra_resource_limits:
           nvidia.com/gpu: '1'
   hub:
+    image:
+      # Temporary image with jupyterhub-fancy-profiles 0.6.0
+      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
     config:
       GenericOAuthenticator:
         token_url: https://auth.openveda.cloud/realms/maap/protocol/openid-connect/token

--- a/config/clusters/nasa-ghg-hub/prod.values.yaml
+++ b/config/clusters/nasa-ghg-hub/prod.values.yaml
@@ -5,6 +5,10 @@ basehub:
         gitRepoBranch: bootstrap5-nasa-ghg-prod
         # FIXME: use this repository again, once the changes in the bootstrap5-nasa-ghg-staging branch of 2i2c-org/default-hub-homepage have been ported to it
         # gitRepoUrl: "https://github.com/US-GHG-Center/ghgc-hub-homepage"
+    hub:
+      image:
+        # Temporary image with jupyterhub-fancy-profiles 0.6.0
+        tag: 0.0.1-0.dev.git.15540.hbaaa997ce
 
   binderhub-service:
     config:


### PR DESCRIPTION
Rolls out jupyterhub-fancy-profiles 0.6.0 with the permalink feature to all remaining VEDA prod hubs (GHG prod, MAAP prod and disasters prod) while we wait for https://github.com/2i2c-org/infrastructure/pull/8068. It's already rolled out to VEDA prod hub in https://github.com/2i2c-org/infrastructure/pull/8127.