### PR TITLE
[CloudBank] Test oauthenticator-latest on GoogleOAuthenticator hubs

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -28,6 +28,9 @@ jupyterhub:
           name: CloudBank
           url: http://cloudbank.org/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -36,7 +36,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - mail.ccsf.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -26,6 +26,9 @@ jupyterhub:
           name: CloudBank
           url: http://cloudbank.org/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -34,7 +34,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - my.smccd.edu
         - smccd.edu
         strip_domain: false

--- a/config/clusters/cloudbank/csm.values.yaml
+++ b/config/clusters/cloudbank/csm.values.yaml
@@ -28,7 +28,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -27,6 +27,9 @@ jupyterhub:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
       tag: 6d61d3c15d47
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -29,7 +29,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/elcamino.values.yaml
+++ b/config/clusters/cloudbank/elcamino.values.yaml
@@ -35,7 +35,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - elcamino.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - glendale.edu
         - student.glendale.edu
         strip_domain: false

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -21,7 +21,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/glendale.values.yaml
+++ b/config/clusters/cloudbank/glendale.values.yaml
@@ -19,6 +19,9 @@ jupyterhub:
           name: CloudBank
           url: http://cloudbank.org/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/nicc.values.yaml
+++ b/config/clusters/cloudbank/nicc.values.yaml
@@ -32,7 +32,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - nicc.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/nicc.values.yaml
+++ b/config/clusters/cloudbank/nicc.values.yaml
@@ -24,6 +24,9 @@ jupyterhub:
           name: Northeast Iowa Community College
           url: https://www.nicc.edu/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/nicc.values.yaml
+++ b/config/clusters/cloudbank/nicc.values.yaml
@@ -26,7 +26,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -25,6 +25,9 @@ jupyterhub:
           name: CloudBank
           url: http://cloudbank.org/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/pasadena.values.yaml
+++ b/config/clusters/cloudbank/pasadena.values.yaml
@@ -33,7 +33,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - go.pasadena.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -25,6 +25,9 @@ jupyterhub:
           name: Saddleback College
           url: https://www.saddleback.edu/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/saddleback.values.yaml
+++ b/config/clusters/cloudbank/saddleback.values.yaml
@@ -33,7 +33,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - saddleback.edu
         - ivc.edu
         strip_domain: false

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -27,7 +27,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - pipeline.sbcc.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -21,7 +21,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/sbcc.values.yaml
+++ b/config/clusters/cloudbank/sbcc.values.yaml
@@ -19,6 +19,9 @@ jupyterhub:
           name: CloudBank
           url: http://cloudbank.org/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -28,6 +28,9 @@ jupyterhub:
           logo_url: http://skylinecollege.edu/mcpr/images/logos/png/skyline_logo_horiz_cmyk.png
           url: https://www.skylinecollege.edu/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -36,7 +36,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - my.smccd.edu
         - smccd.edu
         strip_domain: false

--- a/config/clusters/cloudbank/skyline.values.yaml
+++ b/config/clusters/cloudbank/skyline.values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -126,7 +126,7 @@ jupyterhub:
         authenticator_class: google
       GoogleOAuthenticator:
         username_claim: email
-        hosted_domain:
+        allowed_hosted_domains:
         - sou.edu
         strip_domain: false
         allow_all: true

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -118,6 +118,9 @@ jupyterhub:
           name: Southern University Oregon
           url: https://sou.edu/
   hub:
+    image:
+      name: quay.io/2i2c/oauthenticator-latest
+      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
     config:
       JupyterHub:
         authenticator_class: google

--- a/config/clusters/cloudbank/sou.values.yaml
+++ b/config/clusters/cloudbank/sou.values.yaml
@@ -120,7 +120,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/oauthenticator-latest
-      tag: "0.0.1-0.dev.git.16543.h8ea1d8b9f"
+      tag: 0.0.1-0.dev.git.16543.h8ea1d8b9f
     config:
       JupyterHub:
         authenticator_class: google

--- a/helm-charts/chartpress.yaml
+++ b/helm-charts/chartpress.yaml
@@ -28,3 +28,9 @@ charts:
           REQUIREMENTS_FILE: quotas-requirements.txt
         contextPath: images/hub
         dockerfilePath: images/hub/Dockerfile
+      oauthenticator-latest:
+        imageName: quay.io/2i2c/oauthenticator-latest
+        buildArgs:
+          REQUIREMENTS_FILE: oauthenticator-latest-requirements.txt
+        contextPath: images/hub
+        dockerfilePath: images/hub/Dockerfile

--- a/helm-charts/images/hub/oauthenticator-latest-requirements.txt
+++ b/helm-charts/images/hub/oauthenticator-latest-requirements.txt
@@ -1,0 +1,2 @@
+jupyterhub-fancy-profiles==0.6.0
+git+https://github.com/jupyterhub/oauthenticator.git@7d80b0000d8b11e639f3fe0f63d0711e057a15df


### PR DESCRIPTION
- Adds an experimental `oauthenticator-latest` hub image
- Used docs/howto/image-management/custom-jupyterhub-image.md
- I only loaded this image on cloudbank deployments using GoogleOAuthenticator
- Once oauthenticator releases a new version this should be reverted
