### PR TITLE
Refactor: move `JUPYTERHUB_API_URL` into Jsonnet

### DIFF
--- a/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
+++ b/config/clusters/2i2c-aws-us/orcid-demo.values.yaml
@@ -326,6 +326,3 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: *url
     username: *username
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.orcid-demo.svc.cluster.local:8081/hub/api

--- a/config/clusters/aimatx-2i2c-hub/prod.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/prod.values.yaml
@@ -19,6 +19,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/aimatx-2i2c-hub-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/aimatx-2i2c-hub/staging.values.yaml
+++ b/config/clusters/aimatx-2i2c-hub/staging.values.yaml
@@ -19,6 +19,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/aimatx-2i2c-hub-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/bnext-bio/prod.values.yaml
+++ b/config/clusters/bnext-bio/prod.values.yaml
@@ -33,6 +33,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/bnext-bio-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/bnext-bio/staging.values.yaml
+++ b/config/clusters/bnext-bio/staging.values.yaml
@@ -90,6 +90,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/bnext-bio-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -22,10 +22,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/disasters-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: https://hub.disasters.2i2c.cloud/hub/api
-
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-00174260142d50e1b

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -26,10 +26,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/disasters-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api
-
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-08f3d124fcfd518b0

--- a/config/clusters/leap/public.values.yaml
+++ b/config/clusters/leap/public.values.yaml
@@ -149,6 +149,3 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: https://us-central1-docker.pkg.dev
     username: _json_key
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.public.svc.cluster.local:8081/hub/api

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -249,10 +249,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/maap-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api
-
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0cb9118aa95971a6a

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -250,10 +250,6 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/maap-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api
-
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-043cd887a98827319

--- a/config/clusters/neurohackademy/prod.values.yaml
+++ b/config/clusters/neurohackademy/prod.values.yaml
@@ -7,9 +7,6 @@ binderhub-service:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/neurohackademy-prod-
 
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-07a7e98969ef8e8c3

--- a/config/clusters/neurohackademy/staging.values.yaml
+++ b/config/clusters/neurohackademy/staging.values.yaml
@@ -7,9 +7,6 @@ binderhub-service:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/neurohackademy-staging-
 
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-0d3344882a11b2b08

--- a/config/clusters/nmfs-openscapes/noaa-only.values.yaml
+++ b/config/clusters/nmfs-openscapes/noaa-only.values.yaml
@@ -258,6 +258,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-noaa-only-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.noaa-only.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/prod.values.yaml
+++ b/config/clusters/nmfs-openscapes/prod.values.yaml
@@ -38,6 +38,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/staging.values.yaml
+++ b/config/clusters/nmfs-openscapes/staging.values.yaml
@@ -37,6 +37,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/nmfs-openscapes-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -38,6 +38,3 @@ jupyterhub-home-nfs:
 
 binderhub-service:
   enabled: false
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.workshop.svc.cluster.local:8081/hub/api

--- a/config/clusters/opensci/sciencecore.values.yaml
+++ b/config/clusters/opensci/sciencecore.values.yaml
@@ -173,6 +173,3 @@ binderhub-service:
   buildPodsRegistryCredentials:
     server: https://quay.io
     username: imagebuilding-non-gcp-hubs+image_builder
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.sciencecore.svc.cluster.local:8081/hub/api

--- a/config/clusters/projectpythia/prod.values.yaml
+++ b/config/clusters/projectpythia/prod.values.yaml
@@ -32,7 +32,3 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liWxGyeDz5ETgPF3
                   text: Revoke GitHub Token
                   newBrowserTab: true
-binderhub-service:
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/projectpythia/staging.values.yaml
+++ b/config/clusters/projectpythia/staging.values.yaml
@@ -29,7 +29,3 @@ jupyterhub:
                   url: https://github.com/settings/connections/applications/Ov23liD6D2SAPk4ctcyU
                   text: Revoke GitHub Token
                   newBrowserTab: true
-binderhub-service:
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/advanced.values.yaml
+++ b/config/clusters/temple/advanced.values.yaml
@@ -13,6 +13,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-advanced-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.advanced.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/prod.values.yaml
+++ b/config/clusters/temple/prod.values.yaml
@@ -15,6 +15,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-prod-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.prod.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/research.values.yaml
+++ b/config/clusters/temple/research.values.yaml
@@ -152,6 +152,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-research-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.research.svc.cluster.local:8081/hub/api

--- a/config/clusters/temple/staging.values.yaml
+++ b/config/clusters/temple/staging.values.yaml
@@ -19,6 +19,3 @@ binderhub-service:
   config:
     BinderHub:
       image_prefix: quay.io/imagebuilding-non-gcp-hubs/temple-staging-
-  extraEnv:
-  - name: JUPYTERHUB_API_URL
-    value: http://hub.staging.svc.cluster.local:8081/hub/api

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -241,13 +241,13 @@ local binderhubServiceConfig = {
         },
       },
     } else {},
-    // For auth
-    extraEnv: [
-      { 
-        name: 'JUPYTERHUB_API_URL',
-        value: 'http://hub.%s.svc.cluster.local:8081/hub/api' % hub_name
-      }
-    ]
+  // For auth
+  extraEnv: [
+    {
+      name: 'JUPYTERHUB_API_URL',
+      value: 'http://hub.%s.svc.cluster.local:8081/hub/api' % hub_name,
+    },
+  ],
 };
 
 // We define a service account that is attached by default to all Jupyter user pods

--- a/helm-charts/basehub/values.jsonnet
+++ b/helm-charts/basehub/values.jsonnet
@@ -241,6 +241,13 @@ local binderhubServiceConfig = {
         },
       },
     } else {},
+    // For auth
+    extraEnv: [
+      { 
+        name: 'JUPYTERHUB_API_URL',
+        value: 'http://hub.%s.svc.cluster.local:8081/hub/api' % hub_name
+      }
+    ]
 };
 
 // We define a service account that is attached by default to all Jupyter user pods


### PR DESCRIPTION
Now that we use this in most hub configs, we can lower it to the base config — it should be harmless for non binderhubs, and more complex existing hubs already clobber this list.