### PR TITLE
Security: Command Injection via Shell Argument in jsonnet.py

### DIFF
--- a/deployer/utils/jsonnet.py
+++ b/deployer/utils/jsonnet.py
@@ -53,14 +53,15 @@ def render_jsonnet(
         "--jpath",
         str(jsonnet_file.parent),
         "--ext-str",
-        f"VARS_2I2C_CLUSTER_NAME={cluster_name}",
+        f"VARS_2I2C_CLUSTER_NAME={shlex.quote(cluster_name)}",
     ]
     if hub_name is not None:
-        command += ["--ext-str", f"VARS_2I2C_HUB_NAME={hub_name}"]
+        command += ["--ext-str", f"VARS_2I2C_HUB_NAME={shlex.quote(hub_name)}"]
     if hub_domain is not None:
-        command += ["--ext-str", f"VARS_2I2C_HUB_DOMAIN={hub_domain}"]
-    command += ["--ext-str", f"VARS_2I2C_PROVIDER={provider}"]
-    command += ["--ext-str", f"VARS_2I2C_ACCOUNT_ID={account_id}"]
+        command += ["--ext-str", f"VARS_2I2C_HUB_DOMAIN={shlex.quote(hub_domain)}"]
+    command += ["--ext-str", f"VARS_2I2C_PROVIDER={shlex.quote(provider)}"]
+    if account_id is not None:
+        command += ["--ext-str", f"VARS_2I2C_ACCOUNT_ID={shlex.quote(account_id)}"]
     # Make the jsonnet file passed be an absolute path, but do not *resolve*
     # it - so symlinks are resolved by jsonnet rather than us. This is important
     # for daskhub compatibility.


### PR DESCRIPTION
## Summary

Security: Command Injection via Shell Argument in jsonnet.py

## Problem

**Severity**: `High` | **File**: `deployer/utils/jsonnet.py:L28`

The `render_jsonnet` function in `deployer/utils/jsonnet.py` constructs a shell command by directly interpolating user-controlled variables (`cluster_name`, `provider`, `account_id`, `hub_name`, `hub_domain`) into command-line arguments passed to `jsonnet`. While `shlex.join` is used for display purposes, the actual command execution via `subprocess.check_call(command)` passes a list where external variables are interpolated without sanitization. If any of these variables contain shell metacharacters or malicious content, they could alter the command execution. More critically, the `jsonnet_file` path is passed directly without validation, and if an attacker controls the path or any ext-str values, they could potentially execute arbitrary commands or read sensitive files.

## Solution

Validate and sanitize all external inputs before passing them to subprocess. Use `shlex.quote()` for string arguments, or better yet, avoid shell execution entirely by using the Python jsonnet library directly. Ensure `jsonnet_file` is validated to be within an allowed directory (path traversal check).

## Changes

- `deployer/utils/jsonnet.py` (modified)