### PR TITLE
[CloudBank] Change CCSF tag: 26_2a

### DIFF
--- a/config/clusters/cloudbank/ccsf.values.yaml
+++ b/config/clusters/cloudbank/ccsf.values.yaml
@@ -7,7 +7,7 @@ jupyterhub:
       limit: 1.5G
     image:
       name: quay.io/ccsf/jupyterhub
-      tag: fa26_1a
+      tag: fa26_2a
   custom:
     2i2c:
       add_staff_user_ids_to_admin_users: true


### PR DESCRIPTION
Bumps the CCSF user image tag from fa26_1a to fa26_2a.