### PR TITLE
[cloudbank, unc-chapel-hill] Enable node placeholder deployment

### DIFF
--- a/config/clusters/cloudbank/unc-chapel-hill.values.yaml
+++ b/config/clusters/cloudbank/unc-chapel-hill.values.yaml
@@ -1,3 +1,10 @@
+nodePlaceholder:
+  enabled: true
+  nodeSelector:
+    node.kubernetes.io/instance-type: n2-highmem-4
+  # Control number of nodes required to run
+  # Reserves baseline capacity, not surge capacity
+  replicas: 0
 jupyterhub:
   singleuser:
     defaultUrl: /lab

--- a/config/clusters/cloudbank/unc-chapel-hill.values.yaml
+++ b/config/clusters/cloudbank/unc-chapel-hill.values.yaml
@@ -2,6 +2,7 @@ nodePlaceholder:
   enabled: true
   nodeSelector:
     node.kubernetes.io/instance-type: n2-highmem-4
+    2i2c/hub-name:
   # Control number of nodes required to run
   # Reserves baseline capacity, not surge capacity
   replicas: 0


### PR DESCRIPTION
@sean-morris this is a simple deployment that turns on node placeholders

You can control the number of replicas to determine how many nodes are required to exist. Unlike user placeholders, this doesn't ensure you _always_ have $N$ nodes free. Rather, it ensures that you have "up to" $N$ nodes free, i.e. if you have three nodes occupied by regular users, you'll have $N-3$ extra nodes from this deployment.

This means that you need to tune the number according to the expected baseline users plus the surge.

Although this deployment is managed by unc-chapel-hill, it scales up the underlying nodes that are shared across all clusters.

I'm merging this with the replicas set to zero, which you can tweak. You'll likely want to tweak them via CI to ensure that the change isn't clobbered by other deployments.