### PR TITLE
[CloudBank] Fix Google OAuth allow config: hosted_domain + allow_all

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -33,8 +33,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - mail.ccsf.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         allowed_users:
         - sonnyzadeh@gmail.com

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -31,9 +31,11 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - my.smccd.edu
         - smccd.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -29,8 +29,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - elcamino.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -24,9 +24,11 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - glendale.edu
         - student.glendale.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - simon@glendale.edu

--- a/config/clusters/cloudbank/nicc.values.yaml
+++ b/config/clusters/cloudbank/nicc.values.yaml
@@ -29,8 +29,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - nicc.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - sean.smorris@berkeley.edu

--- a/config/clusters/cloudbank/palomar.values.yaml
+++ b/config/clusters/cloudbank/palomar.values.yaml
@@ -24,8 +24,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - palomar.edu
+        strip_domain: false
+        allow_all: true
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -30,8 +30,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - go.pasadena.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - yxchang@go.pasadena.edu

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -30,9 +30,11 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - saddleback.edu
         - ivc.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -24,8 +24,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - pipeline.sbcc.edu
+        strip_domain: false
+        allow_all: true
       OAuthenticator:
         # WARNING: Don't use allow_existing_users with config to allow an
         #          externally managed group of users, such as

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -30,8 +30,11 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - my.smccd.edu
+        - smccd.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -123,8 +123,10 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        allowed_domains:
+        hosted_domain:
         - sou.edu
+        strip_domain: false
+        allow_all: true
       Authenticator:
         admin_users:
         - ericvd@berkeley.edu


### PR DESCRIPTION
The CILogon→Google conversion (d7f171dc2) carried `allowed_domains` over to `GoogleOAuthenticator`, but `allowed_domains` is a **CILogon-only** trait — it does not exist on `GoogleOAuthenticator` in any oauthenticator version (verified against 17.4.0 and latest `main`). It was silently ignored, leaving no allow rule at all:

```
[W] Config option `allowed_domains` not recognized by `GoogleOAuthenticator`.
[W] No allow config found, it's possible that nobody can login to your Hub!
```

So only `admin_users` could log in; every non-admin user was locked out the moment each hub restarted (which is what happened on skyline today).

## Fix

Replace `allowed_domains` with the valid Google equivalents on all 11 Google-auth hubs (ccsf, csm, elcamino, glendale, nicc, palomar, pasadena, saddleback, sbcc, skyline, sou):

```yaml
GoogleOAuthenticator:
  username_claim: email
  hosted_domain:        # restrict sign-in via the Google hd claim
    - <same domain(s)>
  strip_domain: false   # keep full-email usernames → preserve home dirs
  allow_all: true       # grant access to everyone past the hosted_domain filter
```

- `hosted_domain` is a filter, not an allow rule; `allow_all` is the allow rule. Both are required.
- `strip_domain: false` is essential — a single `hosted_domain` entry otherwise strips `@domain` from usernames, renaming every user and orphaning their NFS home directories.
- skyline also gains `smccd.edu` alongside `my.smccd.edu`.

## Status

All 11 hubs already deployed manually to unblock students during the incident; skyline verified with a live login (existing home directory intact). This PR brings `main` in line with what is live so CD does not revert it.

Note on `hd`: `hosted_domain` matches the Google `hd` claim, not the email domain. Subdomain hubs (ccsf `mail.ccsf.edu`, pasadena `go.pasadena.edu`, sbcc `pipeline.sbcc.edu`) may report a parent-domain `hd`; if so, add that value to the hub's `hosted_domain` list.