### PR TITLE
[CloudBank] Add morehouse.edu to CAU hub allowed domains

### DIFF
--- a/config/clusters/cloudbank/cau.values.yaml
+++ b/config/clusters/cloudbank/cau.values.yaml
@@ -35,6 +35,7 @@ jupyterhub:
               username_claim: email
             allowed_domains:
             - cau.edu
+            - morehouse.edu
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: email


### PR DESCRIPTION
Adds `morehouse.edu` to the allowed domains on the Microsoft (Outlook) IdP for the **CAU** (Clark Atlanta University) hub, so Morehouse College users can log into the existing shared hub.

Morehouse runs on Microsoft 365 (same IdP CAU already uses as its default), so this is a one-line `allowed_domains` addition — no new CILogon client, terraform disk, or separate hub.

Shared-hub arrangement for now (Atlanta University Center consortium).
