### PR TITLE
[CloudBank] OIT user image tag gui-demo

### DIFF
--- a/config/clusters/cloudbank/oit.values.yaml
+++ b/config/clusters/cloudbank/oit.values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
       limit: 4G
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/c-sharp-user-image
-      tag: ee7f63c2b8e4
+      tag: gui-demo
   custom:
     2i2c:
       add_staff_user_ids_of_type: google


### PR DESCRIPTION
Updates the OIT (Oregon Institute of Technology) C# user image tag to gui-demo.

This change was already deployed to the running hub; this PR persists it to config so a redeploy from main doesn't revert it.
