### PR TITLE
[utoronto] Use `login_id` instead of `sis_user_id` 

### DIFF
--- a/config/clusters/utoronto/common-canvas.values.yaml
+++ b/config/clusters/utoronto/common-canvas.values.yaml
@@ -13,7 +13,7 @@ jupyterhub:
         token_url: https://utoronto.instructure.com/login/oauth2/token
         userdata_url: https://utoronto.instructure.com/api/v1/users/self/profile
         authorize_url: https://utoronto.instructure.com/login/oauth2/auth
-        username_claim: sis_user_id
+        username_claim: login_id
         allow_all: true
         scope:
         - url:GET|/api/v1/users/:user_id/profile


### PR DESCRIPTION
`sis_user_id` is only available to particular "roles" on Canvas. It requires permissions that most users are not granted, and should not be granted (ability to read sis data). We'll pivot to the `login_id` field which should be equivalent, and should be more stable than email.