### PR TITLE
Bump the dev env flake, and add eksctl version

### DIFF
--- a/build-tools/environment.yaml
+++ b/build-tools/environment.yaml
@@ -3,9 +3,14 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+  # Pins by compatibility
+  ## Upper bound / hard pins
 - google-cloud-sdk 570.*
-- go-sops >=3.13.1,<4
 - kubernetes-helm 3.17.0.*
+  ## Lower bound
+- eksctl >=0.221.0,<=0.228.*
+  # Pins to reduce variance
+- go-sops >=3.13.1,<4
 - go-jsonnet >=0.22.0,<0.23
 - git
 - kubernetes >=1.34.3,<2

--- a/docs/hub-deployment-guide/new-cluster/new-cluster.md
+++ b/docs/hub-deployment-guide/new-cluster/new-cluster.md
@@ -223,11 +223,11 @@ Make sure to run this command **inside** the `eksctl` directory, otherwise it ca
 ```
 
 ```{note}
-The `--install-nvidia-plugin=false` flag is only required whilst https://github.com/eksctl-io/eksctl/issues/8550 remains unfixed and unreleased.
+`eksctl>=0.221.0` is needed to fix GPU plugin support.
 ```
 
 ```bash
-eksctl create cluster --config-file=$CLUSTER_NAME.eksctl.yaml --install-nvidia-plugin=false 
+eksctl create cluster --config-file=$CLUSTER_NAME.eksctl.yaml 
 ```
 
 This might take a few minutes.

--- a/flake.lock
+++ b/flake.lock
@@ -25,33 +25,33 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1780145889,
+        "narHash": "sha256-md0zn0RnwNvPyASas1yG5YUuwQ4ALA6ucL50l0DvqCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
         "type": "github"
       }
     },
     "nixpkgs-gcloud": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1780145889,
+        "narHash": "sha256-md0zn0RnwNvPyASas1yG5YUuwQ4ALA6ucL50l0DvqCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "8c50a710ddca43d7a530fb805ad55bde8d0141c5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,11 @@
 {
   inputs = {
     nixpkgs-helm.url = "github:NixOS/nixpkgs/9b100cfb67ccb2ff6e723b78d4ae2f9c88654a1c";
-    nixpkgs-gcloud.url = "github:NixOS/nixpkgs/5912c1772a44e31bf1c63c0390b90501e5026886";
     # Perf: use a fixed hash to maximise overlap with other nixpkgs.
     #       nixpkgs _can_ be updated, but no need.
     # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs.url = "github:NixOS/nixpkgs/5912c1772a44e31bf1c63c0390b90501e5026886";
+    nixpkgs-gcloud.url = "github:NixOS/nixpkgs/8c50a710ddca43d7a530fb805ad55bde8d0141c5";
+    nixpkgs.url = "github:NixOS/nixpkgs/8c50a710ddca43d7a530fb805ad55bde8d0141c5";
 
     dev-python = {
       url = "github:agoose77/dev-flakes/v10?dir=python";


### PR DESCRIPTION
This adds eksctl to the build environment, and sets its version LB so that in future we can use the device plugin again.