### PR TITLE
Cloudbank Cilogon Google IdP to Google OAuth

### DIFF
--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -28,16 +28,12 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - my.smccd.edu
-            - smccd.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - my.smccd.edu
+        - smccd.edu
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -26,15 +26,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - elcamino.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - elcamino.edu
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/enc-csm.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-csm.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:m/b+9e7+cI+/ZbRYDNQQkMZPVD+pvcVSbxXSQxBFEATmxSHNz7RAq0sIIZ/NQIVUeE96A1ZnaKtoOYg8ne44dFLyiL4Yb8Rz,iv:49zM2nhHRMJsB7AYC225fUeTmFRLPDsCePVFoDFGPPM=,tag:wqYy2SqRTcgaXhBxqfl+OQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:5DDW++Lpb8RZ0Ydm4YvNWBtFmzGos1CljYqEpeNGACoXmzE=,iv:+jE5p4tZq3L2hYnq3Yg89Ka3TvpQukI4bkDqcACkr3Y=,tag:NoQ9UsIb1liE19BWxEhJEw==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:m/b+9e7+cI+/ZbRYDNQQkMZPVD+pvcVSbxXSQxBFEATmxSHNz7RAq0sIIZ/NQIVUeE96A1ZnaKtoOYg8ne44dFLyiL4Yb8Rz,iv:49zM2nhHRMJsB7AYC225fUeTmFRLPDsCePVFoDFGPPM=,tag:wqYy2SqRTcgaXhBxqfl+OQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:5DDW++Lpb8RZ0Ydm4YvNWBtFmzGos1CljYqEpeNGACoXmzE=,iv:+jE5p4tZq3L2hYnq3Yg89Ka3TvpQukI4bkDqcACkr3Y=,tag:NoQ9UsIb1liE19BWxEhJEw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:28:32Z"
-          enc: CiUA4OM7eFAfLQXL6b08LClOkJqXvvbKUk4Z9rpN/E+SuFIzsa5nEkgAmy+ekpTqeI3WN+IZfkiE5L0Lmke6pKXQqcbBwLeS46fnEaaTpXZ5jX/mQoLARnwDMqp2VPvK2m7VpL6TccPpM+5CnoTAGwk=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:28:32Z"
-    mac: ENC[AES256_GCM,data:rg59bupeMd5OEUo/hCDWkUJYnK2v3VpbWTv5QBmcWwJfTS51C/bMCQFetECwC2pwdl5dDZiKe/IYTx8p9ZJfZpAhWq3BiFWAC750kMrWDLe7zYIECvSUFagBhh7QByEMsbZ0TyqeNoTrniv5mhUuspA3HGqrEQO/m1GaLi8Jths=,iv:83iwbUliwH3ttGc1Ux7vy+ZBt1R6KzhHjGWtHCgpAGA=,tag:OuJg5cSrV3wCkfXlyRlCEg==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:28:32Z'
+    enc: CiUA4OM7eFAfLQXL6b08LClOkJqXvvbKUk4Z9rpN/E+SuFIzsa5nEkgAmy+ekpTqeI3WN+IZfkiE5L0Lmke6pKXQqcbBwLeS46fnEaaTpXZ5jX/mQoLARnwDMqp2VPvK2m7VpL6TccPpM+5CnoTAGwk=
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:28:32Z'
+  mac: ENC[AES256_GCM,data:rg59bupeMd5OEUo/hCDWkUJYnK2v3VpbWTv5QBmcWwJfTS51C/bMCQFetECwC2pwdl5dDZiKe/IYTx8p9ZJfZpAhWq3BiFWAC750kMrWDLe7zYIECvSUFagBhh7QByEMsbZ0TyqeNoTrniv5mhUuspA3HGqrEQO/m1GaLi8Jths=,iv:83iwbUliwH3ttGc1Ux7vy+ZBt1R6KzhHjGWtHCgpAGA=,tag:OuJg5cSrV3wCkfXlyRlCEg==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-csm.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-csm.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:GQCsROpo+xCxylVXdYSPbtHE3Z7ospBOOedxM4T+C+tcRjODcH6jSEf0MaG6Q84gixO5,iv:yadRwo2DaR8Xn5B1DzWxl314CbRcFK9esA6T67UagVM=,tag:VKaSAH+/h3sgpRrPC8hUqw==,type:str]
-        client_secret: ENC[AES256_GCM,data:HjLNL2ZSrDDOa+8JXFB3kNWhi/CH0IbrbNzEJLScK9vDEHL99Uie3npiRudSD01uiVmjnJb+biHywxFufzwDC9MkukZWH14R/NaIcwUUfvANeIWPt8g=,iv:A7lQLmPoof4u7unfI/NzbhxN51PYiG1X29J9WTatrTA=,tag:ptQF7JQOHpJI1ZdMG5ipPw==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:m/b+9e7+cI+/ZbRYDNQQkMZPVD+pvcVSbxXSQxBFEATmxSHNz7RAq0sIIZ/NQIVUeE96A1ZnaKtoOYg8ne44dFLyiL4Yb8Rz,iv:49zM2nhHRMJsB7AYC225fUeTmFRLPDsCePVFoDFGPPM=,tag:wqYy2SqRTcgaXhBxqfl+OQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:5DDW++Lpb8RZ0Ydm4YvNWBtFmzGos1CljYqEpeNGACoXmzE=,iv:+jE5p4tZq3L2hYnq3Yg89Ka3TvpQukI4bkDqcACkr3Y=,tag:NoQ9UsIb1liE19BWxEhJEw==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2022-12-15T19:03:07Z'
-    enc: CiUA4OM7eFM07UOM/KE5+uDY/L+fNHNcNPAjh8uFHGpJ7ar74LFBEkkA+0T9hWL+MO6J0koNwAAG8FNc491ENtY5W0ejiORbHV6Cs4UMFAbg/+jrSyaykA6TTpYutsqaNtThNoa2OTvlqyJm9N+QvxyW
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2022-12-15T19:03:08Z'
-  mac: ENC[AES256_GCM,data:j+HUs73CebjLFBEy6yyacOj1Mq8A5dDXkjvRD18GdxoIpks+K8gm6RwEF4xKsu24jSEMganS6gttbnvSkU7pyJJ4PcJItnpFnqEw3+b+ohbpmznYtp0Z5/SMoI0olcEzICEAsIlV0XxyfDjF7Mk+mz1xW0gopEbzwtLCWMSQRDI=,iv:rIercrpRBQNELT8wbYljWAUBEFO7ZIFsG7j9SsGRREQ=,tag:QYBjeC3Ao2CSTdDy9W+f0A==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:28:32Z"
+          enc: CiUA4OM7eFAfLQXL6b08LClOkJqXvvbKUk4Z9rpN/E+SuFIzsa5nEkgAmy+ekpTqeI3WN+IZfkiE5L0Lmke6pKXQqcbBwLeS46fnEaaTpXZ5jX/mQoLARnwDMqp2VPvK2m7VpL6TccPpM+5CnoTAGwk=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:28:32Z"
+    mac: ENC[AES256_GCM,data:rg59bupeMd5OEUo/hCDWkUJYnK2v3VpbWTv5QBmcWwJfTS51C/bMCQFetECwC2pwdl5dDZiKe/IYTx8p9ZJfZpAhWq3BiFWAC750kMrWDLe7zYIECvSUFagBhh7QByEMsbZ0TyqeNoTrniv5mhUuspA3HGqrEQO/m1GaLi8Jths=,iv:83iwbUliwH3ttGc1Ux7vy+ZBt1R6KzhHjGWtHCgpAGA=,tag:OuJg5cSrV3wCkfXlyRlCEg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-elcamino.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-elcamino.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:ZlxbWQS5SNsFNZdJ6y772H4ABpMw7r4Zxf/TH9jWF3t1I9671cZQXE4h3auDQ6PydnaEkWfLDmsNHOn4C3aQVp2WmjafmiyM,iv:W9bPj5SVpKpnxTepbSlJ+X6hphv9IF/aOfsQkS1hbr4=,tag:qeubyL6U5tg/O3TDeNJ6xQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:iz9sTzQcMKeqDeQVNcI4IQ1HF6z9omYHzgATVEaJlJITeq4=,iv:OCP/S8NQ/LNaeY0sfGfz6pjcVCM9S9JOqt8qCeux7eo=,tag:q1F+ud6XXmQX59+HZj2oJQ==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:ZlxbWQS5SNsFNZdJ6y772H4ABpMw7r4Zxf/TH9jWF3t1I9671cZQXE4h3auDQ6PydnaEkWfLDmsNHOn4C3aQVp2WmjafmiyM,iv:W9bPj5SVpKpnxTepbSlJ+X6hphv9IF/aOfsQkS1hbr4=,tag:qeubyL6U5tg/O3TDeNJ6xQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:iz9sTzQcMKeqDeQVNcI4IQ1HF6z9omYHzgATVEaJlJITeq4=,iv:OCP/S8NQ/LNaeY0sfGfz6pjcVCM9S9JOqt8qCeux7eo=,tag:q1F+ud6XXmQX59+HZj2oJQ==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:21Z"
-          enc: CiUA4OM7eMvUNBRrXSVMDDXTC1d7t3xexfIFZxNJ3Pt2uk3h5mnwEkkAmy+eklDdHdKH67W7mndprso1Lo4ukEdD1LFkUF6gFcHptA3zJkfsZ6ZkZvhvg5rOmbm9Z4pdrSQvfQYBuVJx0p7FFSFhxqUH
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:22Z"
-    mac: ENC[AES256_GCM,data:Qc2OOcu9xtFQde53gz4bGpw54ZCV6lzMDIuxAn25cxlKbiB36pqICbngYc+BO6FlcSrUiyozHpgfXpB3f+bCK82Bf17Wku4c6CG+QMZftwdjYgoZcbCONQxtzmRAm9A77R8slMa627y8UBn1CQNLpxdbmRNHEgqxbL/n3WaskHQ=,iv:9AyAR5G8PwAl9zi46yxzyPZuSmLuG015GG+Bmj9FYsc=,tag:A/Rqg0RKxzIIDnKRW8tRoA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:21Z'
+    enc: CiUA4OM7eMvUNBRrXSVMDDXTC1d7t3xexfIFZxNJ3Pt2uk3h5mnwEkkAmy+eklDdHdKH67W7mndprso1Lo4ukEdD1LFkUF6gFcHptA3zJkfsZ6ZkZvhvg5rOmbm9Z4pdrSQvfQYBuVJx0p7FFSFhxqUH
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:22Z'
+  mac: ENC[AES256_GCM,data:Qc2OOcu9xtFQde53gz4bGpw54ZCV6lzMDIuxAn25cxlKbiB36pqICbngYc+BO6FlcSrUiyozHpgfXpB3f+bCK82Bf17Wku4c6CG+QMZftwdjYgoZcbCONQxtzmRAm9A77R8slMa627y8UBn1CQNLpxdbmRNHEgqxbL/n3WaskHQ=,iv:9AyAR5G8PwAl9zi46yxzyPZuSmLuG015GG+Bmj9FYsc=,tag:A/Rqg0RKxzIIDnKRW8tRoA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-elcamino.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-elcamino.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:mhtNzhpv8Wo9dWrELvuiceuwRDjdW6zeVR3T3LlP/pFgXMf726IK2FIWtsS6KlwSWvw+,iv:ShNdhGivQkRqHRUBLau+/D/IyMZarcwaPOsXcL20T0U=,tag:+vFxLLWVSM6KzADZmp17oQ==,type:str]
-        client_secret: ENC[AES256_GCM,data:GCtevet+pbL5X1MvjWtAYMenatZUl9BJNbmYV4GYT6ZkXRnHGoIriY6GwNOUIaTtsb7SzQFbBrThgFC70Kut6EBvZ8rpEMIBkyMf4xyeNV8rm7+hzh0=,iv:wjFe3WXnXXzzxvyNoKEwtUmHRnHXn6mj/WdePhC9W/E=,tag:srYg9GsGe35qQTVnRfp7Bg==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:ZlxbWQS5SNsFNZdJ6y772H4ABpMw7r4Zxf/TH9jWF3t1I9671cZQXE4h3auDQ6PydnaEkWfLDmsNHOn4C3aQVp2WmjafmiyM,iv:W9bPj5SVpKpnxTepbSlJ+X6hphv9IF/aOfsQkS1hbr4=,tag:qeubyL6U5tg/O3TDeNJ6xQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:iz9sTzQcMKeqDeQVNcI4IQ1HF6z9omYHzgATVEaJlJITeq4=,iv:OCP/S8NQ/LNaeY0sfGfz6pjcVCM9S9JOqt8qCeux7eo=,tag:q1F+ud6XXmQX59+HZj2oJQ==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-03-10T13:38:30Z'
-    enc: CiUA4OM7eG0PUZWZ5PhjBXmqzFMVUxFss3Qa/pk9AzIgXd5XCVO1EkkALQgViJobxsfWsojroy42sJeXvZUtlZMi9qPzXE0vUO9JWFVWtjPHXeMCf7x8gQdH9QMjCKMZ5BlwYtXD7WFEpBINu0HGCdhV
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-03-10T13:38:31Z'
-  mac: ENC[AES256_GCM,data:PgWrkixpNr3hdzS+zI9G3L91vNVJz6wSG5FIhbIarA62OeGeM1YXmeQ5vcG4ELmRxNRpLekI+TLGbZt4gqh07BVpamoKlK+4WXelILsZ97N2dXrTGxTWG+upiSJjRx3QZmlbVaoW9/IyLZdHAZGDSEv3z+zUFre/naZSHrs0q0g=,iv:crvsUIYSoEULbW+dWPYFiiz7jiRJLCzM6BJQOrsOUn4=,tag:T20oZxGAXWzX+vg1Z3ONLw==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.3
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:21Z"
+          enc: CiUA4OM7eMvUNBRrXSVMDDXTC1d7t3xexfIFZxNJ3Pt2uk3h5mnwEkkAmy+eklDdHdKH67W7mndprso1Lo4ukEdD1LFkUF6gFcHptA3zJkfsZ6ZkZvhvg5rOmbm9Z4pdrSQvfQYBuVJx0p7FFSFhxqUH
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:22Z"
+    mac: ENC[AES256_GCM,data:Qc2OOcu9xtFQde53gz4bGpw54ZCV6lzMDIuxAn25cxlKbiB36pqICbngYc+BO6FlcSrUiyozHpgfXpB3f+bCK82Bf17Wku4c6CG+QMZftwdjYgoZcbCONQxtzmRAm9A77R8slMa627y8UBn1CQNLpxdbmRNHEgqxbL/n3WaskHQ=,iv:9AyAR5G8PwAl9zi46yxzyPZuSmLuG015GG+Bmj9FYsc=,tag:A/Rqg0RKxzIIDnKRW8tRoA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-glendale.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-glendale.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:D44NJLZB+HEmAGEtHoZqJUXJltdZ1PzEbCCSl7jsXaBVaX0ZOm5oSk5pF6Vkj/NHbqDKX36WWweqq0f7WnqJJNTL1nMXrkL+,iv:M80nyNuw20LpHiuQDZAZUBpsvT+HbZmlVg6x4BkY6Ww=,tag:Mauw/B74bDA4cHvK/lMV9Q==,type:str]
-                client_secret: ENC[AES256_GCM,data:xTAN6YRa+VdS5E/QcnCGILszNYxEgvrUK+J8GW4fWrdCsdg=,iv:ObRIktxGoD2q7AjdkJrE1p+6I/E9LX3mCQSdn3JcGMU=,tag:Xu/KQk9xoQSg4G6m5huSDQ==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:D44NJLZB+HEmAGEtHoZqJUXJltdZ1PzEbCCSl7jsXaBVaX0ZOm5oSk5pF6Vkj/NHbqDKX36WWweqq0f7WnqJJNTL1nMXrkL+,iv:M80nyNuw20LpHiuQDZAZUBpsvT+HbZmlVg6x4BkY6Ww=,tag:Mauw/B74bDA4cHvK/lMV9Q==,type:str]
+        client_secret: ENC[AES256_GCM,data:xTAN6YRa+VdS5E/QcnCGILszNYxEgvrUK+J8GW4fWrdCsdg=,iv:ObRIktxGoD2q7AjdkJrE1p+6I/E9LX3mCQSdn3JcGMU=,tag:Xu/KQk9xoQSg4G6m5huSDQ==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:23Z"
-          enc: CiUA4OM7eAQBxazbeCKoIJ5WJ6Pw0CINWNQJkGU6036x7mJluLt/EkkAmy+eksmarxQ/GXv4oATr+bKB+AxslWe8OX98Y56EwSTFw73oWhrFftg9yjLh5W0ojdj1WPWmKyMklvJICOQ2nOlndOM+/YVu
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:24Z"
-    mac: ENC[AES256_GCM,data:v7CAJYgaVcEKRdnv6BZ7/t/w9lfdQUU6lgIGDMt0LePNOnOI09pZc7lIUVgnh5n0Q6eizS4Ty4yRsi+wOAxlZU69MafJHFFfqz0Ld71alZdFE0iRy+A/ZF/ywltk1cBj56eJQ/1mN1PWWj/hl5w0J3Oy2CV0R9tByjS7OkT0fH0=,iv:vGYGGFt1JAKJWsuQKcDwAcC20DzOopU8Rv8unObYThA=,tag:Xdjc7vK9imifLAhSL7UN+Q==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:23Z'
+    enc: CiUA4OM7eAQBxazbeCKoIJ5WJ6Pw0CINWNQJkGU6036x7mJluLt/EkkAmy+eksmarxQ/GXv4oATr+bKB+AxslWe8OX98Y56EwSTFw73oWhrFftg9yjLh5W0ojdj1WPWmKyMklvJICOQ2nOlndOM+/YVu
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:24Z'
+  mac: ENC[AES256_GCM,data:v7CAJYgaVcEKRdnv6BZ7/t/w9lfdQUU6lgIGDMt0LePNOnOI09pZc7lIUVgnh5n0Q6eizS4Ty4yRsi+wOAxlZU69MafJHFFfqz0Ld71alZdFE0iRy+A/ZF/ywltk1cBj56eJQ/1mN1PWWj/hl5w0J3Oy2CV0R9tByjS7OkT0fH0=,iv:vGYGGFt1JAKJWsuQKcDwAcC20DzOopU8Rv8unObYThA=,tag:Xdjc7vK9imifLAhSL7UN+Q==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-glendale.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-glendale.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:U5pPy0yt2iWT8ifX3ds8ZKhM3rcVx3QbMtuKZt3KlvWUXICWAdTNMzt6eHAUqmWfTNag,iv:FAd9yBqAzUfSmhip96uAPivy3EFEDUl4F57xaQC6rkE=,tag:QTmWlvR8ljTa2GdBUsSjUA==,type:str]
-        client_secret: ENC[AES256_GCM,data:KaC2695gWoiXwNh1fIJjC4Se1fjTBx5BufZwQx6JtiVYkU59hbYfdP3NxYHGwfn4NkmEHh/q2iZwR9SGAJ1idHt7sKpCk3bUEKV594PGwNdhSR8RStQ=,iv:GlVEwKcOFHbzbMjHbZ/mQzYTTezh512J0a8NLP1avHM=,tag:S/WxwC7tp5PexrsRmJwUtw==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:D44NJLZB+HEmAGEtHoZqJUXJltdZ1PzEbCCSl7jsXaBVaX0ZOm5oSk5pF6Vkj/NHbqDKX36WWweqq0f7WnqJJNTL1nMXrkL+,iv:M80nyNuw20LpHiuQDZAZUBpsvT+HbZmlVg6x4BkY6Ww=,tag:Mauw/B74bDA4cHvK/lMV9Q==,type:str]
+                client_secret: ENC[AES256_GCM,data:xTAN6YRa+VdS5E/QcnCGILszNYxEgvrUK+J8GW4fWrdCsdg=,iv:ObRIktxGoD2q7AjdkJrE1p+6I/E9LX3mCQSdn3JcGMU=,tag:Xu/KQk9xoQSg4G6m5huSDQ==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2022-06-30T21:42:52Z'
-    enc: CiQA4OM7eCzoC4vPS6Q8/RPxZ4XjpPaWRRA41PYj5kbUXHeYtogSSQBq6cPrnUan9oNVvo6lyAF+Q6zFg1C6208pIFGKOvdvkCr5Y+UQ7XDhPwBDDS8xiJnIxt9s7G5a300h9rLDSKOuE4UxN7BChrU=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2022-06-30T21:42:52Z'
-  mac: ENC[AES256_GCM,data:JSZB7IWuFdfSEQki4oKPwJZvfpBgWuBDTEtMs0m7KkXgP28jIWrmQ2Wyd3UtEJOcgCwmxAMe9LA15N8w2mq3GyPT/uSevS3tREp5K9lF6CXRDT5hkbNw6voaRDco1jMK/cEm7SbsibGaw/OFNzpa3Pe4SnfmElZ6zLwEOXbvvEQ=,iv:S0oE61OOKliQBgCuvEjQ6YqohxJ0NBUDtTIhiCQys/4=,tag:+Z9p9k9UyKweTBvH4Mm9HA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:23Z"
+          enc: CiUA4OM7eAQBxazbeCKoIJ5WJ6Pw0CINWNQJkGU6036x7mJluLt/EkkAmy+eksmarxQ/GXv4oATr+bKB+AxslWe8OX98Y56EwSTFw73oWhrFftg9yjLh5W0ojdj1WPWmKyMklvJICOQ2nOlndOM+/YVu
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:24Z"
+    mac: ENC[AES256_GCM,data:v7CAJYgaVcEKRdnv6BZ7/t/w9lfdQUU6lgIGDMt0LePNOnOI09pZc7lIUVgnh5n0Q6eizS4Ty4yRsi+wOAxlZU69MafJHFFfqz0Ld71alZdFE0iRy+A/ZF/ywltk1cBj56eJQ/1mN1PWWj/hl5w0J3Oy2CV0R9tByjS7OkT0fH0=,iv:vGYGGFt1JAKJWsuQKcDwAcC20DzOopU8Rv8unObYThA=,tag:Xdjc7vK9imifLAhSL7UN+Q==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-nicc.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-nicc.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:z7jhdetBr9dtqyc/gMZVgJE+x4BXdynfurIrQkqWPLRQxl4rUt/eM+M6RN1qTTYJsT0fI3FT+XLF4XBauUDLv65j+RYHWvH3,iv:W1+kj3WUA639ftsWNVRh0Wl6kSeVSLZKO6nduN+j/1c=,tag:owxPWbD81ZEVK8ADLcBp9g==,type:str]
-                client_secret: ENC[AES256_GCM,data:Etp9EJpVsOkvFtrlyL4Ap6ooIvsjvtuqCL+Fotv9fwQws+w=,iv:VpiLziF6wwp3HkzVHe+iG17xksAfcO7G+Khz4DdVmNA=,tag:a9sQ91MKY6sQnxTKCtLP8g==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:z7jhdetBr9dtqyc/gMZVgJE+x4BXdynfurIrQkqWPLRQxl4rUt/eM+M6RN1qTTYJsT0fI3FT+XLF4XBauUDLv65j+RYHWvH3,iv:W1+kj3WUA639ftsWNVRh0Wl6kSeVSLZKO6nduN+j/1c=,tag:owxPWbD81ZEVK8ADLcBp9g==,type:str]
+        client_secret: ENC[AES256_GCM,data:Etp9EJpVsOkvFtrlyL4Ap6ooIvsjvtuqCL+Fotv9fwQws+w=,iv:VpiLziF6wwp3HkzVHe+iG17xksAfcO7G+Khz4DdVmNA=,tag:a9sQ91MKY6sQnxTKCtLP8g==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:25Z"
-          enc: CiUA4OM7eMlBAAZpMSzCHTcxOeYARMDM1gzzdAw5ygCjMYOBXpzpEkkAmy+ekrOkFJ6hfV0QzY7y36TWj2ICpg80mkZdPvv2Qnyjd+4qqrkFpoNF1wHHwtZnSIFfkSR3XH/w2M0Y6phKW73GNK0xCNdW
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:25Z"
-    mac: ENC[AES256_GCM,data:qPRW1OecXnBDUYReAuA6WVCXO6ly22W6ddZb9lHyeUHzj8Gij//LhJlbq8r+2Sgh5Wcs9C75WqnP+FOKvsUXyRRBRLezHflEm2kaRFAzG4vk/ydf7/EtugmQDjqTgOD7wFFqHyNFHCeSlB4Kp0UY1xNuJe9DZsmEBiHB8lSsiyE=,iv:AT0CZ9HI3NUkym7T1IumvIU0nFUh4CNceq0F5/CWwo8=,tag:WVHdyavllPVWhjVlGTF8vg==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:25Z'
+    enc: CiUA4OM7eMlBAAZpMSzCHTcxOeYARMDM1gzzdAw5ygCjMYOBXpzpEkkAmy+ekrOkFJ6hfV0QzY7y36TWj2ICpg80mkZdPvv2Qnyjd+4qqrkFpoNF1wHHwtZnSIFfkSR3XH/w2M0Y6phKW73GNK0xCNdW
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:25Z'
+  mac: ENC[AES256_GCM,data:qPRW1OecXnBDUYReAuA6WVCXO6ly22W6ddZb9lHyeUHzj8Gij//LhJlbq8r+2Sgh5Wcs9C75WqnP+FOKvsUXyRRBRLezHflEm2kaRFAzG4vk/ydf7/EtugmQDjqTgOD7wFFqHyNFHCeSlB4Kp0UY1xNuJe9DZsmEBiHB8lSsiyE=,iv:AT0CZ9HI3NUkym7T1IumvIU0nFUh4CNceq0F5/CWwo8=,tag:WVHdyavllPVWhjVlGTF8vg==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-nicc.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-nicc.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:r4xK1/Wx+7g4jZIgAMHagWOvpx9Ocl4e55KWiLmlnDQvSrwoMkGlsPMdJ45Gd2+kc0X4,iv:YTrR9sgPdVEbkngnnu8Ryx5TGlYC68Hig0nAPYg2O7o=,tag:Pn9vXEvue2FrrslLGkRiGQ==,type:str]
-        client_secret: ENC[AES256_GCM,data:7CKtFvZ6jOmmvqfF5Vexk2/wUDIUohzKVV6mEoDEh20G5EfUvDQEo6SuBLfLVkrKRW1b/4XzcsCMpi0pzr/8gaVKm2BbYDeS1Dto2S//DMw1Vb3aQWQ=,iv:4qsF6c4CNUuPfPl8Usm2KTofwkOSOwCRYcnMcWMsRxI=,tag:0ffCorleSzaCNuC4nAffXg==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:z7jhdetBr9dtqyc/gMZVgJE+x4BXdynfurIrQkqWPLRQxl4rUt/eM+M6RN1qTTYJsT0fI3FT+XLF4XBauUDLv65j+RYHWvH3,iv:W1+kj3WUA639ftsWNVRh0Wl6kSeVSLZKO6nduN+j/1c=,tag:owxPWbD81ZEVK8ADLcBp9g==,type:str]
+                client_secret: ENC[AES256_GCM,data:Etp9EJpVsOkvFtrlyL4Ap6ooIvsjvtuqCL+Fotv9fwQws+w=,iv:VpiLziF6wwp3HkzVHe+iG17xksAfcO7G+Khz4DdVmNA=,tag:a9sQ91MKY6sQnxTKCtLP8g==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2026-06-15T18:10:08Z'
-    enc: CiUA4OM7eJI9q0NjbEIZmyQlDFl2SywhxwccdXa+Rur7CyaG4SCaEkkAmy+ekvh+kbrMebcAXXxD/Fq280KwXWkUojk/6FfeyyoNtkUmS1M/VGkurSDGPgEgVbWAGjKYgsAkglK8jPKMTJJk4gTCmWE9
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2026-06-15T18:10:09Z'
-  mac: ENC[AES256_GCM,data:+a9ng1MTFCAR1lG6g+3jcoPK7D94+0WLuUodB4CzWC9UYaZMQIi+uTHyTN7u0HmjHdxQ+4Xsq4XxmqHQiPREMXSOvnSDSP7gCY9QW1u4TIYEvBZXITIrQ+3aA3ZtotQKcQsr1kKb0McBbwpplMxHoJGGywGNKM5kCLWqkU8CWB0=,iv:jNBq3vG7UnEDVavG975qoNBq80yMIqW9vXUI2lLot1Y=,tag:JXl7gylZS/kHo+2aGq7ydw==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.8.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:25Z"
+          enc: CiUA4OM7eMlBAAZpMSzCHTcxOeYARMDM1gzzdAw5ygCjMYOBXpzpEkkAmy+ekrOkFJ6hfV0QzY7y36TWj2ICpg80mkZdPvv2Qnyjd+4qqrkFpoNF1wHHwtZnSIFfkSR3XH/w2M0Y6phKW73GNK0xCNdW
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:25Z"
+    mac: ENC[AES256_GCM,data:qPRW1OecXnBDUYReAuA6WVCXO6ly22W6ddZb9lHyeUHzj8Gij//LhJlbq8r+2Sgh5Wcs9C75WqnP+FOKvsUXyRRBRLezHflEm2kaRFAzG4vk/ydf7/EtugmQDjqTgOD7wFFqHyNFHCeSlB4Kp0UY1xNuJe9DZsmEBiHB8lSsiyE=,iv:AT0CZ9HI3NUkym7T1IumvIU0nFUh4CNceq0F5/CWwo8=,tag:WVHdyavllPVWhjVlGTF8vg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-palomar.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-palomar.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:j3cH+C8qQHCSyw4ojJLjE7nQWbG/McxySqG2KDeWKPipAVO4tuhDXcvdVN/hr7Lwll+fGjYWduxqtPnEujF3TwKow+VbMwBN,iv:5xxniuI0uyIF1MzIrSEm47IHFytK0IR67Jfgv9YenpQ=,tag:CIa2uBq2dFHbjRRXqsggZQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:eo9ms1ufJWnMHMN6NI4M+aC+gJYqHrh/gFO3Fn/WLXtJLjE=,iv:pvxC3TWVEY7xhiu0bYLPTF1s6//OTB9yhAvAhcXaLDk=,tag:k2eXDNAAUeVahk6OiIj/Tw==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:j3cH+C8qQHCSyw4ojJLjE7nQWbG/McxySqG2KDeWKPipAVO4tuhDXcvdVN/hr7Lwll+fGjYWduxqtPnEujF3TwKow+VbMwBN,iv:5xxniuI0uyIF1MzIrSEm47IHFytK0IR67Jfgv9YenpQ=,tag:CIa2uBq2dFHbjRRXqsggZQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:eo9ms1ufJWnMHMN6NI4M+aC+gJYqHrh/gFO3Fn/WLXtJLjE=,iv:pvxC3TWVEY7xhiu0bYLPTF1s6//OTB9yhAvAhcXaLDk=,tag:k2eXDNAAUeVahk6OiIj/Tw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:26Z"
-          enc: CiUA4OM7eLLPWGFbBVow4Tg3oYN1KTg99pkcWmBZBe/ivhTed2TWEkkAmy+ekp1CzbOGtFCtnW5nK1wF/7WsuZFvkeIJyqNPRB6+HyV14lzL7yEOfca/DFl/yyeTflJRLyTVRTOuA4P09qcCiYzerfFo
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:27Z"
-    mac: ENC[AES256_GCM,data:uO8H4EZ9WGCy742Ofo1xn13ul6Exmjz4YzemScrgYV5ORWSQKYZ7BUcH4LfVbU0cnfiC+Hsp4j4hKyhEIHeHwRoTw9AIHF8IWyjNYDpKYC+XyYRh5TpnOSRA8kVFMGsjsMDw/FwtC7ehEDbosbHwKtt6rxpPzD72TIwAvv5stwY=,iv:0SHjXqcluMJ/D8r3D6yK4+x6wIQAuXphh4xLUP1OiFM=,tag:kqy6/KTLxEhNw5KF5vfd7A==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:26Z'
+    enc: CiUA4OM7eLLPWGFbBVow4Tg3oYN1KTg99pkcWmBZBe/ivhTed2TWEkkAmy+ekp1CzbOGtFCtnW5nK1wF/7WsuZFvkeIJyqNPRB6+HyV14lzL7yEOfca/DFl/yyeTflJRLyTVRTOuA4P09qcCiYzerfFo
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:27Z'
+  mac: ENC[AES256_GCM,data:uO8H4EZ9WGCy742Ofo1xn13ul6Exmjz4YzemScrgYV5ORWSQKYZ7BUcH4LfVbU0cnfiC+Hsp4j4hKyhEIHeHwRoTw9AIHF8IWyjNYDpKYC+XyYRh5TpnOSRA8kVFMGsjsMDw/FwtC7ehEDbosbHwKtt6rxpPzD72TIwAvv5stwY=,iv:0SHjXqcluMJ/D8r3D6yK4+x6wIQAuXphh4xLUP1OiFM=,tag:kqy6/KTLxEhNw5KF5vfd7A==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-palomar.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-palomar.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:vP1OiD0XQTCyclmbLELgf0lu+E+byLMHDAXX5QyWobCBG+6BYjdToouLvkHIlzXbEq2r,iv:uch5gwkOty3zauXBpfFFu2n2KqYmOT9d6m6yXQCMNMo=,tag:RbZmpO3QcEucrmhDIbnf3g==,type:str]
-        client_secret: ENC[AES256_GCM,data:Anw2LKLPaYMhADhA0r2zlPIE5Zte1N7Oqg1cMlbpF89XoGIeOPa4iThWD7W82HXFVIaDXi2anqlNP1yqVZU3/cn3hGKiUlXqlXFB+Znv+EVw+Uj/nko=,iv:CbFIEeNKDw6pTfYspnJ37E1S+X+6ClxaQbIs5+sSXOI=,tag:N7kZlNpn/CdAUCO8PLUrgg==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:j3cH+C8qQHCSyw4ojJLjE7nQWbG/McxySqG2KDeWKPipAVO4tuhDXcvdVN/hr7Lwll+fGjYWduxqtPnEujF3TwKow+VbMwBN,iv:5xxniuI0uyIF1MzIrSEm47IHFytK0IR67Jfgv9YenpQ=,tag:CIa2uBq2dFHbjRRXqsggZQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:eo9ms1ufJWnMHMN6NI4M+aC+gJYqHrh/gFO3Fn/WLXtJLjE=,iv:pvxC3TWVEY7xhiu0bYLPTF1s6//OTB9yhAvAhcXaLDk=,tag:k2eXDNAAUeVahk6OiIj/Tw==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-03-10T13:52:02Z'
-    enc: CiUA4OM7eDZe3TpdZxcCE6BvLcW6wEX4Imt5lTapdACvir6YHseTEkkALQgViL+wpWR7FRV3OyNkr5g8hrVSanpdDB1CPSqevac8d+lCytst4O5MiQj3vHt5K6hq0QMHKe83LCxulAz+3JIfpYoX2JIh
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-03-10T13:52:03Z'
-  mac: ENC[AES256_GCM,data:5GXX/i1i5dnBgu9u3BVaJ3D6VHbatgNn8oGFdtSpQoQcfTkG0exAvT6mXDh/E9Ux0MzMJZPN7OmwHNafISq/iwhPeahFikZGPYJI8PFeFKH9vWfUQwlMleYGqLgD3C9ig5JQIS/bxrT8wmIYc0bdhmLW6YJ7WCvZwywtPj5tk48=,iv:FunnWPMkubTOeBCo96iubBdKUJfUdA3ZKcP/wIhcRDI=,tag:5lZ3BjpKam0VbBVSOxabIA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.3
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:26Z"
+          enc: CiUA4OM7eLLPWGFbBVow4Tg3oYN1KTg99pkcWmBZBe/ivhTed2TWEkkAmy+ekp1CzbOGtFCtnW5nK1wF/7WsuZFvkeIJyqNPRB6+HyV14lzL7yEOfca/DFl/yyeTflJRLyTVRTOuA4P09qcCiYzerfFo
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:27Z"
+    mac: ENC[AES256_GCM,data:uO8H4EZ9WGCy742Ofo1xn13ul6Exmjz4YzemScrgYV5ORWSQKYZ7BUcH4LfVbU0cnfiC+Hsp4j4hKyhEIHeHwRoTw9AIHF8IWyjNYDpKYC+XyYRh5TpnOSRA8kVFMGsjsMDw/FwtC7ehEDbosbHwKtt6rxpPzD72TIwAvv5stwY=,iv:0SHjXqcluMJ/D8r3D6yK4+x6wIQAuXphh4xLUP1OiFM=,tag:kqy6/KTLxEhNw5KF5vfd7A==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-pasadena.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-pasadena.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:QkvVlOCH6Fjb8Uc3bRRHdMEbtSGtjuC+a7zD+u3vhQ4wnzobCyDmuQRib0bCg4X3tHQLJJVmcq2EeqNsSG/xS9RynW8vIzX4,iv:JqvaBzMv33ZP54SoJv78y2BYCFcgaAAhw1CjUT7E9dg=,tag:Y/0ydUZbpEHhBYMHDwZoEA==,type:str]
-                client_secret: ENC[AES256_GCM,data:rgKFn5+RYQRQNOo3aas5yYNT4rlOic05adFgBU0sYaXMB9Y=,iv:YqLFMjunm+79Kc3cRTrqpCzV+pX/ZYCbbsO6OptBFcI=,tag:5JRqX7GwS48zNVTHY2jBeQ==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:QkvVlOCH6Fjb8Uc3bRRHdMEbtSGtjuC+a7zD+u3vhQ4wnzobCyDmuQRib0bCg4X3tHQLJJVmcq2EeqNsSG/xS9RynW8vIzX4,iv:JqvaBzMv33ZP54SoJv78y2BYCFcgaAAhw1CjUT7E9dg=,tag:Y/0ydUZbpEHhBYMHDwZoEA==,type:str]
+        client_secret: ENC[AES256_GCM,data:rgKFn5+RYQRQNOo3aas5yYNT4rlOic05adFgBU0sYaXMB9Y=,iv:YqLFMjunm+79Kc3cRTrqpCzV+pX/ZYCbbsO6OptBFcI=,tag:5JRqX7GwS48zNVTHY2jBeQ==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:28Z"
-          enc: CiUA4OM7eL6dyeV9/tTzqcB5xzAapN9G5eshkgjssvFb2qHKuytWEkkAmy+ekjx0eNiXLd0JpDOidoT95d5HerRUZwbs/GQdcaNjMD/LPzgkJgrJxxZfkRu23ElGbOstEcrvYUqjsDbF6bQBj8kPhAY1
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:29Z"
-    mac: ENC[AES256_GCM,data:YoTpPCMIuB+NgI+IGpfdRlD0pVa4cSQD6fGIIzVlzlX9JwaVsLYGHTvOdE7WbG1vxLVx5olNiOABbraGPWcE91Hgngo9XkhqXc7FssY6HciYkxY1nsIB9gsMBXCu56sFnd7NQO7l7GUG9bKfjruhclwsa1r+jLuCk2izPqNSQoE=,iv:3GXP7rAHY3Hc79a4enubPbM6bq7Rs33xOS+h6Cbu75A=,tag:twoC+dEoFBYLsVzO4xB9Mw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:28Z'
+    enc: CiUA4OM7eL6dyeV9/tTzqcB5xzAapN9G5eshkgjssvFb2qHKuytWEkkAmy+ekjx0eNiXLd0JpDOidoT95d5HerRUZwbs/GQdcaNjMD/LPzgkJgrJxxZfkRu23ElGbOstEcrvYUqjsDbF6bQBj8kPhAY1
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:29Z'
+  mac: ENC[AES256_GCM,data:YoTpPCMIuB+NgI+IGpfdRlD0pVa4cSQD6fGIIzVlzlX9JwaVsLYGHTvOdE7WbG1vxLVx5olNiOABbraGPWcE91Hgngo9XkhqXc7FssY6HciYkxY1nsIB9gsMBXCu56sFnd7NQO7l7GUG9bKfjruhclwsa1r+jLuCk2izPqNSQoE=,iv:3GXP7rAHY3Hc79a4enubPbM6bq7Rs33xOS+h6Cbu75A=,tag:twoC+dEoFBYLsVzO4xB9Mw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-pasadena.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-pasadena.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:Fs6EOrDq6BfyAaYFns+/ijIljm5Fpsklr9cXB6txUFNBPsKPXXISgtfD2bPotzdFNK1J,iv:84L6VKIxE39uJBkP1eyI3kNTxiVJSJYwY1X+yzOyTPQ=,tag:gwNRmJFgLcM7PhfuDOg1Fw==,type:str]
-        client_secret: ENC[AES256_GCM,data:+PX+pfvtys6M3uYifcpDWxRmysPiIlbYfhetYV1+2VST0j1Y65gJPt0TOqObec2+NF+cpKkqQLYoHW85JaBk/ScQ0L7ZiK1OGBUfgUwTgtZcxzF475k=,iv:8dapaHzdbQlS8tlPs30oB/BBTDLCoJET9Ru3tfrkd18=,tag:jrQpQMRCPO59aW7uOLsY6Q==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:QkvVlOCH6Fjb8Uc3bRRHdMEbtSGtjuC+a7zD+u3vhQ4wnzobCyDmuQRib0bCg4X3tHQLJJVmcq2EeqNsSG/xS9RynW8vIzX4,iv:JqvaBzMv33ZP54SoJv78y2BYCFcgaAAhw1CjUT7E9dg=,tag:Y/0ydUZbpEHhBYMHDwZoEA==,type:str]
+                client_secret: ENC[AES256_GCM,data:rgKFn5+RYQRQNOo3aas5yYNT4rlOic05adFgBU0sYaXMB9Y=,iv:YqLFMjunm+79Kc3cRTrqpCzV+pX/ZYCbbsO6OptBFcI=,tag:5JRqX7GwS48zNVTHY2jBeQ==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2022-09-21T01:46:01Z'
-    enc: CiQA4OM7eJafRlSiv8jeKg4O6XRpSJxCfDsPls6KBgX3br5lmikSSQDuy/p8gRrBm1bQVyBQ9eNEcCWlSn0sk3f+gQctea45XVAJBarkmLrmZv7ANQ65bMc2OQsFTZQRlOvlMIttKqYoY07Kky7PgI0=
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2022-09-21T01:46:02Z'
-  mac: ENC[AES256_GCM,data:EuwADE8cct7HlVipJDqDez25f+Fw2qlsB0jZQZxmVPET2qryzGbzs1dCLUGbTwxDBbwzkKbh6cJqcdLrBoB1rHGTUfafw8Qu/xOOa44P1D4URiQWirRhIX5x6ug6tdsETHLvdua2eXAM+RPhncE+js0UnLtDs5rrkUJjNWrMqho=,iv:69dMeOlq/GwfVn9vUEzBgeqQ+TIuTRUsO9tOvWc6kl4=,tag:AcY7z7p0xHuCCDnRVGBMDA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:28Z"
+          enc: CiUA4OM7eL6dyeV9/tTzqcB5xzAapN9G5eshkgjssvFb2qHKuytWEkkAmy+ekjx0eNiXLd0JpDOidoT95d5HerRUZwbs/GQdcaNjMD/LPzgkJgrJxxZfkRu23ElGbOstEcrvYUqjsDbF6bQBj8kPhAY1
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:29Z"
+    mac: ENC[AES256_GCM,data:YoTpPCMIuB+NgI+IGpfdRlD0pVa4cSQD6fGIIzVlzlX9JwaVsLYGHTvOdE7WbG1vxLVx5olNiOABbraGPWcE91Hgngo9XkhqXc7FssY6HciYkxY1nsIB9gsMBXCu56sFnd7NQO7l7GUG9bKfjruhclwsa1r+jLuCk2izPqNSQoE=,iv:3GXP7rAHY3Hc79a4enubPbM6bq7Rs33xOS+h6Cbu75A=,tag:twoC+dEoFBYLsVzO4xB9Mw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-saddleback.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-saddleback.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:XpNJb75qrsxl7WCP6J5fDk9Qw0HtodY92371+CvZZEs2RJ/bDeIomuIfQ63hVy2xU5PO,iv:qqyddthu+IrUI7wHRH78xfkt0zCqmrzBtKV6QjYu12I=,tag:PPJrdcs4LFMFbOX83VHkrQ==,type:str]
-        client_secret: ENC[AES256_GCM,data:6ft3IIR7gzhR2e8TtOJLLzLayHs4zQNBKrVXuYfdgYC4i15MugN8Ps9rW6nGAYi474D/jmTyJY76680S3rfbiaMs20Isi82Ce8kGkv3ekkruwZJ3mgM=,iv:fJ4rKuilpNQvGqF2EKd+47ILH6RX/H7drGiNQxOufT8=,tag:vUP8IbJiXbMcPvuDNQeVNA==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:dHVTjGbftS7Xt34+ILKmZVGqMbhHF+iIGNG60ubSO//jUWcTaLJdW/wbUhwSjSj+sd1P+MEcDUtHtVQ49q6Xhd2EA6759djy,iv:X7ZA0e7d/D4zOtOPN+ctXMTNWaPO2TE6/WX6N44u88A=,tag:CQbyQCRCzPll84EKSP7BUg==,type:str]
+                client_secret: ENC[AES256_GCM,data:TjgGsP48d1tE7Zhe5aAIuv5NINStBQDbGYskUxTpPRMS1Yk=,iv:uYSSNbV1DssCtBWagXsmSGTyDf7mi0ldUSlyiJ7Rxrw=,tag:FQmQ7paMGJ4EbQH/7m28kg==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-06-27T21:20:24Z'
-    enc: CiUA4OM7eMAF9A97+q6LBVLHrVzihHjPZpUsTGWuwSLThAY9bZNLEkkAyiwFHNa+mnszvv502IvYwbcLUZy8IbEQ3UblOPrxZ87o72AAJlX115RsH0aKRDdT7S9APdPQPnpjYJJbvQgfszYri31sR945
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-06-27T21:20:25Z'
-  mac: ENC[AES256_GCM,data:guL6xVsanT4vh7MV3ATCD6vRbBmtoOE1cu6tjjFgxw6atPbuTE7oScFrd46Lnd5w02vMRNnfhG6uJZfSt/4PQNnlzkPj5uo6hKNqgp2XtnAiuRUA5cIqNHKXD/Bzpyvd6aRckuTXjBIVKNi4bVPMtBjdwwp/rGPbYJVHhiXEjGM=,iv:yOx/u5HObXF9pqJhPvB3zzYlIsgk9yCDhX2jXWnX2bs=,tag:7yxTEHCKTx3x7jW3HfGsbw==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:30Z"
+          enc: CiUA4OM7ePiJb5i7l0kgvpOcasOyZlTrNTsHRRAenhNc1dYqOPQqEkkAmy+eki3yN8hocqANW9iLnz+RcXuAr4zy/MOTpNJ97qEpdKNwKEniklgl+SeGzf9Iu4cxNb0ngsBva2Gi+tcsyIagbRdeZTny
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:30Z"
+    mac: ENC[AES256_GCM,data:YlICAUf1ACTh1Yqnd22YPDegMee/D1UKqibR6oX7mraFOFX+lC5k1GK4yVH5WBx+WCBwZqTzsrdr/KPca68IqJDUg7QKtF1rkU4gc/nBILyuBgOF6o8TfLlMl4NPT4K779yu5wH7+d4zqgRj+3xzHtCxWDVW21HpeMUmJ1nBKfs=,iv:XLgD1t/h4x7kX7OaggL804/2YkJWdi70ZwORkOxmM6I=,tag:+FS3t1mlM3M2Rd/DMUnUYQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-saddleback.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-saddleback.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:dHVTjGbftS7Xt34+ILKmZVGqMbhHF+iIGNG60ubSO//jUWcTaLJdW/wbUhwSjSj+sd1P+MEcDUtHtVQ49q6Xhd2EA6759djy,iv:X7ZA0e7d/D4zOtOPN+ctXMTNWaPO2TE6/WX6N44u88A=,tag:CQbyQCRCzPll84EKSP7BUg==,type:str]
-                client_secret: ENC[AES256_GCM,data:TjgGsP48d1tE7Zhe5aAIuv5NINStBQDbGYskUxTpPRMS1Yk=,iv:uYSSNbV1DssCtBWagXsmSGTyDf7mi0ldUSlyiJ7Rxrw=,tag:FQmQ7paMGJ4EbQH/7m28kg==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:dHVTjGbftS7Xt34+ILKmZVGqMbhHF+iIGNG60ubSO//jUWcTaLJdW/wbUhwSjSj+sd1P+MEcDUtHtVQ49q6Xhd2EA6759djy,iv:X7ZA0e7d/D4zOtOPN+ctXMTNWaPO2TE6/WX6N44u88A=,tag:CQbyQCRCzPll84EKSP7BUg==,type:str]
+        client_secret: ENC[AES256_GCM,data:TjgGsP48d1tE7Zhe5aAIuv5NINStBQDbGYskUxTpPRMS1Yk=,iv:uYSSNbV1DssCtBWagXsmSGTyDf7mi0ldUSlyiJ7Rxrw=,tag:FQmQ7paMGJ4EbQH/7m28kg==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:30Z"
-          enc: CiUA4OM7ePiJb5i7l0kgvpOcasOyZlTrNTsHRRAenhNc1dYqOPQqEkkAmy+eki3yN8hocqANW9iLnz+RcXuAr4zy/MOTpNJ97qEpdKNwKEniklgl+SeGzf9Iu4cxNb0ngsBva2Gi+tcsyIagbRdeZTny
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:30Z"
-    mac: ENC[AES256_GCM,data:YlICAUf1ACTh1Yqnd22YPDegMee/D1UKqibR6oX7mraFOFX+lC5k1GK4yVH5WBx+WCBwZqTzsrdr/KPca68IqJDUg7QKtF1rkU4gc/nBILyuBgOF6o8TfLlMl4NPT4K779yu5wH7+d4zqgRj+3xzHtCxWDVW21HpeMUmJ1nBKfs=,iv:XLgD1t/h4x7kX7OaggL804/2YkJWdi70ZwORkOxmM6I=,tag:+FS3t1mlM3M2Rd/DMUnUYQ==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:30Z'
+    enc: CiUA4OM7ePiJb5i7l0kgvpOcasOyZlTrNTsHRRAenhNc1dYqOPQqEkkAmy+eki3yN8hocqANW9iLnz+RcXuAr4zy/MOTpNJ97qEpdKNwKEniklgl+SeGzf9Iu4cxNb0ngsBva2Gi+tcsyIagbRdeZTny
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:30Z'
+  mac: ENC[AES256_GCM,data:YlICAUf1ACTh1Yqnd22YPDegMee/D1UKqibR6oX7mraFOFX+lC5k1GK4yVH5WBx+WCBwZqTzsrdr/KPca68IqJDUg7QKtF1rkU4gc/nBILyuBgOF6o8TfLlMl4NPT4K779yu5wH7+d4zqgRj+3xzHtCxWDVW21HpeMUmJ1nBKfs=,iv:XLgD1t/h4x7kX7OaggL804/2YkJWdi70ZwORkOxmM6I=,tag:+FS3t1mlM3M2Rd/DMUnUYQ==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-sbcc.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-sbcc.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:I/tk2BCD9vIH6Nl68203LXZ3Pol/HmP4+vcTkXQJ5vDr1zfD16Pnpx7ssRAPThA5saER,iv:SXbf2qbqlE+JxQ7nm7ZBOqBvwnJmizKtnD/7j3cXd+Y=,tag:rSCaqzkEha5KCj6OKZJgPg==,type:str]
-        client_secret: ENC[AES256_GCM,data:AdK+mNLtMZUD382xRRDxc8Zh5g4eaFTMxN0uLCFN0oDcBjlQLnOYyTkKeo8EWQJAZiNe/4ODDHkhc8KAF3CrMDsU9kfBb0zME4yg/+j54DvoheQgTGU=,iv:RMwk/vD+DSZmlYFpqm9YIyJAzXQqORAEJ+e9zb91CCM=,tag:eWOzUXbUj4XnMzUpibLZGg==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:uhE3g61CQ8Pv3uUdhPHwvDb/sHDQapKTcRBhi/z11o0c5t9F/waB8bBJp1tifpQjwKXVPhr6N3ZYXxlP900z3K7FKA2ydEjw,iv:lIkI3DvNiAsRgWcAD8T1KgfPiucS7J7WhJSXTTKDfz4=,tag:q/p14r9RIAEWEtRLH2HEvg==,type:str]
+                client_secret: ENC[AES256_GCM,data:URPin0rdm1R01ZzdVd6NszfpmWkyMvrClJVuUYKQ1s7U1BI=,iv:gP4BEOr9ic1rgiUvFQyP+Ylerho0Nap6DCxUApOxP+Y=,tag:5Tr5rLDpTrKcwX/+ebf3Tw==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-03-10T13:55:15Z'
-    enc: CiUA4OM7eN0pYO4+jSk/uhx/Ci17uaSOxcyeOdxNFh4VOIiSj4ikEkkALQgViPwbrmVgS8k/yz3CiFqTNRsClBRTM5l/sQ9dGi09PKPq9aIg2eZClK5mDhVMxPoNjHWj/G4JjikpYrjABUMRgcJpfYWG
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-03-10T13:55:16Z'
-  mac: ENC[AES256_GCM,data:ldntPecmMkytYZKyldzsOqaxt7NNOE8aeDqF9Td58Iv6poQl2tmOQiwt7fpoKMg+dYRVS0IW09UJ8evDErxeauLXvyc/QEzdKUZvKRjrhFbV3om2vNQd8sK+7gQ1vRd1pGucyrlrAVDmMJe02I4xTLZSOkHQAuVHtoJ9d9eaNoY=,iv:tyfi2G1egQigimq7h4aUVVr40A0YJg6x4fq2Cqm8/MI=,tag:6aRzAb1TPoml4fyvfwGzcA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.3
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:31Z"
+          enc: CiUA4OM7eDwT/EPOKHKosEJYZzoxszX9JrayWqJVHnhBt+JCbkDFEkkAmy+ektP0vAycLkUj5vYHbIzMua6uYdM/jQZ/PkAwcSV2S8RqY0l3H3fE/ZKYpdbjU1ocxUWgbSSZUFwcjAuMXbe2BLc365lN
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:32Z"
+    mac: ENC[AES256_GCM,data:WA0I0FVnUfzDj6F7NBslZlsjylsFEB63qmUH7V2QVaI4aQC6exczFrGg/KMusrtQ16wIKnKFO20kRcUF+p2sQZGl1F08571zwBdrL60uSfkEfs1LZQJvU113uvAyWDBUriB2y2oLn3Sd1bIzDR5fbX8WRuhBeh8Z/QfTLKSEfwM=,iv:UOuz1ehLQH3LHFhPFpa8khFvo2fsOJTst7I8MWgzsHQ=,tag:QkvccqBgs0V4xa2B8TeYfg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-sbcc.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-sbcc.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:uhE3g61CQ8Pv3uUdhPHwvDb/sHDQapKTcRBhi/z11o0c5t9F/waB8bBJp1tifpQjwKXVPhr6N3ZYXxlP900z3K7FKA2ydEjw,iv:lIkI3DvNiAsRgWcAD8T1KgfPiucS7J7WhJSXTTKDfz4=,tag:q/p14r9RIAEWEtRLH2HEvg==,type:str]
-                client_secret: ENC[AES256_GCM,data:URPin0rdm1R01ZzdVd6NszfpmWkyMvrClJVuUYKQ1s7U1BI=,iv:gP4BEOr9ic1rgiUvFQyP+Ylerho0Nap6DCxUApOxP+Y=,tag:5Tr5rLDpTrKcwX/+ebf3Tw==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:uhE3g61CQ8Pv3uUdhPHwvDb/sHDQapKTcRBhi/z11o0c5t9F/waB8bBJp1tifpQjwKXVPhr6N3ZYXxlP900z3K7FKA2ydEjw,iv:lIkI3DvNiAsRgWcAD8T1KgfPiucS7J7WhJSXTTKDfz4=,tag:q/p14r9RIAEWEtRLH2HEvg==,type:str]
+        client_secret: ENC[AES256_GCM,data:URPin0rdm1R01ZzdVd6NszfpmWkyMvrClJVuUYKQ1s7U1BI=,iv:gP4BEOr9ic1rgiUvFQyP+Ylerho0Nap6DCxUApOxP+Y=,tag:5Tr5rLDpTrKcwX/+ebf3Tw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:31Z"
-          enc: CiUA4OM7eDwT/EPOKHKosEJYZzoxszX9JrayWqJVHnhBt+JCbkDFEkkAmy+ektP0vAycLkUj5vYHbIzMua6uYdM/jQZ/PkAwcSV2S8RqY0l3H3fE/ZKYpdbjU1ocxUWgbSSZUFwcjAuMXbe2BLc365lN
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:32Z"
-    mac: ENC[AES256_GCM,data:WA0I0FVnUfzDj6F7NBslZlsjylsFEB63qmUH7V2QVaI4aQC6exczFrGg/KMusrtQ16wIKnKFO20kRcUF+p2sQZGl1F08571zwBdrL60uSfkEfs1LZQJvU113uvAyWDBUriB2y2oLn3Sd1bIzDR5fbX8WRuhBeh8Z/QfTLKSEfwM=,iv:UOuz1ehLQH3LHFhPFpa8khFvo2fsOJTst7I8MWgzsHQ=,tag:QkvccqBgs0V4xa2B8TeYfg==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:31Z'
+    enc: CiUA4OM7eDwT/EPOKHKosEJYZzoxszX9JrayWqJVHnhBt+JCbkDFEkkAmy+ektP0vAycLkUj5vYHbIzMua6uYdM/jQZ/PkAwcSV2S8RqY0l3H3fE/ZKYpdbjU1ocxUWgbSSZUFwcjAuMXbe2BLc365lN
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:32Z'
+  mac: ENC[AES256_GCM,data:WA0I0FVnUfzDj6F7NBslZlsjylsFEB63qmUH7V2QVaI4aQC6exczFrGg/KMusrtQ16wIKnKFO20kRcUF+p2sQZGl1F08571zwBdrL60uSfkEfs1LZQJvU113uvAyWDBUriB2y2oLn3Sd1bIzDR5fbX8WRuhBeh8Z/QfTLKSEfwM=,iv:UOuz1ehLQH3LHFhPFpa8khFvo2fsOJTst7I8MWgzsHQ=,tag:QkvccqBgs0V4xa2B8TeYfg==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-skyline.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-skyline.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:cX9kTXz4mGJTyH5vAvDVJmiMdjxDr8lHATC5r2kLm6qPuZktZ8Stp0SDq0tFrRstPjBrpIf6yrzBf9hYUJ41542Bf5Jpx57p,iv:fNFP2qL0+AHonRpiM9akIHcV3CI73sGsUBIhpzJytNs=,tag:zGZqNQlWKdDfjhhrgzHxiQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:cGVxKA0nwW6Yc0jc1tFilZb7mfSFv1v/r1NchJIOxvEfi0o=,iv:RGrZUfGqyt+xm2QkSWOZ7NiDwNZNYbh2dqT3Wi9vHYo=,tag:fSIPOxFXNrFXo86WNpcPOw==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:cX9kTXz4mGJTyH5vAvDVJmiMdjxDr8lHATC5r2kLm6qPuZktZ8Stp0SDq0tFrRstPjBrpIf6yrzBf9hYUJ41542Bf5Jpx57p,iv:fNFP2qL0+AHonRpiM9akIHcV3CI73sGsUBIhpzJytNs=,tag:zGZqNQlWKdDfjhhrgzHxiQ==,type:str]
+        client_secret: ENC[AES256_GCM,data:cGVxKA0nwW6Yc0jc1tFilZb7mfSFv1v/r1NchJIOxvEfi0o=,iv:RGrZUfGqyt+xm2QkSWOZ7NiDwNZNYbh2dqT3Wi9vHYo=,tag:fSIPOxFXNrFXo86WNpcPOw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:33Z"
-          enc: CiUA4OM7eJvPpsDLetaTOqH5p6hxbCA0upG+T7giJZHsYc/I3k/tEkkAmy+ekgVU36v7rH1jW+JRMFwETMeNbj6hEJ/SnKmE3YeDDcseTCSlVlcsP+sNUYLqTOwvvLoT9iZvFXr8cDq/PPNN1yLVLMM3
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:34Z"
-    mac: ENC[AES256_GCM,data:j6lCdzNar1McJrJHcQJOMXI4ebRMyx53sqozl3h4pBLppZ+XOIGcep4WuIYQbI01yeo5k9AkczU2KXyi3vGh394+jX9W2PjsfRGlmu8/ELrZRSNDuopYAVVVPU7LCNygETCpwIo8wglcrE50OS4nhkmTBnmf9jWELKIMe5U0Q4s=,iv:smFLZ7FthVykfns+5TnDEAxoF+CUAPOkKgToTT7QBDE=,tag:gU1R8AW+ypnv4lTUk2THnw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:33Z'
+    enc: CiUA4OM7eJvPpsDLetaTOqH5p6hxbCA0upG+T7giJZHsYc/I3k/tEkkAmy+ekgVU36v7rH1jW+JRMFwETMeNbj6hEJ/SnKmE3YeDDcseTCSlVlcsP+sNUYLqTOwvvLoT9iZvFXr8cDq/PPNN1yLVLMM3
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:34Z'
+  mac: ENC[AES256_GCM,data:j6lCdzNar1McJrJHcQJOMXI4ebRMyx53sqozl3h4pBLppZ+XOIGcep4WuIYQbI01yeo5k9AkczU2KXyi3vGh394+jX9W2PjsfRGlmu8/ELrZRSNDuopYAVVVPU7LCNygETCpwIo8wglcrE50OS4nhkmTBnmf9jWELKIMe5U0Q4s=,iv:smFLZ7FthVykfns+5TnDEAxoF+CUAPOkKgToTT7QBDE=,tag:gU1R8AW+ypnv4lTUk2THnw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-skyline.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-skyline.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:N1eQH8M/wdCODIp5GyHtccc3If1STyWm4kVmsRQvSNj090iLgHaWskbpF3liNyJrC7Z3,iv:Mna2Q8kNUdojulXoUwuIV4E8Ad4H8rae4/vL2KFPbhk=,tag:DiUzQrM4/c7iy613LRagrg==,type:str]
-        client_secret: ENC[AES256_GCM,data:m70L4vY2OKVjp1+nyx84HJpsYCSq0LAQUlWAc3g4/U8Ju83xdOI3YkLK2yKGdDGJM6c0wJBPf3O9Mjlk+tfZenCI6KUPSkgFYnuQ16TOd+o3JN+9HdI=,iv:MA2ODGeAk6WnoZuy5Jo0VFy8dHsOrz2PI1y+ZSDFO9w=,tag:Ywg/PlLIWY7LeWOa5Xn2fw==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:cX9kTXz4mGJTyH5vAvDVJmiMdjxDr8lHATC5r2kLm6qPuZktZ8Stp0SDq0tFrRstPjBrpIf6yrzBf9hYUJ41542Bf5Jpx57p,iv:fNFP2qL0+AHonRpiM9akIHcV3CI73sGsUBIhpzJytNs=,tag:zGZqNQlWKdDfjhhrgzHxiQ==,type:str]
+                client_secret: ENC[AES256_GCM,data:cGVxKA0nwW6Yc0jc1tFilZb7mfSFv1v/r1NchJIOxvEfi0o=,iv:RGrZUfGqyt+xm2QkSWOZ7NiDwNZNYbh2dqT3Wi9vHYo=,tag:fSIPOxFXNrFXo86WNpcPOw==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2023-03-10T13:45:38Z'
-    enc: CiUA4OM7eDUHozGolT+xsDGCnh6bjdPgEqIvVe8D05NyZmuBP7dOEkkALQgViGlDZU30CQlNLV67b7YXIKp3Qe2sLM0b7V66GM/1bkbsMrnOXda39vpY7WPfSw+HZExo1jy3TBgKB2s85X5aCWs8e8EJ
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2023-03-10T13:45:38Z'
-  mac: ENC[AES256_GCM,data:X7DcK5kxwgtybl21FS9NsOIMgRnKGnj3ydoRqU7YQID0twiNMRRcRrw4KsMsV6t7ez/qTXP2R9lIMBf059lrwL+hsezTZzc6u5MN5e68fE2hymZgpy2frq4kyMa4ZVJFrJjFZeZJWQPJ1UC58y1oT16Rf85xY9UZx+1KEqEMhpA=,iv:drWC+MXA7I4UkSTzR2/YQv1xQ/TCQWfC80B3CsWKjo8=,tag:qwcSG3n6AdPRDyUu49TnmA==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.7.3
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:33Z"
+          enc: CiUA4OM7eJvPpsDLetaTOqH5p6hxbCA0upG+T7giJZHsYc/I3k/tEkkAmy+ekgVU36v7rH1jW+JRMFwETMeNbj6hEJ/SnKmE3YeDDcseTCSlVlcsP+sNUYLqTOwvvLoT9iZvFXr8cDq/PPNN1yLVLMM3
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:34Z"
+    mac: ENC[AES256_GCM,data:j6lCdzNar1McJrJHcQJOMXI4ebRMyx53sqozl3h4pBLppZ+XOIGcep4WuIYQbI01yeo5k9AkczU2KXyi3vGh394+jX9W2PjsfRGlmu8/ELrZRSNDuopYAVVVPU7LCNygETCpwIo8wglcrE50OS4nhkmTBnmf9jWELKIMe5U0Q4s=,iv:smFLZ7FthVykfns+5TnDEAxoF+CUAPOkKgToTT7QBDE=,tag:gU1R8AW+ypnv4lTUk2THnw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/enc-sou.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-sou.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-    hub:
-        config:
-            GoogleOAuthenticator:
-                client_id: ENC[AES256_GCM,data:7vyhwZxABBuSKfwSDSr/D/YqnP6H3Cz3C9hfGiNrjBOMuAP8FvqiS9LKIs+MYq2hgouMTOgqjti+WLf1Rinzsa5Cr7s/cbgl,iv:y8xnMnQhcphFTcFJn7Zljsc6+pBsOv8Ii1nM/CmeOg8=,tag:inx4Omo4NR2VDKyqIRA7bA==,type:str]
-                client_secret: ENC[AES256_GCM,data:YCbAq8iMedjp0F7w8wog5kXyyr1zbyDanUofQ7GK9KfWwzA=,iv:ScsyEL+0Kl0M68pAohVuLXuW61W1fbqDTKJPI3pxJ1A=,tag:uKjMOGRJrIND+BCge1O97Q==,type:str]
+  hub:
+    config:
+      GoogleOAuthenticator:
+        client_id: ENC[AES256_GCM,data:7vyhwZxABBuSKfwSDSr/D/YqnP6H3Cz3C9hfGiNrjBOMuAP8FvqiS9LKIs+MYq2hgouMTOgqjti+WLf1Rinzsa5Cr7s/cbgl,iv:y8xnMnQhcphFTcFJn7Zljsc6+pBsOv8Ii1nM/CmeOg8=,tag:inx4Omo4NR2VDKyqIRA7bA==,type:str]
+        client_secret: ENC[AES256_GCM,data:YCbAq8iMedjp0F7w8wog5kXyyr1zbyDanUofQ7GK9KfWwzA=,iv:ScsyEL+0Kl0M68pAohVuLXuW61W1fbqDTKJPI3pxJ1A=,tag:uKjMOGRJrIND+BCge1O97Q==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2026-07-01T23:41:35Z"
-          enc: CiUA4OM7eJtRtUpwKknYVY6dEvzfajwRYiz2LIfsQQZZ8MOOH2/kEkkAmy+ekrbRm53qm+S22bI/x/xmcWj0G05reUF89ntlACZviJcmiST5abmFxN5Dn7MX0KdLOeoAJxExoYQsqktHfXvcPyrH1RQo
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2026-07-01T23:41:35Z"
-    mac: ENC[AES256_GCM,data:9GDPziWzp/OYqlLb2oUTWoc6XZPKQIVNuKd+M4Oe1ysV81YcYs2ONMn4+WCN24n/y9mcn7MtRAUDuzPcRjH9fT6yS5mTRdOA5iKx50Q5ziG55jajG+wpNboEXDh9i02MIahCCbley/0SPcW8iVFxeRQoh21RF1YeeTFGgjg+grI=,iv:3YomWrmIDLL+TqWb6tk4lm0t9Mka2xEYmxGq6pcr8mA=,tag:qsbH8vYMIghhmfUEAD+01w==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.8.1
+  kms: []
+  gcp_kms:
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-07-01T23:41:35Z'
+    enc: CiUA4OM7eJtRtUpwKknYVY6dEvzfajwRYiz2LIfsQQZZ8MOOH2/kEkkAmy+ekrbRm53qm+S22bI/x/xmcWj0G05reUF89ntlACZviJcmiST5abmFxN5Dn7MX0KdLOeoAJxExoYQsqktHfXvcPyrH1RQo
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: '2026-07-01T23:41:35Z'
+  mac: ENC[AES256_GCM,data:9GDPziWzp/OYqlLb2oUTWoc6XZPKQIVNuKd+M4Oe1ysV81YcYs2ONMn4+WCN24n/y9mcn7MtRAUDuzPcRjH9fT6yS5mTRdOA5iKx50Q5ziG55jajG+wpNboEXDh9i02MIahCCbley/0SPcW8iVFxeRQoh21RF1YeeTFGgjg+grI=,iv:3YomWrmIDLL+TqWb6tk4lm0t9Mka2xEYmxGq6pcr8mA=,tag:qsbH8vYMIghhmfUEAD+01w==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/config/clusters/cloudbank/enc-sou.secret.values.yaml
+++ b/config/clusters/cloudbank/enc-sou.secret.values.yaml
@@ -1,20 +1,20 @@
 jupyterhub:
-  hub:
-    config:
-      CILogonOAuthenticator:
-        client_id: ENC[AES256_GCM,data:ih+NRhda0MTitsDhwec0LO0NSy/OO/Smcv7HwaoSshAM5A4rq7wR8lsAKmUx/Z+7KtoR,iv:7Jx5EmmmpRgQgEm/21Xupg6sy04ilkO2Y4CKFgKTl1E=,tag:PEE5BBBLZq7UyeRly5q5IQ==,type:str]
-        client_secret: ENC[AES256_GCM,data:lbV26yHogIrtg0Sp9QAD+aTWZl8inShmXUQdxXheQ84OXiAbQvg5GnEkMpGHtNtq54i6A0uzWjIjkx70vGcLYxUdPJVccmkUk62lHzNruY7AjaWgJAQ=,iv:y/hDoUr1pOGksnv116/pJmUyNmm8++4pAJ70eH1X49M=,tag:ceUFFFzALeCzpun7xQl0/A==,type:str]
+    hub:
+        config:
+            GoogleOAuthenticator:
+                client_id: ENC[AES256_GCM,data:7vyhwZxABBuSKfwSDSr/D/YqnP6H3Cz3C9hfGiNrjBOMuAP8FvqiS9LKIs+MYq2hgouMTOgqjti+WLf1Rinzsa5Cr7s/cbgl,iv:y8xnMnQhcphFTcFJn7Zljsc6+pBsOv8Ii1nM/CmeOg8=,tag:inx4Omo4NR2VDKyqIRA7bA==,type:str]
+                client_secret: ENC[AES256_GCM,data:YCbAq8iMedjp0F7w8wog5kXyyr1zbyDanUofQ7GK9KfWwzA=,iv:ScsyEL+0Kl0M68pAohVuLXuW61W1fbqDTKJPI3pxJ1A=,tag:uKjMOGRJrIND+BCge1O97Q==,type:str]
 sops:
-  kms: []
-  gcp_kms:
-  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-    created_at: '2025-10-23T23:15:21Z'
-    enc: CiUA4OM7eGBWgrE6r/3GgjnVNK2L+ogox7OQsjQFp3Kp6kbCpg4zEkkAXpa10H020uqisEdXAz2cleNhaaQdzO54ZbkfbEbrOhgcGLLldr+yQPtEwHKMphfm3Sc4lFRwfgv6v7cU20o0F19DwOx7RfKK
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: '2025-10-23T23:15:21Z'
-  mac: ENC[AES256_GCM,data:XmYfZmJ/W+0Wz3eURnXdpdE8UK0LzQCNwtPd0+vclY9nwsXptB4EvWxuwnX2GEtIeFaHfqSoJcGXrNNz7F2hdBB+PQ5VonLgjsLkArt/F9YYmbUaTVKTSzT7gBhCCqOT3qqW9ZTLTD1ZjJZYdJ9xtpYMFHeRAgpzxl4SdlfNgXE=,iv:WmBB4ML4r954fLd0zlEV4QW7mf1jCjSlFZiN5HU5/Cw=,tag:dVSD3juDj5O9Ik6nsZij7Q==,type:str]
-  pgp: []
-  unencrypted_suffix: _unencrypted
-  version: 3.8.1
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2026-07-01T23:41:35Z"
+          enc: CiUA4OM7eJtRtUpwKknYVY6dEvzfajwRYiz2LIfsQQZZ8MOOH2/kEkkAmy+ekrbRm53qm+S22bI/x/xmcWj0G05reUF89ntlACZviJcmiST5abmFxN5Dn7MX0KdLOeoAJxExoYQsqktHfXvcPyrH1RQo
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-01T23:41:35Z"
+    mac: ENC[AES256_GCM,data:9GDPziWzp/OYqlLb2oUTWoc6XZPKQIVNuKd+M4Oe1ysV81YcYs2ONMn4+WCN24n/y9mcn7MtRAUDuzPcRjH9fT6yS5mTRdOA5iKx50Q5ziG55jajG+wpNboEXDh9i02MIahCCbley/0SPcW8iVFxeRQoh21RF1YeeTFGgjg+grI=,iv:3YomWrmIDLL+TqWb6tk4lm0t9Mka2xEYmxGq6pcr8mA=,tag:qsbH8vYMIghhmfUEAD+01w==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -21,16 +21,12 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - glendale.edu
-            - student.glendale.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - glendale.edu
+        - student.glendale.edu
       Authenticator:
         admin_users:
         - simon@glendale.edu

--- a/config/clusters/cloudbank/nicc.values.yaml
+++ b/config/clusters/cloudbank/nicc.values.yaml
@@ -26,15 +26,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - nicc.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - nicc.edu
       Authenticator:
         admin_users:
         - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -21,13 +21,9 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -24,6 +24,8 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
+        allowed_domains:
+        - palomar.edu
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -27,15 +27,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - go.pasadena.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - go.pasadena.edu
       Authenticator:
         admin_users:
         - yxchang@go.pasadena.edu

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -27,16 +27,12 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - saddleback.edu
-            - ivc.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - saddleback.edu
+        - ivc.edu
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -24,6 +24,8 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
+        allowed_domains:
+        - pipeline.sbcc.edu
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -21,12 +21,9 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: email
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -27,15 +27,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - my.smccd.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - my.smccd.edu
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -120,15 +120,11 @@ jupyterhub:
   hub:
     config:
       JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: email
-            allowed_domains:
-            - sou.edu
+        authenticator_class: google
+      GoogleOAuthenticator:
+        username_claim: email
+        allowed_domains:
+        - sou.edu
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu


### PR DESCRIPTION
Converts the other 10 (I tested the 11th, ccsf, in a earlier PR) CloudBank hubs that authenticate via Google from **CILogon Google IdP** to **Google OAuth**.

Hubs: csm, elcamino, glendale, nicc, palomar, pasadena, saddleback, sbcc, skyline, sou

Handles Issse  #8673 