### PR TITLE
Remove custom tags for fancy-profiles 0.6.0

### DIFF
--- a/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
+++ b/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
@@ -48,9 +48,6 @@ jupyterhub:
           name: 2i2c
           url: https://2i2c.org
   hub:
-    image:
-      # Temporary image with jupyterhub-fancy-profiles 0.6.0
-      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
     allowNamedServers: true
     extraConfig:
       01-orcid: |

--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -32,9 +32,6 @@ jupyterhub:
           name: NASA
           url: https://www.earthdata.nasa.gov/esds
   hub:
-    image:
-      # Temporary image with jupyterhub-fancy-profiles 0.6.0
-      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
     allowNamedServers: true
     loadRoles:
       server:

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -51,9 +51,6 @@ jupyterhub:
           name: NASA
           url: https://www.earthdata.nasa.gov/esds
   hub:
-    image:
-      # Temporary image with jupyterhub-fancy-profiles 0.6.0
-      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
     allowNamedServers: true
     loadRoles:
       server:

--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -41,9 +41,6 @@ basehub:
             name: NASA ICESat-2 Science Team
             url: https://icesat-2.gsfc.nasa.gov/science_definition_team
     hub:
-      image:
-        # Temporary image with jupyterhub-fancy-profiles 0.6.0
-        tag: 0.0.1-0.dev.git.15540.hbaaa997ce
       allowNamedServers: true
       config:
         JupyterHub:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -47,9 +47,6 @@ basehub:
             name: NASA
             url: https://www.earthdata.nasa.gov/esds
     hub:
-      image:
-        # Temporary image with jupyterhub-fancy-profiles 0.6.0
-        tag: 0.0.1-0.dev.git.15540.hbaaa997ce
       allowNamedServers: true
       loadRoles:
         server:

--- a/config/clusters/projectpythia/common.values.yaml
+++ b/config/clusters/projectpythia/common.values.yaml
@@ -35,9 +35,6 @@ jupyterhub:
         scopes:
         - self
         - admin:auth_state!user
-    image:
-      # Temporary image with jupyterhub-fancy-profiles 0.6.0
-      tag: 0.0.1-0.dev.git.15540.hbaaa997ce
     allowNamedServers: true
     extraConfig:
       00-set-gitconfig.py: |


### PR DESCRIPTION
We recently rolled this out to all of our hubs, so now we do not need these exceptions.