### PR TITLE
Use a workload identity pool instead of long-lived service account

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -10,7 +10,8 @@
 #     - uses: ./.github/actions/setup-deploy
 #       with:
 #         provider: gcp
-#         GCP_KMS_DECRYPTOR_KEY: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+#         gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+#         gcp_workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 #
 # General action configuration reference:
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#about-yaml-syntax-for-github-actions
@@ -31,10 +32,13 @@ inputs:
     description: Cloud provider a cluster runs on
     required: true
     default: gcp
-  GCP_KMS_DECRYPTOR_KEY:
+  gcp_project_id:
     description: >-
-      A Google Cloud Service Account Key with KMS Decryption privileges. This allows
-      us to unlock our sops-encrypted secrets required for a deploy.
+      The ID of the GCP project used for secret management.
+    required: true
+  gcp_workload_identity_provider:
+    description: >-
+      A Google Cloud Workload Identity Provider resource whose service account has KMS Decryption privileges. This is used to unlock sops-encrypted secrets.
     required: true
 
 # runs (for composite actions) configuration reference:
@@ -132,4 +136,5 @@ runs:
   - name: Setup sops credentials to decrypt repo secrets
     uses: google-github-actions/auth@v3
     with:
-      credentials_json: ${{ inputs.GCP_KMS_DECRYPTOR_KEY }}
+      project_id: ${{ inputs.gcp_project_id }}
+      workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}

--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -52,7 +52,8 @@ jobs:
     - name: Setup sops credentials to decrypt repo secrets
       uses: google-github-actions/auth@v3
       with:
-        credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Deploy grafana dashboards for ${{ matrix.cluster_name }}
       run: |

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -38,11 +38,12 @@ jobs:
     - name: Install sops
       uses: mdgreenwald/mozilla-sops-action@v1.6.0
 
-      # Authenticate with the correct KMS key that sops will use.
+        # Authenticate with the correct KMS key that sops will use.
     - name: Setup sops credentials to decrypt repo secrets
       uses: google-github-actions/auth@v3
       with:
-        credentials_json: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: ensure uptime checks are set up
       run: |

--- a/.github/workflows/reusable-health-check.yaml
+++ b/.github/workflows/reusable-health-check.yaml
@@ -24,7 +24,9 @@ on:
         required: true
         type: string
     secrets:
-      GCP_KMS_DECRYPTOR_KEY:
+      gcp_project_id:
+        required: true
+      gcp_workload_identity_provider:
         required: true
     outputs:
       health_check_output:
@@ -56,7 +58,8 @@ jobs:
       uses: ./.github/actions/setup-deploy
       with:
         provider: ${{ inputs.provider }}
-        GCP_KMS_DECRYPTOR_KEY: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Run health check against ${{ inputs.cluster }} ${{ inputs.hub }}
       uses: nick-fields/retry@v4

--- a/.github/workflows/run-health-check.yaml
+++ b/.github/workflows/run-health-check.yaml
@@ -109,7 +109,8 @@ jobs:
       uses: ./.github/actions/setup-deploy
       with:
         provider: ${{ matrix.jobs.provider }}
-        GCP_KMS_DECRYPTOR_KEY: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Run health check against ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
       uses: nick-fields/retry@v4
@@ -121,7 +122,6 @@ jobs:
           echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
           deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} | tee --append "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
-
 
   upgrade-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Something's amiss with our KMS secret decryption in CI. Whilst this might not be the fix, we should switch to OIDC from an improved security perspective. Following https://github.com/google-github-actions/auth#preferred-direct-workload-identity-federation, I've authored this PR.

Note — the OIDC tokens are currently provisioned per-job, and live for 10m. This means a deploy of a single hub cannot take more than 10m, which I think is acceptable but we may discover not to be the case.