### PR TITLE
[utoronto, highmem] Use Canvas authentication

### DIFF
--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -63,6 +63,8 @@ hubs:
   helm_chart: basehub
   helm_chart_values_files:
   - common.values.yaml
+  - common-canvas.values.yaml
   - python-common.values.yaml
   - highmem.values.yaml
+  - enc-common-canvas.secret.values.yaml
   - enc-highmem.secret.values.yaml


### PR DESCRIPTION
Closes https://github.com/2i2c-org/infrastructure/issues/7783

We've already created symlinks that map home directories onto the previous naming scheme. Some users are not mapped, but UToronto are happy for a hub-wide strategy to handle those complaints on a per-student basis — in reality, we have a small percentage of accounts that are not mapped and `highmem` is a low-population hub.

This PR will be merged just before 9AM ET.