### PR TITLE
fix: do not default to GCP for provider

### DIFF
--- a/.github/actions/setup-deploy/action.yaml
+++ b/.github/actions/setup-deploy/action.yaml
@@ -31,7 +31,7 @@ inputs:
   provider:
     description: Cloud provider a cluster runs on
     required: false
-    default: gcp
+    default:
 
 # runs (for composite actions) configuration reference:
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-actions


### PR DESCRIPTION
This should reduce the setup time for deployer.