### PR TITLE
fix: Get Docker build to generate new wheel

### DIFF
--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -36,7 +36,6 @@ basehub:
         # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
         name: quay.io/2i2c/jupyterhub-usage-quotas
         tag: 0.1.3
-        pullPolicy: Always
       extraConfig:
         001-username-claim: |
           import json

--- a/config/clusters/earthscope/common.values.yaml
+++ b/config/clusters/earthscope/common.values.yaml
@@ -36,6 +36,7 @@ basehub:
         # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
         name: quay.io/2i2c/jupyterhub-usage-quotas
         tag: 0.1.3
+        pullPolicy: Always
       extraConfig:
         001-username-claim: |
           import json

--- a/helm-charts/images/hub/Dockerfile
+++ b/helm-charts/images/hub/Dockerfile
@@ -22,6 +22,6 @@ COPY ${REQUIREMENTS_FILE} /tmp/
 
 USER root
 
-RUN pip install -r /tmp/${REQUIREMENTS_FILE}
+RUN pip install --force-reinstall -r /tmp/${REQUIREMENTS_FILE}
 
 USER $NB_USER

--- a/helm-charts/images/hub/quotas-requirements.txt
+++ b/helm-charts/images/hub/quotas-requirements.txt
@@ -1,4 +1,4 @@
 jupyterhub-usage-quotas==0.1.3
 jupyterhub-fancy-profiles==0.6.0
-jupyterhub-kubespawner @ git+https://github.com/jupyterhub/kubespawner@19ae3849a538940d8cc46062da247bec392501f0
+jupyterhub-kubespawner @ git+https://github.com/jupyterhub/kubespawner.git@19ae3849a538940d8cc46062da247bec392501f0
 


### PR DESCRIPTION
For some reason pip wasn't building a wheel for packages installed from a GitHub hash without `--force-reinstall` enabled.

This will increase build time a bit, but I don't think we do this build in CI.

Ref: https://github.com/2i2c-org/infrastructure/issues/7160