### PR TITLE
[projectpythia] Bump rate limit for BinderHub service

### DIFF
--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -32,3 +32,7 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liWxGyeDz5ETgPF3
                   text: Revoke GitHub Token
                   newBrowserTab: true
+binderhub-service:
+  config:
+    RateLimiter:
+      limit: 3600


### PR DESCRIPTION
This is a temporary PR to fix rate limiting for image builds
Ref #8362 