### PR TITLE
[CloudBank] Fix CAU login: use unify-logins-2 homepage branch for shared-password form

### DIFF
--- a/config/clusters/cloudbank/cau.values.yaml
+++ b/config/clusters/cloudbank/cau.values.yaml
@@ -9,6 +9,7 @@ jupyterhub:
       add_staff_user_ids_of_type: google
       add_staff_user_ids_to_admin_users: false
     homepage:
+      gitRepoBranch: unify-logins-2
       templateVars:
         designed_by:
           name: 2i2c


### PR DESCRIPTION
Follow-up to #8638 (CAU switched to shared-password auth).

**Symptom:** the CAU login page showed only a "Sign in" button that looped back to `/hub/login` — no username/password fields — so nobody could log in.

**Cause:** CAU inherited the basehub default homepage template branch `master`, whose `login.html` only renders the OAuth-style "Sign in" button. `SharedPasswordAuthenticator` needs the username/password form, which lives in the `unify-logins-2` branch of `2i2c-org/default-hub-homepage` — the same branch the working gpu-demo shared-password hub pins.

**Fix:** pin `custom.homepage.gitRepoBranch: unify-logins-2` for CAU, matching gpu-demo.

Verified against the live cluster: gpu-demo (unify-logins-2) renders the password form; CAU (master) did not.
