### PR TITLE
Cleanup event prep docs and add section about image pre-pulling

### DIFF
--- a/docs/howto/features/dedicated-nodepool.md
+++ b/docs/howto/features/dedicated-nodepool.md
@@ -1,5 +1,5 @@
 (features:shared-cluster:dedicated-nodepool)=
-# Setup a dedicated nodepool for a hub on a shared cluster
+# Setup a dedicated nodepool for a hub on a shared GCP cluster
 
 ```{important}
 On AWS, all clusters have dedicated nodepools for each hub.
@@ -11,10 +11,6 @@ Some hubs on shared clusters require dedicated nodepools, for a few reasons:
    without worrying about effects from other hubs on the same cluster.
 2. (In the future) Helpful with cost isolation, as we can track how much a
    nodepool is costing us.
-
-`````{tab-set}
-````{tab-item} GCP
-:sync: gcp-key
 
 1. Setup a new nodepool in terraform, via the `<cluster-name>.tfvars` for the
    cluster. Add the new nodepool to `notebook_nodes`:
@@ -77,13 +73,6 @@ Some hubs on shared clusters require dedicated nodepools, for a few reasons:
 
    This tells JupyterHub to place user pods from this hub on the nodepool we had
    just created!
-````
-
-````{tab-item} AWS
-:sync: aws-key
-On AWS, all clusters have dedicated nodepools for each hub.
-````
-`````
 
 ## Node type and minimum nodepool size considerations
 

--- a/docs/howto/image-management/index.md
+++ b/docs/howto/image-management/index.md
@@ -6,4 +6,5 @@ This documentation covers tasks related to image management.
 ```{toctree}
 custom-jupyterhub-image
 update-env
+pre-pull-user-image
 ```

--- a/docs/howto/image-management/pre-pull-user-image.md
+++ b/docs/howto/image-management/pre-pull-user-image.md
@@ -1,4 +1,4 @@
-(continuous-image-pull)=
+(pre-pull-user-images)=
 # Pre-pull user images at node startup
 
 Image pre-pulling before user arrival is not a feature enabled by default on the hubs, as it comes with an increase in cloud costs. However, there are cases when users need faster startup times like exams, events, or even just a hub with large images. In this situations, given that communities understand the cost tradeoff, this feature can be enabled.

--- a/docs/howto/image-management/pre-pull-user-image.md
+++ b/docs/howto/image-management/pre-pull-user-image.md
@@ -1,13 +1,13 @@
 (pre-pull-user-images)=
 # Pre-pull user images at node startup
 
-Image pre-pulling before user arrival is not a feature enabled by default on the hubs, as it comes with an increase in cloud costs. However, there are cases when users need faster startup times like exams, events, or even just a hub with large images. In this situations, given that communities understand the cost tradeoff, this feature can be enabled.
+Image pre-pulling before user arrival is not a feature enabled by default on the hubs, because it comes with an increase in cloud costs. However, there are situations like exams, events, or even just a hub with large images when users need faster startup times. If communities agreed to the cost tradeoff, then this feature should be enabled.
 
 More about it at https://z2jh.jupyter.org/en/stable/administrator/optimization.html#pulling-images-before-users-arrive
 
 ## Enable `continuous-image-puller`
 
-The following config will pre-pull all explicitly specified images either through profiles or directly, on all nodes  when they start up.
+The following config will pre-pull all images specified through profile lists or directly, on all nodes, when they start up.
 
 ```yaml
 jupyterhub:

--- a/docs/howto/image-management/pre-pull-user-image.md
+++ b/docs/howto/image-management/pre-pull-user-image.md
@@ -1,0 +1,37 @@
+(continuous-image-pull)=
+# Pre-pull user images at node startup
+
+Image pre-pulling before user arrival is not a feature enabled by default on the hubs, as it comes with an increase in cloud costs. However, there are cases when users need faster startup times like exams, events, or even just a hub with large images. In this situations, given that communities understand the cost tradeoff, this feature can be enabled.
+
+More about it at https://z2jh.jupyter.org/en/stable/administrator/optimization.html#pulling-images-before-users-arrive
+
+## Enable `continuous-image-puller`
+
+The following config will pre-pull all explicitly specified images either through profiles or directly, on all nodes  when they start up.
+
+```yaml
+jupyterhub:
+  prePuller:
+    continuous:
+      enabled: true
+```
+
+## Explicitly specify extra images to pre-pull
+
+You can also specify additional images to pre-pull on the nodes. This can be either images used by init containers or extra containers.
+
+Example:
+
+```yaml
+jupyterhub:
+  prePuller:
+    continuous:
+      enabled: true
+      extraImages:
+        nbgitpuller:
+          name: public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init
+          tag: 97eb45f9d23b128aff810e45911857d5cffd05c2
+        s3fs:
+          name: mas.dit.maap-project.org/root/che-sidecar-s3fs
+          tag: 2i2c # This is a mutable tag, so may trigger re-pulls
+```

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -25,6 +25,11 @@ If the hub that's having an event is running on a shared cluster, then we might 
 Follow the guide at [](features:shared-cluster:dedicated-nodepool) in order to setup a dedicated nodepool before an event.
 ```
 
+## Analyze Grafana workshop dashboard results
+```{warning}
+This is a work in progress.
+```
+
 ## Reduce server startup time
 
 There are two components that we can "pre-warm" before an event, to reduce server startup time and make sure are ready to use right away:

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -12,10 +12,10 @@ We must ensure that the quotas from the cloud provider are high-enough to handle
 - follow the [GCP quota guide](hub-deployment-guide:cloud-accounts:aws-quotas) for information about how to check the quotas in a GCP project
 ```
 
-## On shared GCP clusters, consider dedicated nodepools
+## Consider dedicated nodepools
 
 ```{important}
-On AWS, all clusters have dedicated nodepools for each hub.
+On AWS, clusters already have dedicated nodepools for each hub.
 ```
 
 If the hub that's having an event is running on a shared cluster, then we might want to consider putting it on a dedicated nodepool as that will help with cost isolation, scaling up/down effectively, and avoid impacting other hub's users performance.
@@ -133,8 +133,10 @@ The `deployer generate resource-allocation`:
 ````
 
 ### 3.2. Setting a minimum node count on a specific node pool
-```{warning}
-This section is a Work in Progress!
+
+```{admonition} Action to take
+:class: tip
+Follow the guide at [](scaling-nodepools) to on how to set a minimum node count on a specific node pool.
 ```
 
 ### 3.4 Add user placeholders

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -140,42 +140,16 @@ Follow the guide at [](scaling-nodepools) to on how to set a minimum node count 
 ```
 
 ### 3.4 Add user placeholders
-
-
-#### Introducing user placeholders
-Whilst one strategy to minimising startup times is to increase the number of user pods that fit onto a single node (thereby reducing the number of times a node needs to be scaled up across the event), this approach will still introduce waiting points when a scale up is required.
-
-A useful mechanism for reducing the likelihood of a blocking scale up is the use of [user-placeholders](https://z2jh.jupyter.org/en/stable/administrator/optimization.html#scaling-up-in-time-user-placeholders). This technique involves scheduling pods that represent a "seat" or "placeholder" for anticipated user servers. Once users join the cluster, these pods are evicted by the scheduler to make room for the real user pods. 
-
-To illustrate this, consider a hub with a dedicated user nodepool. Each node can support 64 singleuser pods. Let's imagine that the number of user placeholder replicas is set to 32:
-
-- Initially, there will be 32 user placeholder pods running on a single user node.
-- For the next 32 users that join, no scaling up will occur, and once all of the users have joined, the node will be "full" with 32 users and 32 placeholders.
-- Once the 33rd user joins, one of the user placeholders will be evicted, triggering a scale up to maintain the 32 user-node replica requirement.
-
-Conventionally, one might imaging that the 34th user (and the 35th, etc.) will immediately be able to spawn their server pod, as the scheduler continues to evict pods. In practice this is not what happens. Instead, once the first placeholder pod is evicted and the autoscaler triggers a scale up, subsequent user pods are directly scheduled on the not-yet-ready node. This introduces head-of-line blocking for 31 of these 32 subsequent users.
-
-#### Choosing placeholder resources
-As such, it is more effective to create a singular placeholder pods that represents $N$ users. For example, if we wish to reserve capacity for 32 users, and each user is guaranteed 1GiB of memory, then we would create a placeholder pod with a 32GiB memory request. In the extreme case, we might wish to reserve an entire node. We must be careful not to request more RAM than is available _after_ the kube-system pods have been started on the node. In practice, this might mean leaving ~2GiB of memory (though this should be confirmed through testing).
-
-In event conditions, we might anticipate a particular rate at which users attempt to start their servers. Measurements of this value can be derived from previous event instances. If one such event needs to support 60 users every 3 minutes, and it takes 10 minutes for a node to spin up, we will need to have room for $60/3 * 10 = 200$ users. We can compute the appropriate number of resources accordingly.
-
-#### Auxiliary considerations
-Simply ensuring that a node is ready to accept user pods is not sufficient to ensure that users do not experience delays when the user node pool is scaled up. In order to start user pods, the cluster needs to pull their respective OCI container images from the container registry. If we do not do this ahead of time, the first user to require a particular image will need to wait for it to be pulled to the cluster, as will all other image users. 
-
-We can anticipate this be pre-pulling the various images required at node startup time, using the continuous image puller (see [](pre-pull-image)). This should only be used on dedicated nodepools in which the number of images is small (as pulling a set of images delays the time until the node is considered available to user pods).
-
-An example configuration might look something like
-```yaml
-jupyterhub:
-  prePuller:
-    continuous:
-      enabled: true
-  scheduling:
-    userPlaceholder:
-      # Keep at least half of a 64 GiB node free
-      replicas: 1
-      resources:
-        requests:
-          memory: 32Gi
+```{warning}
+This section is a work in progress.
 ```
+
+Checkout [](topic:user-placeholders) to find out more about this topic
+
+## Evaluate scratch space needs
+
+```{warning}
+This section is a work in progress.
+```
+
+See https://github.com/2i2c-org/initiatives/issues/61 for more details on the progress of this topic.

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -1,8 +1,8 @@
 # Event infrastructure preparation checklist
 
-Below are listed the main aspects to consider adjusting on a hub to prepare it for an event:
+Main aspects to consider adjusting on a hub to prepare it for an event:
 
-## 1. Quotas
+## Quotas
 
 We must ensure that the quotas from the cloud provider are high-enough to handle expected usage. It might be that the number of users attending the event is very big, or their expected resource usage is big, or both. Either way, we need to check the the existing quotas will accommodate the new numbers.
 
@@ -12,7 +12,7 @@ We must ensure that the quotas from the cloud provider are high-enough to handle
 - follow the [GCP quota guide](hub-deployment-guide:cloud-accounts:aws-quotas) for information about how to check the quotas in a GCP project
 ```
 
-## 2. Consider dedicated nodepools on shared clusters
+## On shared GCP clusters, consider dedicated nodepools
 
 ```{important}
 On AWS, all clusters have dedicated nodepools for each hub.
@@ -25,39 +25,55 @@ If the hub that's having an event is running on a shared cluster, then we might 
 Follow the guide at [](features:shared-cluster:dedicated-nodepool) in order to setup a dedicated nodepool before an event.
 ```
 
-## 3. Pre-warm the hub to reduce wait times
+## Reduce server startup time
 
-There are two mechanisms that we can use to pre-warm a hub before an event:
+There are two components that we can "pre-warm" before an event, to reduce server startup time and make sure are ready to use right away:
 
-- making sure some **nodes are ready** when users arrive
+- the **user image** through pre-pulling
+- user **nodes** though making sure a fair number of them are ready for users
 
-    This can be done using node sharing via profile lists or by setting a minimum node count.
-  
-    ```{note}
-    You can read more about what to consider when setting resource allocation options in profile lists in [](topic:resource-allocation).
-    ```
+```{warning}
+Although both of these approaches are helpful, they also come with an increase in cloud costs and engineering work, so they should be considered keeping these aspects in mind.
+```
 
-    ```{admonition} Expand this to find out the benefits of node sharing via profile lists
-    :class: dropdown
-    Specifically for events, the node sharing benefits via profile lists vs. setting a minimum node count are:
+(pre-pull-image)=
+### 1. Pre-pulling the image
 
-      - **no `terraform/eks` infrastructure changes**
+This should be considered if either of the following are true:
 
-        they shouldn't require modifying terraform/eks code in order to change the underlying cluster architecture thanks to [](topic:cluster-design:instance-type) that should cover most usage needs
+- the image is huge
+- faster server startup times were requested at the cost of the cloud cost increase 
 
-      - **more cost flexibility**
+Follow the guide at [](pre-pull-user-images) to enable this.
 
-        we can setup the infrastructure a few days before the event by opening a PR, and then just merge it as close to the event as possible. Deploying an infrastructure change for an event a few days before isn't as costly as starting "x" nodes before, which required an engineer to be available to make terraform changes as close to the event as possible due to costs
+### 2. Pre-warming user nodes
 
-      - **less engineering intervention needed**
+This can be done in a few different ways:
 
-        the instructors are empowered to "pre-warm" the hub by starting notebook servers on nodes they wish to have ready.
-    ```
+- node sharing via profile lists
+- setting a minimum node count on a specific node pool
+- using node placeholders
 
-- the user **image is not huge**, otherwise pre-pulling it must be considered
+However, **the preferred way to do this is through node sharing via profile lists**.
 
+```{admonition} Expand this to find out the benefits of node sharing via profile lists
+:class: dropdown
+Specifically for events, the node sharing benefits via profile lists vs. setting a minimum node count are:
 
-### 3.1. Node sharing via profile lists
+  - **no `terraform/eks` infrastructure changes**
+
+    they shouldn't require modifying terraform/eks code in order to change the underlying cluster architecture thanks to [](topic:cluster-design:instance-type) that should cover most usage needs
+
+  - **more cost flexibility**
+
+    we can setup the infrastructure a few days before the event by opening a PR, and then just merge it as close to the event as possible. Deploying an infrastructure change for an event a few days before isn't as costly as starting "x" nodes before, which required an engineer to be available to make terraform changes as close to the event as possible due to costs
+
+  - **less engineering intervention needed**
+
+    the instructors are empowered to "pre-warm" the hub by starting notebook servers on nodes they wish to have ready.
+```
+
+#### 2.1 Node sharing via profile lists
 
 ```{important}
 Currently, this is the recommended way to handle an event on a hub. However, for some communities that don't already use profile lists, setting up one just before an event might be confusing, we might want to consider setting up a minimum node count in this case.
@@ -65,7 +81,7 @@ Currently, this is the recommended way to handle an event on a hub. However, for
 
 During events, we want to tilt the balance towards reducing server startup time. The docs at [](topic:resource-allocation) have more information about all the factors that should be considered during resource allocation.
 
-Assuming this hub already has a profile list, before an event, you should check the following:
+Assuming this hub already has a profile list, you should check the following before an event:
 
 1. **Information is available**
 
@@ -179,26 +195,6 @@ Assuming this hub already has a profile list, before an event, you should check 
 ### 3.2. Setting a minimum node count on a specific node pool
 ```{warning}
 This section is a Work in Progress!
-```
-(pre-pull-image)=
-### 3.3. Pre-pulling the image
-
-```{warning}
-This section is a Work in Progress!
-```
-
-Relevant discussions:
-- https://github.com/2i2c-org/infrastructure/issues/2541
-- https://github.com/2i2c-org/infrastructure/pull/3313
-- https://github.com/2i2c-org/infrastructure/pull/3341
-
-```{important}
-To get a deeper understanding of the resource allocation topic, you can read up these issues and documentation pieces:
-- https://github.com/2i2c-org/infrastructure/issues/2121
-- https://github.com/2i2c-org/infrastructure/pull/3030
-- https://github.com/2i2c-org/infrastructure/issues/3132
-- https://github.com/2i2c-org/infrastructure/issues/3293
-- https://infrastructure.2i2c.org/topic/resource-allocation/#factors-to-balance
 ```
 
 ### 3.4 Add user placeholders

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -84,116 +84,117 @@ Currently, this is the recommended way to handle an event on a hub. However, for
 
 During events, we want to tilt the balance towards reducing server startup time. The docs at [](topic:resource-allocation) have more information about all the factors that should be considered during resource allocation.
 
+
 Assuming this hub already has a profile list, you should check the following before an event:
 
-1. **Information is available**
+```{admonition} 1. **Information is available**
+:class: dropdown
+Make sure the information in the event GitHub issue was filled in, especially the number of expected users before an event and their expected resource needs (if that can be known by the community beforehand).
+```
 
-    Make sure the information in the event GitHub issue was filled in, especially the number of expected users before an event and their expected resource needs (if that can be known by the community beforehand).
+```{admonition} 2. **Given the current setup, calculate how many users will fit on a node?**
+:class: dropdown
+Check that the current number of users/node respects the following general event wishlist.
+```
 
-2. **Given the current setup, calculate how many users will fit on a node?**
+````{admonition} 3. **Minimize startup time**
+:class: dropdown
+- have at least `3-4 people on a node` as few users per node cause longer startup times, but [no more than ~100]( https://kubernetes.io/docs/setup/best-practices/cluster-large/#:~:text=No%20more%20than%20110%20pods,more%20than%20300%2C000%20total%20containers)
 
-    Check that the current number of users/node respects the following general event wishlist.
+- don't have more than 30% of the users waiting for a node to come up
 
-3. **Minimize startup time**
+  If the current number of users per node doesn't respect the rules above, you should adjust the instance type so that it does.
+  Note that if you are changing the instance type, you should also consider re-writing the allocation options, especially if you are going with a smaller machine than the original one.
 
-  - have at least `3-4 people on a node` as few users per node cause longer startup times, but [no more than ~100]( https://kubernetes.io/docs/setup/best-practices/cluster-large/#:~:text=No%20more%20than%20110%20pods,more%20than%20300%2C000%20total%20containers)
+  ```{code-block}
+  deployer generate resource-allocation choices <instance type>
+  ```
+````
 
-  - don't have more than 30% of the users waiting for a node to come up
+```{admonition} 4. **Don't oversubscribe resources**
+:class: dropdown
+The oversubscription factor is how much larger a limit is than the actual request (aka, the minimum guaranteed amount of a resource that is reserved for a container). When this factor is greater, then a more efficient node packing can be achieved because usually most users don't use resources up to their limit, and more users can fit on a node.
 
-    ````{admonition} Action to take
-    :class: tip
+However, a bigger oversubscription factor also means that the users that use more resources than they are guaranteed can get their kernels killed or CPU throttled at some other times, based on what other users are doing. This inconsistent behavior is confusing to end users and the hub, so we should try and avoid this during events.
+```
 
-    If the current number of users per node doesn't respect the rules above, you should adjust the instance type so that it does.
-    Note that if you are changing the instance type, you should also consider re-writing the allocation options, especially if you are going with a smaller machine than the original one.
+`````{admonition} Action to take
+:class: tip
 
-    ```{code-block}
-    deployer generate resource-allocation choices <instance type>
-    ```
-    ````
+For an event, you should consider an oversubscription factor of 1.
 
-4. **Don't oversubscribe resources**
+- if the instance type remains unchanged, then just adjust the limit to match the memory guarantee if not already the case
 
-    The oversubscription factor is how much larger a limit is than the actual request (aka, the minimum guaranteed amount of a resource that is reserved for a container). When this factor is greater, then a more efficient node packing can be achieved because usually most users don't use resources up to their limit, and more users can fit on a node.
+- if the instance type also changes, then you can use the `deployer generate resource-allocation` command, passing it the new instance type and optionally the number of choices.
 
-    However, a bigger oversubscription factor also means that the users that use more resources than they are guaranteed can get their kernels killed or CPU throttled at some other times, based on what other users are doing. This inconsistent behavior is confusing to end users and the hub, so we should try and avoid this during events.
+  You can then use its output to:
+    - either replace all allocation options with the ones for the new node type
+    - or pick the choice(s) that will be used during the event based on expected usage and just don't show the others
 
-    `````{admonition} Action to take
-    :class: tip
+````{admonition} Example
+For example, if the community expects to only use ~3GB of memory during an event, and no other users are expected to use the hub for the duration of the event, then you can choose to only make available that one option.
 
-    For an event, you should consider an oversubscription factor of 1.
+Assuming they had 4 options on a `n2-highmem-2` machine and we wish to move them on a `n2-highmem-4` for the event, we could run:
 
-    - if the instance type remains unchanged, then just adjust the limit to match the memory guarantee if not already the case
+```{code-block}
+deployer generate resource-allocation choices n2-highmem-4 --num-allocations 4
+```
 
-    - if the instance type also changes, then you can use the `deployer generate resource-allocation` command, passing it the new instance type and optionally the number of choices.
+which will output:
 
-      You can then use its output to:
-        - either replace all allocation options with the ones for the new node type
-        - or pick the choice(s) that will be used during the event based on expected usage and just don't show the others
+```{code-block}
+# pick this option to present the single ~3GB memory option for the event
+mem_3_4:
+  display_name: 3.4 GB RAM, upto 3.485 CPUs
+  kubespawner_override:
+    mem_guarantee: 3662286336
+    mem_limit: 3662286336
+    cpu_guarantee: 0.435625
+    cpu_limit: 3.485
+    node_selector:
+      node.kubernetes.io/instance-type: n2-highmem-4
+  default: true
+mem_6_8:
+  display_name: 6.8 GB RAM, upto 3.485 CPUs
+  kubespawner_override:
+    mem_guarantee: 7324572672
+    mem_limit: 7324572672
+    cpu_guarantee: 0.87125
+    cpu_limit: 3.485
+    node_selector:
+      node.kubernetes.io/instance-type: n2-highmem-4
+(...2 more options)
+```
+And we would have this in the profileList configuration:
+```{code-block}
+profileList:
+  - display_name: Workshop
+    description: Workshop environment
+    default: true
+    kubespawner_override:
+      image: python:6ee57a9
+    profile_options:
+      requests:
+        display_name: Resource Allocation
+        choices:
+          mem_3_4:
+            display_name: 3.4 GB RAM, upto 3.485 CPUs
+            kubespawner_override:
+              mem_guarantee: 3662286336
+              mem_limit: 3662286336
+              cpu_guarantee: 0.435625
+              cpu_limit: 3.485
+              node_selector:
+                node.kubernetes.io/instance-type: n2-highmem-4
+```
+````
 
-    ````{admonition} Example
-    For example, if the community expects to only use ~3GB of memory during an event, and no other users are expected to use the hub for the duration of the event, then you can choose to only make available that one option.
-
-    Assuming they had 4 options on a `n2-highmem-2` machine and we wish to move them on a `n2-highmem-4` for the event, we could run:
-    
-    ```{code-block}
-    deployer generate resource-allocation choices n2-highmem-4 --num-allocations 4
-    ```
-
-    which will output:
-
-    ```{code-block}
-    # pick this option to present the single ~3GB memory option for the event
-    mem_3_4:
-      display_name: 3.4 GB RAM, upto 3.485 CPUs
-      kubespawner_override:
-        mem_guarantee: 3662286336
-        mem_limit: 3662286336
-        cpu_guarantee: 0.435625
-        cpu_limit: 3.485
-        node_selector:
-          node.kubernetes.io/instance-type: n2-highmem-4
-      default: true
-    mem_6_8:
-      display_name: 6.8 GB RAM, upto 3.485 CPUs
-      kubespawner_override:
-        mem_guarantee: 7324572672
-        mem_limit: 7324572672
-        cpu_guarantee: 0.87125
-        cpu_limit: 3.485
-        node_selector:
-          node.kubernetes.io/instance-type: n2-highmem-4
-    (...2 more options)
-    ```
-    And we would have this in the profileList configuration:
-    ```{code-block}
-    profileList:
-      - display_name: Workshop
-        description: Workshop environment
-        default: true
-        kubespawner_override:
-          image: python:6ee57a9
-        profile_options:
-          requests:
-            display_name: Resource Allocation
-            choices:
-              mem_3_4:
-                display_name: 3.4 GB RAM, upto 3.485 CPUs
-                kubespawner_override:
-                  mem_guarantee: 3662286336
-                  mem_limit: 3662286336
-                  cpu_guarantee: 0.435625
-                  cpu_limit: 3.485
-                  node_selector:
-                    node.kubernetes.io/instance-type: n2-highmem-4
-    ```
-    ````
-
-    ````{warning}
-    The `deployer generate resource-allocation`:
-    - cam only generate options where guarantees (requests) equal limits!
-    - supports the instance types located in `node-capacity-info.json` file
-    ````
-    `````
+````{warning}
+The `deployer generate resource-allocation`:
+- cam only generate options where guarantees (requests) equal limits!
+- supports the instance types located in `node-capacity-info.json` file
+````
+`````
 
 ### 3.2. Setting a minimum node count on a specific node pool
 ```{warning}

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -57,9 +57,7 @@ This can be done in a few different ways:
 - setting a minimum node count on a specific node pool
 - using node placeholders
 
-However, **the preferred way to do this is through node sharing via profile lists**.
-
-```{admonition} Expand this to find out the benefits of node sharing via profile lists
+```{admonition} However, **the preferred way to do this is through node sharing via profile lists**.
 :class: dropdown
 Specifically for events, the node sharing benefits via profile lists vs. setting a minimum node count are:
 
@@ -87,19 +85,19 @@ During events, we want to tilt the balance towards reducing server startup time.
 
 Assuming this hub already has a profile list, you should check the following before an event:
 
-```{admonition} 1. **Information is available**
+```{admonition} 1. **Make sure information is available**
 :class: dropdown
-Make sure the information in the event GitHub issue was filled in, especially the number of expected users before an event and their expected resource needs (if that can be known by the community beforehand).
+Make sure the information in the event GitHub issue was filled in, especially the hub that is going to be used, the number of expected users before an event and their expected resource needs (if that can be known by the community beforehand).
 ```
 
-```{admonition} 2. **Given the current setup, calculate how many users will fit on a node?**
+```{admonition} 2. **Calculate how many users will fit on a node?**
 :class: dropdown
 Check that the current number of users/node respects the following general event wishlist.
 ```
 
-````{admonition} 3. **Minimize startup time**
+````{admonition} 3. **Choose the node packing**
 :class: dropdown
-- have at least `3-4 people on a node` as few users per node cause longer startup times, but [no more than ~100]( https://kubernetes.io/docs/setup/best-practices/cluster-large/#:~:text=No%20more%20than%20110%20pods,more%20than%20300%2C000%20total%20containers)
+- have at least `3-4 people on a node` as few users per node cause longer startup times, but [no more than ~100](https://kubernetes.io/docs/setup/best-practices/cluster-large/#:~:text=No%20more%20than%20110%20pods,more%20than%20300%2C000%20total%20containers)
 
 - don't have more than 30% of the users waiting for a node to come up
 
@@ -111,17 +109,13 @@ Check that the current number of users/node respects the following general event
   ```
 ````
 
-```{admonition} 4. **Don't oversubscribe resources**
+````{admonition} 4. **Don't oversubscribe resources**
 :class: dropdown
 The oversubscription factor is how much larger a limit is than the actual request (aka, the minimum guaranteed amount of a resource that is reserved for a container). When this factor is greater, then a more efficient node packing can be achieved because usually most users don't use resources up to their limit, and more users can fit on a node.
 
 However, a bigger oversubscription factor also means that the users that use more resources than they are guaranteed can get their kernels killed or CPU throttled at some other times, based on what other users are doing. This inconsistent behavior is confusing to end users and the hub, so we should try and avoid this during events.
-```
 
-`````{admonition} Action to take
-:class: tip
-
-For an event, you should consider an oversubscription factor of 1.
+**For an event, you should consider an oversubscription factor of 1.**
 
 - if the instance type remains unchanged, then just adjust the limit to match the memory guarantee if not already the case
 
@@ -131,70 +125,12 @@ For an event, you should consider an oversubscription factor of 1.
     - either replace all allocation options with the ones for the new node type
     - or pick the choice(s) that will be used during the event based on expected usage and just don't show the others
 
-````{admonition} Example
-For example, if the community expects to only use ~3GB of memory during an event, and no other users are expected to use the hub for the duration of the event, then you can choose to only make available that one option.
-
-Assuming they had 4 options on a `n2-highmem-2` machine and we wish to move them on a `n2-highmem-4` for the event, we could run:
-
-```{code-block}
-deployer generate resource-allocation choices n2-highmem-4 --num-allocations 4
-```
-
-which will output:
-
-```{code-block}
-# pick this option to present the single ~3GB memory option for the event
-mem_3_4:
-  display_name: 3.4 GB RAM, upto 3.485 CPUs
-  kubespawner_override:
-    mem_guarantee: 3662286336
-    mem_limit: 3662286336
-    cpu_guarantee: 0.435625
-    cpu_limit: 3.485
-    node_selector:
-      node.kubernetes.io/instance-type: n2-highmem-4
-  default: true
-mem_6_8:
-  display_name: 6.8 GB RAM, upto 3.485 CPUs
-  kubespawner_override:
-    mem_guarantee: 7324572672
-    mem_limit: 7324572672
-    cpu_guarantee: 0.87125
-    cpu_limit: 3.485
-    node_selector:
-      node.kubernetes.io/instance-type: n2-highmem-4
-(...2 more options)
-```
-And we would have this in the profileList configuration:
-```{code-block}
-profileList:
-  - display_name: Workshop
-    description: Workshop environment
-    default: true
-    kubespawner_override:
-      image: python:6ee57a9
-    profile_options:
-      requests:
-        display_name: Resource Allocation
-        choices:
-          mem_3_4:
-            display_name: 3.4 GB RAM, upto 3.485 CPUs
-            kubespawner_override:
-              mem_guarantee: 3662286336
-              mem_limit: 3662286336
-              cpu_guarantee: 0.435625
-              cpu_limit: 3.485
-              node_selector:
-                node.kubernetes.io/instance-type: n2-highmem-4
-```
-````
-
-````{warning}
+```{warning}
 The `deployer generate resource-allocation`:
-- cam only generate options where guarantees (requests) equal limits!
+- can only generate options where guarantees (requests) equal limits!
 - supports the instance types located in `node-capacity-info.json` file
+```
 ````
-`````
 
 ### 3.2. Setting a minimum node count on a specific node pool
 ```{warning}

--- a/docs/howto/prepare-for-events/event-prep.md
+++ b/docs/howto/prepare-for-events/event-prep.md
@@ -44,7 +44,10 @@ This should be considered if either of the following are true:
 - the image is huge
 - faster server startup times were requested at the cost of the cloud cost increase 
 
-Follow the guide at [](pre-pull-user-images) to enable this.
+```{admonition} Action to take
+:class: tip
+Follow the guide at [](pre-pull-user-images) to enable image pre-pulling.
+```
 
 ### 2. Pre-warming user nodes
 

--- a/docs/howto/prepare-for-events/index.md
+++ b/docs/howto/prepare-for-events/index.md
@@ -9,7 +9,7 @@ The communities we serve have the responsibility to notify us about an event the
 The events might vary in type, so the following list is not complete and does not cover all of them (yet). Most common event types are exams, workshops etc.
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 event-prep.md
 exam.md
 ```

--- a/docs/sre-guide/node-scale-up/aws.md
+++ b/docs/sre-guide/node-scale-up/aws.md
@@ -9,22 +9,49 @@ server startup faster.
 1. Open the appropriate `.jsonnet` file for the cluster in question (located in the `eksctl` folder).
    Depending on how you intend to scale the nodepools, there are two approaches you may take.
 
-   1. **Scale all nodepools.**
-      To scale all nodepools, locate the `minSize` property of the `nb` node group and change the value to what you want.
-      An example can be found here:
-      <https://github.com/2i2c-org/infrastructure/blob/f40cfbc2b5bd236a1f95e406a6f6d9bec99e55d2/eksctl/2i2c-aws-us.jsonnet#L102>
+1. Scale the desired nodepool
 
-   2. **Scale a specific nodepool.**
-      If you only wish to scale a specific nodepool, you can add the `minSize` property to the local `notebookNodes` variable next to the `instanceType` that you wish to scale.
-
-   ```{warning}
-   It is currently unclear if *lowering* the `minSize` property just allows
-   the autoscaler to reclaim nodes, or if it actively destroys nodes at time
-   of application! If it actively destroys nodes, it is unclear if it does
-   so regardless of user pods running in these nodes! Until this can be
-   determined, please do scale-downs only when there are no users on
-   the nodes.
+Depending on which nodepool(s) you want to scale up, tweak the arguments of `cluster.withNodeGroupConfigOverride` to match your needs.
+   ```json
+   cluster.withNodeGroupConfigOverride(
+      c,
+      kind='notebook',
+      instanceType='r5.4xlarge',
+      hubName='prod',
+      overrides={
+         desiredCapacity: 10,
+         minSize: 10,
+      }
+   )
    ```
+   Where:
+   - `c` is the cluster object created with `cluster.makeCluster` defined in `eksctl/libsonnet/cluster.jsonnet`
+   - both `minSize` and `desiredCapacity` represent the number of nodes wanted in the nodepool
+
+   ````{tip}
+   You can also chain multiple `cluster.withNodeGroupConfigOverride` for better matching of nodepools to scale.
+   ```json
+   cluster.withNodeGroupConfigOverride(
+      cluster.withNodeGroupConfigOverride(
+         c,
+         kind='notebook',
+         instanceType='r5.4xlarge',
+         hubName='pythia-binder',
+         overrides={
+            desiredCapacity: 11,
+            minSize: 11,
+         }
+      ),
+      kind='notebook',
+      instanceType='r5.4xlarge',
+      hubName='prod',
+      overrides={
+         desiredCapacity: 11,
+         minSize: 11,
+      }
+   )
+   ```
+   ````
 
 2. Render the `.jsonnet` file into a YAML file with:
    ```bash

--- a/docs/sre-guide/node-scale-up/aws.md
+++ b/docs/sre-guide/node-scale-up/aws.md
@@ -12,7 +12,7 @@ server startup faster.
 1. Scale the desired nodepool
 
 Depending on which nodepool(s) you want to scale up, tweak the arguments of `cluster.withNodeGroupConfigOverride` to match your needs.
-   ```json
+   ```{code-block}
    cluster.withNodeGroupConfigOverride(
       c,
       kind='notebook',
@@ -30,7 +30,7 @@ Depending on which nodepool(s) you want to scale up, tweak the arguments of `clu
 
    ````{tip}
    You can also chain multiple `cluster.withNodeGroupConfigOverride` for better matching of nodepools to scale.
-   ```json
+   ```{code-block}
    cluster.withNodeGroupConfigOverride(
       cluster.withNodeGroupConfigOverride(
          c,

--- a/docs/sre-guide/node-scale-up/index.md
+++ b/docs/sre-guide/node-scale-up/index.md
@@ -1,3 +1,4 @@
+(scaling-nodepools)=
 # Scaling nodepools
 
 When we provision Kubernetes clusters, we setup two, sometimes three, nodepools:

--- a/docs/topic/infrastructure/index.md
+++ b/docs/topic/infrastructure/index.md
@@ -12,4 +12,5 @@ hub-helm-charts.md
 network.md
 storage-layer.md
 cryptnono.md
+user-placeholders.md
 ```

--- a/docs/topic/infrastructure/user-placeholders.md
+++ b/docs/topic/infrastructure/user-placeholders.md
@@ -1,0 +1,40 @@
+(topic:user-placeholders)=
+# User placeholders
+
+Whilst one strategy to minimising startup times is to increase the number of user pods that fit onto a single node (thereby reducing the number of times a node needs to be scaled up across the event), this approach will still introduce waiting points when a scale up is required.
+
+A useful mechanism for reducing the likelihood of a blocking scale up is the use of [user-placeholders](https://z2jh.jupyter.org/en/stable/administrator/optimization.html#scaling-up-in-time-user-placeholders). This technique involves scheduling pods that represent a "seat" or "placeholder" for anticipated user servers. Once users join the cluster, these pods are evicted by the scheduler to make room for the real user pods. 
+
+To illustrate this, consider a hub with a dedicated user nodepool. Each node can support 64 singleuser pods. Let's imagine that the number of user placeholder replicas is set to 32:
+
+- Initially, there will be 32 user placeholder pods running on a single user node.
+- For the next 32 users that join, no scaling up will occur, and once all of the users have joined, the node will be "full" with 32 users and 32 placeholders.
+- Once the 33rd user joins, one of the user placeholders will be evicted, triggering a scale up to maintain the 32 user-node replica requirement.
+
+Conventionally, one might imaging that the 34th user (and the 35th, etc.) will immediately be able to spawn their server pod, as the scheduler continues to evict pods. In practice this is not what happens. Instead, once the first placeholder pod is evicted and the autoscaler triggers a scale up, subsequent user pods are directly scheduled on the not-yet-ready node. This introduces head-of-line blocking for 31 of these 32 subsequent users.
+
+## Choosing placeholder resources
+
+As such, it is more effective to create a singular placeholder pods that represents $N$ users. For example, if we wish to reserve capacity for 32 users, and each user is guaranteed 1GiB of memory, then we would create a placeholder pod with a 32GiB memory request. In the extreme case, we might wish to reserve an entire node. We must be careful not to request more RAM than is available _after_ the kube-system pods have been started on the node. In practice, this might mean leaving ~2GiB of memory (though this should be confirmed through testing).
+
+In event conditions, we might anticipate a particular rate at which users attempt to start their servers. Measurements of this value can be derived from previous event instances. If one such event needs to support 60 users every 3 minutes, and it takes 10 minutes for a node to spin up, we will need to have room for $60/3 * 10 = 200$ users. We can compute the appropriate number of resources accordingly.
+
+## Auxiliary considerations
+Simply ensuring that a node is ready to accept user pods is not sufficient to ensure that users do not experience delays when the user node pool is scaled up. In order to start user pods, the cluster needs to pull their respective OCI container images from the container registry. If we do not do this ahead of time, the first user to require a particular image will need to wait for it to be pulled to the cluster, as will all other image users. 
+
+We can anticipate this be pre-pulling the various images required at node startup time, using the continuous image puller (see [](pre-pull-image)). This should only be used on dedicated nodepools in which the number of images is small (as pulling a set of images delays the time until the node is considered available to user pods).
+
+An example configuration might look something like
+```yaml
+jupyterhub:
+  prePuller:
+    continuous:
+      enabled: true
+  scheduling:
+    userPlaceholder:
+      # Keep at least half of a 64 GiB node free
+      replicas: 1
+      resources:
+        requests:
+          memory: 32Gi
+```


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/8542

Preview is available at https://2i2c-pilot-hubs--8533.org.readthedocs.build/howto/prepare-for-events/event-prep/#reduce-server-startup-time

I've:
- added section about pre-pulling images
- updated section about scaling up aws nodepools
- moved the info we had on user placeholders into a `topic` section in the SRE docs as it was too fluffy for a `how-to` guide and it wasn't clear what is the action was (cc @agoose77 )
- added a `todo` section about scratch tmp storage and linked back to the initiative