### PR TITLE
[earthscope] Add /tmp scratch storage

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -188,6 +188,19 @@ basehub:
     singleuser:
       cloudMetadata:
         blockWithIptables: false
+      storage:
+        extraVolumes:
+          002-scratch-session:
+            name: scratch-session
+            emptyDir:
+              # Limit total size, to prevent pod being evicted
+              # with over use by any one user. This can be increased,
+              # but may need to increase the size of the node disk
+              sizeLimit: 20Gi
+        extraVolumeMounts:
+          002-scratch-session:
+            name: scratch-session
+            mountPath: /tmp
       profileList:
       - display_name: Choose your environment and resources
         default: true

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -41,7 +41,7 @@ local c = cluster.withNodeGroupConfigOverride(
         },
       }
     ),
-    kind="notebook",
+    kind='notebook',
     overrides={
       // 80 GiB reserved + 4*20GiB (four users)
       volumeSize: 120,

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -31,7 +31,7 @@ local c = cluster.withNodeGroupConfigOverride(
             instanceType: 'g4dn.xlarge',
           },
         ],
-        nodeGroupGenerations=['b']
+        nodeGroupGenerations=['b', 'c', 'd']
       ),
       // Add provenence of resources
       overrides={
@@ -44,7 +44,7 @@ local c = cluster.withNodeGroupConfigOverride(
     kind='notebook',
     overrides={
       // 80 GiB reserved + 4*20GiB (four users)
-      volumeSize: 120,
+      volumeSize: 160,
       // Ensure that /tmp is faster
       volumeIOPS: 3000,
       volumeThroughput: 500,

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -31,7 +31,7 @@ local c = cluster.withNodeGroupConfigOverride(
             instanceType: 'g4dn.xlarge',
           },
         ],
-        nodeGroupGenerations=['b', 'c', 'd']
+        nodeGroupGenerations=['b', 'd']
       ),
       // Add provenence of resources
       overrides={

--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -1,42 +1,54 @@
 local cluster = import './libsonnet/cluster.jsonnet';
 
 local c = cluster.withNodeGroupConfigOverride(
-  cluster.makeCluster(
-    name='earthscope',
-    region='us-east-2',
-    nodeAz='us-east-2a',
-    version='1.34',
-    coreNodeInstanceType='r8i-flex.large',
-    notebookCPUInstanceTypes=[
-      'r5.xlarge',
-      'r5.4xlarge',
-      'r5.16xlarge',
-    ],
-    daskInstanceTypes=[
-      // Allow for a range of spot instance types
-      [
-        'r5.xlarge',
-        'r5.4xlarge',
-        'r6i.xlarge',
-        'r6i.4xlarge',
-        'r7i.xlarge',
-        'r7i.4xlarge',
-      ],
-    ],
-    hubs=['staging', 'prod', 'binder'],
-    notebookGPUNodeGroups=[
-      {
-        instanceType: 'g4dn.xlarge',
-      },
-    ],
-    nodeGroupGenerations=['b']
-  ),
-  // Add provenence of resources
-  overrides={
-    tags+: {
-      'earthscope:application:name': 'geolab',
-      'earthscope:application:owner': 'research-onramp-to-the-cloud',
-    },
-  }
+  cluster.withNodeGroupConfigOverride(
+    cluster.withNodeGroupConfigOverride(
+      cluster.makeCluster(
+        name='earthscope',
+        region='us-east-2',
+        nodeAz='us-east-2a',
+        version='1.34',
+        coreNodeInstanceType='r8i-flex.large',
+        notebookCPUInstanceTypes=[
+          'r5.xlarge',
+          'r5.4xlarge',
+          'r5.16xlarge',
+        ],
+        daskInstanceTypes=[
+          // Allow for a range of spot instance types
+          [
+            'r5.xlarge',
+            'r5.4xlarge',
+            'r6i.xlarge',
+            'r6i.4xlarge',
+            'r7i.xlarge',
+            'r7i.4xlarge',
+          ],
+        ],
+        hubs=['staging', 'prod', 'binder'],
+        notebookGPUNodeGroups=[
+          {
+            instanceType: 'g4dn.xlarge',
+          },
+        ],
+        nodeGroupGenerations=['b']
+      ),
+      // Add provenence of resources
+      overrides={
+        tags+: {
+          'earthscope:application:name': 'geolab',
+          'earthscope:application:owner': 'research-onramp-to-the-cloud',
+        },
+      }
+    ),
+    kind="notebook",
+    overrides={
+      // 80 GiB reserved + 4*20GiB (four users)
+      volumeSize: 120,
+      // Ensure that /tmp is faster
+      volumeIOPS: 3000,
+      volumeThroughput: 500,
+    }
+  )
 );
 c

--- a/eksctl/libsonnet/cluster.jsonnet
+++ b/eksctl/libsonnet/cluster.jsonnet
@@ -1,6 +1,7 @@
 local escapeName(name) = std.strReplace(name, '.', '-');
 local lowerCaseLetter(i) = std.char(97 + i);
-local trim63(s) = if std.length(s) > 63 then s[0:62] else s;
+// Build 63-char (max) name with untouched generation.
+local buildName(parts, generation) = std.join('-', parts)[:63 - 1 - std.length(generation)] + '-' + generation;
 
 {
   /**
@@ -60,11 +61,12 @@ local trim63(s) = if std.length(s) > 63 then s[0:62] else s;
     // Include name prefix, escaped instance type (because names can't have .)
     // and name generation
     local instanceTypes = if std.isString(instanceType) then [instanceType] else instanceType,
-    name: trim63(std.join('-', [
-      namePrefix,
-    ] + std.map(escapeName, instanceTypes) + [
+    name: buildName(
+      [
+        namePrefix,
+      ] + std.map(escapeName, instanceTypes),
       generation,
-    ])),
+    ),
     availabilityZones: availabilityZones,
     minSize: minSize,
     maxSize: maxSize,


### PR DESCRIPTION
We already have this implicitly due to the kubelet providing ephemeral storage. This PR now codifies the upper bound via `emptyDir`. This provides 20GiB per user, and sets the performance of the disk to 3000 IOPs, 500 MiB/s. I chose the Throughput with consideration to general performance needs — a regular non-cloud SSD is ~5000MiB/s, and a cloud SSD more like 1200MiB/s — but, I suspect that 500MiB/s is above our home directory performance at the moment, so it's an improvement (and not crazy expensive).