### PR TITLE
Drop use of actions to provide binaries for deployment

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yaml
+++ b/.github/workflows/deploy-grafana-dashboards.yaml
@@ -4,7 +4,11 @@ on:
   schedule:
     # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
   - cron: 0 5 * * *
-  workflow_dispatch:
+  workflow_dispatch
+
+defaults:
+  run:
+    shell: bash -l {0}:
 
 jobs:
   identify_clusters:
@@ -35,22 +39,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v6
+    - name: Setup deploy for ${{ matrix.jobs.cluster_name }} cluster
+      uses: ./.github/actions/setup-deploy
       with:
-        python-version: '3.13'
-
-    - name: Install deployer
-      run: |
-        python3 -m pip install --editable .
-
-    - name: Install jsonnet (go-jsonnet)
-      run: |
-        JSONNET_VERSION=0.20.0
-        wget -qO- https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz \
-            | tar -xvz --one-top-level=$HOME/.local/bin
-
-    - name: Install sops
-      uses: mdgreenwald/mozilla-sops-action@v1.6.0
+        provider: ${{ matrix.jobs.provider }}
 
     - name: Setup sops credentials to decrypt repo secrets
       uses: google-github-actions/auth@v3

--- a/.github/workflows/ensure-uptime-checks.yaml
+++ b/.github/workflows/ensure-uptime-checks.yaml
@@ -23,6 +23,10 @@ concurrency: ${{ github.workflow }}
 env:
   TERM: xterm
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   ensure-uptime-checks:
     runs-on: ubuntu-latest
@@ -33,13 +37,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-      # Uptime checks are set up and managed via terraform
-    - uses: hashicorp/setup-terraform@v4
-
-      # We use sops to store encrypted GCP ServiceAccount Key that terraform uses
-      # to run, as well as PagerDuty config terraform uses
-    - name: Install sops
-      uses: mdgreenwald/mozilla-sops-action@v1.6.0
+    - name: Setup deploy
+      uses: ./.github/actions/setup-deploy
 
         # Authenticate with the correct KMS key that sops will use.
     - name: Setup sops credentials to decrypt repo secrets
@@ -48,7 +47,7 @@ jobs:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-    - name: ensure uptime checks are set up
+    - name: Ensure uptime checks are set up
       run: |
         cd terraform/uptime-checks
         # Decrypt the GCP ServiceAccount key with permissions to run terraform

--- a/build-tools/environment.yaml
+++ b/build-tools/environment.yaml
@@ -1,13 +1,14 @@
 name: build-tools
 channels:
-- conda-forge
-- nodefaults
+  - conda-forge
+  - nodefaults
 dependencies:
-- google-cloud-sdk 570.*
-- go-sops >=3.13.1,<4
-- kubernetes-helm 3.17.0.*
-- go-jsonnet >=0.22.0,<0.23
-- git
-- kubernetes >=1.34.3,<2
-- pip
-- python=3.13.*
+  - google-cloud-sdk 570.*
+  - go-sops >=3.13.1,<4
+  - kubernetes-helm 3.17.0.*
+  - go-jsonnet >=0.22.0,<0.23
+  - git
+  - kubernetes >=1.34.3,<2
+  - terraform >=1.15.6,<1.16.0
+  - pip
+  - python=3.13.*


### PR DESCRIPTION
In order to improve deployment robustness, I'm replacing "only provision what you need" workflows that e.g. only set up sops with workflows that use the full environment.