### PR TITLE
[CloudBank] Switch CAU hub to shared-password auth

### DIFF
--- a/config/clusters/cloudbank/cau.values.yaml
+++ b/config/clusters/cloudbank/cau.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
   custom:
     2i2c:
       add_staff_user_ids_of_type: google
-      add_staff_user_ids_to_admin_users: true
+      add_staff_user_ids_to_admin_users: false
     homepage:
       templateVars:
         designed_by:
@@ -26,19 +26,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - cau.edu
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: email
+        authenticator_class: shared-password
       Authenticator:
+        manage_groups: false
+        # Allow everyone with the shared password to log in
+        allow_all: true
         admin_users:
         - sean.smorris@berkeley.edu
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/enc-cau.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-cau.secret.values.yaml
@@ -1,23 +1,23 @@
 jupyterhub:
-    hub:
-        config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:CFRqEnCKHoBj+wEEooOlUftjeoH9oHO9yl5JnsaCEz2gcWptbhJfcd4vnCnT6T6xhhPU,iv:z7wqdwHLhjk3NnpCNUbwEjwtgEo8bj2MHhpgqHT0qwo=,tag:8F2lj7vAsTiGengMvA83xQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:uZa45XAgLdnYwOrwz/XTKdnhq05nEuiPBxSQCezGVufMpHnDV7fv1FemFgUJ5zkZ3/cU+jcQxrhED4al4PLsq5kfTRibgZfnxWEVCiOJXgOwKAAKkZM=,iv:6JK5JIZqjp07fCJhLbqsUllPBdc+evpuPzNrjcMh5xY=,tag:HhsfOBhz54IvmvJf8NBpdA==,type:str]
-            SharedPasswordAuthenticator:
-                user_password: ENC[AES256_GCM,data:9lJrfmcsHsbhfDloxDfa,iv:heApW1qYq8VPOHz4mUD+5Rb5JReszeWf3TDkQQexhqM=,tag:sn9hEGCP26q39A8diiO4kw==,type:str]
-                admin_password: ENC[AES256_GCM,data:QXw34Z5Lxp/JG7M0yT0rnBO3tAlrAqn8QQ5qoxYdksLt9RYwqsi+mqKTiiHce+l4,iv:OxUaMTXupHqBXe7gmgOXub+VV+huAWrnk3Mxj7rQ6Uk=,tag:rB1Ue+hkbpmV0B+S1L400A==,type:str]
+  hub:
+    config:
+      CILogonOAuthenticator:
+        client_id: ENC[AES256_GCM,data:CFRqEnCKHoBj+wEEooOlUftjeoH9oHO9yl5JnsaCEz2gcWptbhJfcd4vnCnT6T6xhhPU,iv:z7wqdwHLhjk3NnpCNUbwEjwtgEo8bj2MHhpgqHT0qwo=,tag:8F2lj7vAsTiGengMvA83xQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:uZa45XAgLdnYwOrwz/XTKdnhq05nEuiPBxSQCezGVufMpHnDV7fv1FemFgUJ5zkZ3/cU+jcQxrhED4al4PLsq5kfTRibgZfnxWEVCiOJXgOwKAAKkZM=,iv:6JK5JIZqjp07fCJhLbqsUllPBdc+evpuPzNrjcMh5xY=,tag:HhsfOBhz54IvmvJf8NBpdA==,type:str]
+      SharedPasswordAuthenticator:
+        user_password: ENC[AES256_GCM,data:9lJrfmcsHsbhfDloxDfa,iv:heApW1qYq8VPOHz4mUD+5Rb5JReszeWf3TDkQQexhqM=,tag:sn9hEGCP26q39A8diiO4kw==,type:str]
+        admin_password: ENC[AES256_GCM,data:QXw34Z5Lxp/JG7M0yT0rnBO3tAlrAqn8QQ5qoxYdksLt9RYwqsi+mqKTiiHce+l4,iv:OxUaMTXupHqBXe7gmgOXub+VV+huAWrnk3Mxj7rQ6Uk=,tag:rB1Ue+hkbpmV0B+S1L400A==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-06-26T19:31:41Z"
-          enc: CiUA4OM7eE+4PZaNWiOjo+YMp+gznqwoJvVZzF4F92s38aw4gOfrEkkAmy+ekqTQZrAE//DkHJDtDEAgRZSuDjtqvY7YuXWqiwFTs/zTBPTUZEL9RwZSr6OUU3w+vYNm1LZMA3+dBId0QuI0j2KqajjF
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-06-26T19:31:41Z"
-    mac: ENC[AES256_GCM,data:ntLqUWT5T9qJlcHusEl+JnNBbZSUlnnzH1VUP7dRTuX0Ka9q4w1EisLIzjLm+0bpMCU1ojn2xQ4eHhrM81OLNHf6Uyoqp6hLena+AJZDZR9ATEevZF/Wl1bnwxl9LSy6UBqjeebsLJbMQ5D6g7mPLqjp2xjQCE7GTKwLUNUIfNc=,iv:IrT5yS1UPXMvhKnFYxsMSjV/XDqRFbRwIoEglPcDRqI=,tag:IpVq6SLk1q0cy2KmQKFTNw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-26T19:31:41Z'
+    enc: CiUA4OM7eE+4PZaNWiOjo+YMp+gznqwoJvVZzF4F92s38aw4gOfrEkkAmy+ekqTQZrAE//DkHJDtDEAgRZSuDjtqvY7YuXWqiwFTs/zTBPTUZEL9RwZSr6OUU3w+vYNm1LZMA3+dBId0QuI0j2KqajjF
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-06-26T19:31:41Z'
+  mac: ENC[AES256_GCM,data:ntLqUWT5T9qJlcHusEl+JnNBbZSUlnnzH1VUP7dRTuX0Ka9q4w1EisLIzjLm+0bpMCU1ojn2xQ4eHhrM81OLNHf6Uyoqp6hLena+AJZDZR9ATEevZF/Wl1bnwxl9LSy6UBqjeebsLJbMQ5D6g7mPLqjp2xjQCE7GTKwLUNUIfNc=,iv:IrT5yS1UPXMvhKnFYxsMSjV/XDqRFbRwIoEglPcDRqI=,tag:IpVq6SLk1q0cy2KmQKFTNw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-cau.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-cau.secret.values.yaml
@@ -1,20 +1,23 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:+QIJaQPFcdqrWi1EcyYLpQHok5VEARI0UUBWA7BwrWTUUAKtmy9T0L/1SA0l4uGDHxr9,iv:51oraeagC3qPdCGTA5bkJDpYyu/3zJYXopu2dGzSRTM=,tag:V2WkmbxS93eN+UFBVTziEA==,type:str]
-        client_secret: ENC[AES256_GCM,data:4ocSK0daGh2vIVxIorN6nejyk763JpuwoACBeWz4x5n9dYGOsY62GlCaszdAHNT0oXoS1X4MKBJ8rFH+ZqFvFd+jdUT9M3aPjbPb/LhO7UH4IFWxNa8=,iv:mkHctnFEb8h0dAY4XlxHkJ6KpOwJgHutZewDedvfnwA=,tag:NnGXsfZ0uUu+FFHQznzR7g==,type:str]
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:CFRqEnCKHoBj+wEEooOlUftjeoH9oHO9yl5JnsaCEz2gcWptbhJfcd4vnCnT6T6xhhPU,iv:z7wqdwHLhjk3NnpCNUbwEjwtgEo8bj2MHhpgqHT0qwo=,tag:8F2lj7vAsTiGengMvA83xQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:uZa45XAgLdnYwOrwz/XTKdnhq05nEuiPBxSQCezGVufMpHnDV7fv1FemFgUJ5zkZ3/cU+jcQxrhED4al4PLsq5kfTRibgZfnxWEVCiOJXgOwKAAKkZM=,iv:6JK5JIZqjp07fCJhLbqsUllPBdc+evpuPzNrjcMh5xY=,tag:HhsfOBhz54IvmvJf8NBpdA==,type:str]
+            SharedPasswordAuthenticator:
+                user_password: ENC[AES256_GCM,data:9lJrfmcsHsbhfDloxDfa,iv:heApW1qYq8VPOHz4mUD+5Rb5JReszeWf3TDkQQexhqM=,tag:sn9hEGCP26q39A8diiO4kw==,type:str]
+                admin_password: ENC[AES256_GCM,data:QXw34Z5Lxp/JG7M0yT0rnBO3tAlrAqn8QQ5qoxYdksLt9RYwqsi+mqKTiiHce+l4,iv:OxUaMTXupHqBXe7gmgOXub+VV+huAWrnk3Mxj7rQ6Uk=,tag:rB1Ue+hkbpmV0B+S1L400A==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-06-19T21:24:09Z'
-    enc: CiUA4OM7eFSKYSnt7EL9fME51H53C3rXWH8nX1MaxU/DtNEwfRpmEkkAmy+ekgroNKsvVywtNnCcMI7XD/O8Muh0HAEEjtPpMyQgkgAMPTdpZruR+Y6QnmGLl9Dh35xeU5+00dU1LbaujE8Gbh2ozmlb
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-06-19T21:24:10Z'
-  mac: ENC[AES256_GCM,data:7eX1KrLy9PyW4ntqG+4rZXSWW1+9OM7QaYjsUhThDrG3R2urv/OM5zPT5e8TTMZfZDdVGUHyu5o9zLjKIzsBtM3P8InYNbwptJRkIxxg4tIZeh8l75js/4Mg2dsutro/VFDsbAgR47mH3icTQHzU4vo6mM2NruzedNjooBWxwXo=,iv:+vVl8SoTPWrzUal2xX/dxsP5YvDERSNOs3IHdUt1R2c=,tag:2fZXdDzYFMsCs3GvG+vitQ==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.8.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-06-26T19:31:41Z"
+          enc: CiUA4OM7eE+4PZaNWiOjo+YMp+gznqwoJvVZzF4F92s38aw4gOfrEkkAmy+ekqTQZrAE//DkHJDtDEAgRZSuDjtqvY7YuXWqiwFTs/zTBPTUZEL9RwZSr6OUU3w+vYNm1LZMA3+dBId0QuI0j2KqajjF
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-06-26T19:31:41Z"
+    mac: ENC[AES256_GCM,data:ntLqUWT5T9qJlcHusEl+JnNBbZSUlnnzH1VUP7dRTuX0Ka9q4w1EisLIzjLm+0bpMCU1ojn2xQ4eHhrM81OLNHf6Uyoqp6hLena+AJZDZR9ATEevZF/Wl1bnwxl9LSy6UBqjeebsLJbMQ5D6g7mPLqjp2xjQCE7GTKwLUNUIfNc=,iv:IrT5yS1UPXMvhKnFYxsMSjV/XDqRFbRwIoEglPcDRqI=,tag:IpVq6SLk1q0cy2KmQKFTNw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
Switches the **CAU** (Clark Atlanta University) hub from CILogon to **shared-password** authentication, matching the gpu-demo hub's setup.

- `authenticator_class: shared-password` with `allow_all: true` so anyone with the shared password can log in (covers cau.edu and morehouse.edu users without per-domain config).
- Shared user password + admin password added to `enc-cau.secret.values.yaml` under `SharedPasswordAuthenticator`. The existing CILogon client creds are left in place so reverting to SSO is a one-line change.
- `add_staff_user_ids_to_admin_users` set to false (no OAuth identity to map staff IDs against under shared-password).

Supersedes #8637 (adding morehouse.edu to CILogon allowed_domains) — that path is no longer used.
