### PR TITLE
[CloudBank] Fix gpu-demo default-image profile override

### DIFF
--- a/config/clusters/cloudbank/gpu-demo.values.yaml
+++ b/config/clusters/cloudbank/gpu-demo.values.yaml
@@ -39,7 +39,7 @@ jupyterhub:
               display_name: Default Image
               description: RStudio, VS Code, JupyterLab, Python, R
               kubespawner_override:
-                name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:6d61d3c15d47
+                image: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:bde8b3293fd2
             00-slm:
               display_name: Small Language Models - Workshop hub
               description: Python typical DS plus SLM packages


### PR DESCRIPTION
kubespawner_override used `name:` instead of `image:` for the 00-base-user-image choice. The continuous-image-puller only checks .kubespawner_override.image, so this image was never pre-pulled, and name isn't a recognized KubeSpawner override key for setting the container image in the first place.