### PR TITLE
[uw-escience] set default URL to /lab

### DIFF
--- a/config/clusters/uw-escience/common.values.yaml
+++ b/config/clusters/uw-escience/common.values.yaml
@@ -45,6 +45,7 @@ jupyterhub:
         admin_users:
         - scottyhq
   singleuser:
+    defaultUrl: /lab
     extraEnv:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23liUgKLAUO3UUsGqx
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/uw-escience-gh-scoped-creds


### PR DESCRIPTION
Sets JupyterLab as the default interface for the uw-escience hub.

If I understand correctly /tree is the default for 2i2c jupyterhubs:

https://github.com/2i2c-org/infrastructure/blob/48b7cd5ce485535af4d5ef855347d851ad9aad8a/helm-charts/basehub/values.yaml#L751

And that default wins even if the image defines /lab via it's entrypoint!

https://github.com/2i2c-org/infrastructure/blob/48b7cd5ce485535af4d5ef855347d851ad9aad8a/config/clusters/uw-escience/common.values.yaml#L66-L72

We'd rather have /lab as default for all images (including bring-your-own)