### PR TITLE
fix: update links to sciencecloud dashboards

### DIFF
--- a/config/clusters/disasters/cluster.yaml
+++ b/config/clusters/disasters/cluster.yaml
@@ -1,6 +1,6 @@
 name: disasters
 provider: aws
-provider_url: https://smce-aws-disasters.signin.aws.amazon.com/console
+provider_url: https://d-9067c5bbc5.awsapps.com/start/
 metadata:
   2i2c:
     hubspot_deal_id: 86933236464

--- a/config/clusters/maap/cluster.yaml
+++ b/config/clusters/maap/cluster.yaml
@@ -1,6 +1,6 @@
 name: maap
 provider: aws
-provider_url: https://916098889494.signin.aws.amazon.com/console
+provider_url: https://d-9067c5bbc5.awsapps.com/start/
 metadata:
   2i2c:
     hubspot_deal_id: 86933236464

--- a/config/clusters/nasa-ghg-hub/cluster.yaml
+++ b/config/clusters/nasa-ghg-hub/cluster.yaml
@@ -1,6 +1,6 @@
 name: nasa-ghg-hub
 provider: aws
-provider_url: https://smce-ghg-center.signin.aws.amazon.com/console
+provider_url: https://d-9067c5bbc5.awsapps.com/start/
 metadata:
   2i2c:
     hubspot_deal_id: 86933236464

--- a/config/clusters/nasa-veda/cluster.yaml
+++ b/config/clusters/nasa-veda/cluster.yaml
@@ -1,6 +1,6 @@
 name: nasa-veda
 provider: aws
-provider_url: https://smce-veda.signin.aws.amazon.com/console
+provider_url: https://d-9067c5bbc5.awsapps.com/start/
 metadata:
   2i2c:
     hubspot_deal_id: 86933236464


### PR DESCRIPTION
This means that `deployer debug dashboard maap` now goes to the right place.