### PR TITLE
[2i2c-aws-us] Initial QoS spike to 2i2c-aws-us staging

### DIFF
--- a/config/clusters/2i2c-aws-us/chart.yaml
+++ b/config/clusters/2i2c-aws-us/chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+appVersion: '1.0'
+description: Deployment Chart for JupyterHub
+name: basehub
+# Updates to this version must be kept in sync with the dependency reference in
+# the daskhub chart. Since we don't publish this, we opt to have it frozen at
+# version 0.1.0 instead.
+version: 0.1.0
+dependencies:
+- name: jupyterhub
+    # Updates to this version should follow go hand in hand with updates to
+    # images/hub/Dockerfile, and will also involve manually building and pushing
+    # the Dockerfile to https://quay.io/2i2c/pilot-hub. Details about this can
+    # be found in the Dockerfile's comments.
+  version: 4.3.3
+  repository: https://jupyterhub.github.io/helm-chart/
+- name: binderhub-service
+  version: 0.1.0-0.dev.git.336.hca79dc0
+  repository: https://2i2c.org/binderhub-service/
+  condition: binderhub-service.enabled
+- name: dask-gateway
+  version: 2026.3.0
+  repository: https://helm.dask.org/
+  condition: dask-gateway.enabled
+- name: jupyterhub-home-nfs
+  version: 1.2.1-0.dev.git.1.h46a7299
+  repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs
+  condition: jupyterhub-home-nfs.enabled
+- name: jupyterhub-groups-exporter
+  version: 1.1.1-0.dev.git.133.hd9f9ccc
+  repository: https://2i2c.org/jupyterhub-groups-exporter
+  condition: jupyterhub-groups-exporter.enabled

--- a/config/clusters/2i2c-aws-us/cluster.yaml
+++ b/config/clusters/2i2c-aws-us/cluster.yaml
@@ -25,6 +25,7 @@ hubs:
   helm_chart_values_files:
   - staging.values.yaml
   - enc-staging.secret.values.yaml
+  chart_override: chart.yaml
 - name: showcase
   display_name: 2i2c Showcase
   domain: showcase.2i2c.cloud

--- a/config/clusters/2i2c-aws-us/staging.values.yaml
+++ b/config/clusters/2i2c-aws-us/staging.values.yaml
@@ -11,6 +11,21 @@ jupyterhub-home-nfs:
     config:
       QuotaManager:
         hard_quota: 10 # in GiB
+  nfsServer:
+    extraGaneshaConfig: |
+      QOS {
+        enable_qos = true;
+        enable_bw_control = true;
+        enable_iops_control = true;
+        # Assume the BW of the disk is Read + Write
+        combined_rw_bw_control = true;
+        # We only use Ganesha with one export, 
+        # so only set this on client vs. per_export_per_client
+        qos_type = "Per_Client";
+        # 10000 (bytes?) per second
+        max_client_combined_bw = 10000;
+      }
+
 jupyterhub:
   scheduling:
     userScheduler:


### PR DESCRIPTION
This PR deploys the QoS Ganesha spike to 2i2c-aws-us staging, imposing a per-client (user) limit of 10_000 Bytes per second.

I will test this!