### PR TITLE
Queue GitHub deployments

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -46,6 +46,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || 'not-a-pr' }}
   cancel-in-progress: false
+  # Queue deployments in order
+  queue: max
 
 env:
   TERM: xterm


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/infrastructure/issues/8630, where _pending_ concurrent jobs in the same concurrency groups are cancelled. In our case, the concurrency group key for `main` deployments is just the workflow name.


This PR now enforces queuing.