### PR TITLE
Add command to generate MAUs

### DIFF
--- a/deployer/dev_commands/__init__.py
+++ b/deployer/dev_commands/__init__.py
@@ -14,6 +14,7 @@ import deployer.dev_commands.generate.dedicated_cluster.aws  # noqa: F401
 import deployer.dev_commands.generate.dedicated_cluster.gcp  # noqa: F401
 import deployer.dev_commands.generate.hub_asset.cluster_entry  # noqa: F401
 import deployer.dev_commands.generate.hub_asset.hub_files  # noqa: F401
+import deployer.dev_commands.generate.mau  # noqa: F401
 import deployer.dev_commands.generate.placeholders  # noqa: F401
 import deployer.dev_commands.generate.resource_allocation.daemonset_requests  # noqa: F401
 import deployer.dev_commands.generate.resource_allocation.generate_choices  # noqa: F401

--- a/deployer/dev_commands/__init__.py
+++ b/deployer/dev_commands/__init__.py
@@ -8,7 +8,6 @@ import deployer.dev_commands.exec.cost_monitoring.cost_monitoring_app  # noqa: F
 import deployer.dev_commands.exec.get_quota_usage  # noqa: F401
 import deployer.dev_commands.exec.infra_components  # noqa: F401
 import deployer.dev_commands.exec.promql  # noqa: F401
-import deployer.dev_commands.generate.mau  # noqa: F401
 import deployer.dev_commands.generate.cryptnono_config  # noqa: F401
 import deployer.dev_commands.generate.dedicated_cluster.aws  # noqa: F401
 import deployer.dev_commands.generate.dedicated_cluster.gcp  # noqa: F401

--- a/deployer/dev_commands/__init__.py
+++ b/deployer/dev_commands/__init__.py
@@ -8,6 +8,7 @@ import deployer.dev_commands.exec.cost_monitoring.cost_monitoring_app  # noqa: F
 import deployer.dev_commands.exec.get_quota_usage  # noqa: F401
 import deployer.dev_commands.exec.infra_components  # noqa: F401
 import deployer.dev_commands.exec.promql  # noqa: F401
+import deployer.dev_commands.generate.mau  # noqa: F401
 import deployer.dev_commands.generate.cryptnono_config  # noqa: F401
 import deployer.dev_commands.generate.dedicated_cluster.aws  # noqa: F401
 import deployer.dev_commands.generate.dedicated_cluster.gcp  # noqa: F401

--- a/deployer/dev_commands/generate/mau.py
+++ b/deployer/dev_commands/generate/mau.py
@@ -1,22 +1,22 @@
+import calendar
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Annotated, Optional
 
-from rich import progress
-from rich.table import Table
-from rich.live import Live
-from deployer.cli_app import generate_app
-import typer
-import csv
-import calendar
 import requests
-from pathlib import Path
-from datetime import datetime, timedelta, timezone
+import typer
+from rich import progress
+from rich.live import Live
+from rich.table import Table
 from yarl import URL
+
+from deployer.cli_app import generate_app
 from deployer.infra_components.cluster import Cluster
 
 # Usernames to ignore when calculating MAU
-USERNAMES_TO_IGNORE = set([
+USERNAMES_TO_IGNORE = {
     "deployment-service-check",
-
     # 2i2c staff GitHub IDs
     "agoose77",
     "choldgraf",
@@ -27,7 +27,6 @@ USERNAMES_TO_IGNORE = set([
     "jnywong",
     "yuvipanda",
     "jmunroe",
-
     # 2i2c staff google ids
     "ahollands@2i2c.org",
     "choldgraf@2i2c.org",
@@ -37,14 +36,19 @@ USERNAMES_TO_IGNORE = set([
     "hcampbell@2i2c.org",
     "jwong@2i2c.org",
     "yuvipanda@2i2c.org",
-    "jmunroe@2i2c.org"
-])
+    "jmunroe@2i2c.org",
+}
+
 
 @generate_app.command()
 def mau(
     month: str = typer.Argument(help="Month to generate MAU data for"),
-    cluster_name: Optional[str] = typer.Option(None, help="Restrict to just one cluster"),
-    csv_file: Annotated[Path | None, typer.Option(help="Output data to csv file at this path")] = None
+    cluster_name: Optional[str] = typer.Option(
+        None, help="Restrict to just one cluster"
+    ),
+    csv_file: Annotated[
+        Path | None, typer.Option(help="Output data to csv file at this path")
+    ] = None,
 ):
     """
     Generate MAU for all (or some) clusters for a given month
@@ -67,13 +71,21 @@ def mau(
         dates_progress = progress_bar.add_task("Days")
 
         for cluster in clusters:
-            progress_bar.update(clusters_progress, description=f"Processing {cluster.spec['name']}", advance=1)
-            promql_api = URL(f"{cluster.get_external_prometheus_url()}/api/v1/query_range")
+            progress_bar.update(
+                clusters_progress,
+                description=f"Processing {cluster.spec['name']}",
+                advance=1,
+            )
+            promql_api = URL(
+                f"{cluster.get_external_prometheus_url()}/api/v1/query_range"
+            )
 
             time_parts = month.split("-", 2)
 
             # Explicitly construct the datetime as UTC, so we get standardized MAU for all our clusters
-            start_date = datetime(int(time_parts[0]), int(time_parts[1]), 1, tzinfo=timezone.utc)
+            start_date = datetime(
+                int(time_parts[0]), int(time_parts[1]), 1, tzinfo=timezone.utc
+            )
 
             # Get all pods that start with jupyter-.*, and treat them as user servers.
             # We could join with kube_pod_labels for a more accurate version of this.
@@ -98,12 +110,16 @@ def mau(
                 start_time = start_date + timedelta(days=i)
                 end_time = start_time + timedelta(days=1) - timedelta(seconds=1)
 
-                progress_bar.update(dates_progress, completed=i, description=f"Processing {start_time.strftime('%Y-%m-%d')}")
+                progress_bar.update(
+                    dates_progress,
+                    completed=i,
+                    description=f"Processing {start_time.strftime('%Y-%m-%d')}",
+                )
                 params = {
                     "query": query,
                     "start": int(start_time.timestamp()),
                     "end": int(end_time.timestamp()),
-                    "step": "1m"
+                    "step": "1m",
                 }
 
                 query_api = promql_api.with_query(params)
@@ -113,7 +129,7 @@ def mau(
 
                 result = resp.json()["data"]["result"]
                 for row in result:
-                    username = row['metric']['annotation_hub_jupyter_org_username']
+                    username = row["metric"]["annotation_hub_jupyter_org_username"]
 
                     if username in USERNAMES_TO_IGNORE:
                         continue
@@ -121,8 +137,10 @@ def mau(
                     # Since "step" is 1m, each value that is present indicates this pod was present
                     # for that minute. So the total number of values present indicates how long the
                     # user was active.
-                    minutes_active = len(row['values'])
-                    user_activity[username] = user_activity.get(username, 0) + minutes_active
+                    minutes_active = len(row["values"])
+                    user_activity[username] = (
+                        user_activity.get(username, 0) + minutes_active
+                    )
             cluster_activity[cluster.spec["name"]] = len(user_activity)
 
             table.add_row(cluster.spec["name"], str(len(user_activity)))

--- a/deployer/dev_commands/generate/mau.py
+++ b/deployer/dev_commands/generate/mau.py
@@ -1,8 +1,6 @@
-from time import timezone
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Optional
 
 from rich import progress
-from rich.console import Console
 from rich.table import Table
 from rich.live import Live
 from deployer.cli_app import generate_app

--- a/deployer/dev_commands/generate/mau.py
+++ b/deployer/dev_commands/generate/mau.py
@@ -1,0 +1,137 @@
+from time import timezone
+from typing import Annotated, Literal, Optional
+
+from rich import progress
+from rich.console import Console
+from rich.table import Table
+from rich.live import Live
+from deployer.cli_app import generate_app
+import typer
+import csv
+import calendar
+import requests
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+from yarl import URL
+from deployer.infra_components.cluster import Cluster
+
+# Usernames to ignore when calculating MAU
+USERNAMES_TO_IGNORE = set([
+    "deployment-service-check",
+
+    # 2i2c staff GitHub IDs
+    "agoose77",
+    "choldgraf",
+    "colliand",
+    "GeorgianaElena",
+    "Gman0909",
+    "haroldcampbell",
+    "jnywong",
+    "yuvipanda",
+    "jmunroe",
+
+    # 2i2c staff google ids
+    "ahollands@2i2c.org",
+    "choldgraf@2i2c.org",
+    "colliand@2i2c.org",
+    "georgianaelena@2i2c.org",
+    "gmaciocci@2i2c.org",
+    "hcampbell@2i2c.org",
+    "jwong@2i2c.org",
+    "yuvipanda@2i2c.org",
+    "jmunroe@2i2c.org"
+])
+
+@generate_app.command()
+def mau(
+    month: str = typer.Argument(help="Month to generate MAU data for"),
+    cluster_name: Optional[str] = typer.Option(None, help="Restrict to just one cluster"),
+    csv_file: Annotated[Path | None, typer.Option(help="Output data to csv file at this path")] = None
+):
+    """
+    Generate MAU for all (or some) clusters for a given month
+    """
+    if cluster_name:
+        clusters = [Cluster.from_name(cluster_name)]
+    else:
+        clusters = Cluster.get_all()
+
+    cluster_activity: dict[str, int] = {}
+
+    table = Table()
+    table.add_column("Cluster")
+    table.add_column("MAU")
+
+    with Live(table) as live:
+        progress_bar = progress.Progress(console=live.console)
+        progress_bar.start()
+        clusters_progress = progress_bar.add_task("Clusters", total=len(clusters))
+        dates_progress = progress_bar.add_task("Days")
+
+        for cluster in clusters:
+            progress_bar.update(clusters_progress, description=f"Processing {cluster.spec['name']}", advance=1)
+            promql_api = URL(f"{cluster.get_external_prometheus_url()}/api/v1/query_range")
+
+            time_parts = month.split("-", 2)
+
+            # Explicitly construct the datetime as UTC, so we get standardized MAU for all our clusters
+            start_date = datetime(int(time_parts[0]), int(time_parts[1]), 1, tzinfo=timezone.utc)
+
+            # Get all pods that start with jupyter-.*, and treat them as user servers.
+            # We could join with kube_pod_labels for a more accurate version of this.
+            # We can't use the username in the pod label because it is escaped, and we won't
+            # get the full username for filtering.
+            query = """
+            max(
+                kube_pod_annotations{pod=~"jupyter-.*"}
+            )
+            by (annotation_hub_jupyter_org_username)
+            """
+
+            # Users mapped to how many minutes their server was active this month
+            user_activity: dict[str, int] = {}
+
+            days_in_month = calendar.monthrange(start_date.year, start_date.month)[1]
+            progress_bar.update(dates_progress, total=days_in_month)
+
+            prometheus_creds = cluster.get_cluster_prometheus_creds()
+            for i in range(days_in_month):
+                # Start time and End time are inclusive, so we want time from 00:00:00 to 23:59:59
+                start_time = start_date + timedelta(days=i)
+                end_time = start_time + timedelta(days=1) - timedelta(seconds=1)
+
+                progress_bar.update(dates_progress, completed=i, description=f"Processing {start_time.strftime('%Y-%m-%d')}")
+                params = {
+                    "query": query,
+                    "start": int(start_time.timestamp()),
+                    "end": int(end_time.timestamp()),
+                    "step": "1m"
+                }
+
+                query_api = promql_api.with_query(params)
+
+                resp = requests.get(str(query_api), auth=prometheus_creds)
+                resp.raise_for_status()
+
+                result = resp.json()["data"]["result"]
+                for row in result:
+                    username = row['metric']['annotation_hub_jupyter_org_username']
+
+                    if username in USERNAMES_TO_IGNORE:
+                        continue
+
+                    # Since "step" is 1m, each value that is present indicates this pod was present
+                    # for that minute. So the total number of values present indicates how long the
+                    # user was active.
+                    minutes_active = len(row['values'])
+                    user_activity[username] = user_activity.get(username, 0) + minutes_active
+            cluster_activity[cluster.spec["name"]] = len(user_activity)
+
+            table.add_row(cluster.spec["name"], str(len(user_activity)))
+
+    if csv_file:
+        with open(csv_file, "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(("cluster_name", "mau"))
+            for name, active_users in cluster_activity.items():
+                writer.writerow((name, str(active_users)))

--- a/docs/topic/billing/mau.md
+++ b/docs/topic/billing/mau.md
@@ -1,0 +1,13 @@
+# Monthly Active Users (MAU)
+
+## Definition
+
+We define an active user as someone who has:
+
+1. Started a server, for any duration of time
+2. Is not our health check service account `deployment-service-check`
+3. Is not a 2i2c employee (for GitHub & Google IDs)
+
+## Generating MAU metrics
+
+You can generate MAU metrics for all clusters by running `deployer generate mau YYYY-MM`. You can generate a csv file with the output by passing a filename to the `--csv-file` parameter.

--- a/docs/topic/billing/mau.md
+++ b/docs/topic/billing/mau.md
@@ -8,6 +8,13 @@ We define an active user as someone who has:
 2. Is not our health check service account `deployment-service-check`
 3. Is not a 2i2c employee (for GitHub & Google IDs)
 
+### Caveats
+
+1. We don't filter out 2i2c staff from hubs that use other authentication systems
+   (like KeyCloak, Auth0, Canvas, etc)
+2. We count each 'launch' on a binderhub as an active user, and we don't split
+   that out separately here.
+
 ## Generating MAU metrics
 
 You can generate MAU metrics for all clusters by running `deployer generate mau YYYY-MM`. You can generate a csv file with the output by passing a filename to the `--csv-file` parameter.

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -397,6 +397,8 @@ jupyterhub:
       # jupyterhub_config.py snippet as declared in hub.extraConfig?
       add_staff_user_ids_to_admin_users: false
       add_staff_user_ids_of_type: ""
+      # Add to list of users to ignore for MAU calculation
+      # in deployer/dev_commands/generate/mau.py when you change this
       staff_github_ids:
         - agoose77
         - choldgraf


### PR DESCRIPTION
- Actively define what an MAU is clearly
- Filter out 2i2c users where we can from MAU calculation
- Filter out our service account from MAU calculation
- Filter that at a *cluster* level, as multiple hubs can be in the same cluster and we don't want to overcharge.
- Do this *actually* for each month, rather than roughly using '30d at last of month' as we were

Previously, there were a few hacky methods for calculating MAU that relied on complex prometheus queries. However, those were hard to validate if they are 'correct', due to the datamodel of prometheus. We push that logic on to Python here, and that allows us to do this clearly and cleanly.

I intentionally do not discount staging hubs, as I think that should be counted as part of MAU. Filtering out 2i2c usernames should do the job there.

Fixes https://github.com/2i2c-org/data/issues/4