### PR TITLE
Bump bnext-bio home dir quota

### DIFF
--- a/config/clusters/bnext-bio/staging.values.yaml
+++ b/config/clusters/bnext-bio/staging.values.yaml
@@ -85,6 +85,10 @@ jupyterhub:
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-09363d84917d28027
+  quotaEnforcer:
+    config:
+      QuotaManager:
+        hard_quota: 2 # in GiB
 
 binderhub-service:
   config:


### PR DESCRIPTION
The test user has exceeded the quota and and deployment fails because of this.

The solution is https://github.com/2i2c-org/infrastructure/issues/7182, but this will unblock us for now