### PR TITLE
[utoronto, r-staging] Use new dev key for Canvas authentication

### DIFF
--- a/config/clusters/utoronto/enc-r-staging.secret.values.yaml
+++ b/config/clusters/utoronto/enc-r-staging.secret.values.yaml
@@ -6,17 +6,17 @@ jupyterhub:
   hub:
     config:
       GenericOAuthenticator:
-        client_id: ENC[AES256_GCM,data:3iXy31r8mXNFnuJTO2iay5F2,iv:rzL3jdcIfDrlpdMfapLed+Mi+aNUjSaSOyVuWujk1R0=,tag:Hm5eN0cKyfYKCXglA7MHfQ==,type:str]
-        client_secret: ENC[AES256_GCM,data:6I1lsIDxmgYTlwOgyjfEy8fmYcD26KxhatLHmfJE0zodF7WsUiG27S8pp9FKi4+UI9GE8Vm/+UqcqB9SQU+L/A==,iv:C+QbHmDamkhYrNTrp6NQAGPQaDWwsxOQ4x6cXfM4L5A=,tag:LFmuC1Nv8iXW026F4Pu2bg==,type:str]
+        client_id: ENC[AES256_GCM,data:z0OCyU92ZykzEGFbDU0URWLF,iv:YttIXKpNDU+v/yJB4DRl/XhmK58k8ukntpYLwwMuSnE=,tag:UayS73jTuduyRsU1zuY34Q==,type:str]
+        client_secret: ENC[AES256_GCM,data:qNoW0+jv/i1zb738ELo2mBVU5QLHJwfrAzpwlk9qyB3oZ0PMLMkU1Q00cWV8YiKC77TShXsIjy2TCvFS0Z/+gw==,iv:qQV0Jm5DWpIGDn/DR5burcl8RJ/mp18IUfjJL6bb1/M=,tag:vjfVIAv8zipxzC9ro3+pCA==,type:str]
       CILogonOAuthenticator:
         client_id: ENC[AES256_GCM,data:DnYA2sJgWkCCZpCTjoZ5XcxhO1uhfV9dch13K9erQQK8IXB2IMnHd64c+KcqzQI12Uiw,iv:uF0FhQFmFgFbTv+sXAW819XSDHFdMqmmudDqLOylGxw=,tag:GY+fEBPtB/RbB/DrOeUkFg==,type:str]
         client_secret: ENC[AES256_GCM,data:xgxkU5aVMuwgnf8lWSrBpUyyft6SqKC8+FOoQpGu1cUTSR53IeXfUuC5s7I4EbTGFhsaLTSPtbtZyEGOqnlV5Zfi7sS3fDk5fhfiEnzh0RyS0mWoS34=,iv:LI1owPscYbUbuHZM03qsNS6JwWQfU+gHXqFsiKv0AwM=,tag:JmRu/X/KFUZOibeJ+LzJBw==,type:str]
 sops:
   gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-06-09T16:43:26Z'
+  - created_at: '2023-06-09T16:43:26Z'
     enc: CiUA4OM7eImkcPappqi2n0nibml1DPRAQdUjOFw04tqZ+3ebMwtEEkkAyiwFHGWVXZSIevQL7zrgJ3eTBe6NU2wds/R9pPUg3Fo1fLE2KLDRB+eZRo8fj/y8jF4vskd5ORolrC8DNNM/0FagXz5ThO0f
-  lastmodified: '2026-03-25T17:43:58Z'
-  mac: ENC[AES256_GCM,data:HGuSV2Ie1sAtp50fJx/AzMRfax2wbbqyynSqzp6SjS6tV1hTa2IqgxiMD2wM/ZSS6u94Bu+nv8pmbbSaGVCe8NFw+Vh3Vi9VHgB0/8gNaXYix/a4vsKxXo0Fnh/L7+QEOb9Uo2gbL0hBmjj0tw/2GYast3K0aY7niyYiKihNRrI=,iv:5Rp9E2IGvArDiRWa0u7lMMbIjMs9BoQS//zruuWC9Ok=,tag:P6Qo6PrcQ3adBeT9iss6gw==,type:str]
+    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+  lastmodified: '2026-06-25T15:48:19Z'
+  mac: ENC[AES256_GCM,data:9Rhd7QV/fUSOuF0ubvlnBwQBLNTbXaK56t4nfpGCzI0itF3G6/3p6CFWm1fa9mlEKEgsmCyH2ErEKXIprgmqOwnwsKghaNeriNrC4firo2C0w78GAJfKpynK1LIT+N3paoISBAF4Guo8L6dBumSHoDduOT9pnnjaT5Pik73WeVg=,iv:a86F+tPqYwQQP/j3SU/S+BSGDYRZgSn/b+6SgHmoZgs=,tag:KrSqv+4DL/W0+GmGLuzuAQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.13.1


### PR DESCRIPTION
This is in preparation for the production roll-out using a single key.