### PR TITLE
Improve incident report recurrent issue 

### DIFF
--- a/.github/workflows/recurrent-incident-reporting.yaml
+++ b/.github/workflows/recurrent-incident-reporting.yaml
@@ -8,8 +8,16 @@ jobs:
   compute-week:
     uses: ./.github/workflows/is-this-sprint-week.yaml
 
+  check-if-issue-already-exits:
+    uses: benlei/find-issue-by-title@v1
+    id: find-issue
+    with:
+      title: Debt - incident report writing
+      state: open
+      labels: recurrent
+
   create-issue:
-    if: ${{ needs.compute-week.outputs.valid_week == 'True' }}
+    if: ${{ needs.compute-week.outputs.valid_week == 'True' && (needs.check-if-issue-already-exits.outputs.id == '' || needs.check-if-issue-already-exists.outputs.id == null) }}
     needs: compute-week
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/recurrent-incident-reporting.yaml
+++ b/.github/workflows/recurrent-incident-reporting.yaml
@@ -2,7 +2,7 @@ name: 'Recurrent Debt: Incident Report Writing'
 on:
   workflow_dispatch:
   schedule:
-  - cron: 0 4 * * 1
+  - cron: 0 4 * * 3
 
 jobs:
   compute-week:

--- a/.github/workflows/recurrent-incident-reporting.yaml
+++ b/.github/workflows/recurrent-incident-reporting.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: benlei/find-issue-by-title@v1
     id: find-issue
     with:
-      title: Debt - incident report writing
+      title: Debt [engineers] - incident report writing
       state: open
       labels: recurrent
 

--- a/.github/workflows/recurrent-incident-reporting.yaml
+++ b/.github/workflows/recurrent-incident-reporting.yaml
@@ -37,28 +37,28 @@ jobs:
         body: |
           ### Context
 
-          Each sprint, the Infrastructure Engineering team is scheduled to take the following actions, for unpublished **outages that have happened between September 1st 2025 and February 10th 2026**, starting from the most recent ones, until we have paid out all debt:
+          For unpublished **outages that have happened between September 1st 2025 and February 10th 2026**, the Infrastructure Engineering team is scheduled to take the following actions each sprint:
             - handle incident reports
             - handle action items and incident resolution
-            - archive outage-related Slack channels
+            - archive outage-related Slack channels that have their reports published
 
           ### What we need to do
 
           Choose at least one activity from the following list and follow the steps listed.
 
-          **1. Handle incident report review**
-            - review at least one of the ["Draft" incidents in PagerDuty](https://2i2c-org.pagerduty.com/postmortems),
+          1. Handle incident report review
+            - review at least one of the "Draft" incidents in [PagerDuty](https://2i2c-org.pagerduty.com/postmortems),
             - edit it and change its status to "Reviewed" when you are done
             - let the owner know either via the #post-outage-actions Slack channel or this issue
 
-          **2. Handle incident report writing**
-            - get the list of [P1 incidents  in a time frame](https://2i2c-org.pagerduty.com/analytics/insights/incident-activity-report/mTZF8rz8in0fluyZ2m1vjQ)
+          2. Handle incident report writing
+            - get the list of [P1 incidents in a time frame](https://2i2c-org.pagerduty.com/analytics/insights/incident-activity-report/mTZF8rz8in0fluyZ2m1vjQ)
             - compare this list with the list of Postmortems
             - check which incidents do not have postmortems
             - write up any missing Incident Report and save it as a PD draft postmortem
             - let the team know in the #post-outage-actions Slack channel
 
-          **3. Archive outage-related Slack channels**
+          3. Archive outage-related Slack channels
             - review the list of [PD postmortems that are marked as `Closed`](https://2i2c-org.pagerduty.com/postmortems)
             - if any of these still have Slack channels that have not been archived, archive them now
 
@@ -68,5 +68,5 @@ jobs:
           - [ ] @agoose77
           - [ ] @GeorgianaElena
         fields: Status,Estimate,End date
-        values: Up Next,2,${{ env.deadline_as_iso_date }}
+        values: Up Next,1,${{ env.deadline_as_iso_date }}
         GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}

--- a/.github/workflows/recurrent-incident-resolution-review.yaml
+++ b/.github/workflows/recurrent-incident-resolution-review.yaml
@@ -8,8 +8,16 @@ jobs:
   compute-week:
     uses: ./.github/workflows/is-this-sprint-week.yaml
 
+  check-if-issue-already-exits:
+    uses: benlei/find-issue-by-title@v1
+    id: find-issue
+    with:
+      title: Debt - review past outage resolution and actions
+      state: open
+      labels: recurrent
+
   create-issue:
-    if: ${{ needs.compute-week.outputs.valid_week == 'True' }}
+    if: ${{ needs.compute-week.outputs.valid_week == 'True' && (needs.check-if-issue-already-exits.outputs.id == '' || needs.check-if-issue-already-exists.outputs.id == null) }}
     needs: compute-week
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/recurrent-incident-resolution-review.yaml
+++ b/.github/workflows/recurrent-incident-resolution-review.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup recurrent issue for incident reporting
       uses: ./.github/actions/setup-recurrent-issues
       with:
-        title: Debt - review past outage resolution and actions
+        title: Debt [team lead] - review past outage resolution and actions
         assignee: yuvipanda,agoose77,GeorgianaElena
         body: |
           ### Context

--- a/.github/workflows/recurrent-incident-resolution-review.yaml
+++ b/.github/workflows/recurrent-incident-resolution-review.yaml
@@ -2,7 +2,7 @@ name: 'Recurrent Debt: Incident Resolution Review'
 on:
   workflow_dispatch:
   schedule:
-  - cron: 0 4 * * 1
+  - cron: 0 4 * * 3
 
 jobs:
   compute-week:

--- a/.github/workflows/recurrent-incident-resolution-review.yaml
+++ b/.github/workflows/recurrent-incident-resolution-review.yaml
@@ -40,7 +40,7 @@ jobs:
           Each sprint, the Team Lead is scheduled to review the resolution and action items of the outages that have happened **between September 1st 2025 and February 10th 2026** until we have paid out all debt.
 
           ### What we need to do
-          - [ ] review the resolution and the action items of a PD postmortem marked as ["Reviewed" in PD postmortems](https://2i2c-org.pagerduty.com/postmortems)
+          - [ ] review the resolution and the action items of a PD postmortem marked as "Reviewed" in [PD postmortems](https://2i2c-org.pagerduty.com/postmortems)
           - [ ] let the team know either in this issue, or the #post-outage-actions Slack channel and ask any clarifying questions
 
           ### Definition of Done
@@ -49,4 +49,4 @@ jobs:
 
         fields: Status,Estimate,End date
         GH_TOKEN: ${{ secrets.PROJECT_BOARD_PAT_TOKEN }}
-        values: Up Next,2,${{ env.deadline_as_iso_date }}
+        values: Up Next,1,${{ env.deadline_as_iso_date }}


### PR DESCRIPTION
It's been raised, at least a couple of times during planning, that the recurrence of this issues clutters the Up Next column. This is especially true when the task from previous sprint is not completed.

This should fix it, by adding a new check, that validates if an open issue with the same title isn't already there.

Ref https://github.com/2i2c-org/infrastructure/issues/8720