### PR TITLE
[earthscope, *] Fix `auth_state_hook`

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -49,7 +49,6 @@ basehub:
             if auth_state:
               url_parts = urlparse(spawner.authenticator.token_url)
               base_url = f"{url_parts.scheme}://{url_parts.netloc}"
-              scope_str = " ".join(spawner.authenticator.scope)
 
               # Bootstrap EarthScope SDK settings
               settings = {
@@ -57,7 +56,7 @@ basehub:
                   "audience": spawner.authenticator.extra_authorize_params.get("audience", ""),
                   "client_id": spawner.authenticator.client_id,
                   "domain": base_url,
-                  "scope": scope_str,
+                  "scope": auth_state.get("scope", ""),
                   "access_token": auth_state.get("access_token", ""),
                   "id_token": auth_state.get("id_token", ""),
                   "refresh_token": auth_state.get("refresh_token", "")


### PR DESCRIPTION
I noticed that `scope_str = " ".join(spawner.authenticator.scope)` was using the general traitlets config values and not dynamically updated from the scopes in the user's `auth_state`.