### PR TITLE
Add OceanHackWeek teams and image to CryoCloud

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -63,6 +63,8 @@ basehub:
           - CryoInTheCloud:csdms-2025-workshop
           - CryoInTheCloud:fish-pace
           - CryoInTheCloud:continuous-dems-workshops
+          - oceanhackweek:ohw26-organizers-fellows-mentors
+          - oceanhackweek:ohw26-participants
         Authenticator:
           # We are restricting profiles based on GitHub Team membership and
           # so need to persist auth state
@@ -152,6 +154,11 @@ basehub:
                 kubespawner_override:
                   # From https://2i2c.freshdesk.com/a/tickets/1537
                   image: openscapes/matlab:latest
+              06-oceanhackweek:
+                display_name: OceanHackWeek Python Image
+                description: OceanHackWeek environment with many geospatial libraries for tutorials and projects
+                kubespawner_override:
+                  image: ghcr.io/oceanhackweek/python:latest
           resource_allocation:
             display_name: Resource Allocation
             choices:
@@ -165,6 +172,8 @@ basehub:
                 - CryoInTheCloud:fish-pace
                 - CryoInTheCloud:continuous-dems-workshops
                 - 2i2c-org:hub-access-for-2i2c-staff
+                - oceanhackweek:ohw26-organizers-fellows-mentors
+                - oceanhackweek:ohw26-participants
                 kubespawner_override:
                   mem_guarantee: 1951419879
                   mem_limit: 1951419879


### PR DESCRIPTION
OceanHackWeek is using CryoCloud for the event this year. Adding OHW teams directly to help track event usage and adds the event image to the menu.

@tsnow03 