### PR TITLE
Disable prometheus metrics endpoint scraping

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -76,6 +76,9 @@ prometheus:
           name: prometheus-auth
           key: username
           optional: false
+  scrapeConfigs:
+    prometheus:
+      enabled: false
 
   alertmanager:
     enabled: false


### PR DESCRIPTION
I've noticed that this was throwing a 401. This is probably happening since we've enabled prometheus basic auth.

Also, this endpoint is enabled by default and I don't think we're actually using metrics from it for anything atm, so I'm explicitly disabling it.

To enable it and have it working, revert his PR and and add the following config:
```
prometheus:
  scrapeConfigs:
      prometheus:
        basic_auth:
          username: ***
          password: ***
``` 