### PR TITLE
[nasa-veda, nasa-ghg-hub, maap, disasters, *] Enable improved kubespawner messages

### DIFF
--- a/config/clusters/disasters/common.values.yaml
+++ b/config/clusters/disasters/common.values.yaml
@@ -33,9 +33,9 @@ jupyterhub:
           url: https://www.earthdata.nasa.gov/esds
   hub:
     image:
-      # Usage quotas 0.1.2 and fancy-profiles 0.6.0
+      # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
       name: quay.io/2i2c/jupyterhub-usage-quotas
-      tag: 90c1065209cf89554c2e7e73b7e2120c5d27a167
+      tag: 0.0.1-0.dev.git.16538.hb055b381d
     services:
       usage-quota:
         url: http://hub:9000

--- a/config/clusters/disasters/enc-prod.secret.values.yaml
+++ b/config/clusters/disasters/enc-prod.secret.values.yaml
@@ -14,13 +14,13 @@ jupyterhub:
     extraFiles:
       usage_quota_config_secret:
         mountPath: ENC[AES256_GCM,data:iUAOOY4d17dbRJ4v01PziqJtwYHOsZqHjc6o1tfnviiQlYT8vsJjX2lIXh9sK6xA+jPjsTXKp4Tc9ac+7OtSoHWu20NlH8qb1fFrMF1iMzrEhiHJYjM=,iv:FZ4Zt0jtmPpFrAEZwGt5zmhFKh9697jkcwX+lDiie4Y=,tag:YcGtX47oLFViBSO8mNYWFw==,type:str]
-        stringData: ENC[AES256_GCM,data:FcN+Wlz4CJuCX89cWrxGzQ+nmhgxvB/rid+d1SNN+3kc2Aw9IPPmvlG2onifdxwkjLKn1jHYjEI0fNwBqYXkYhSgqTxI+gjQAeyD//x9kC77QWvoKGpvYhxTDCyqpNDOIOPumDSZeH9gTNfjXM3i4Wa3En4ZVhQQqP8Ir0v8KzD4p5CHcOQokoQM5rg3ReCfJJPyg2F4sf+DAQsuktKARK6rK4e00uMa/o1HBszVHsWN2cYcI3P4y9cLkJoLkEsyNwkPTGX0bJXZU6g4aub6s6U+86rlUF+IoFTxErOJ+9P9XryFfL+t5oIFxUOpQMj12fpqn9o/vU89rPGwPo8vTKT2MGhxzJJWx4nx2R7Tkz9zoD+T+flTXUoY+QRwJ3dQQHTuF0wToc9vOdSZG5s=,iv:OmMKB5e99bxMlwscjqIIpz5FD+JjI4+3dHa+grlFtp4=,tag:mj6AVrJmggR2PQhV4PDUGw==,type:str]
+        stringData: ENC[AES256_GCM,data:ypMu+dZOtuXlSWhrsE/aNqd55t1agLVLRpTQv65k7cqBVBpuumAjtqw+7Sh3Ebq/1pRMWWWBlngfqul4VflR0cnedJCOdOlq5g2lGrpK7qRptLHPk8C7/BUoHeBOCRXURSFNxHgRGSjnFiEFC+GRYorpHOTPvA1UyL4UxhsIXHYYvT2VHytNvDjbwrfhMVDXUrm7BTdLHw+oQS+0fo+InDLkVt/4ihlr9XPosXzG2r77xH/bY5X3yZehJuiGRzJGq4ayvUplZQXNLBZsIh7rIlDuTKTxyBJ4ENsJkzSaVx/9IYaREfIoZuYFZyO3C1bu/eP6x4BykmVIgnGG1rNGT8meLfyLpp0L8rEjxtEqh1dDShapIdBz8Ofku9Nt1LgvM2B1OymunMc7+BkpD+VG6C855+k7pTtEKADPJ4ntkE7GciH4sZ8z6QvON4fAD4Jo9KBDwkhOjZ0jgHhMTsf5yCZn/WPqBR8ugiZ1xCJyKCZ43wT4xyt7QmBvRWvxwFY8s4BcZlsNwhd/eUSqyO9IXWIoxmy+alKewmXjYk6LTV9UoXDzyum3asCOBuQAs5VYFdegHeHZkR+vv2eewktM1Mny9F9srxxKoiP8pQkmZdf9T5EHrPs937WZBq0A0HFL4x2j8fHGDqZ8Uc4I0JAHwp39fpX/T99qPk7EDA==,iv:VlKVAG3JGnKHQOt21pqBUkBp9889bTcDS9IFp0QXAgA=,tag:MQJlNrw4Qvaxt1snLbKYAA==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-26T10:20:08Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-26T10:20:08Z'
     enc: CiUA4OM7eBp0plriNLFNedNM5E3rxTVBiRE/N00nc78CHjjDskKPEkkAmy+ekrn3hjXG+ZgR3WPlwSshaD+57OwZHAKxerdgBqHh6cGq6DX2OjTUCl5xJuWhjo90dzNcHRFnNpq5Rw1GHYvnUxijj/fr
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-26T10:20:09Z'
-  mac: ENC[AES256_GCM,data:Q10encTz/0ufIqE8Z5lBcU5GBF44p1VaZh/4vh/BTPSVP72vVLuOgo3savgk1FdW659C6KeIiJW4m0RCeWSKuWK6u5Gz59B8edyEX0+qUfEwvN60tJSqE3tn1TtWbGiYWUaKw98mQzUoDaoDXvQSjjTJqkAhY2M9Vybol3eR6nk=,iv:JnEz6fL6yt6H7ofCNY7Nr3X6u6ojwY2sQeoAVE6TFDk=,tag:GmHU5mwTWVmrAWWFasSCLw==,type:str]
+  lastmodified: '2026-07-30T19:24:54Z'
+  mac: ENC[AES256_GCM,data:sZ4FtC0bLrNoHlYPKNAUJwAitd5BcU6g4E3cpCz38lB4VOZY/Rxbrik1TbLfWOfa45zixjDpmTj0CNjS7nHGSheBvWznn1XXpitbyhnZ8zVMQU2zEZ+Ntqeh1AC8UZRfMeFHOJFLUYWEUvlQ2auDTyI5QIQuZSvo6H45+IBCWNc=,iv:YMQdSm7YOi+70whOXmzeWgNLuygCp8oiSPYqmW13PSQ=,tag:/EdyRxjwPBRn3lSy87+m8g==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/disasters/enc-staging.secret.values.yaml
+++ b/config/clusters/disasters/enc-staging.secret.values.yaml
@@ -10,13 +10,13 @@ jupyterhub:
     extraFiles:
       usage_quota_config_secret:
         mountPath: ENC[AES256_GCM,data:syqQzm/HePapAegMEgQ2rB7lovw1Hdta9VxNsLKYBRedioGHEmaEcrgQdMPlIq05n/8z0hmHF4yFTFbyydUQiIXtCnUs2yoJehzVsNmqWu/AOeQvM8k=,iv:UfY4SpFOkATRzcPutobMyuYUKWKBw79YK7GKJtu/41s=,tag:7Tb4WhSRME9yQHsdqwNouA==,type:str]
-        stringData: ENC[AES256_GCM,data:RxKF1okRlE+tsrr38r6VcLR/yo3oEWQgctVkWQQjFBKUHAYlCbxqco57IP8bNh2l5khGa23mBcYtTBttLnkcYUyQsUqrm/J1MuL0vAjvp6m7xeTDp2VhBAZ7igwBfucPiZyqj1Ty45Foyx3mWuJ46q/TlYSEipdVgVS8fJOvQkYboLa8MLAcB2Z24ZBRW61luUyO2iOUbZs9Crtw2Tvuhpk8frR9Q0UNJ3691RhBKGjSNpYHleJQe/zJbYeAOdVW5Fe9L1tYUMkrILCFz6H9yX0LedhNpFYZB+EN5XhzgV9MXRABAMm9Rq73bbVepBiK28wbkA2AU5RyryDuHXXNKMGmF42porKFdBYRhb3eDSlN86BiAH6QgLhEvJrGsCpRd/1zL6volloAf+o63+U=,iv:43PHd67OtcmLaM1L7Nb1XnwHS4EQAnF2bafOboncI+I=,tag:vMGwNM9wNYsq/UMhjIopvw==,type:str]
+        stringData: ENC[AES256_GCM,data:xp2SalgQiyzcWUrbplv+k1yj6HMwFnx/fuDEXGxXr2cHlLectS8W0tbag4X6W4XI1nJOFNASgGWLUFeSzbgPVcch3Zzc7NnwiSIZZAPMUIjtiJOs+Gu+ZfSQYMW8QepSZCg1pZuImeeRAmM8x4b9hwRn57Df7NPK3Gn6tgAzNRh49UoFieeaXFMlBfBe+NXxyPJAVbQUFsOdcQq3ox/ZTgwpfeV/NALJ/Zk4HDjb3eUwXo+U/+YUb/KAVSCno46nLI940gb4y0YGESoLgShIA/Wj1ga4Xyj4NFeSXXgLh2NqS2FYIxEGdY/KeTin1q+ddS7QkruEQQTTWB2JrD0PvaMlJEeLZmjptIVA4C8NhM321rBEGAfaRzpvFyW3hQEHePyRdUHTWBwnGBxZ/yQFZIFndo9io04tcsE9LJDe5985drg6rLni+8iaqPiPWLH5gLal7yJ6zX35w7cU46YFUS3OeH+TCIrqBOEa5i3DBjDgMaG8pTALyLcROq7J0G5yv++WTTa1MgzGdVRT5jj7jFb3BCgObC5O7KXOjV6llyxEFrtL/A47x17VrvnII/UTL0pQWI+ClirJMxGPqY+jDvDMP18siUXOg4C0ZEbbKhduKpjJMXkw12t+yPGejCw1vfxEnWQ5l3HKTYBQjsxBfArXn0TjTVw+azOq1g==,iv:cEziju87OAWf0UOn/7qdyeSC8W6fSg+oqb1nG1l7LNo=,tag:r6df0rMvConYmOvqs3V7QQ==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-26T10:19:59Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-26T10:19:59Z'
     enc: CiUA4OM7eINuKJ7EneuckMU+05k7E4bin+Uko4RRe63E0X1JMtLzEkkAmy+ekna8RgYdcnuMNz0FQBGHduo38ApWhO5gKwHbskRSGojlxQ1raH91Lon5GwOTvuk7YF7tpoPio5GDXQSOT+1FJQI5fBGj
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-26T10:20:01Z'
-  mac: ENC[AES256_GCM,data:VTgDq9YuMK70uSGTikDffbn2Hq4GCaE7KWQPqKARFzoM7QpcuTCcbAaGmZUuqrlPMp5S1bOVZSsHr4iVcWWj1eJoI5DRVxMtRx/TPo4AIwO0y/cuTbv/o3u7qKnXYR5QlGKQLd7fDsf/LitplII10QUwtoj137ppxrMGELq3BTc=,iv:CU2+948axQNrT/jrI7RJ+G1tyTIQcm4/r+uWS5A1wRI=,tag:IRgRBcdVbYIxSqC1lT+bVg==,type:str]
+  lastmodified: '2026-07-30T19:23:59Z'
+  mac: ENC[AES256_GCM,data:40N/LxIfpa3z3UJdfHDWWB18mLWl1TGOajs/lLaoPYdowY/hZfJKEz3bTG+jfPu+99ShGRLLoV978OgDR9HZOl/6c40YfVGRfuf9r80vzjFlnC3HfhTDHdtAxvq2XXp+tRRGkxDXG2z1zM8zo7zZ7LYSVXhGTdCcsN4gPRxBsho=,iv:PS0KjW67CYBTZADNu5JhFDIydV+q5jG7ya1DjIeSNl8=,tag:upPn9QFZQL3C6fsn+0kSwA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/disasters/prod.values.yaml
+++ b/config/clusters/disasters/prod.values.yaml
@@ -8,8 +8,10 @@ jupyterhub:
       usage_quotas_config:
         mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
         stringData: |
-          c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-          c.UsageConfig.hub_namespace = "prod"
+          c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageQuotaManager.hub_namespace = "prod"
+          c.UsageViewer.hub_namespace = "prod"
           c.UsageViewer.public_hub_url = "https://hub.disasters.2i2c.cloud/"
           c.UsageViewer.enable_compute = False
 

--- a/config/clusters/disasters/staging.values.yaml
+++ b/config/clusters/disasters/staging.values.yaml
@@ -8,8 +8,10 @@ jupyterhub:
       usage_quotas_config:
         mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
         stringData: |
-          c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-          c.UsageConfig.hub_namespace = "staging"
+          c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageQuotaManager.hub_namespace = "staging"
+          c.UsageViewer.hub_namespace = "staging"
           c.UsageViewer.public_hub_url = "https://staging.hub.disasters.2i2c.cloud/"
           c.UsageViewer.enable_compute = False
     config:

--- a/config/clusters/maap/common.values.yaml
+++ b/config/clusters/maap/common.values.yaml
@@ -40,9 +40,9 @@ jupyterhub:
     # exclusive, so it cannot be shared here in common.
   hub:
     image:
-      # Usage quotas 0.1.2 and fancy-profiles 0.6.0
+        # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
       name: quay.io/2i2c/jupyterhub-usage-quotas
-      tag: 90c1065209cf89554c2e7e73b7e2120c5d27a167
+      tag: 0.0.1-0.dev.git.16538.hb055b381d
     services:
       usage-quota:
         url: http://hub:9000

--- a/config/clusters/maap/enc-prod.secret.values.yaml
+++ b/config/clusters/maap/enc-prod.secret.values.yaml
@@ -14,13 +14,13 @@ jupyterhub:
     extraFiles:
       usage_quota_config_secret:
         mountPath: ENC[AES256_GCM,data:d7A6gdYZajaza+3/X4MCQyVx9WGb80EyEZ6QG7H07c543EVgM9MVe6XItMWAYwHQrnlCyxdd1FPGZ7cwiSE05pLbgzJmolZF0A5mpnyc7bQXgg8JzEo=,iv:6GWG99d9rq3QxprcWNmUzk4vnJBuUdjOPvhqYVAKBRk=,tag:9yk8NIuCE2E4/BLabZlkXg==,type:str]
-        stringData: ENC[AES256_GCM,data:GvEUQ024flmXdbbwpg7OQZ35n6lkwHZ4y343Qpz0fCi9c6ub7o9ln+LrqL2j4N4zeU2egWSazJxxjEDtkFwY7+nDuNENkKKMQQYpf/nwgJgFddJCAJPiacYpNGT8odxW1AxSdtPppMpij8hcSEqvpcQ4Y2Jgja3+uCea4umb9zVIts9kFJgPHQjgB2oDwtQdnnrm3oZGAyb6BHKpwK4hpPUgWpZHI3qmVdfSrX+4ISdCJxqvO3sUBf4fP90kIKgfu+I1tlOodwX3RR+HCif4f82ZHYHlMbyJenCVY4kMTiqvHmDWvIfF0d60GsDY+HlbSJO4dP14nDFscL5dyL7XL9jNV4C1XcDUFUmxlD0HFUCtTlxEkZPT/j29GOTGJAigeb2nCtVen1pXhv4JAzs=,iv:HpfxgKNTdjcTvMz4tgIwE3pVloJD5rVLCM7ss78T25o=,tag:j5n3e6aSlXHwLyy09ZJcYg==,type:str]
+        stringData: ENC[AES256_GCM,data:jqrbM8d0LpEMxBKlpiLiAjoRjbwAzCu9PNSJC6LIbX2HDxH93tqYPVGZN8ib53MFYydPwR4oNc8N3yKsj/MyZ3LZ2ShVKKQ7Toj9/jmc/KynKd5hKhwVABAOmzER5kKyBSysYE5Go1ol4L4yyzqm0bNfzvc3oLFoiMkIdvnzQnCjMeBiwJdchHdO97FMNcEOwYNjxIO13gVmtzr/WfmIE9D8SA6pwrq3fboAlEFts7HDhLLzNFDPQlPq/qsd/rLBb+1jW7vIWXESKD+/4JFHc/eEM/TOpJQ3xwYtVQjAi2yZmqMScJdr+Z8NtlJtEu+sS8TJ2bQ7wGNxhMiRnuscavgGF6hvYsFGxwNjQw9z1orAqO5nGGQnockUNO1B+98BUr20fVde6+Kp1Yw6xt1KdYXHk1475k+UDuUL/dhQ0SJDpoLQEOP7S6ed0CO7dfUI7MGiXRoxeCcY1AAg6bmlcbwEOqxZmjG8wowga1s9xri+kHkv/+5HmiPMcRijk4jq5KyqXwlpcvOKPLxuf88/VuOjT3IqxWX9rFUP5Brkiv/Myk8PPY+JXk4VDCVJEF12iczmC4UFxWNi8lx3b8zaptQxg1B7GV7Sfa1WpfS5CqHEIwxHKV5aOADM5QJ/UrK7cKKmareKnfE0op/Z7PsklZp0tOb4P67RFLf8XQ==,iv:sgjNcxauNcS5w9BK9aVTepNmANWL/jCdST9Uz5+Wz9o=,tag:T+9Y6GlMO9I4BO4NrIstVQ==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-26T08:53:26Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-26T08:53:26Z'
     enc: CiUA4OM7eMHoxJ45f44IDSbeC+03FfVVw3R0oYUF0Hf+d5q5oTSREkkAmy+ekpb0Ohuh76CLLl3CiOPIew9+YN+dzjfL2nutAzKiBVSPrRBXRdCMbX1RfwIeXoA+s+BPmEGH51/meugcVwfGlYkJsjbP
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-26T08:53:28Z'
-  mac: ENC[AES256_GCM,data:2Zex50H1bJ8lbY6UaDBF5A/GmhoXcLIXYW6wo4XY3dghYPIQpEmYp1aRzZo/UZjKT+70CV5Fz3yR60RCRd27qaZhS9ZUpSSEHadc1t23gbCrKSFEotkRoJh60Uv2lNHOnnuYjMX+1PtpjBCN0j+/I7it2iBXg/Z8EzHEDm1Psyo=,iv:JDF/nSpD1VAodQKx5JUrg5y391fGBFDfH3axa+5+T50=,tag:wymX/2eCNzTbtcpym+XqbQ==,type:str]
+  lastmodified: '2026-07-30T19:22:39Z'
+  mac: ENC[AES256_GCM,data:FINUSzhsVsPoqX9hYyLg0gHVRhUChJvOlfi1VMviNGGVrbIcIu2QrpcnM/k1s2WgseYBaQMSH9cCHTq3g/9iRwbbL05s3vqMTKvqhvwMwwCK/myzIOaK3NUOXOMpkNjYZo/Puts5FU4H2XMZ3b6ev8qzHzPOGJNpIWIhI5yAqLs=,iv:0YeKrfqIq5Xr4D4Gpm3PpWw7XDEssaEKbMfx0/hV9kQ=,tag:DL77xBi9aCl71RiXMtxZsg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/maap/enc-staging.secret.values.yaml
+++ b/config/clusters/maap/enc-staging.secret.values.yaml
@@ -10,13 +10,13 @@ jupyterhub:
     extraFiles:
       usage_quota_config_secret:
         mountPath: ENC[AES256_GCM,data:h1JGk7qfvi0PrUDyHNxm7jqxD2FPPB8lEZm+5AZxsAQkS4mAbUBK3jCk2JchhmDEo+VYKjNxGe3vtwPCKAMPXGN2vAwWMI0JBy0LQXOAigE5BH9iWL0=,iv:1YC5ckR43GQeEWxaiy87crgpWDhb9BT3jLOSjRlGK6w=,tag:BdiQWpVXObyf4hFlMKqTcg==,type:str]
-        stringData: ENC[AES256_GCM,data:pXIYgCG6z8a3wzFQe9NWUZR3xEbZ5DFlR3AwKewo7etSWNV1jk05HG8r1Mq6uxzs98KYKl2KiQA7rXauYyhwsydaxllZJPWnaxEEtNV06gxLKSd/8ARql07ESxCs4hYP78Cb8FecFML2EduedvuXl3wdy883y6t9iEFSCwIpDdjxTmWxuOVWYGZvufjW677JcxQU6pdO2wexqoBD0cxDgjGAtuQHyIMGgC2txSV8g90QPH7qDIC0zyY+o4UNg8cHBqoCKzXmf9gOrLaNwhjql8i6NbLxWQrPv0g1LhKRJp/tXUQbLDjIbq5AsqEU0Ly06dixervIYIFj54eGg7ihcqtWFqS76L9iO50NVp/L2z+ocehR/DLYh3MFOJWEFZ6V6V9OBpFmyJPo8fcvSA==,iv:gGJhVulJ78xhHKZ7wmgVu6kDTRttlaCbFwHQZCf/Cxs=,tag:PC2IVhlw4rBu/ab0mVis8g==,type:str]
+        stringData: ENC[AES256_GCM,data:rRBQZ4eUNjRzjXz/RtWQS5AIs6fVCTFuQchVwYJmDtf38+XbVrTCxx+NVmA/vRKEf0efzrmC0WtqW3abaLteOTulKZNgSA8nyA2ee4I/TqGb9pcApI12X8nJ+b66V4MoJgs6qGRBs5d4r0fJLg4iRMW6olRcB07dYu2cUHiBXYZydy9IhYc5W7r3gRRZsGZcHg0Q3lkPVwO2YG0yHv9zphUXD0LH/nE7BhXTmfqJSf9kOE5N2o7XZYNi8EcXzcgtCGtQGIW2bKdV3payK9uq9efRYPY2zIfrJBL4gSY2DrDupfA4374CNK8v/6ap0yW/2AsorU2Q1ZrFnPEL+AdWlPrkalRTxJGzuMVv+xkFTapoecChinCyKiQZvZWr/yVSb4usR6frrRvvYXeAlRobVn5nZjUKxchGDVa1EN3TmtRN0ExVud/U+ADRRrn+KgVokK7FfxZXkDxGcJZ7iQ1kwB5UR9UMMsB2QV9jZF4wHOWTw54/ZXQOS8TJl6wxp9lv2j6u6bjUzBpQgW0yu/9+VxG1E/krSBgLkYZ59He3bEvZdZVwnqWM8FUxU3MLtFbNgaQ9nqUgF5v0whXoldl03Svo1gGuaonCaVOuP1gOocUJpGHX+kgAcOwsiZWBwHYoZseuPdUIl1LMdSk5td4IlBA2rjuMl6sTIp9d,iv:D1YV9Hx/b9eK1Q0IgastHRlDXscYNL9R4CcAwEn4SqQ=,tag:GbLO7z+QGTs4FlaKwGuFng==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-26T08:53:13Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-26T08:53:13Z'
     enc: CiUA4OM7eEbn+hfb+1QQ6Us0AMds0bP1F9bPVQFkyMNsg14NAGbNEkkAmy+ekquBsSij2yIz2FVucPle+W0HOJqLeJsUavZRwgQTjVbtUvGF71cqb80YaPLtSEiyU794VU24H4UWiSLvzTrBTd2r7oAq
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-26T08:53:15Z'
-  mac: ENC[AES256_GCM,data:SPME8ECWVq0gvMGsDaA0hJiPNF8RJu+/hXRgMjCrxtisFa3PFPCI03g1Y41QbkgYE1aJ6cIKlolvCSTDoiCXgawvgh7C2Avp1YtiSLAXfoZ4wAVPvy0i1WfIBMdZY0wHABaIf4gjigJ1TJLA0iQAlank84aVTqo+/HZhX+ao9k8=,iv:HV69mh1WPSWR7pQWcIWLZgaTjsltKeT9mgQLYtQ1vr4=,tag:M54KxlpLwI5HvbOiiqXoPQ==,type:str]
+  lastmodified: '2026-07-30T19:21:37Z'
+  mac: ENC[AES256_GCM,data:GkTgPyHx+tBuX8gjLo/JG7rx0QbiqtFtRGjPcQvpREIu3WmMPv7PDGOIyO7GPINGm9L3fqXEgv9xPYJ5mvQh0cVQfn7z3o6801vaK8cC0EZOTOkKzBrsStY6uFqJGbiuv6c84i7AQWQ7aD3DK5uqDZvtoFzmwbtHHj3l6k5aBRQ=,iv:N5sFIMfC8+Qxulfk9gVopyrDZB1dvv/ed27bV+0BnTg=,tag:rGB1r6oDd/cCLoqCsVAGwA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/maap/prod.values.yaml
+++ b/config/clusters/maap/prod.values.yaml
@@ -232,8 +232,10 @@ jupyterhub:
       usage_quotas_config:
         mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
         stringData: |
-          c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-          c.UsageConfig.hub_namespace = "prod"
+          c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageQuotaManager.hub_namespace = "prod"
+          c.UsageViewer.hub_namespace = "prod"
           c.UsageViewer.public_hub_url = "https://hub.maap-project.org/"
           c.UsageViewer.enable_compute = False
     config:

--- a/config/clusters/maap/staging.values.yaml
+++ b/config/clusters/maap/staging.values.yaml
@@ -229,8 +229,10 @@ jupyterhub:
       usage_quotas_config:
         mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
         stringData: |
-          c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-          c.UsageConfig.hub_namespace = "staging"
+          c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+          c.UsageQuotaManager.hub_namespace = "staging"
+          c.UsageViewer.hub_namespace = "staging"
           c.UsageViewer.public_hub_url = "https://staging.hub.maap-project.org/"
           c.UsageViewer.enable_compute = False
     extraConfig:

--- a/config/clusters/nasa-ghg-hub/common.values.yaml
+++ b/config/clusters/nasa-ghg-hub/common.values.yaml
@@ -37,9 +37,9 @@ basehub:
             url: https://earth.gov/ghgcenter
     hub:
       image:
-        # Usage quotas 0.1.2 and fancy-profiles 0.6.0
+        # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
         name: quay.io/2i2c/jupyterhub-usage-quotas
-        tag: 90c1065209cf89554c2e7e73b7e2120c5d27a167
+        tag: 0.0.1-0.dev.git.16538.hb055b381d
       services:
         usage-quota:
           url: http://hub:9000

--- a/config/clusters/nasa-ghg-hub/enc-prod.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-prod.secret.values.yaml
@@ -12,13 +12,13 @@ basehub:
       extraFiles:
         usage_quota_config_secret:
           mountPath: ENC[AES256_GCM,data:4fLfkCmuAFkRIFSnTrMwy+3YDZ19kK+P2vZpXpT6WWQYvVzWhVDZQRyuiRPYu7M71TBFmMBke2gMdN3ZtiXMtlmBAmQTra/3NcAV/T2s2jy9tV4ivrM=,iv:EzFOP6czYp62YTfLDRtXjWfp2k96mcWXQGFwHrMZlRY=,tag:YnauzTNtkiuNA7rL1XhTgQ==,type:str]
-          stringData: ENC[AES256_GCM,data:YR8XOLKiHKj0L/hC1XByuHc2bmtdeudD4ZzVub3wa7rlTJ516eTeT6k34L/H+fBs5u3VcTllg1QNIg7N7eH1SfJ3STrx9RElJvH344OlvB1ARi0tl8PHl0/1Ivz6E756KTjYXHa6+QAZsEX/c76Y3OYr1DpFsNcMvEyMt2Y9IjwkwOd/o6o+U11gEC+yFxfjrPipoF/M1dIVZy2GHA/UupVUtSm7R7jBXZw3EUgt4nUiSGJdLxkQz8bEWON2DF21hAOn6KqXiwD/r0NlecuYIzVU3mibHCmHFl+t8RyVIFtYIIdyFNXtKZwCPWY2DQieH6x4ceQx2ppncBRjnlOsXzvKxTN/BvWFCoP47am/PJtquFlQYKN5LKSV+V9uSVPsP8Toj7r4xvCi5lnjQSQ=,iv:6DkWEubMksRg4QI6DI9RtxZ3kTosQ/rWnRglhGlbZP0=,tag:Zg2wKkviJHjcCqMa6p2bVQ==,type:str]
+          stringData: ENC[AES256_GCM,data:aUT+GOJGVi2Na7B54wFQlWFJrf5h4FSeNPbeijT9QIzj04rte15c7Mqt5QHcZIDFZ70NSGcsUauN41aNSkh0wzYoz+OYmKrBdhVQ0ngdOdKbsUY9Lthc8VrpZOm/eqEGx2IG+4ygdX2cfzmnov5a5L8yys6GJCg8atmYPRF17wDAIq8k9GMTbnhKrrZsuqdDB9zUFG2Bl4oK4x13/bw7FvBcgnhYLLBDV7dwi+ohdZyJueGd8/fEMxjy8HH7TwpJZT/6W01avj38esDph66zFYcXgLDnYehuDrHhifjy768XtD35DKl/ruTXnD8RP9PcUgtmvBIqCkPhM2VC7/H6GXU9p2DwCgHpiQ1x7DOQa/dd3b58tMMi1lpLARAH3BUXhixbRexfaX6OJwIMrk/jWZ1IPnp1VwE+LHYAUom/8eRyfeM0fVchLDsqxKa4ya5B+5zzjHAkTI0LNmUKjjBW+TapQzD19q8p1IEpolWIYTSlI5EBV1k1qcnlaX4GHT+3aJsAK1bV+wbtRCn9i+KQLQcUCD3CMKax4zIoTeA342JOYAGPth+bbE17yc1X1EodSZeHulIeSFTp9xjH3n5xw/k91JKGj+KiwjOCiNBiaRoagxHp1tLQp0qVA268FOXox1qnlobp7/APOC3Pc+puScuoSOOOog==,iv:1fQMJq4xWwuNRGIA3I5c0u503seaTJcKmGbjEwbbr/w=,tag:cOxME/RmsjzrJ7w6bQS8hA==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-22T11:23:15Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-22T11:23:15Z'
     enc: CiUA4OM7eMHYuDnjdRvo5zftvVGkKClOCkQPy1/mUK9IR+MIcQO3EkkAmy+eku9MNxbneqWyKX98kRq/u1sCK6E8CRUQju6POTsUG35zwf8BBvBWQCsHqtnQqNsgxvBKf1JV+DCgwZzOkx4+hlKGObGQ
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-22T11:23:15Z'
-  mac: ENC[AES256_GCM,data:mF4c2fZimbLD9AecrJAlQKYboRZ8NAZkvGuQGYZv9TnxQLc/sBQ1sJ0UAmiKo1bPByYzM8yBWSKiEbGvcQ6J1mCngo4DiRkvrL6TvxK2ErwxFT4+hZnDvY4TjGvpQZz/p+1CjYLgXaDobY4KXz3i0UUhKKcVAeMXYOrMDgDqD98=,iv:s/qL2VjixOU5bPvDFa3enDIOhKByr62ntVIh6j9SKO0=,tag:8RB7+7Klk6ix44tZHc9r+w==,type:str]
+  lastmodified: '2026-07-31T08:40:37Z'
+  mac: ENC[AES256_GCM,data:D0K5ar7REaqe0+Me2kJSN9+pUMSwVHTjxRXyAcr+yjFcTBOvoTo43IqJafbkMXuulX+A3eemEMzLo//YvWpr+l8FZAHlcIOPGDtDd+uYbXCLZAw3IDrOIxXB3XIbQyhFAIJmd99OBHfoYJfldpXkFQt82xT/Q4+18XrM9t+PRZI=,iv:t1qMgFxlnC/8qhLtj3qyf4ddPjUyC4+WoaLcpcMEEJI=,tag:CPxws+8HArq1XIu+6vr5bQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
+++ b/config/clusters/nasa-ghg-hub/enc-staging.secret.values.yaml
@@ -8,13 +8,13 @@ basehub:
       extraFiles:
         usage_quota_config_secret:
           mountPath: ENC[AES256_GCM,data:YoIUATRviF07/y0VaDl7TzRWGYMlh3AUvNmXNoDpml/TynJOyXDG1t8khp8epMJMWE1fRbpta+oJdvrRcDOYPB5PpFKSiDO761/KMUN7/wASv/2zPl4=,iv:t3r964LB/HCotuugWrTpKe9THwS9IapuoD/Ynl6HMbY=,tag:hDyu3bF81rMj1ckyTGfzJQ==,type:str]
-          stringData: ENC[AES256_GCM,data:GvGWM2X3fRXErjTmCo/VvMV7m7Fdyyyw8k9acJPYwhDNDClxj2liXsO689QB8BaafA6z6yzLu1s4byeRxvN3FUq7ZUI+L5kXHTc8geSiSqMOWCBJmqn5IlqMu4KYQEgSPGkgnX1fEeRrF9zx38yrO5710IE+taJn3dZwZKfh5FpGsoy9VwTGp3gES+jjAHv+znWngm7OV/yGdA/E+DUkg2rxt2lFj4284UtWcHlREwqdjQUqhT5kCOQZdl2I5O3D87r9OHOF0jYgSoD0CRsVrJ2X1ncQ7dl3Q3+5CwVL0SUF7B/fMhOhHwenL83MJs+Bptoau5wUOTlPUidmxcvS+wyq+DKopNNFY6UtqZzcxfL3LryuDqkbVCSFEZtBs9lZL5DjXvIZ6iC/uz1vjgg=,iv:H/LBlJPxVBc4Q7hlVGp7ONO105vqhXhC9WptJvo8mk4=,tag:XfMskFmBdb5jU50ewoIQIQ==,type:str]
+          stringData: ENC[AES256_GCM,data:fjaVdrqHQqAfiVKrycEoYWE7w8dIwhjU/QamPp+8rVafeGNb5n0JaFecQnsJPJcq/8E5PpRyt6XO9BfaYNXS51P9dioxLZ2bsozHbPu+fGiJsxiGGSakneMGbCeYVuh5oS5Wor2eEncmCbd76LJr0ur1cT/tomx3rI3mZR3TmpouIwORGabapqanBqhJ6oK1EZQHpZ1ZkwVQXnB1hNXwXSpQS+mknDo4s7Xnh5GJaolFkUubjp4ZqHeurpmEjeXNmzl7QPRqRmvzkKwF3QOiG1C0ne95wPC0IR2UOnI9OihykSCvZS0dMf8Kma+BzWwdBJBx+E4UcQEjtZXDdl5+LIvEH2xGamvhW/3608y15fjYIOR7nmvYPND8OhYzCmfmdkrHqwLk2V0eyF/j0gS32C/0HhOKPrTDtu+0jzDCBp/fJyfSG+H3xWt3lgBVnxE/BhjIQElOl5h466W/tGTsj/x1Hk2zGdjZkjy78BT9MkIICiriRtdvpSuyMQYIvwS+JgFgTHE+lYeUnwZy0IGjopeXCTWHASW//4biOdxsfvsk177rAgqY0xx8+PYZDdKPJKHd0IZ5Wy7jULiajg6Esrl58yQvkBhdTjNcNpQZzwLZDD4/JSqyiBrDaWYBvoGRwEVporH116Mx1Eu4hk+yT5XM3QIMS6uH7laSBA==,iv:ZUDqOzZVvKJQ/KFbkpDZ+f4oVAeMtsjx5LEYIxi7mLY=,tag:OWHqU2FcB/irWPt52qas8g==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-22T07:22:38Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-22T07:22:38Z'
     enc: CiUA4OM7eMIE2Kj/Xafz9xX6V+QfXn4znDyNQSZlMNX2YwzBPVJ0EkkAmy+eks6T9T9NRkR6/z+HEweYXKcJzkRmaTNm9EWIDGsSZISDuBUExHRzQUSbYetzkcaDmfF/eNBuao/eHL5rbGzn8Hf5ldDR
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-22T07:22:39Z'
-  mac: ENC[AES256_GCM,data:ctlorZHrMVOnS7h4gFms8j9cQUbzpFVooTQE8lr38+Xr9TTCj2UADeDSApODd2dqzN3SSbr45a2hSH/pCoNCkAUiPsx8ZO4O37eK4t2VAe3TUzBGZERRy9V80PxgOoKoTJ7ARKSTvoMMe00jd5gcgIyfv7Yn4gfyU8KCg14WuGs=,iv:1oVdPUiow3WdU71OPcZNgHQ1q5e9cEOUyTP0xZobtv0=,tag:s7VKpdnoldAEWiIlg5Jrzw==,type:str]
+  lastmodified: '2026-07-31T08:39:56Z'
+  mac: ENC[AES256_GCM,data:PEBNWE16f4MTgcltaXFoKIEPKcepTWgn/tbx5s1zpk/xzBnIpk7VMT+k1eAzNiR1VvNsCs4d1DjsUevwwvuW450+wH+w8DstiAcsL3ui6ljsf2qbA9o+Js7bXspbAn43DsAaVeUXanagLpA/v/nNY/Y1/KrHNzOODJYTqpUpTVA=,iv:HpIhNVhkwm1Te52xDYBhHeaFc7AWbhp0bwgburCxd0c=,tag:72bnbw/mnH7thOjH5q36zg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/nasa-ghg-hub/prod.values.yaml
+++ b/config/clusters/nasa-ghg-hub/prod.values.yaml
@@ -10,8 +10,10 @@ basehub:
         usage_quotas_config:
           mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
           stringData: |
-            c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-            c.UsageConfig.hub_namespace = "prod"
+            c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageQuotaManager.hub_namespace = "prod"
+            c.UsageViewer.hub_namespace = "prod"
             c.UsageViewer.public_hub_url = "https://hub.ghg.center/"
             c.UsageViewer.enable_compute = False
 

--- a/config/clusters/nasa-ghg-hub/staging.values.yaml
+++ b/config/clusters/nasa-ghg-hub/staging.values.yaml
@@ -9,8 +9,10 @@ basehub:
         usage_quotas_config:
           mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
           stringData: |
-            c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-            c.UsageConfig.hub_namespace = "staging"
+            c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageQuotaManager.hub_namespace = "staging"
+            c.UsageViewer.hub_namespace = "staging"
             c.UsageViewer.public_hub_url = "https://staging.ghg.2i2c.cloud/"
             c.UsageViewer.enable_compute = False
   binderhub-service:

--- a/config/clusters/nasa-veda/common.values.yaml
+++ b/config/clusters/nasa-veda/common.values.yaml
@@ -48,9 +48,9 @@ basehub:
             url: https://www.earthdata.nasa.gov/esds
     hub:
       image:
-        # Usage quotas 0.1.2 and fancy-profiles 0.6.0
+        # Usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
         name: quay.io/2i2c/jupyterhub-usage-quotas
-        tag: 90c1065209cf89554c2e7e73b7e2120c5d27a167
+        tag: 0.0.1-0.dev.git.16538.hb055b381d
       services:
         usage-quota:
           url: http://hub:9000

--- a/config/clusters/nasa-veda/enc-prod.secret.values.yaml
+++ b/config/clusters/nasa-veda/enc-prod.secret.values.yaml
@@ -12,13 +12,13 @@ basehub:
       extraFiles:
         usage_quota_config_secret:
           mountPath: ENC[AES256_GCM,data:rK9ZXdYcvxzyX5QCqU6qQzd1R1cpUvRwvwsqQqXb9u3LIs9a37vQvQDd5PhQMAA6f+GzI0qyU34lke4X/nKZNJB3wdUNdBxxbBL5/76WmuLkKLFsPe8=,iv:vsJpEbwSB2/WC9Sq2XejzbbSj/2fviZh/YdmmChQIBc=,tag:utrNy9xwISaF4Lyt330Zxw==,type:str]
-          stringData: ENC[AES256_GCM,data:mWN6WbK/4WO3V8dZhGYhmoIOS14BJzXO4wDtUNs341mSc+S7BJTnqhGcMQKTWNXaq/krtPArqnH0QxQvVHxX8bW7JRKOuRY/QQJG6GSe0QvAiU8TXO8KbYNjhJh3D9BpMPoizdKu0RwvKu5+3EZQ399vfIcv32tKdHKaSV2HdhMv1camkLurYNL9O6CeOzHPzePHtof3sVAzPGK8vCVbpQJyD5CTXjW7k/ou+lhPAtinYXkocyRM7BI4xieN1jZwbJ8uwQOLwEqJ9QgKkse4xe+HepTgRPn7yZzjGVq8dkc2FcvxIIobrGKtgqlZ4oqc60xXUQ6UXapBeLiuU+JcAbxOf0SUTN4Daql/wDRvwL56+c/+1it+oJBEZoEdv3Gci0aLubMyXPiaYizc6Eo=,iv:6Lt5gjbvMSqB533inqswyOsWotrJ1kSxCRpkJ7L6mBs=,tag:6xGN6ejm0vNwEybKhnlq2A==,type:str]
+          stringData: ENC[AES256_GCM,data:N/+6FviRaf/Kwep+kRTef+br6BeaDkUcHMGHibC/Uj3an3SKZflh8u8jCdxgPTIPDpUHovNZFSSR+Hc76IM6G8Vqzmr3nooeGNyWunnsnb9TnCC5C6Q3ofgtxbtmrM/1qPP22sp9O37vOd1zzAPil9NHwTmRHJ9xCChIWJgLH5RMoi/axJBhy3s/rqpWs8BJUWVvNrKLeSRqD65pGKbbXyFTLrkiZDgBZUJF3JXlxhITdS5cK7zlzPAOB85vXQBEvGYDjSi0VvbA0d0dBlr8EB/XRw/d1zUy0gf3B4GgSP7Oab8kNNDk73v7cfpR5P2m2FcVy0pa6ZtcPbuDy8Wqus/8pG07cR3Q2wT0Smxym3lozqx7I82F03g3GAJw5RbP3DRMmACrLe9uUNQAp3tWQ58YXhouhOZo/fE1caKDvn6mr7V0rft5tEUoYaOShzB+nkQCh8nRhVZ7coKNdmb68MTUj1NqKO8qSa1M7cjRFIrAEurOv+LPJTdNr4ozZXMv6fbr2lzw9Ba3todwod60u+oiBiXpLHgvzyBZZiLCENH9z+LRSlDsRT5n3p9IzMw9V1vIZ7vUNaE6+YLVpFKWsRdfVcXXKEUa4V3et5NhdjZXCIYG3k7fcoDJA42JO4118ibWtbRvzFpC0E6FX6StVxdtMoJ445gCqcKO3A==,iv:b/iv5it/uIPdBrNEfscgtbwNuod4zRaE7NVmtd2THbI=,tag:W4pb3bVhl/5r7YeohOirSQ==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-25T14:53:43Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-25T14:53:43Z'
     enc: CiUA4OM7eMURDnfO80Bdxdmcz9PMy4IEjXLoHnr6xMulcXX3C6GqEkkAmy+eklKTUmHXw74PG80pDTl6LPPQd3tSsn9AP4M1xOC+ooqe1O9Au5Ofc4uDUbcz4xtDr7BqXfD04uz4ah/Q1FiVmxd2kN4L
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-25T14:53:45Z'
-  mac: ENC[AES256_GCM,data:h/lSDZskxPC7QAYU1/PXR9I/L76wM5k2Q1R4wrSxhHzFT1x8q0cZ62cRD7HcuiQ516PmazbBK3cNYiOUlRjsHfhqSHJSaMzL0Yur+FjCqCTRVyMCa8CNAYzcKdLAvstoxBSUq19UsSUpiNLW4hp3A5TO8sr+sXzfOn5EKnAJx8Q=,iv:Un7O/d/AKIOwG30iQr2LBiCZfhI0ogF4kDE5tGPqwgs=,tag:we7eTE2nnZokFk9baQbKCw==,type:str]
+  lastmodified: '2026-07-30T19:12:25Z'
+  mac: ENC[AES256_GCM,data:lWTE9TSpsgN7wMvZ8eZLFrR/bfjf/FtLBr7Z26H54Urc9lGwKrAlFLlpJM2X2o3kzG0Uu1p7Wgl05kZSpgo/rpbtncql6zoMacxghrnwd1vAJt9643Vb7ncil92nTR528WpDcQhETxztaw8aeTZ+QkDeBD8Y6CDLvcSh5x3prPQ=,iv:Ou+/uobBzweLR8JAPNFrYFillCOoUGwinDyJ3CfnsfE=,tag:SaaNQh1OHuIHNPluoRq8/g==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/nasa-veda/enc-staging.secret.values.yaml
+++ b/config/clusters/nasa-veda/enc-staging.secret.values.yaml
@@ -12,13 +12,13 @@ basehub:
       extraFiles:
         usage_quota_config_secret:
           mountPath: ENC[AES256_GCM,data:aRdgvhs1SflplAx6oJ7xFCyTAcm23OTX9eZZgjNwE08DJF9Ern2YDqeSg5uMdjWD3kDLFXTBHV38Ha6JG9xQ2QyMxGuUbiqYhBg/qeWd2xL19RBdYsk=,iv:aFtpIT5KagecEWOhZIcsof2iCU5AIW/m5VWpo0VUl34=,tag:+TrGIF4V3fpC7Pv2/VDjLQ==,type:str]
-          stringData: ENC[AES256_GCM,data:0eXwe4x5UQ8VQVVBKPLRUfpGQVh5CYYJPOXsRvC3+vKO+42MWs6zkOrpvCB8nEf6cTmDkkOJHiIHCJaraZ86/aNX7xWsghaB8Ss+Znta1Njy33hbwgjf5klGLaD3jTdogHdhy/KeBDttdx58LYRMafeCl14xslz48H3FUClytikzzq5DUVNI7hXVD1098GfZBQKRI8bpH52boKYCwwyK19cCD9N8CP/kyL0llgfXEesazpMEe6jVTLbLhXbMWa0XOjyb1iyIBkA4hLF/Hjmk4f2vmWe7dwHQCAN6XqN9KK5FgSCw8QZpJTJK5ofdeXfszZcXCdZ505cGkXWTAZrkWxHIil6Gztc+7UPmsG2eAjxDpJ5GeTzIJBDzmGV2V/v2PsCoUeUAMnz8sIr1fYg=,iv:6/U+EwGMSMai0i591u4BRkcju+FFvKiVI0WjjecT2Eo=,tag:5g1XeSLwOOV092tP2NF91w==,type:str]
+          stringData: ENC[AES256_GCM,data:GecxXMA9BiDDNxCsh9mC0vJdArJ4oOLYQDdtZGgbXxWM+FPi92gnDVTKX8N9dd8/Gtyfq8/u2gknN7Tna6X+MwnBty/nEfV/4UVoqcHlxuK+Vu2Gx9l+d4t+x7qJGMupLky8dtKb3R3c5NuNe2Ze01bGJI+qSJi0lFaLJMN044lRWuyzbmQV/+kJmiqLCemz918ieckg9ZeDECZZRYsBxLhyIWfpxZ53yM5im9X4XhszSAwILO04YBcL0WBARprgKkf8uPkdN5SpwLT8v0Kn34LTeQ1rVNrbZMOScHygBfnTHmNzQgVWw1KhSYKyWv7PftY25hNXJaljleqN2/EtkD8BSOqyCy2WjSw56gAtmgzJJZQpl0J05iEmk7Y85YlLi3he1t+BnR5mPqRlioOsGIG//vIfvDGCGLLGG7opXcPx6acyUTC0dftj5u4RJutffLcxnl/iwI9YqZjRTHlapMH8CR6AS8DKIS6OGDlJo2x31dSQcwSBEUTvWUDZBsKTOaXmjBFnxYHgiP4wt0sxZdBY/e5iFpIERWrL88dN8osq9CLQ2tpdxCFjpomUAIzzVhTYScEOmh/6IC0w0fMdNNqlyypgEa1BWVHrtRsoMxoB9Tttv2Mh9KglzYY5ABWXLcRTUMkDfhm1fzR3Ku6PguBR3j8brfpYHgpfvQ==,iv:x+T/CjC/iy03TCV8ka1mvTmwKROQ1awRoTH0NXS9c7Q=,tag:aO9XHoi9Ep8bZk6SFZzweQ==,type:str]
 sops:
   gcp_kms:
-  - created_at: '2026-06-25T14:53:33Z'
+  - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+    created_at: '2026-06-25T14:53:33Z'
     enc: CiUA4OM7eOVI6DncpyXnwSzngp8EHD/NUqkLur0rypgKq+eB+g5yEkkAmy+ekr/MpPjAV+HciZKSJ8Bt4Md2xeSiPfMV/6uOlvKAbybHiU44Ims/vC+7m4kxg+xntdLEzRMBVdvB+ssnG7qF5lwe4Fyf
-    resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-  lastmodified: '2026-06-25T14:53:34Z'
-  mac: ENC[AES256_GCM,data:+0jJ5VtVtbFjT8+nbsFklWgzcXpUROUoo9zI4MzzM/rxvFnRhrQ5ZDhXGJqAmYDmjmgpaOIxoizYad7i+/WAxFI3LlK1sYhk4Yc5hiqm2nFd6H25kDyIZOt5Y3AYVZD7VX9M/2NXCQJadZ3EuMMwvKzkx2lWETUKVf3Xohnip60=,iv:c5AdjTjOTfYCJxl5sKcSiiGr8uJZRmrTNRMoRBBeqHo=,tag:5Hd56fBAQy1lFCQhvYOLzw==,type:str]
+  lastmodified: '2026-07-30T19:11:13Z'
+  mac: ENC[AES256_GCM,data:+D4RlWequI8ky6efWpc0JttMvTL3lTMyC9LGATHquulIEqaFsvcDUqkCZ9StdHlN1LMhRo1AkXVZIkLUr7/zWDI8hwaVsQik8rxGahe+6YnygB6XB+VwLFfcvB6D4jfb1pTRMLtx0rctjYbtqkBeONlpGUwf+EqyN0bGTsIPF4Y=,iv:9UZ4RDPogZKilPuz/Gq3RvQsHLBzqSJ9F9nOfQhJ3Bg=,tag:RT6MUZvf+AHCwG7f8uQlYg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/config/clusters/nasa-veda/prod.values.yaml
+++ b/config/clusters/nasa-veda/prod.values.yaml
@@ -8,8 +8,10 @@ basehub:
         usage_quotas_config:
           mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
           stringData: |
-            c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-            c.UsageConfig.hub_namespace = "prod"
+            c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageQuotaManager.hub_namespace = "prod"
+            c.UsageViewer.hub_namespace = "prod"
             c.UsageViewer.public_hub_url = "https://hub.openveda.cloud/"
             c.UsageViewer.enable_compute = False
     custom:

--- a/config/clusters/nasa-veda/staging.values.yaml
+++ b/config/clusters/nasa-veda/staging.values.yaml
@@ -5,16 +5,17 @@ basehub:
   jupyterhub:
     hub:
       image:
-        # Usage quotas 0.1.2 and fancy-profiles commit 7ed7d8ce8ec9f76b816ac9ec8afe70d846b3097b from
-        # from https://github.com/2i2c-org/jupyterhub-fancy-profiles/pull/158
+        # Usage quotas 0.1.3, kubespawner @19ae3849 and fancy-profiles @6e67df85 
         name: quay.io/2i2c/jupyterhub-usage-quotas
-        tag: 0.0.1-0.dev.git.16212.hedfb20e7c
+        tag: fancy-profiles-test
       extraFiles:
         usage_quotas_config:
           mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_usage_quotas_config.py
           stringData: |
-            c.UsageConfig.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
-            c.UsageConfig.hub_namespace = "staging"
+            c.UsageQuotaManager.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageViewer.prometheus_url = "http://support-prometheus-server.support.svc.cluster.local"
+            c.UsageQuotaManager.hub_namespace = "staging"
+            c.UsageViewer.hub_namespace = "staging"
             c.UsageViewer.public_hub_url = "https://staging.hub.openveda.cloud/"
             c.UsageViewer.enable_compute = False
     custom:


### PR DESCRIPTION
Ref https://github.com/2i2c-org/infrastructure/issues/8745

Includes

- updated image with usage quotas 0.1.3, fancy-profiles 0.6.0 and Kubespawner @19ae3849
  - for veda:staging, image has usage quotas 0.1.3, kubespawner @19ae3849 and fancy-profiles @6e67df85 
- updated config for usage quotas 0.1.3 https://github.com/2i2c-org/jupyterhub-usage-quotas/blob/main/CHANGELOG.md#v013-2026-07-24
