### PR TITLE
[cloudbank] Bump Prometheus disk

### DIFF
--- a/config/clusters/cloudbank/support.values.yaml
+++ b/config/clusters/cloudbank/support.values.yaml
@@ -6,7 +6,7 @@ prometheus:
       requests:
         memory: 5.5Gi
     persistentVolume:
-      size: 750Gi
+      size: 1000Gi
     ingress:
       enabled: true
       hosts:


### PR DESCRIPTION
This PR bumps the Prometheus disk of cloudbank to mitigate a disk-space warning (97%).