### PR TITLE
Ignore continuous-image-puller for "pending" checks

### DIFF
--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -126,7 +126,7 @@ local makePodStuckInPendingForTooLongAlert = function(
   severity,
                                              ) {
   alert: 'Pod stuck in Pending for at least 30m',
-  # Ignore continuous image pre-pullers, as on large images it can take more than 30min to pull
+  // Ignore continuous image pre-pullers, as on large images it can take more than 30min to pull
   expr: |||
     max by (namespace, pod) (kube_pod_status_phase{phase="Pending", pod!~"^continuous-image-puller-.*"}) > 0
   |||,

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -126,8 +126,9 @@ local makePodStuckInPendingForTooLongAlert = function(
   severity,
                                              ) {
   alert: 'Pod stuck in Pending for at least 30m',
+  # Ignore continuous image pre-pullers, as on large images it can take more than 30min to pull
   expr: |||
-    max by (namespace, pod) (kube_pod_status_phase{phase="Pending"}) > 0
+    max by (namespace, pod) (kube_pod_status_phase{phase="Pending", pod!~"^continuous-image-puller-.*"}) > 0
   |||,
   'for': '30m',
   labels: {


### PR DESCRIPTION
Our alerts for "pending" checks have become useless with "expected" failures, primarily due to 'continuous image puller' taking 30+min sometimes. This check ignores those, as they don't cause any functional problems.