### PR TITLE
neurohackademy: Enable g4dn.2xlarge GPU instances

### DIFF
--- a/eksctl/neurohackademy.jsonnet
+++ b/eksctl/neurohackademy.jsonnet
@@ -17,6 +17,9 @@ local c = cluster.makeCluster(
     {
       instanceType: 'g4dn.xlarge',
     },
+    {
+      instanceType: 'g4dn.2xlarge',
+    },
   ],
   nodeGroupGenerations=['c']
 );


### PR DESCRIPTION
They needed more RAM than a g4dn.xlarge allowed last time, so we bumped them to g4dn.2xlarge. The hub config carried over, but was missed in eksctl

https://github.com/2i2c-org/infrastructure/pull/6537