### PR TITLE
Support specifying path to infra repo

### DIFF
--- a/deployer/utils/file_acquisition.py
+++ b/deployer/utils/file_acquisition.py
@@ -15,7 +15,10 @@ from ruamel.yaml.scanner import ScannerError
 
 yaml = YAML(typ="safe", pure=True)
 
-REPO_ROOT_PATH = Path(__file__).parent.parent.parent
+try:
+    REPO_ROOT_PATH = Path(os.environ["DEPLOYER_ROOT_PATH"])
+except KeyError:
+    REPO_ROOT_PATH = Path(__file__).parent.parent.parent
 HELM_CHARTS_DIR = REPO_ROOT_PATH.joinpath("helm-charts")
 CONFIG_CLUSTERS_PATH = REPO_ROOT_PATH.joinpath("config/clusters")
 


### PR DESCRIPTION
This PR makes it possible to install deployer in a non-editable fashion. There may be follow ups. The goal is make it possible to pin down deployer e.g. in a container.