### PR TITLE
Disable auth refresh for all GitHub auth hubs

### DIFF
--- a/config/clusters/neurohackademy/common.values.yaml
+++ b/config/clusters/neurohackademy/common.values.yaml
@@ -57,6 +57,7 @@ jupyterhub:
         admin_users:
         - arokem
         - noahbenson
+        auth_refresh_age: 0
     loadRoles:
       user:
         scopes:

--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -888,6 +888,11 @@ jupyterhub:
         enable_auth_state: true
         manage_groups: true
         populate_teams_in_auth_state: true
+        # Temporarily turn off auth refresh, as it causes widespread
+        # full length failures when GitHub is down.
+        # By putting this config under GitHubOAuthenticator, we
+        # only apply this to GitHub authenticated hubs
+        auth_refresh_age: 0
         scope:
           - read:org
       Authenticator:


### PR DESCRIPTION
Neurohackademy reported issues with anyone being able to use the hubs. Investigating showed that the problem is GitHub REST API being down, and this caused widespread outage in the authentication of the hubs completely due to OAuthenticator trying to 'refresh' the user's group membership every 5minutes.

We've turned off the refreshing, which means users will have to log out and back in to see new membership. But that's better than a full blown outage.