### PR TITLE
[earthscope] Add a couple of more instance types to the dask list

### DIFF
--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -14,7 +14,13 @@ local c = cluster.withNodeGroupConfigOverride(
     ],
     daskInstanceTypes=[
       // Allow for a range of spot instance types
-      ['r5.4xlarge', 'r7i.4xlarge', 'r6i.4xlarge'],
+      [
+        'r5.xlarge',
+        'r5.2xlarge',
+        'r5.4xlarge',
+        'r7i.4xlarge',
+        'r6i.4xlarge',
+      ],
     ],
     hubs=['staging', 'prod', 'binder'],
     notebookGPUNodeGroups=[

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -16,10 +16,11 @@ local c = cluster.withNodeGroupConfigOverride(
       // Allow for a range of spot instance types
       [
         'r5.xlarge',
-        'r5.2xlarge',
         'r5.4xlarge',
-        'r7i.4xlarge',
+        'r6i.xlarge',
         'r6i.4xlarge',
+        'r7i.xlarge',
+        'r7i.4xlarge',
       ],
     ],
     hubs=['staging', 'prod', 'binder'],


### PR DESCRIPTION
@yuvipanda, what do you think? Should we also add more of the newer Intel ones as well?
They tried three times to bring up dask workers and couldn't because of lack of resources. Every time I tried the next day, in my time zone, it worked.

Hopefully this will unblock the community so they can test the latest dask-gateway version. 

Ref https://github.com/2i2c-org/infrastructure/issues/7982 and https://github.com/2i2c-org/infrastructure/issues/8467