### PR TITLE
fix: update support workflow

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -235,6 +235,9 @@ jobs:
       matrix:
         jobs: ${{ fromJson(needs.generate-jobs.outputs.support-jobs) }}
 
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
The recent workflow improvements missed an OIDC permission bit that we need.