### PR TITLE
earthscope: Add r8i and r8i-flex instances for dask workers

### DIFF
--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -18,11 +18,10 @@ local c = cluster.withNodeGroupConfigOverride(
           // Allow for a range of spot instance types
           [
             'r5.xlarge',
-            'r5.4xlarge',
             'r6i.xlarge',
-            'r6i.4xlarge',
             'r7i.xlarge',
-            'r7i.4xlarge',
+            'r8i.xlarge',
+            'r8i-flex.xlarge',
           ],
         ],
         hubs=['staging', 'prod', 'binder'],


### PR DESCRIPTION
r8i and r8i flex instances seem to have more spot availability than older instances

Removed unused generation "b"

Remove 4xlarge nodes, just use xlarge nodes

Ref https://github.com/2i2c-org/infrastructure/issues/8242