### PR TITLE
[earthscope] Bump performance of `/tmp` disks

### DIFF
--- a/eksctl/earthscope.jsonnet
+++ b/eksctl/earthscope.jsonnet
@@ -30,7 +30,8 @@ local c = cluster.withNodeGroupConfigOverride(
             instanceType: 'g4dn.xlarge',
           },
         ],
-        nodeGroupGenerations=['b', 'd']
+        // FIXME: clean up D generation (only nb-prod-r5-xlarge-d)
+        nodeGroupGenerations=['d', 'e']
       ),
       // Add provenence of resources
       overrides={
@@ -45,8 +46,8 @@ local c = cluster.withNodeGroupConfigOverride(
       // 80 GiB reserved + 4*20GiB (four users)
       volumeSize: 160,
       // Ensure that /tmp is faster
-      volumeIOPS: 3000,
-      volumeThroughput: 500,
+      volumeIOPS: 10000,
+      volumeThroughput: 590,
     }
   )
 );


### PR DESCRIPTION
This triples IOPs, and bumps throughput. 
I think the ceiling for throughput is ~597 for the node, and the performance drops if users consume the max for too long.

We will need to clean up the `-d` generation, which is currently cordoned and the node-pool manually tainted.