### PR TITLE
fix: revert Canvas auth on highmem hub

### DIFF
--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -63,8 +63,6 @@ hubs:
   helm_chart: basehub
   helm_chart_values_files:
   - common.values.yaml
-  - common-canvas.values.yaml
   - python-common.values.yaml
   - highmem.values.yaml
-  - enc-common-canvas.secret.values.yaml
   - enc-highmem.secret.values.yaml


### PR DESCRIPTION
In my testing, I do not have the `sis_user_id` field on the production Canvas instance.

I'm reverting the configuration whilst I debug.