### PR TITLE
[leap] Move edu image to leap-controlled repository

### DIFF
--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -169,7 +169,7 @@ basehub:
                 display_name: LEAP Education Notebook (Testing Prototype)
                 slug: leap_edu
                 kubespawner_override:
-                  image: quay.io/jbusecke/leap-edu-image:fa442ab4851c
+                  image: quay.io/2i2c/leap-edu-image:278370f204a2
         kubespawner_override:
           cpu_limit:
           mem_limit:
@@ -259,7 +259,7 @@ basehub:
                 display_name: LEAP Education Notebook (Testing Prototype)
                 slug: leap_edu
                 kubespawner_override:
-                  image: quay.io/jbusecke/leap-edu-image:fa442ab4851c
+                  image: quay.io/2i2c/leap-edu-image:278370f204a2
         kubespawner_override: &medium_kubespawner_override
           cpu_limit:
           mem_limit:


### PR DESCRIPTION
This will resolve the environment, but shouldn't change which packages are present (bar different solves)

Noticed as part of https://2i2c.freshdesk.com/a/tickets/5603, but not required for that ticket.