### PR TITLE
fix(disasters): CSDA bucket access on Disasters IRSA

### DIFF
--- a/terraform/aws/projects/disasters.tfvars
+++ b/terraform/aws/projects/disasters.tfvars
@@ -62,26 +62,8 @@ hub_cloud_permissions = {
               "arn:aws:s3:::nasa-disasters/*",
               "arn:aws:s3:::sentinel-s2-l1c",
               "arn:aws:s3:::sentinel-s2-l1c/*",
-              "arn:aws:s3:::csda-data-vendor-airbus-optical",
-              "arn:aws:s3:::csda-data-vendor-airbus-optical/*",
-              "arn:aws:s3:::csdap-ghgsat-delivery",
-              "arn:aws:s3:::csdap-ghgsat-delivery/*",
-              "arn:aws:s3:::csda-data-vendor-umbra",
-              "arn:aws:s3:::csda-data-vendor-umbra/*",
-              "arn:aws:s3:::csdap-capellaspace-delivery",
-              "arn:aws:s3:::csdap-capellaspace-delivery/*",
-              "arn:aws:s3:::csdap-airbus-delivery",
-              "arn:aws:s3:::csdap-airbus-delivery/*",
-              "arn:aws:s3:::csdap-blacksky-delivery",
-              "arn:aws:s3:::csdap-blacksky-delivery/*",
-              "arn:aws:s3:::csda-data-vendor-satellogic",
-              "arn:aws:s3:::csda-data-vendor-satellogic/*",
-              "arn:aws:s3:::csdap-iceye-delivery",
-              "arn:aws:s3:::csdap-iceye-delivery/*",
               "arn:aws:s3:::naip-analytic",
               "arn:aws:s3:::naip-analytic/*",
-              "arn:aws:s3:::csdap-planet-skysat-delivery",
-              "arn:aws:s3:::csdap-planet-skysat-delivery/*",
               "arn:aws:s3:::nasa-disasters-dev",
               "arn:aws:s3:::nasa-disasters-dev/*",
               "arn:aws:s3:::nasa-disasters-staging",
@@ -92,6 +74,42 @@ hub_cloud_permissions = {
             "Effect": "Allow",
             "Action": "s3:ListAllMyBuckets",
             "Resource": "*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:GetObjectTagging"
+            ],
+            "Resource": [
+              "arn:aws:s3:::csda-data-vendor-airbus-optical/disasters/*",
+              "arn:aws:s3:::csdap-ghgsat-delivery/disasters/*",
+              "arn:aws:s3:::csda-data-vendor-umbra/disasters/*",
+              "arn:aws:s3:::csdap-capellaspace-delivery/disasters/*",
+              "arn:aws:s3:::csdap-airbus-delivery/disasters/*",
+              "arn:aws:s3:::csdap-blacksky-delivery/disasters/*",
+              "arn:aws:s3:::csda-data-vendor-satellogic/disasters/*",
+              "arn:aws:s3:::csdap-iceye-delivery/disasters/*",
+              "arn:aws:s3:::csdap-planet-skysat-delivery/disasters/*"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": [
+              "arn:aws:s3:::csda-data-vendor-airbus-optical",
+              "arn:aws:s3:::csdap-ghgsat-delivery",
+              "arn:aws:s3:::csda-data-vendor-umbra",
+              "arn:aws:s3:::csdap-capellaspace-delivery",
+              "arn:aws:s3:::csdap-airbus-delivery",
+              "arn:aws:s3:::csdap-blacksky-delivery",
+              "arn:aws:s3:::csda-data-vendor-satellogic",
+              "arn:aws:s3:::csdap-iceye-delivery",
+              "arn:aws:s3:::csdap-planet-skysat-delivery"
+            ],
+            "Condition": {
+              "StringLike": {"s3:prefix": ["disasters/*", "disasters]}
+            }
           }
         ]
       }
@@ -142,26 +160,8 @@ hub_cloud_permissions = {
               "arn:aws:s3:::nasa-disasters/*",
               "arn:aws:s3:::sentinel-s2-l1c",
               "arn:aws:s3:::sentinel-s2-l1c/*",
-              "arn:aws:s3:::csda-data-vendor-airbus-optical",
-              "arn:aws:s3:::csda-data-vendor-airbus-optical/*",
-              "arn:aws:s3:::csdap-ghgsat-delivery",
-              "arn:aws:s3:::csdap-ghgsat-delivery/*",
-              "arn:aws:s3:::csda-data-vendor-umbra",
-              "arn:aws:s3:::csda-data-vendor-umbra/*",
-              "arn:aws:s3:::csdap-capellaspace-delivery",
-              "arn:aws:s3:::csdap-capellaspace-delivery/*",
-              "arn:aws:s3:::csdap-airbus-delivery",
-              "arn:aws:s3:::csdap-airbus-delivery/*",
-              "arn:aws:s3:::csdap-blacksky-delivery",
-              "arn:aws:s3:::csdap-blacksky-delivery/*",
-              "arn:aws:s3:::csda-data-vendor-satellogic",
-              "arn:aws:s3:::csda-data-vendor-satellogic/*",
-              "arn:aws:s3:::csdap-iceye-delivery",
-              "arn:aws:s3:::csdap-iceye-delivery/*",
               "arn:aws:s3:::naip-analytic",
               "arn:aws:s3:::naip-analytic/*",
-              "arn:aws:s3:::csdap-planet-skysat-delivery",
-              "arn:aws:s3:::csdap-planet-skysat-delivery/*",
               "arn:aws:s3:::nasa-disasters-dev",
               "arn:aws:s3:::nasa-disasters-dev/*",
               "arn:aws:s3:::nasa-disasters-staging",
@@ -172,6 +172,42 @@ hub_cloud_permissions = {
             "Effect": "Allow",
             "Action": "s3:ListAllMyBuckets",
             "Resource": "*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:GetObjectTagging"
+            ],
+            "Resource": [
+              "arn:aws:s3:::csda-data-vendor-airbus-optical/disasters/*",
+              "arn:aws:s3:::csdap-ghgsat-delivery/disasters/*",
+              "arn:aws:s3:::csda-data-vendor-umbra/disasters/*",
+              "arn:aws:s3:::csdap-capellaspace-delivery/disasters/*",
+              "arn:aws:s3:::csdap-airbus-delivery/disasters/*",
+              "arn:aws:s3:::csdap-blacksky-delivery/disasters/*",
+              "arn:aws:s3:::csda-data-vendor-satellogic/disasters/*",
+              "arn:aws:s3:::csdap-iceye-delivery/disasters/*",
+              "arn:aws:s3:::csdap-planet-skysat-delivery/disasters/*"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": [
+              "arn:aws:s3:::csda-data-vendor-airbus-optical",
+              "arn:aws:s3:::csdap-ghgsat-delivery",
+              "arn:aws:s3:::csda-data-vendor-umbra",
+              "arn:aws:s3:::csdap-capellaspace-delivery",
+              "arn:aws:s3:::csdap-airbus-delivery",
+              "arn:aws:s3:::csdap-blacksky-delivery",
+              "arn:aws:s3:::csda-data-vendor-satellogic",
+              "arn:aws:s3:::csdap-iceye-delivery",
+              "arn:aws:s3:::csdap-planet-skysat-delivery"
+            ],
+            "Condition": {
+              "StringLike": {"s3:prefix": ["disasters/*", "disasters]}
+            }
           }
         ]
       }

--- a/terraform/aws/projects/disasters.tfvars
+++ b/terraform/aws/projects/disasters.tfvars
@@ -108,7 +108,7 @@ hub_cloud_permissions = {
               "arn:aws:s3:::csdap-planet-skysat-delivery"
             ],
             "Condition": {
-              "StringLike": {"s3:prefix": ["disasters/*", "disasters]}
+              "StringLike": {"s3:prefix": ["disasters/*", "disasters"]}
             }
           }
         ]
@@ -206,7 +206,7 @@ hub_cloud_permissions = {
               "arn:aws:s3:::csdap-planet-skysat-delivery"
             ],
             "Condition": {
-              "StringLike": {"s3:prefix": ["disasters/*", "disasters]}
+              "StringLike": {"s3:prefix": ["disasters/*", "disasters"]}
             }
           }
         ]


### PR DESCRIPTION
CSDA ↔ Disasters risk mitigation (excess permissions allowing root source modification): 

1. Use designated prefixes over broader root access
1. Define CSDA bucket access separately to isolate from write/delete permissions

cc @vperekadan