### PR TITLE
Remove unnecessary scopes from the fancy-profiles binderhub role

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1062,12 +1062,6 @@ jupyterhub:
         oauth_no_confirm: true
       jupyterhub-groups-exporter: {}
     loadRoles:
-      binder:
-        services:
-        - binder
-        scopes:
-        - servers
-        - read:users
       jupyterhub-groups-exporter:
         services:
           - jupyterhub-groups-exporter


### PR DESCRIPTION
Fancy profiles passes user tokens to binderhub as bearer token and the fancy profiles binderhub only talks to the hub api to validate the token. And since fancy profiles uses binderhub to build images only, and not to spawn user servers, the binderhub service role doesn't really need any scopes at all.