### PR TITLE
Reduce size of home dir disks on showcase / staging hubs

### DIFF
--- a/terraform/aws/projects/2i2c-aws-us.tfvars
+++ b/terraform/aws/projects/2i2c-aws-us.tfvars
@@ -34,13 +34,13 @@ hub_cloud_permissions = {
 
 ebs_volumes = {
   "staging" = {
-    size        = 100 # in GB
+    size        = 10 # in GB
     type        = "gp3"
     name_suffix = "staging"
     tags        = { "2i2c:hub-name" : "staging" }
   }
   "showcase" = {
-    size        = 500 # in GB
+    size        = 100 # in GB
     type        = "gp3"
     name_suffix = "showcase"
     tags        = { "2i2c:hub-name" : "showcase" }


### PR DESCRIPTION
This costs us a bunch of money without really being used. Applying this would destroy the disks, but I don't believe there should be any actively useful data in there.