### PR TITLE
[earthscope, *] Update common.values.yaml

### DIFF
--- a/build-tools/environment.yaml
+++ b/build-tools/environment.yaml
@@ -1,14 +1,14 @@
 name: build-tools
 channels:
-  - conda-forge
-  - nodefaults
+- conda-forge
+- nodefaults
 dependencies:
-  - google-cloud-sdk 570.*
-  - go-sops >=3.13.1,<4
-  - kubernetes-helm 3.17.0.*
-  - go-jsonnet >=0.22.0,<0.23
-  - git
-  - kubernetes >=1.34.3,<2
-  - terraform >=1.15.6,<1.16.0
-  - pip
-  - python=3.13.*
+- google-cloud-sdk 570.*
+- go-sops >=3.13.1,<4
+- kubernetes-helm 3.17.0.*
+- go-jsonnet >=0.22.0,<0.23
+- git
+- kubernetes >=1.34.3,<2
+- terraform >=1.15.6,<1.16.0
+- pip
+- python=3.13.*

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -247,6 +247,9 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-sm
+                - vm-md
+                - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 3902839759
                   mem_limit: 3902839759
@@ -262,6 +265,9 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-sm
+                - vm-md
+                - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 7805679519
                   mem_limit: 7805679519
@@ -277,6 +283,9 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-sm
+                - vm-md
+                - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 15611359038
                   mem_limit: 15611359038
@@ -292,6 +301,9 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-sm
+                - vm-md
+                - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 31222718077
                   mem_limit: 31222718077
@@ -306,6 +318,8 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-md
+                - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 64020707016
                   mem_limit: 64020707016
@@ -320,6 +334,7 @@ basehub:
                 - geolab:dev
                 - geolab:power
                 - vm-lg
+                - vm-xl
                 kubespawner_override:
                   mem_guarantee: 128041414033
                   mem_limit: 128041414033


### PR DESCRIPTION
Since we are only passing the largest of a user's magic strings in each category in the acces token, vm-sizes should enable access to all servers smaller than the users max vm size.