### PR TITLE
Send Kubernetes Events to CloudWatch with Fluent-Bit

### DIFF
--- a/config/clusters/maap/support.values.yaml
+++ b/config/clusters/maap/support.values.yaml
@@ -36,6 +36,19 @@ cluster-autoscaler:
 calico:
   enabled: true
 
+fluent-bit:
+  enabled: true
+  config:
+    outputs: |
+      [OUTPUT]
+          Name cloudwatch_logs
+          Match *
+          region us-west-2
+          log_group_name /2i2c/maap/k8s-events
+          log_stream_name events
+          auto_create_group On
+          log_retention_days 30
+
 # FIXME: remove this once eksctl is fixed
 nvidiaDevicePlugin:
   aws:

--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -58,3 +58,10 @@ dependencies:
   - name: reflector
     version: "10.0.61"
     repository: oci://ghcr.io/emberstack/helm-charts
+
+  # fluent-bit, used to ship Kubernetes Events to CloudWatch Logs so we have a
+  # durable record of pod scheduling / image pull / container start timings.
+  - name: fluent-bit
+    version: "0.57.9"
+    repository: https://fluent.github.io/helm-charts
+    condition: fluent-bit.enabled

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -109,7 +109,7 @@ local makePodRestartAlert = function(
             sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~"%s"})
           -
             sum by (pod, namespace) (kube_pod_container_status_restarts_total{pod=~"%s"} offset 10m)
-      ) >= 1    
+      ) >= 1
   ||| % [pod_name_regex, pod_name_regex],
   'for': '5m',
   labels: {
@@ -236,6 +236,15 @@ local configCostMonitoring = {
       // See terraform/aws/cost-monitoring.tf
       'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/jupyterhub_cost_monitoring_iam_role' % account_id,
     },
+  },
+};
+
+local configFluentBit = {
+  serviceAccount: {
+    annotations: if provider_name == 'aws' then {
+      // See terraform/aws/k8s-event-exporter.tf
+      'eks.amazonaws.com/role-arn': 'arn:aws:iam::%s:role/k8s_event_exporter_cloudwatch' % account_id,
+    } else {},
   },
 };
 
@@ -455,4 +464,5 @@ local configCostMonitoring = {
     },
   },
   'jupyterhub-cost-monitoring': if provider_name == 'aws' then configCostMonitoring else { enabled: false },
+  'fluent-bit': configFluentBit,
 }

--- a/helm-charts/support/values.schema.yaml
+++ b/helm-charts/support/values.schema.yaml
@@ -15,6 +15,7 @@ required:
   - jupyterhub-cost-monitoring
   - disableCoredumps
   - global
+  - fluent-bit
 properties:
   # We don't control validation of dependent charts here
   cluster-autoscaler:
@@ -39,6 +40,9 @@ properties:
     type: object
     additionalProperties: true
   reflector:
+    type: object
+    additionalProperties: true
+  fluent-bit:
     type: object
     additionalProperties: true
 

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -453,6 +453,49 @@ jupyterhub-cost-monitoring:
     cpu: 5m
     memory: 100Mi
 
+# fluent-bit ships Kubernetes Events to CloudWatch Logs, giving us a durable
+# record of pod scheduling, image pulls and container start times.
+#
+# A cluster enabling this must also
+# provide `config.outputs` (the cloudwatch_logs block, which needs the region
+# and log group name), and needs the IAM role from
+# terraform/aws/k8s-event-exporter.tf. The role-arn annotation itself is set in
+# values.jsonnet, as it needs the AWS account id.
+#
+# values ref: https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml
+#
+fluent-bit:
+  enabled: false
+  # Note: Events come from the k8s API rather than from files on each node like for logs,
+  # so this is a Deployment and not the chart's default DaemonSet. It must stay at
+  # exactly one replica to avoid sending duplicate events from multiple replicas.
+  kind: Deployment
+  replicaCount: 1
+  rbac:
+    eventsAccess: true
+  resources:
+    requests:
+      cpu: 5m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  config:
+    # These are strings rather than maps, so anything set here replaces the
+    # chart's default entirely rather than merging with it.
+    #
+    # The chart defaults to a `tail` input for pod logs plus a `systemd` input
+    # for kubelet logs. Whereas we're only after Events for now.
+    inputs: |
+      [INPUT]
+          Name kubernetes_events
+          Tag k8s_events
+
+    # The chart's default is a `kubernetes` filter, which enriches records by
+    # looking up the pod a log line came from. That's meaningless for Events
+    # (they're API objects, not pod output), so we blank it out.
+    filters: ""
+
 # Configuration of templates provided directly by this chart
 # -------------------------------------------------------------------------------
 #

--- a/terraform/aws/k8s-event-exporter.tf
+++ b/terraform/aws/k8s-event-exporter.tf
@@ -1,0 +1,66 @@
+// IAM role for the fluent-bit deployment in the support chart, which ships
+// Kubernetes Events to CloudWatch Logs.
+
+locals {
+  k8s_event_exporter_log_group_name = "/2i2c/${var.cluster_name}/k8s-events"
+}
+
+resource "aws_iam_role" "k8s_event_exporter_cloudwatch" {
+  count = var.enable_k8s_event_exporter ? 1 : 0
+
+  name = "k8s_event_exporter_cloudwatch"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow",
+      Action = "sts:AssumeRoleWithWebIdentity",
+      Principal = {
+        Federated = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}"
+      },
+
+      Condition = {
+        StringEquals = {
+          "${replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")}:sub" = "system:serviceaccount:support:support-fluent-bit"
+        }
+      },
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "k8s_event_exporter_cloudwatch" {
+  count = var.enable_k8s_event_exporter ? 1 : 0
+  name  = "k8s_event_exporter_cloudwatch"
+  role  = aws_iam_role.k8s_event_exporter_cloudwatch[count.index].name
+  # These are the permissions fluent-bit's cloudwatch_logs output needs given
+  # we let it create the group itself and set a retention policy on it.
+  # ref: https://docs.fluentbit.io/manual/data-pipeline/outputs/cloudwatch
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:PutRetentionPolicy",
+        ],
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${local.k8s_event_exporter_log_group_name}",
+          "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${local.k8s_event_exporter_log_group_name}:*",
+        ],
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policies_exclusive" "k8s_event_exporter_cloudwatch" {
+  count        = var.enable_k8s_event_exporter ? 1 : 0
+  role_name    = aws_iam_role.k8s_event_exporter_cloudwatch[count.index].name
+  policy_names = [aws_iam_role_policy.k8s_event_exporter_cloudwatch[count.index].name]
+}
+
+output "k8s_event_exporter_cloudwatch_k8s_sa_annotation" {
+  value = var.enable_k8s_event_exporter ? "eks.amazonaws.com/role-arn: ${aws_iam_role.k8s_event_exporter_cloudwatch[0].arn}" : null
+}

--- a/terraform/aws/projects/maap.tfvars
+++ b/terraform/aws/projects/maap.tfvars
@@ -229,3 +229,5 @@ ebs_volumes = {
 enable_nfs_backup = true
 
 enable_jupyterhub_cost_monitoring = true
+
+enable_k8s_event_exporter = true

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -299,6 +299,15 @@ variable "enable_jupyterhub_cost_tags" {
   EOT
 }
 
+variable "enable_k8s_event_exporter" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Create an IAM role letting the support chart's fluent-bit deployment write
+  Kubernetes Events to CloudWatch Logs.
+  EOT
+}
+
 variable "enable_efs_backup" {
   type        = bool
   default     = true


### PR DESCRIPTION
This relates to https://github.com/2i2c-org/infrastructure/issues/8398#issuecomment-4995001206 and https://github.com/NASA-IMPACT/veda-jupyterhub/issues/126.

We're using Fluent-bit because we also plan to use it to collect logs and send them to Cloudwatch as part of https://github.com/2i2c-org/infrastructure/issues/6688

This PR adds fluent-bit as an optional support chart dependency. It reads Kubernetes Events from the API server and writes them to a CloudWatch log group, giving us a way to query pod scheduling, node scale-up and image pull timings.

It runs as a single-replica Deployment, not as a DaemonSet which is the chart's default, because Events come from the API server rather than from files on each node like logs.

Enabled on maap only for now, writing to /2i2c/maap/k8s-events with 30 day retention. Note that fluent-bit creates the log group itself, so terraform does not manage it and will not remove it on teardown.

I've deployed and tested this on MAAP:

```
aws logs filter-log-events \
  --log-group-name /2i2c/maap/k8s-events \
  --start-time $(( ($(date +%s) - 900) * 1000 )) \
  --filter-pattern '"jupyter-tarashish"' \
  --region us-west-2 \
  --output json | jq -r '.events[].message' | jq -r '[.reason, .message] | @tsv'

FailedScheduling        0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. preemption: 0/3 nodes are available: 3 Preemption is not helpful for scheduling.
TriggeredScaleUp        pod triggered scale-up: [{eks-nb-staging-r5-xlarge-d-86ce48cb-82a6-e798-c3b0-0dc0ce305be9 0->1 (max: 100)}]
Scheduled       Successfully assigned staging/jupyter-tarashish to ip-192-168-19-200.us-west-2.compute.internal
Pulling Pulling image "public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2"
TaintManagerEviction    Cancelling deletion of Pod staging/jupyter-tarashish
Pulled  Successfully pulled image "public.ecr.aws/nasa-veda/jupyterhub-gitpuller-init:97eb45f9d23b128aff810e45911857d5cffd05c2" in 47.581s (47.581s including waiting). Image size: 108156044 bytes.
Created Created container: jupyterhub-gitpuller-init
Started Started container jupyterhub-gitpuller-init
Pulled  Container image "quay.io/jupyterhub/k8s-network-tools:4.1.0" already present on machine
Created Created container: block-nfs-access
Started Started container block-nfs-access
Pulling Pulling image "mas.dit.maap-project.org/root/maap-workspaces/2i2c/pangeo:develop"
Pulled  Successfully pulled image "mas.dit.maap-project.org/root/maap-workspaces/2i2c/pangeo:develop" in 1m40.153s (1m40.153s including waiting). Image size: 2133483009 bytes.
Created Created container: notebook
Started Started container notebook
Pulling Pulling image "mas.dit.maap-project.org/root/che-sidecar-s3fs:2i2c"
Pulled  Successfully pulled image "mas.dit.maap-project.org/root/che-sidecar-s3fs:2i2c" in 449ms (449ms including waiting). Image size: 193221950 bytes.
Created Created container: s3fs
Started Started container s3fs
```