### PR TITLE
Enable new fancy-profiles for cryocloud

### DIFF
--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -208,21 +208,10 @@ jupyterhub:
       # Undo unnecessary common config
       00-volumes-and-volume-mounts-as-dict: ''
     loadRoles:
-      binder:
-        services:
-        - binder
-        scopes:
-        - servers
-        - read:users
       user:
         scopes:
         - self
         - access:services!service=binder
-    services:
-      binder:
-        oauth_client_id: service-binderhub
-        oauth_no_confirm: true
-        oauth_redirect_uri: https://staging.hub.maap-project.org/services/binder/oauth_callback
     config:
       GenericOAuthenticator:
         token_url: https://keycloak.delta-backend.xyz/realms/maap/protocol/openid-connect/token

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -37,6 +37,9 @@ basehub:
             name: NASA ICESat-2 Science Team
             url: https://icesat-2.gsfc.nasa.gov/science_definition_team
     hub:
+      image:
+        # Temporary image with jupyterhub-fancy-profiles 0.6.0
+        tag: 0.0.1-0.dev.git.15540.hbaaa997ce
       allowNamedServers: true
       config:
         JupyterHub:
@@ -78,6 +81,8 @@ basehub:
           - shares!user
           - read:users:name
           - list:users
+          # Access to binder service
+          - access:services!service=binder
     singleuser:
       cloudMetadata:
         blockWithIptables: false

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -9,21 +9,10 @@ basehub:
         # from the PR https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/149 for testing
         tag: 0.0.1-0.dev.git.15561.hd27897dad
       loadRoles:
-        binder:
-          services:
-          - binder
-          scopes:
-          - servers
-          - read:users
         user:
           scopes:
           - self
           - access:services!service=binder
-      services:
-        binder:
-          oauth_client_id: service-binderhub
-          oauth_no_confirm: true
-          oauth_redirect_uri: https://staging.hub.openveda.cloud/services/binder/oauth_callback
     custom:
       homepage:
         gitRepoBranch: staging

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -157,9 +157,9 @@ local jupyterhubConfig =
     hub: {
       services: {
         binder: {
-          # dynamically configure redirect_uri for binderhub service, so we don't have to do that in each hub
-          oauth_redirect_uri: "https://%s/services/binder/oauth_callback" % [hub_domain]
-        }
+          // dynamically configure redirect_uri for binderhub service, so we don't have to do that in each hub
+          oauth_redirect_uri: 'https://%s/services/binder/oauth_callback' % [hub_domain],
+        },
       },
       config: {
         OAuthenticator: {

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -155,6 +155,12 @@ local jupyterhubConfig =
   {
     ingress: hubIngressConfig,
     hub: {
+      services: {
+        binder: {
+          # dynamically configure redirect_uri for binderhub service, so we don't have to do that in each hub
+          oauth_redirect_uri: "https://%s/services/binder/oauth_callback" % [hub_domain]
+        }
+      },
       config: {
         OAuthenticator: {
           // Always set oauth callback URL, to prevent it from being

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1053,11 +1053,19 @@ jupyterhub:
         # We provide an entry here for binderhub-service unconditionally, so the
         # jupyterhub chart will autogenerate a secret with appropriate keys.
         # It's not used if binderhub-service is not enabled.
+        # The redirect_url is configured in values.jsonnet
+        oauth_client_id: service-binderhub
         display: false
         url: http://binderhub:8090
         oauth_no_confirm: true
       jupyterhub-groups-exporter: {}
     loadRoles:
+      binder:
+        services:
+        - binder
+        scopes:
+        - servers
+        - read:users
       jupyterhub-groups-exporter:
         services:
           - jupyterhub-groups-exporter


### PR DESCRIPTION
- Move some of the config for enabling authenticated access to binder-service to base config, so it doesn't need to be repeated
- Leave the user scope addition in the per-hub config, since it's a list and many hubs have their own list of per-user scopes
- Remove some of the extra config from the MAAP staging hub
- Note that this doesn't actually turn on auth for binderhub - that requires https://github.com/2i2c-org/binderhub-service/pull/167

Ref https://github.com/2i2c-org/infrastructure/issues/8453