### PR TITLE
[utoronto, r-prod, highmem] Revert Canvas auth

### DIFF
--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -65,8 +65,6 @@ hubs:
   helm_chart: basehub
   helm_chart_values_files:
   - common.values.yaml
-  - common-canvas.values.yaml
   - python-common.values.yaml
   - highmem.values.yaml
-  - enc-common-canvas.secret.values.yaml
   - enc-highmem.secret.values.yaml

--- a/config/clusters/utoronto/cluster.yaml
+++ b/config/clusters/utoronto/cluster.yaml
@@ -54,10 +54,8 @@ hubs:
   helm_chart: basehub
   helm_chart_values_files:
   - common.values.yaml
-  - common-canvas.values.yaml
   - r-common.values.yaml
   - r-prod.values.yaml
-  - enc-common-canvas.secret.values.yaml
   - enc-r-prod.secret.values.yaml
 - name: highmem
   display_name: University of Toronto (highmem)


### PR DESCRIPTION
I made a mistake during the prep for the migration — I misunderstood our bespoke home directory system as being shared across hubs. Rather, the drive is shared, but the per-hub home is as usual. As such, we did not migrate all of the users.

I will follow up with UToronto to resolve this, and revert the change in the meantime.