### PR TITLE
fix: oauth ID of binder service

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -1058,7 +1058,7 @@ jupyterhub:
         # jupyterhub chart will autogenerate a secret with appropriate keys.
         # It's not used if binderhub-service is not enabled.
         # The redirect_url is configured in values.jsonnet
-        oauth_client_id: service-binderhub
+        oauth_client_id: service-binder
         display: false
         url: http://binderhub:8090
         oauth_no_confirm: true


### PR DESCRIPTION
In 2026 we added this `oauth_client_id` to the basehub, but the value doesn't match the default service name. This breaks using authenticated BinderHub UIs.

This PR refactors this with the proper service name.