### PR TITLE
Remove jupyterbook.pub service

### DIFF
--- a/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
+++ b/config/clusters/2i2c-aws-us/enc-staging.secret.values.yaml
@@ -1,8 +1,5 @@
 jupyterhub:
   hub:
-    services:
-      jupyterbook-pub:
-        api_token: ENC[AES256_GCM,data:06jVzCg6Zv6Xvd5lFR8IkSbBKiaD3GZGh4uqu8A=,iv:TlaJ1sWJnKgs4nWmkc9cvXzFXwk2VAOILl2mjN5n73M=,tag:xQ2QIb6aCVob5UxtUEM8rA==,type:str]
     config:
       GitHubOAuthenticator:
         client_id: ENC[AES256_GCM,data:cCcFsREidFJE+8mNguzsiglaDNU=,iv:8/ONoisn8fresVPcztUejV5j1njBJe1TiyTPbzsl9ag=,tag:1zUsouNBoTdAAoVwZCrXNw==,type:str]
@@ -12,7 +9,7 @@ sops:
   - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
     created_at: '2023-01-05T15:13:06Z'
     enc: CiUA4OM7ePFTK8jhF1PvaNsOlsH2PwopRPJE7K+2pVikF/Brl4zPEkkA+0T9hUjgsZa2zAOVqZHOAjeg91553kP+YnHnIW2QPPnSha1dlGfrTcesxV5hsrbeqc3fxs7OnKow5KK3fr48Djf31CYGOgLY
-  lastmodified: '2026-05-08T15:42:36Z'
-  mac: ENC[AES256_GCM,data:0BYTIrtIw5paTmBqv2x1UGOuhlIO+OYGfnpORF3epIw79xa14d0Qm8a6J+4SmO9uk8dSWT7XY48SRcB9CMPGoYY7ljai4emorsOYhJ2w6gfyv3Lo5orz/EdKZnHbR6x7TpGa3kUb0r4+DpNjuUU/m3cnm1HgNJvKjjGlyuy9OdA=,iv:m8OKmdpVGZDwkL+3cPiSN8fV/ZmLbMNy4ZEHD7p3nLI=,tag:Hydfs39bQMJNBSaaLWTwHA==,type:str]
+  lastmodified: '2026-06-11T15:12:12Z'
+  mac: ENC[AES256_GCM,data:p4Py5HQPrVHEe9P5n1jWvwA4fxa6mpOL/iSpxbJ4GMFIlqwLHe2+4Y/Wf9lDECl2xCWq3/euKKftzc0bEomc5IiuhYy0vd+aKQlSQnHPoNtoV54phbAeu/L5wx27GZpmgBYHXX6qxydGuTfM1fZYYSMxEbTk5UCdg76XOn+Ed/M=,iv:LQCo6dwubgoI1mvqoHL/10CkiLBjEpgjec7pc9exatU=,tag:2HvgDjDMBxSH0G8EhP+TVg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -19,13 +19,6 @@ jupyterhub:
     config:
       JupyterHub:
         authenticator_class: github
-    services:
-      jupyterbook-pub:
-        # Auth
-        # api_token: <see secret>
-        oauth_client_id: service-jupyterbook-pub
-        oauth_no_confirm: true
-        url: http://jupyterbook-pub-service
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true
@@ -48,42 +41,3 @@ jupyterhub:
   singleuser:
     extraEnv:
       SCRATCH_BUCKET: s3://2i2c-aws-us-scratch-staging/$(JUPYTERHUB_USER)
-
-jupyterbook-pub-service:
-  enabled: true
-
-    # Run the core service on the core nodes
-  nodeSelector: &nodeSelector
-    hub.jupyter.org/node-purpose: core
-
-  config:
-    JupyterBookPubApp:
-      base_url: /services/jupyterbook-pub/
-      site_subheading: |
-        Instantly render pre-built JupyterBook AST!
-    KubernetesExecutor:
-      resources:
-        requests:
-          memory: 128Mi
-        limits:
-          memory: 500Mi
-      node_selector: *nodeSelector
-
-  extraBuildConfig:
-    name: builder_config.json
-    json:
-      JupyterBook2Builder:
-        allow_source_builds: false
-
-  volumeClaim:
-    enabled: false
-
-  volume:
-    hostPath:
-      path: /var/cache/jupyterbook-pub/
-      type: DirectoryOrCreate
-
-  auth:
-    enabled: true
-    # hub_api_token: <set via deploy>
-    hub_api_url: https://staging.aws.2i2c.cloud/hub/api/

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -83,14 +83,6 @@ jupyterhub:
       nodeSelector:
         capi.stackhpc.com/node-group: user-m3-large
   hub:
-    services:
-      jupyterbook-pub:
-        # Auth
-        # api_token: <a token>
-        # oauth_client_id: service-jupyterbook-pub
-        # oauth_no_confirm: true
-
-        url: http://jupyterbook-pub-service
     nodeSelector:
       capi.stackhpc.com/node-group: core
     loadRoles:

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -170,49 +170,11 @@ binderhub-service:
     value: service-binder
   - name: JUPYTERHUB_API_URL
     value: https://hub.projectpythia.org/hub/api
-    # Without this, the redirect URL to /hub/api/... gets
-    # appended to binderhub's URL instead of the hub's
+      # Without this, the redirect URL to /hub/api/... gets
+      # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL
     value: https://hub.projectpythia.org/
   # The password to the registry is stored encrypted in the hub's encrypted config file
   buildPodsRegistryCredentials:
     server: *url
     username: *username
-
-jupyterbook-pub-service:
-  enabled: true
-  # See https://agoose77.github.io/jupyterbook-pub-service/
-  # Run the core service on the core nodes
-  nodeSelector: &nodeSelector
-    capi.stackhpc.com/node-group: core
-
-  config:
-    JupyterBookPubApp:
-      base_url: /services/jupyterbook-pub/
-    KubernetesExecutor:
-      # Current JS2 certs are not X509 valid
-      disable_strict_ssl_verification: true
-      resources:
-        requests:
-          memory: 128Mi
-        limits:
-          memory: 500Mi
-      node_selector: *nodeSelector
-
-  extraBuildConfig:
-    name: builder_config.json
-    json:
-      JupyterBook2Builder:
-        allow_source_builds: false
-  volumeClaim:
-    enabled: false
-
-  volume:
-    hostPath:
-      path: /var/cache/jupyterbook-pub/
-      type: DirectoryOrCreate
-
-  auth:
-    enabled: false
-    # hub_api_token: <a token>
-    # hub_api_url: https://hub.projectpythia.org/hub/api/

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -30,7 +30,3 @@ dependencies:
     version: 1.1.1-0.dev.git.133.hd9f9ccc
     repository: https://2i2c.org/jupyterhub-groups-exporter
     condition: jupyterhub-groups-exporter.enabled
-  - name: jupyterbook-pub-service
-    version: 0.1.0-0.dev.git.65.h60d7c7f
-    repository: https://agoose77.github.io/jupyterbook-pub-service
-    condition: jupyterbook-pub-service.enabled

--- a/helm-charts/basehub/values.schema.yaml
+++ b/helm-charts/basehub/values.schema.yaml
@@ -218,19 +218,6 @@ properties:
           sendLogsOfLaunchEventsTo2i2c:
             type: boolean
 
-  # jupyterbook-pub-service is a dependency chart with its own schema, but we impose
-  # some additional restrictions below via this chart's schema.
-  jupyterbook-pub-service:
-    type: object
-    additionalProperties: true
-    required:
-      - enabled
-    properties:
-      enabled:
-        type: boolean
-        # https://github.com/agoose77/jupyterbook-pub-service
-        description: |
-          Enable book building with jupyterbook-pub-service
   # jupyterhub is a dependent helm chart and we rely _mostly_ on its schema
   # validation for values passed to it and are not imposing restrictions on
   # most of them in this helm chart.

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1,5 +1,3 @@
-jupyterbook-pub-service:
-  enabled: false
 binderhub-service:
   enabled: false
   ingress:


### PR DESCRIPTION
We tried a spike towards https://github.com/2i2c-org/initiatives/issues/59 recently on the 2i2c-aws-us hub, and the Project Pythia JS2 hubs. 

As we attempt to focus on finishing our initiatives, it's time to close down this spike.