### PR TITLE
utoronto: Switch from ingress-nginx to nginx-ingress

### DIFF
--- a/config/clusters/utoronto/support.values.yaml
+++ b/config/clusters/utoronto/support.values.yaml
@@ -45,16 +45,30 @@ grafana:
       hosts:
       - grafana.utoronto.2i2c.cloud
 
-ingress-nginx:
+clusterEntrypoint:
+  targetController: nginx-ingress
+
+nginx-ingress:
+  # Enable controller
+  enabled: true
   controller:
+    ingressClass:
+      # Claim the `nginx` ingress class
+      create: true
     service:
       annotations:
         # This annotation is a requirement for use in Azure provided
-        # LoadBalancer.
-        #
-        # ref: https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration
-        # ref: https://github.com/Azure/AKS/blob/master/CHANGELOG.md#release-2022-09-11
-        # ref: https://github.com/Azure/AKS/issues/2907#issuecomment-1109759262
-        # ref: https://github.com/kubernetes/ingress-nginx/issues/8501#issuecomment-1108428615
-        #
+        # LoadBalancer - see https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+
+ingress-nginx:
+  controller:
+    # Turn off controller
+    replicaCount: 0
+    ingressClassResource:
+      enabled: false
+    service:
+      annotations:
+        # This annotation is a requirement for use in Azure provided
+        # LoadBalancer - see https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration
         service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz


### PR DESCRIPTION
This is the last leftover. They have a bunch of redirects, which were already not working so there's no loss of functionality

Fixes https://github.com/2i2c-org/infrastructure/issues/8055