### PR TITLE
Revert "[projectpythia] Bump rate limit for BinderHub service"

### DIFF
--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -32,7 +32,3 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liWxGyeDz5ETgPF3
                   text: Revoke GitHub Token
                   newBrowserTab: true
-binderhub-service:
-  config:
-    RateLimiter:
-      limit: 3600


### PR DESCRIPTION
Reverts 2i2c-org/infrastructure#8537
Ref https://github.com/2i2c-org/infrastructure/issues/8362

Reverting while we figure out https://github.com/2i2c-org/jupyterhub-fancy-profiles/issues/157