### PR TITLE
[projectpythia] Add HUB_API_URL to binderhub service

### DIFF
--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -32,3 +32,7 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liWxGyeDz5ETgPF3
                   text: Revoke GitHub Token
                   newBrowserTab: true
+binderhub-service:
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -29,3 +29,7 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liD6D2SAPk4ctcyU
                   text: Revoke GitHub Token
                   newBrowserTab: true
+binderhub-service:
+  extraEnv:
+  - name: JUPYTERHUB_API_URL
+    value: http://hub.staging.svc.cluster.local:8081/hub/api


### PR DESCRIPTION
This was missed during the switch to BinderHub auth