### PR TITLE
[CloudBank] Cloud County Community College Added

### DIFF
--- a/config/clusters/cloudbank/cloud-county.values.yaml
+++ b/config/clusters/cloudbank/cloud-county.values.yaml
@@ -1,0 +1,52 @@
+jupyterhub:
+  singleuser:
+    defaultUrl: /lab
+    memory:
+      guarantee: 512M
+      limit: 1G
+  custom:
+    2i2c:
+      add_staff_user_ids_of_type: google
+      add_staff_user_ids_to_admin_users: true
+    homepage:
+      templateVars:
+        designed_by:
+          name: 2i2c
+          url: https://2i2c.org
+        funded_by:
+          name: CloudBank
+          url: http://cloudbank.org/
+        operated_by:
+          name: CloudBank
+          url: http://cloudbank.org/
+        org:
+          logo_url: https://www.cloud.edu/Assets/templates/header/TBird.jpg
+          name: Cloud County Community College
+          url: https://www.cloud.edu/
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: cilogon
+      CILogonOAuthenticator:
+        allowed_idps:
+          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
+            username_derivation:
+              username_claim: email
+            allowed_domains:
+            - tbirds.cloud.edu
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: email
+      Authenticator:
+        admin_users:
+        - sean.smorris@berkeley.edu
+        - ericvd@berkeley.edu
+        - rlombard@tbirds.cloud.edu
+jupyterhub-home-nfs:
+  gke:
+    volumeId: projects/cb-1003-1696/zones/us-central1-b/disks/hub-nfs-homedirs-cloud-county
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 10 # in GiB

--- a/config/clusters/cloudbank/cluster.yaml
+++ b/config/clusters/cloudbank/cluster.yaml
@@ -112,6 +112,14 @@ hubs:
   - common.values.yaml
   - clarku.values.yaml
   - enc-clarku.secret.values.yaml
+- name: cloud-county
+  display_name: Cloud County Community College
+  domain: cloud-county.cloudbank.2i2c.cloud
+  helm_chart: basehub
+  helm_chart_values_files:
+  - common.values.yaml
+  - cloud-county.values.yaml
+  - enc-cloud-county.secret.values.yaml
 - name: cmu
   display_name: Carnegie Mellon University
   domain: cmu.cloudbank.2i2c.cloud

--- a/config/clusters/cloudbank/enc-cloud-county.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-cloud-county.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:6MO1Sk9SDf4uOeJi5jV32KINQ+vOoaMKwXVFoKaK1lU4JJD6VEAG1rb7KS9LZKt1bZc=,iv:Onus+stce9Gf1ZuurlBrHL+1y4IAt8MaAHl+nUJmEyQ=,tag:8GpNMUXxy0HHgqWyLil+eg==,type:str]
-                client_secret: ENC[AES256_GCM,data:rEzR+u2LDm1mrNYTp4/8Q0AJsTNbb1YKSquTjVeTVdtx6/EZBRG9YkeY7Yxuxh+jKoMb6qRG7F7OVCOayCThGCwhiZBBARjDDLsrCHlSHE3kHc4PKJ4=,iv:H9veSSCiH7s4JcZi2WpEEYWqTBKiLFgkAbyNxRIs5rg=,tag:aWd8eKZAU/qeTtthyywaEA==,type:str]
+  hub:
+    config:
+      CILogonOAuthenticator:
+        client_id: ENC[AES256_GCM,data:6MO1Sk9SDf4uOeJi5jV32KINQ+vOoaMKwXVFoKaK1lU4JJD6VEAG1rb7KS9LZKt1bZc=,iv:Onus+stce9Gf1ZuurlBrHL+1y4IAt8MaAHl+nUJmEyQ=,tag:8GpNMUXxy0HHgqWyLil+eg==,type:str]
+        client_secret: ENC[AES256_GCM,data:rEzR+u2LDm1mrNYTp4/8Q0AJsTNbb1YKSquTjVeTVdtx6/EZBRG9YkeY7Yxuxh+jKoMb6qRG7F7OVCOayCThGCwhiZBBARjDDLsrCHlSHE3kHc4PKJ4=,iv:H9veSSCiH7s4JcZi2WpEEYWqTBKiLFgkAbyNxRIs5rg=,tag:aWd8eKZAU/qeTtthyywaEA==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-06-30T16:50:29Z"
-          enc: CiUA4OM7eCkG3hQAcU859tH+u+4lhhm+oR3J8wDiNIy07oEo6+BYEkkAmy+ekvczY9rm1WdrTuWABwwb0bQDQaTjvSwmvQrFUPiy70rgkSGVNi7EosDER4Re7dpT4Hio6jD2NBgzdJdMPzpkgRDqFUIJ
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-06-30T16:50:30Z"
-    mac: ENC[AES256_GCM,data:DKF7DYDp8Ow4zevpZvl4IAWFfvrK+lgXE1zl0RBKw20uEmDmsz+U7C0X80O1rFYqoZpsY09XK+F8b7K3SBWg5SsmbTZBC9te/7ZG5DNZlH46JRhwHDs3lF2t9iOQs/Opp2q0Nnb3r2HF2hm6I3NYAdwqytUpKET4YP8NWO2/mb0=,iv:noTOWdKYYRjhqanDYYHHJ3Zn6NdpFInhZVmtpS2xyfE=,tag:ZEs1A+xUMiZ0mXhX+Q+RyA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-30T16:50:29Z'
+    enc: CiUA4OM7eCkG3hQAcU859tH+u+4lhhm+oR3J8wDiNIy07oEo6+BYEkkAmy+ekvczY9rm1WdrTuWABwwb0bQDQaTjvSwmvQrFUPiy70rgkSGVNi7EosDER4Re7dpT4Hio6jD2NBgzdJdMPzpkgRDqFUIJ
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-06-30T16:50:30Z'
+  mac: ENC[AES256_GCM,data:DKF7DYDp8Ow4zevpZvl4IAWFfvrK+lgXE1zl0RBKw20uEmDmsz+U7C0X80O1rFYqoZpsY09XK+F8b7K3SBWg5SsmbTZBC9te/7ZG5DNZlH46JRhwHDs3lF2t9iOQs/Opp2q0Nnb3r2HF2hm6I3NYAdwqytUpKET4YP8NWO2/mb0=,iv:noTOWdKYYRjhqanDYYHHJ3Zn6NdpFInhZVmtpS2xyfE=,tag:ZEs1A+xUMiZ0mXhX+Q+RyA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-cloud-county.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-cloud-county.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:6MO1Sk9SDf4uOeJi5jV32KINQ+vOoaMKwXVFoKaK1lU4JJD6VEAG1rb7KS9LZKt1bZc=,iv:Onus+stce9Gf1ZuurlBrHL+1y4IAt8MaAHl+nUJmEyQ=,tag:8GpNMUXxy0HHgqWyLil+eg==,type:str]
+                client_secret: ENC[AES256_GCM,data:rEzR+u2LDm1mrNYTp4/8Q0AJsTNbb1YKSquTjVeTVdtx6/EZBRG9YkeY7Yxuxh+jKoMb6qRG7F7OVCOayCThGCwhiZBBARjDDLsrCHlSHE3kHc4PKJ4=,iv:H9veSSCiH7s4JcZi2WpEEYWqTBKiLFgkAbyNxRIs5rg=,tag:aWd8eKZAU/qeTtthyywaEA==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-06-30T16:50:29Z"
+          enc: CiUA4OM7eCkG3hQAcU859tH+u+4lhhm+oR3J8wDiNIy07oEo6+BYEkkAmy+ekvczY9rm1WdrTuWABwwb0bQDQaTjvSwmvQrFUPiy70rgkSGVNi7EosDER4Re7dpT4Hio6jD2NBgzdJdMPzpkgRDqFUIJ
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-06-30T16:50:30Z"
+    mac: ENC[AES256_GCM,data:DKF7DYDp8Ow4zevpZvl4IAWFfvrK+lgXE1zl0RBKw20uEmDmsz+U7C0X80O1rFYqoZpsY09XK+F8b7K3SBWg5SsmbTZBC9te/7ZG5DNZlH46JRhwHDs3lF2t9iOQs/Opp2q0Nnb3r2HF2hm6I3NYAdwqytUpKET4YP8NWO2/mb0=,iv:noTOWdKYYRjhqanDYYHHJ3Zn6NdpFInhZVmtpS2xyfE=,tag:ZEs1A+xUMiZ0mXhX+Q+RyA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -55,6 +55,10 @@ persistent_disks = {
     size        = 25
     name_suffix = "clarku"
   }
+  "cloud-county" = {
+    size        = 25
+    name_suffix = "cloud-county"
+  }
   "cmu" = {
     size        = 25
     name_suffix = "cmu"


### PR DESCRIPTION
Adds Cloud County Community College as a new CloudBank hub.

- **Hub:** cloud-county — domain cloud-county.cloudbank.2i2c.cloud
- **Auth:** CILogon. Microsoft (login.microsoftonline.com) as the default IdP, domain-restricted to tbirds.cloud.edu, with a Google fallback IdP. (Cloud County is not in CILogon's registered IdP list; tbirds.cloud.edu MX resolves to Microsoft 365.)
- **Admin:** rlombard@tbirds.cloud.edu (plus the standard 2i2c/CloudBank admins).
- **Storage:** 25GB home-dir NFS disk + daily snapshot schedule (terraform applied: 3 added, 0 changed, 0 destroyed).
- CILogon OAuth client cloudbank-cloud-county created; credentials in enc-cloud-county.secret.values.yaml.

Note: allowed_domains is tbirds.cloud.edu (the contact's domain). If students/staff log in with @cloud.edu addresses, that domain should be added — to be confirmed with the contact.
