### PR TITLE
refactor: set token for BinderHub in base config

### DIFF
--- a/config/clusters/earthscope/binder.values.yaml
+++ b/config/clusters/earthscope/binder.values.yaml
@@ -167,13 +167,6 @@ binderhub-service:
       url: &url https://quay.io
       username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.geolab.earthscope.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -126,13 +126,6 @@ binderhub-service:
       - ^2i2c-org/.*
       - ^LorenFrankLab/.*
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.hhmi.2i2c.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/nasa-ghg-hub/binder.values.yaml
+++ b/config/clusters/nasa-ghg-hub/binder.values.yaml
@@ -105,13 +105,6 @@ binderhub-service:
       url: &url https://quay.io
       username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.ghg.2i2c.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/nasa-veda/binder.values.yaml
+++ b/config/clusters/nasa-veda/binder.values.yaml
@@ -100,13 +100,6 @@ binderhub-service:
       url: &url https://quay.io
       username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.openveda.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -120,13 +120,6 @@ binderhub-service:
       url: &url https://quay.io
       username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.big.binder.opensci.2i2c.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -98,13 +98,6 @@ binderhub-service:
       url: &url https://quay.io
       username: &username imagebuilding-non-gcp-hubs+image_builder
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.opensci.2i2c.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -161,13 +161,6 @@ binderhub-service:
         hub.jupyter.org/node-purpose:
         capi.stackhpc.com/node-group: user-m3-large
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: '{{ include "jupyterhub.hub.fullname" . }}'
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.projectpythia.org/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -93,13 +93,6 @@ binderhub-service:
       - ^ProjectPythia/.*$
       - binder-examples/requirements
   extraEnv:
-  - name: JUPYTERHUB_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hub
-        key: hub.services.binder.apiToken
-  - name: JUPYTERHUB_CLIENT_ID
-    value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.binder.pythia.2i2c.cloud/hub/api
     # Without this, the redirect URL to /hub/api/... gets

--- a/config/clusters/templates/common/binderhub-ui-hub.values.yaml
+++ b/config/clusters/templates/common/binderhub-ui-hub.values.yaml
@@ -148,13 +148,6 @@ binderhub-service:
       banner_message: {{ banner_message }}
       about_message: {{ about_message }}
   extraEnv:
-    - name: JUPYTERHUB_API_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: hub
-          key: hub.services.binder.apiToken
-    - name: JUPYTERHUB_CLIENT_ID
-      value: "service-binder"
     - name: JUPYTERHUB_API_URL
       value: "https://{{ jupyterhub_domain }}/hub/api"
     # Without this, the redirect URL to /hub/api/... gets

--- a/docs/howto/features/binderhub-ui.md
+++ b/docs/howto/features/binderhub-ui.md
@@ -169,14 +169,6 @@ These are needed by the jupyterhub software bits that the binderhub software use
 ```yaml
 binderhub-service:
   extraEnv:
-    - name: JUPYTERHUB_API_TOKEN
-      valueFrom:
-        # Any JupyterHub Services api_tokens are exposed in this k8s Secret
-        secretKeyRef:
-          name: hub
-          key: hub.services.binder.apiToken
-    - name: JUPYTERHUB_CLIENT_ID
-      value: "service-binder"
     - name: JUPYTERHUB_API_URL
       value: "https://<hub-public-url>.2i2c.cloud/hub/api"
     # Without this, the redirect URL to /hub/api/... gets

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -64,8 +64,6 @@ binderhub-service:
           key: hub.services.binder.apiToken
     - name: JUPYTERHUB_CLIENT_ID
       value: &binderhub_client_id service-binderhub
-    - name: JUPYTERHUB_API_URL
-      value: http://hub:8081/hub/api
   config:
     BinderHub:
       base_url: /services/binder

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -55,6 +55,17 @@ binderhub-service:
       - key: hub.jupyter.org/dedicated
         value: user
         effect: NoSchedule
+  extraEnv:
+    # Z2jh automatically creates the API token
+    - name: JUPYTERHUB_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hub
+          key: hub.services.binder.apiToken
+    - name: JUPYTERHUB_CLIENT_ID
+      value: &binderhub_client_id service-binderhub
+    - name: JUPYTERHUB_API_URL
+      value: http://hub:8081/hub/api
   config:
     BinderHub:
       base_url: /services/binder
@@ -1056,7 +1067,7 @@ jupyterhub:
         # jupyterhub chart will autogenerate a secret with appropriate keys.
         # It's not used if binderhub-service is not enabled.
         # The redirect_url is configured in values.jsonnet
-        oauth_client_id: service-binderhub
+        oauth_client_id: *binderhub_client_id
         display: false
         url: http://binderhub:8090
         oauth_no_confirm: true


### PR DESCRIPTION
This is a tiny change that ensures the API token and OAuth client ID for BinderHub is always set in the service container, simplifying our existing Hub configs.

This token is only needed for BinderHub's "launch" feature, i.e. not fancy profiles!