### PR TITLE
[reflective, prod] Bump HOME storage

### DIFF
--- a/terraform/aws/projects/reflective.tfvars
+++ b/terraform/aws/projects/reflective.tfvars
@@ -14,7 +14,7 @@ ebs_volumes = {
     tags        = { "2i2c:hub-name" : "staging" }
   },
   "prod" = {
-    size        = 375 # in GB
+    size        = 400 # in GB
     type        = "gp3"
     name_suffix = "prod"
     throughput  = 250 # Double the throughput, as we kept getting alerts for throughput consistently


### PR DESCRIPTION
Following PD alerts about 90% usage.