### PR TITLE
[CloudBank] High inherit common user image

### DIFF
--- a/config/clusters/cloudbank/high.values.yaml
+++ b/config/clusters/cloudbank/high.values.yaml
@@ -7,9 +7,6 @@ jupyterhub:
     cpu:
       guarantee: 1
       limit: 2
-    image:
-      name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/java-user-image
-      tag: ee5edaf8759d
     storage:
       extraVolumeMounts:
       extraVolumes:


### PR DESCRIPTION
Removes the pinned java-user-image override from the high hub so it inherits the cloudbank common singleuser image (base-user-image) from common.values.yaml.

The stale pinned image tag was the cause of the issue on high.cloudbank.2i2c.cloud.
