### PR TITLE
[CloudBank] Toledo switch to tensorflow-notebook image

### DIFF
--- a/config/clusters/cloudbank/toledo.values.yaml
+++ b/config/clusters/cloudbank/toledo.values.yaml
@@ -3,7 +3,7 @@ jupyterhub:
     defaultUrl: /lab
     image:
       name: quay.io/jupyter/tensorflow-notebook
-      tag: "2026-06-29"
+      tag: '2026-06-29'
     memory:
       guarantee: 512M
       limit: 1G

--- a/config/clusters/cloudbank/toledo.values.yaml
+++ b/config/clusters/cloudbank/toledo.values.yaml
@@ -1,6 +1,9 @@
 jupyterhub:
   singleuser:
     defaultUrl: /lab
+    image:
+      name: quay.io/jupyter/tensorflow-notebook
+      tag: "2026-06-29"
     memory:
       guarantee: 512M
       limit: 1G


### PR DESCRIPTION
Switches the Toledo hub's singleuser image to the Jupyter Docker Stacks TensorFlow notebook image.

- Image: quay.io/jupyter/tensorflow-notebook:2026-06-29 (CPU-native tensorflow-cpu build, multi-arch; runs as CPU on the cluster's amd64 nodes).
- Reason: Toledo's notebooks (Energy-Lab labs) require TensorFlow plus numpy/pandas/matplotlib/seaborn/ipywidgets. The previous image (inherited cal-icor base-user-image) had no TensorFlow, forcing `pip install --user tensorflow` in notebooks.
- This image (docker-stacks, FROM scipy-notebook) ships all required packages: TensorFlow 2.21.x, plus the full scipy stack. Chosen over pangeo/ml-notebook because Toledo is CPU-only and the Pangeo ML image is a heavy CUDA build.
