### PR TITLE
Use conda-forge to provision dev environment

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -30,7 +30,7 @@ description: >-
 inputs:
   provider:
     description: Cloud provider a cluster runs on
-    required: true
+    required: false
     default: gcp
 
 # runs (for composite actions) configuration reference:
@@ -42,88 +42,28 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/setup-python@v6
+  - uses: mamba-org/setup-micromamba@v3
     with:
-      python-version: '3.13'
-  - uses: actions/setup-go@v6
+      environment-file: build-tools/environment.yaml
+        # only cache environment
+      cache-environment-key: environment-${{ hashFiles('build-tools/environment.yaml') }}
+      cache-downloads-key: downloads-${{ hashFiles('build-tools/environment.yaml') }}
 
-    # There will always be a cache hit on the cache key when this composite
-    # action is run, as its only done after the "generate-jobs" job has been run
-    # which will save a cache.
+      # There will always be a cache hit on the cache key when this composite
+      # action is run, as its only done after the "generate-jobs" job has been run
+      # which will save a cache.
   - name: Restore pip's install cache
     uses: actions/cache@v5
     with:
       path: ~/.cache/pip
-        # key determines if we define or reuse an existing cache or not. Our
-        # key ensure we cache within a workflow run and its attempts, but not
-        # between workflow runs.
-      key: ${{ github.run_id }}
+        # Local wheels are not cached https://pip.pypa.io/en/stable/topics/caching/#locally-built-wheels
+      key: ${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}
 
-  - name: Install the deployer + go dependency
-    run: |
-      pip install --editable .
-      go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
-    shell: bash
-
-    # This action use the github official cache mechanism internally
-  - uses: azure/setup-helm@v5
-    with:
-        # Manually update a pinning of helm to a minor version based on:
-        #
-        # - it seems to work
-        # - to avoid falling behind
-        #
-        # Related:
-        #
-        # - helm versions: https://github.com/helm/helm/releases
-        #
-      version: v3.14.4
-
-    # Manually update a pinning of kubectl to a minor version based on:
-    #
-    # - the current range of k8s version in our k8s clusters, as of 2024-04-17,
-    #   this is k8s 1.27 - 1.29
-    # - the next expected change in this range, as of 2024-04-17, is to expand
-    #   to include 1.30
-    # - the kubectl <-> k8s api-server skew policy of +/- one minor version
-    # - the policy of attempting to update our kubectl version here to be +/-
-    #   one minor versions of future k8s clusters additions or upgrades, so that
-    #   additions or upgrades of k8s clusters aren't unexpectedly held back
-    #
-    # As an example, we upgraded to kubectl to version 1.24 before we
-    # added/upgraded a k8s cluster to version 1.25.
-    #
-    # Related:
-    #
-    # - k8s versions: https://kubernetes.io/releases/
-    # - Kubectl version skew policy: https://kubernetes.io/releases/version-skew-policy/#kubectl
-    # - 2i2c, k8s upgrades tracked: https://github.com/2i2c-org/infrastructure/issues/2293
-    # - 2i2c, historical issue: https://github.com/2i2c-org/infrastructure/issues/1271
-    #
-  - uses: azure/setup-kubectl@v5
-    with:
-      version: v1.28.8
-
-    # This action use the github official cache mechanism internally
-  - name: Install sops
-    uses: mdgreenwald/mozilla-sops-action@v1.6.0
-
-    # Install pre-requisite for "gcloud container clusters get-credentials"
-    # command with a modern k8s client.
-    #
-    # A manual install step has been needed as they opted to not provide it in
-    # the github-runner image. See
-    # https://github.com/actions/runner-images/issues/5925#issuecomment-1216417721.
-    #
+  - name: Install deployer
+    run: pip install .
+    shell: bash -l {0}
   - name: Install gke-gcloud-auth-plugin
     if: inputs.provider == 'gcp'
     run: |
-      # Disable compilation of Python bytecode for perf
-      export CLOUDSDK_SKIP_PY_COMPILATION=1
-      echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
-      export VER=570.0.0-0
-      sudo apt-get update -y
-      sudo apt-get install -y --allow-downgrades google-cloud-cli=${VER} google-cloud-cli-gke-gcloud-auth-plugin=${VER}
-    shell: bash
+      gcloud components install gke-gcloud-auth-plugin
+    shell: bash -l {0}

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -51,6 +51,10 @@ env:
   TERM: xterm
   USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   # This job runs in Pull Requests and on pushes to the default branch. It identifies
   # which files have been added or modified by recent GitHub activity and parses a list
@@ -73,25 +77,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-    - uses: actions/setup-go@v6
-
-        # There will almost never be a cache hit on the cache key when this job is
-        # run, as it is the first of all jobs in this workflow. An exception is if
-        # this job is re-attempted as part of the same workflow run after
-        # succeeding previously.
-    - name: Save pip's install cache on job completion
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ github.run_id }}
-
-    - name: Install deployer script's Python dependencies
-      run: |
-        pip install --editable .
-        go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+    - name: Setup deployer
+      uses: ./.github/actions/setup-deploy
 
     - name: Get merged/open PR labels
       uses: actions/github-script@v8
@@ -504,14 +491,9 @@ jobs:
       run: |
         deployer deploy ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
 
-        # Retry action: https://github.com/marketplace/actions/retry-step
     - name: Run health check against ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name}}
-      uses: nick-fields/retry@v4
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        command: |
-          deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
+      run: |
+        deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} --attempts 3 --attempt-timeout-s=600
 
     - name: Declare failure status
       id: declare-failure
@@ -637,25 +619,24 @@ jobs:
       with:
         submodules: true
 
+    - name: Setup sops credentials to decrypt repo secrets
+      uses: google-github-actions/auth@v3
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
     - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
       uses: ./.github/actions/setup-deploy
       with:
         provider: ${{ matrix.jobs.provider }}
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
-        gcp_workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}}
 
     - name: Upgrade ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name }}
       run: |
         deployer deploy ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
 
-        # Retry action: https://github.com/marketplace/actions/retry-step
     - name: Run health check against ${{ matrix.jobs.hub_name }} hub on cluster ${{ matrix.jobs.cluster_name}}
-      uses: nick-fields/retry@v4
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        command: |
-          deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
+      run: |
+        deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} --attempts 3 --attempt-timeout-s=600
 
         # https://github.com/ravsamhq/notify-slack-action
         # Needs to be added per job

--- a/.github/workflows/reusable-health-check.yaml
+++ b/.github/workflows/reusable-health-check.yaml
@@ -31,6 +31,11 @@ on:
     outputs:
       health_check_output:
         value: ${{ jobs.run_health_check.outputs.output1 }}
+
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   run_health_check:
     runs-on: ubuntu-latest
@@ -44,24 +49,9 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-    - name: Save pip's install cache on job completion
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ github.run_id }}
-
-    - name: Install deployer script's Python dependencies
-      run: |
-        pip install --editable .
-        go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 
     - name: Setup deploy for ${{ inputs.cluster }} cluster
       uses: ./.github/actions/setup-deploy
-      with:
-        provider: ${{ inputs.provider }}
 
     - name: Setup sops credentials to decrypt repo secrets
       uses: google-github-actions/auth@v3
@@ -70,13 +60,10 @@ jobs:
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Run health check against ${{ inputs.cluster }} ${{ inputs.hub }}
-      uses: nick-fields/retry@v4
       id: health_check
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        command: |
-          set -euo pipefail
-          echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
-          deployer run-hub-health-check ${{ inputs.cluster }} ${{ inputs.hub }} | tee --append "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+      run: |
+        set -euo pipefail
+        echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
+        deployer run-hub-health-check ${{ inputs.cluster }} ${{ inputs.hub }} --attempts 3 --attempt-timeout-s=600 | tee --append "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+

--- a/.github/workflows/run-health-check.yaml
+++ b/.github/workflows/run-health-check.yaml
@@ -23,6 +23,10 @@ env:
   TERM: xterm
   USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   generate-jobs:
     runs-on: ubuntu-latest
@@ -36,19 +40,13 @@ jobs:
       with:
         submodules: true
 
-    - uses: actions/setup-python@v6
+    - name: Setup deploy for ${{ inputs.cluster }} cluster
+      uses: ./.github/actions/setup-deploy
       with:
-        python-version: '3.13'
-
-    - uses: actions/setup-go@v6
-
-    - name: Install deployer script's Python dependencies
-      run: |
-        pip install --editable .
-        go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+        provider: ${{ inputs.provider }}
 
     - name: Identify files that have been added or modified
-      # Action repo: https://github.com/dorny/paths-filter
+        # Action repo: https://github.com/dorny/paths-filter
       uses: dorny/paths-filter@v4
       id: changed-files
       with:
@@ -59,15 +57,15 @@ jobs:
             - added|modified: terraform/**
             - added|modified: eksctl/**
 
-      # This step will create a comment-body.txt file containing the jobs to be run in a
-      # Markdown table format to be posted on a Pull Request
+        # This step will create a comment-body.txt file containing the jobs to be run in a
+        # Markdown table format to be posted on a Pull Request
     - name: Generate matrix jobs
       id: generate-jobs
       run: |
         deployer plan-health-check "${{ steps.changed-files.outputs.changed_files }}"
 
-      # The comment-deployment-plan-pr.yaml workflow won't have the correct context to
-      # know the PR number, so we save it to a file to pass to that workflow
+        # The comment-deployment-plan-pr.yaml workflow won't have the correct context to
+        # know the PR number, so we save it to a file to pass to that workflow
     - name: Save Pull Request number to a file
       if: github.event_name == 'pull_request'
       run: |
@@ -121,15 +119,12 @@ jobs:
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Run health check against ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
-      uses: nick-fields/retry@v4
       id: health_check
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        command: |
-          echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
-          deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} | tee --append "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+      run: |
+        set -euo pipefail
+        echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
+        deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} --attempts 3 --attempt-timeout-s=600 | tee --append "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
 
   upgrade-prod:
     runs-on: ubuntu-latest
@@ -161,12 +156,9 @@ jobs:
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Run health check against ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }}
-      uses: nick-fields/retry@v4
       id: health_check
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        command: |
-          echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
-          deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} | tee --append "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+      run: |
+        set -euo pipefail
+        echo "health_check_output<<EOF" >> "$GITHUB_OUTPUT"
+        deployer run-hub-health-check ${{ matrix.jobs.cluster_name }} ${{ matrix.jobs.hub_name }} --attempts 3 --attempt-timeout-s=600 | tee --append "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"

--- a/build-tools/environment.yaml
+++ b/build-tools/environment.yaml
@@ -1,0 +1,13 @@
+name: build-tools
+channels:
+- conda-forge
+- nodefaults
+dependencies:
+- google-cloud-sdk 570.*
+- go-sops >=3.13.1,<4
+- kubernetes-helm 3.17.0.*
+- go-jsonnet >=0.22.0,<0.23
+- git
+- kubernetes >=1.34.3,<2
+- pip
+- python=3.13.*

--- a/config/clusters/leap/staging.values.yaml
+++ b/config/clusters/leap/staging.values.yaml
@@ -5,7 +5,7 @@ basehub:
         SCRATCH_BUCKET: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
         PERSISTENT_BUCKET: gs://leap-persistent-staging/$(JUPYTERHUB_USER)
         PANGEO_SCRATCH: gs://leap-scratch-staging/$(JUPYTERHUB_USER)
-  # No-op comment
+        # Comment 3
   jupyterhub-home-nfs:
     gke:
       volumeId: projects/leap-pangeo/zones/us-central1-c/disks/hub-nfs-homedirs-staging

--- a/deployer/commands/deployer.py
+++ b/deployer/commands/deployer.py
@@ -186,10 +186,39 @@ def deploy(
                 cleanup_values_schema_json(chart_dir)
 
 
+async def test_health_attempts(
+    hub_url: str,
+    service_api_token: str,
+    hub_type: str,
+    attempts: int,
+    attempt_timeout_s: int,
+):
+    for i in range(attempts):
+        try:
+            async with asyncio.timeout(attempt_timeout_s):
+                await test_hub_healthy(hub_url, service_api_token, hub_type)
+        except asyncio.TimeoutError:
+            print_colour(f"Attempt {i + 1} timed out, retrying", colour="red")
+        except Exception:
+            print_colour(
+                f"An error occurred during attempt {i + 1}, retrying", colour="red"
+            )
+        else:
+            return
+
+    raise RuntimeError("All attempts failed")
+
+
 @app.command(rich_help_panel=CONTINUOUS_DEPLOYMENT)
 def run_hub_health_check(
     cluster_name: str = typer.Argument(..., help="Name of cluster to operate on"),
     hub_name: str = typer.Argument(..., help="Name of hub to operate on"),
+    attempts: int = typer.Option(
+        3, help="Number of failures before declaring unhealthy"
+    ),
+    attempt_timeout_s: int = typer.Option(
+        600, help="Number of seconds before giving up on an attempt"
+    ),
 ):
     """
     Run a health check on a given hub on a given cluster. Optionally check scaling
@@ -255,4 +284,8 @@ def run_hub_health_check(
             )
         service_api_token = base64.b64decode(service_api_token_b64encoded).decode()
 
-    asyncio.run(test_hub_healthy(hub_url, service_api_token, hub.type))
+    asyncio.run(
+        test_health_attempts(
+            hub_url, service_api_token, hub.type, attempts, attempt_timeout_s
+        )
+    )

--- a/deployer/utils/file_acquisition.py
+++ b/deployer/utils/file_acquisition.py
@@ -15,10 +15,14 @@ from ruamel.yaml.scanner import ScannerError
 
 yaml = YAML(typ="safe", pure=True)
 
-try:
+if "DEPLOYER_ROOT_PATH" in os.environ:
     REPO_ROOT_PATH = Path(os.environ["DEPLOYER_ROOT_PATH"])
-except KeyError:
+elif "GITHUB_WORKSPACE" in os.environ:
+    REPO_ROOT_PATH = Path(os.environ["GITHUB_WORKSPACE"])
+else:
     REPO_ROOT_PATH = Path(__file__).parent.parent.parent
+    assert (REPO_ROOT_PATH / "config").is_dir()
+
 HELM_CHARTS_DIR = REPO_ROOT_PATH.joinpath("helm-charts")
 CONFIG_CLUSTERS_PATH = REPO_ROOT_PATH.joinpath("config/clusters")
 


### PR DESCRIPTION
We've recently had CI failures due to drifting dependencies (gcloud CLI). We've also historically had incidents due to local environments being unpinned (Helm). Whilst 2i2c engineers should feel free to use their own env managers, we should try to introduce a source of truth for supported tooling.

This PR uses micromamba to provision the dev tools in CI, making it much easier to reproduce. I thought about using a Docker container or Nix env, but I want this to be lightweight for our existing team to use and easy to update.

Closes #7525, and fixes CI!