### PR TITLE
[uw-escience] New default docker image and remove small RAM profiles

### DIFF
--- a/config/clusters/uw-escience/common.values.yaml
+++ b/config/clusters/uw-escience/common.values.yaml
@@ -77,7 +77,7 @@ jupyterhub:
             kubespawner_override:
               image: '{value}'
           choices:
-            01-GO-BGC:
+            01-go-bgc:
               display_name: GO-BGC 2026 Workshop
               description: GO-BGC Float Data Workshop
               slug: go-bgc-2026
@@ -119,6 +119,7 @@ jupyterhub:
                 cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
+                default: true
             mem_15_gb:
               display_name: ~15 GB RAM, ~1.8 CPUs
               description: Up to ~4 CPUs when available

--- a/config/clusters/uw-escience/common.values.yaml
+++ b/config/clusters/uw-escience/common.values.yaml
@@ -77,19 +77,25 @@ jupyterhub:
             kubespawner_override:
               image: '{value}'
           choices:
-            01-scipy:
+            01-GO-BGC:
+              display_name: GO-BGC 2026 Workshop
+              description: GO-BGC Float Data Workshop
+              slug: go-bgc-2026
+              default: true
+              kubespawner_override:
+                image: quay.io/winghouw/gobgc2026:v1.0.0
+            02-scipy:
               display_name: Jupyter SciPy Notebook
               description: Scientific Python image
               slug: scipy
-              default: true
               kubespawner_override:
                 image: quay.io/jupyter/scipy-notebook:2026-06-29
-            02-pangeo:
+            03-pangeo:
               display_name: Pangeo Notebook Image
               description: Python image with scientific, dask and geospatial tools
               kubespawner_override:
                 image: pangeo/pangeo-notebook:2026-06-29
-            03-rocker:
+            04-rocker:
               display_name: Rocker Geospatial with RStudio
               description: R environment with many geospatial libraries pre-installed
               kubespawner_override:
@@ -103,27 +109,6 @@ jupyterhub:
         resource_allocation:
           display_name: Resource Allocation
           choices:
-            mem_2_gb:
-              display_name: ~2 GB RAM, ~0.2 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 1951419879
-                mem_limit: 1951419879
-                cpu_guarantee: 0.22815625
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
-                default: true
-            mem_4_gb:
-              display_name: ~4 GB RAM, ~0.5 CPUs
-              description: Up to ~4 CPUs when available
-              kubespawner_override:
-                mem_guarantee: 3902839759
-                mem_limit: 3902839759
-                cpu_guarantee: 0.4563125
-                cpu_limit: 3.6505
-                node_selector:
-                  node.kubernetes.io/instance-type: r5.xlarge
             mem_7_gb:
               display_name: ~7 GB RAM, ~0.9 CPUs
               description: Up to ~4 CPUs when available


### PR DESCRIPTION
- Adds new choice for GO-BGC 2026 Workshop and updated existing choices. 
  - Image is for this workshop August 17-21 https://www.go-bgc.org/event/go-bgc-float-data-and-science-workshop
  - Image build repo https://github.com/go-bgc/go-bgc-dataworkshop-2026-docker

- Removed tiny RAM options which are too small for most workshop users. new default: ~7 GB RAM, ~0.9 CPUs

cc @wingho-uw