### PR TITLE
Enable auth on binderhub-service for all hubs

### DIFF
--- a/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
+++ b/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
@@ -133,6 +133,10 @@ jupyterhub:
               username_claim: given_name
             # Don't allow everyone with ORCID to sign in
             allow_all: false
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
   singleuser:
     defaultUrl: /lab
     profileList:
@@ -321,3 +325,6 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: *url
     username: *username
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.orcid-demo.svc.cluster.local:8081/hub/api

--- a/config/clusters/aimatx-2i2c-hub/common.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/common.values.yaml
@@ -159,6 +159,7 @@ jupyterhub:
         scopes:
         - self
         - access:services!service=dask-gateway
+        - access:services!service=binder
     config:
       JupyterHub:
         authenticator_class: github

--- a/config/clusters/aimatx-2i2c-hub/prod.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/prod.values.yaml
@@ -19,3 +19,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/aimatx-2i2c-hub-prod-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/aimatx-2i2c-hub/staging.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/staging.values.yaml
@@ -19,3 +19,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/aimatx-2i2c-hub-staging-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/bnext-bio/common.values.yaml
+++ b/config/clusters/bnext-bio/common.values.yaml
@@ -32,6 +32,7 @@ jupyterhub:
         - shares!user
         - read:users:name
         - list:users
+        - access:services!service=binder
     config:
       KubeSpawner:
         image_pull_policy: Always

--- a/config/clusters/bnext-bio/prod.values.yaml
+++ b/config/clusters/bnext-bio/prod.values.yaml
@@ -33,3 +33,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/bnext-bio-prod-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/bnext-bio/staging.values.yaml
+++ b/config/clusters/bnext-bio/staging.values.yaml
@@ -90,3 +90,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/bnext-bio-staging-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -28,7 +28,7 @@ binderhub-service:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/disasters-staging-
   extraEnv:
   - name: JUPYTERHUB_API_URL
-    value: https://staging.hub.disasters.2i2c.cloud/hub/api
+    value: http://hub.staging.svc.cluster.local:8081/hub/api
 
 jupyterhub-home-nfs:
   eks:

--- a/config/clusters/earthscope/binder.values.yaml
+++ b/config/clusters/earthscope/binder.values.yaml
@@ -175,7 +175,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.geolab.earthscope.cloud/hub/api
+    value: http://hub.binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -103,6 +103,7 @@ basehub:
           - self
           - access:services!service=usage-quota
           - access:services!service=dask-gateway
+          - access:services!service=binder
         server:
           scopes:
           - self

--- a/config/clusters/hhmi/binder.values.yaml
+++ b/config/clusters/hhmi/binder.values.yaml
@@ -134,7 +134,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.hhmi.2i2c.cloud/hub/api
+    value: http://hub.binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/leap/daskhub-common.values.yaml
+++ b/config/clusters/leap/daskhub-common.values.yaml
@@ -62,6 +62,7 @@ basehub:
           scopes:
           - self
           - access:services!service=dask-gateway
+          - access:services!service=binder
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/leap/public.values.yaml
+++ b/config/clusters/leap/public.values.yaml
@@ -45,6 +45,10 @@ jupyterhub:
         admin_users:
         - RobertPincus
         - SammyAgrawal
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
   singleuser:
     initContainers: []
     storage:
@@ -144,3 +148,6 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: https://us-central1-docker.pkg.dev
     username: _json_key
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.public.svc.cluster.local:8081/hub/api

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -236,7 +236,7 @@ binderhub-service:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/maap-prod-
   extraEnv:
   - name: JUPYTERHUB_API_URL
-    value: https://hub.maap-project.org/hub/api
+    value: http://hub.prod.svc.cluster.local:8081/hub/api
 
 jupyterhub-home-nfs:
   eks:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -233,7 +233,7 @@ binderhub-service:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/maap-staging-
   extraEnv:
   - name: JUPYTERHUB_API_URL
-    value: https://staging.hub.maap-project.org/hub/api
+    value: http://hub.staging.svc.cluster.local:8081/hub/api
 
 jupyterhub-home-nfs:
   eks:

--- a/config/clusters/nasa-cryo/prod.values.yaml
+++ b/config/clusters/nasa-cryo/prod.values.yaml
@@ -19,3 +19,6 @@ basehub:
     config:
       BinderHub:
         image_prefix: quay.io/imagebuilding-non-gcp-hubs/nasa-cryo-prod-
+    extraEnv:
+    - name: JUPYTERHUB_API_URL
+      value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/nasa-cryo/staging.values.yaml
+++ b/config/clusters/nasa-cryo/staging.values.yaml
@@ -16,3 +16,6 @@ basehub:
     config:
       BinderHub:
         image_prefix: quay.io/imagebuilding-non-gcp-hubs/nasa-cryo-staging-
+    extraEnv:
+    - name: JUPYTERHUB_API_URL
+      value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/nasa-ghg-hub/binder.values.yaml
+++ b/config/clusters/nasa-ghg-hub/binder.values.yaml
@@ -113,7 +113,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.ghg.2i2c.cloud/hub/api
+    value: http://hub.binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/nasa-ghg-hub/prod.values.yaml
+++ b/config/clusters/nasa-ghg-hub/prod.values.yaml
@@ -21,7 +21,7 @@ basehub:
         image_prefix: quay.io/imagebuilding-non-gcp-hubs/nasa-ghg-prod-
     extraEnv:
     - name: JUPYTERHUB_API_URL
-      value: https://hub.ghg.center/hub/api
+      value: http://hub.prod.svc.cluster.local:8081/hub/api
 
   jupyterhub-home-nfs:
     eks:

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -19,7 +19,7 @@ basehub:
         image_prefix: quay.io/imagebuilding-non-gcp-hubs/nasa-ghg-staging-
     extraEnv:
     - name: JUPYTERHUB_API_URL
-      value: https://staging.ghg.2i2c.cloud/hub/api
+      value: http://hub.staging.svc.cluster.local:8081/hub/api
 
   jupyterhub-home-nfs:
     eks:

--- a/config/clusters/nasa-veda/binder.values.yaml
+++ b/config/clusters/nasa-veda/binder.values.yaml
@@ -108,7 +108,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.openveda.cloud/hub/api
+    value: http://hub.binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -22,7 +22,7 @@ basehub:
         image_prefix: quay.io/imagebuilding-non-gcp-hubs/veda-prod-
     extraEnv:
     - name: JUPYTERHUB_API_URL
-      value: https://hub.openveda.cloud/hub/api
+      value: http://hub.prod.svc.cluster.local:8081/hub/api
 
   jupyterhub-home-nfs:
     eks:

--- a/config/clusters/neurohackademy/common.values.yaml
+++ b/config/clusters/neurohackademy/common.values.yaml
@@ -58,6 +58,10 @@ jupyterhub:
         admin_users:
         - arokem
         - noahbenson
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
   scheduling:
     userScheduler:
       enabled: true

--- a/config/clusters/neurohackademy/prod.values.yaml
+++ b/config/clusters/neurohackademy/prod.values.yaml
@@ -7,6 +7,9 @@ binderhub-service:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/neurohackademy-prod-
 
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-07a7e98969ef8e8c3

--- a/config/clusters/neurohackademy/staging.values.yaml
+++ b/config/clusters/neurohackademy/staging.values.yaml
@@ -7,6 +7,9 @@ binderhub-service:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/neurohackademy-staging-
 
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0d3344882a11b2b08

--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -291,6 +291,7 @@ jupyterhub:
         scopes:
         - self
         - access:services!service=dask-gateway
+        - access:services!service=binder
     config:
       Authenticator:
         admin_users:

--- a/config/clusters/nmfs-openscapes/noaa-only.values.yaml
+++ b/config/clusters/nmfs-openscapes/noaa-only.values.yaml
@@ -258,3 +258,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-noaa-only-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.noaa-only.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -38,3 +38,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-prod-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -37,3 +37,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-staging-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -38,3 +38,6 @@ jupyterhub-home-nfs:
 
 binderhub-service:
   enabled: false
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.workshop.svc.cluster.local:8081/hub/api

--- a/config/clusters/openscapeshub/common.values.yaml
+++ b/config/clusters/openscapeshub/common.values.yaml
@@ -168,6 +168,7 @@ basehub:
           scopes:
           - self
           - access:services!service=dask-gateway
+          - access:services!service=binder
       config:
         JupyterHub:
           authenticator_class: github

--- a/config/clusters/opensci/big-binder.values.yaml
+++ b/config/clusters/opensci/big-binder.values.yaml
@@ -128,7 +128,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.big.binder.opensci.2i2c.cloud/hub/api
+    value: http://hub.big-binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -157,6 +157,10 @@ jupyterhub:
         admin_users:
         - kyttmacmanus   # Kytt MacManus, added as part of https://2i2c.freshdesk.com/a/tickets/1454
 
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
 binderhub-service:
   enabled: true
   networkPolicy:
@@ -168,3 +172,6 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: https://quay.io
     username: imagebuilding-non-gcp-hubs+image_builder
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.sciencecore.svc.cluster.local:8081/hub/api

--- a/config/clusters/opensci/small-binder.values.yaml
+++ b/config/clusters/opensci/small-binder.values.yaml
@@ -106,7 +106,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.opensci.2i2c.cloud/hub/api
+    value: http://hub.small-binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -161,7 +161,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.projectpythia.org/hub/api
+    value: http://hub.binder.svc.cluster.local:8081/hub/api
       # Without this, the redirect URL to /hub/api/... gets
       # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/projectpythia-binder/binderhub.values.yaml
+++ b/config/clusters/projectpythia-binder/binderhub.values.yaml
@@ -161,7 +161,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: http://hub.binder.svc.cluster.local:8081/hub/api
+    value: http://hub.binderhub.svc.cluster.local:8081/hub/api
       # Without this, the redirect URL to /hub/api/... gets
       # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/projectpythia/binderhub-service-common.values.yaml
+++ b/config/clusters/projectpythia/binderhub-service-common.values.yaml
@@ -5,6 +5,11 @@ jupyterhub:
     username: &username imagebuilding-non-gcp-hubs+image_builder
     password: &fakePassword <set-in-encrypted-values>
 
+  hub:
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
 binderhub-service:
   enabled: true
   networkPolicy:

--- a/config/clusters/projectpythia/pythia-binder.values.yaml
+++ b/config/clusters/projectpythia/pythia-binder.values.yaml
@@ -101,7 +101,7 @@ binderhub-service:
   - name: JUPYTERHUB_CLIENT_ID
     value: service-binder
   - name: JUPYTERHUB_API_URL
-    value: https://hub.binder.pythia.2i2c.cloud/hub/api
+    value: http://hub.pythia-binder.svc.cluster.local:8081/hub/api
     # Without this, the redirect URL to /hub/api/... gets
     # appended to binderhub's URL instead of the hub's
   - name: JUPYTERHUB_BASE_URL

--- a/config/clusters/temple/advanced.values.yaml
+++ b/config/clusters/temple/advanced.values.yaml
@@ -13,3 +13,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-advanced-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.advanced.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/common-non-teaching.values.yaml
+++ b/config/clusters/temple/common-non-teaching.values.yaml
@@ -64,6 +64,11 @@ jupyterhub:
                 mem_limit: 31222718077
                 cpu_guarantee: 3.6505
                 cpu_limit: 3.6505
+  hub:
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
 binderhub-service:
   enabled: true
     # Explicitly specify what nodes we want for our builds

--- a/config/clusters/temple/prod.values.yaml
+++ b/config/clusters/temple/prod.values.yaml
@@ -4,8 +4,16 @@ nfs:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0e89a2ab60575e25a
-jupyterhub: {}
+jupyterhub:
+  hub:
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
 binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-prod-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/research.values.yaml
+++ b/config/clusters/temple/research.values.yaml
@@ -152,3 +152,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-research-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.research.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/staging.values.yaml
+++ b/config/clusters/temple/staging.values.yaml
@@ -9,7 +9,15 @@ jupyterhub:
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23libKsm2tlJzjYplj
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/temple-advanced-staging-push
+  hub:
+    loadRoles:
+      user:
+        scopes:
+        - access:services!service=binder
 binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-staging-
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/helm-charts/basehub/Chart.yaml
+++ b/helm-charts/basehub/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     version: 4.3.3
     repository: https://jupyterhub.github.io/helm-chart/
   - name: binderhub-service
-    version: 0.1.0-0.dev.git.321.h6d1ccf4
+    version: 0.1.0-0.dev.git.336.hca79dc0
     repository: https://2i2c.org/binderhub-service/
     condition: binderhub-service.enabled
   - name: dask-gateway

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -57,6 +57,7 @@ binderhub-service:
     BinderHub:
       base_url: /services/binder
       use_registry: true
+      auth_enabled: true
     KubernetesBuildExecutor:
       build_image: quay.io/jupyterhub/repo2docker:2025.12.1.dev94-gd3893dba2
       node_selector:


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/8568

I took the opportunity to convert the external URLs into in-cluster ones. This reduces the complexity (in the long run, we can generate these) and avoids going through the TLS layer altogether.

I tested the generated API URLs by querying the API URL from each hub pod. This is not exactly the same as testing it from the binderhub service but the hub pod has CURL, so it's easier to test.

I tested the binder.pythia.2i2c.cloud launch for unauth binders, too.

### To Do
- [x] BinderHub UI hubs
- [x] Non BinderHub UI hubs

### Notes
We do not need to add the special network policy label, because this is intra-namespace pod comms.

<details><summary>Bash to generate test commands</summary>
<p>

```bash
fd values.yaml -e yaml config/clusters/ | xargs -I{} yq '.["binderhub-service"].extraEnv[].value | "\(filename) \(.)"' {} | rg api | sd "config/clusters/([^/]+)/\S+ http://hub\.([^.]+)\.(\S+)" 'deployer use-cluster-credentials $1 -- kubectl exec -t deployment/hub -n $2 -- curl http://hub.$2.$3/'
```

</p>
</details> 

<details><summary>Ugly migration script</summary>
<p>

```python
import ruamel.yaml as ry
import pathlib

yaml = ry.YAML(typ="rt")


for p in pathlib.Path("../config/clusters").glob("*/cluster.yaml"):
    with open(p) as f:
        cluster = yaml.load(f.read())

    for hub in cluster["hubs"]:
        value_files = hub["helm_chart_values_files"]

        non_encrypted_values = [f for f in value_files if not f.startswith("enc-")]
        has_roles = False

        for filename in non_encrypted_values:
            values_path = p.with_name(filename)

            _cfg = yaml.load(values_path)
            cfg = _cfg.get("basehub", _cfg)

            # Skip binder UI hubs
            if (
                cfg.get("jupyterhub", {})
                .get("custom", {})
                .get("binderhubUI", {})
                .get("enabled", False)
            ):
                print(f"Skipping BinderUI hub {p.parent.name}")
                break

            # Do we have binderhub-service config?
            # We need one of these for the leaf, and possibly common too
            try:
                bs = cfg["binderhub-service"]
            except KeyError:
                continue

            # Skip if we've run this before
            if "extraEnv" in bs:
                print(f"Found existing env in hub {p.parent.name}")
                break

            # Add scopes to earliest config file
            if not has_roles:
                scopes = (
                    cfg.setdefault("jupyterhub", {})
                    .setdefault("hub", {})
                    .setdefault("loadRoles", {})
                    .setdefault("user", {})
                    .setdefault("scopes", [])
                )
                scope = "access:services!service=binder"
                if scope not in scopes:
                    scopes.append(scope)
                has_roles = True
                yaml.dump(_cfg, values_path)

            if filename != non_encrypted_values[-1]:
                continue

            domain = hub["domain"]
            namespace = hub["name"]
            bs["extraEnv"] = [
                {
                    "name": "JUPYTERHUB_API_URL",
                    "value": f"http://hub.{namespace}.svc.cluster.local:8081/hub/api",
                }
            ]

            yaml.dump(_cfg, values_path)

```

</p>
</details> 