### PR TITLE
feat: additional bucket policy

### DIFF
--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -57,6 +57,17 @@ locals {
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document
 data "aws_iam_policy_document" "bucket_access" {
   for_each = { for bp in local.bucket_permissions : "${bp.hub_name}.${bp.bucket_name}" => bp }
+  source_policy_documents = compact([
+    try(
+      replace(
+        var.user_buckets[each.value.bucket_name].bucket_policy,
+        "__BUCKET_ARN__",
+        aws_s3_bucket.user_buckets[each.value.bucket_name].arn
+      ),
+      null
+    )
+  ])
+
   statement {
     effect  = "Allow"
     actions = ["s3:*"]

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -57,25 +57,42 @@ locals {
 # ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document
 data "aws_iam_policy_document" "bucket_access" {
   for_each = { for bp in local.bucket_permissions : "${bp.hub_name}.${bp.bucket_name}" => bp }
-  source_policy_documents = compact([
-    try(
-      replace(
-        var.user_buckets[each.value.bucket_name].bucket_policy,
-        "__BUCKET_ARN__",
-        aws_s3_bucket.user_buckets[each.value.bucket_name].arn
-      ),
-      null
-    )
-  ])
+
+  # Read only
+  dynamic "statement" {
+    for_each = length(var.user_buckets[each.value.bucket_name].extra_read_only_principals) == 0 ? [] : [1]
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:Get*",
+        "s3:List*",
+        "s3:Describe*",
+        "s3-object-lambda:Get*",
+        "s3-object-lambda:List*"
+      ]
+      principals {
+        type        = "AWS"
+        identifiers = var.user_buckets[each.value.bucket_name].extra_read_only_principals
+      }
+      resources = [
+        # Grant access only to the bucket and its contents
+        aws_s3_bucket.user_buckets[each.value.bucket_name].arn,
+        "${aws_s3_bucket.user_buckets[each.value.bucket_name].arn}/*"
+      ]
+    }
+  }
 
   statement {
     effect  = "Allow"
     actions = ["s3:*"]
     principals {
       type = "AWS"
-      identifiers = [
+      identifiers = concat([
         aws_iam_role.irsa_role[each.value.hub_name].arn
-      ]
+        ],
+        var.user_buckets[each.value.bucket_name].extra_full_principals
+
+      )
     }
     resources = [
       # Grant access only to the bucket and its contents

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -13,6 +13,34 @@ user_buckets = {
   },
   "scratch" : {
     "delete_after" : 7,
+    "bucket_policy" : <<-EOT
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "MAAPHubAllowReadOnly",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": [
+                "arn:aws:iam::916098889494:role/maap-staging",
+                "arn:aws:iam::916098889494:role/maap-prod"
+              ]
+            },
+            "Action": [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:ListBucketVersions",
+              "s3:ListBucket",
+              "s3:GetBucketLocation"
+            ],
+            "Resource": [
+              "__BUCKET_ARN__",
+              "__BUCKET_ARN__/*"
+            ]
+          }
+        ]
+      }
+    EOT,
     "tags" : { "2i2c:hub-name" : "prod" },
   },
   "scratch-binder" : {

--- a/terraform/aws/projects/nasa-veda.tfvars
+++ b/terraform/aws/projects/nasa-veda.tfvars
@@ -13,34 +13,7 @@ user_buckets = {
   },
   "scratch" : {
     "delete_after" : 7,
-    "bucket_policy" : <<-EOT
-      {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "MAAPHubAllowReadOnly",
-            "Effect": "Allow",
-            "Principal": {
-              "AWS": [
-                "arn:aws:iam::916098889494:role/maap-staging",
-                "arn:aws:iam::916098889494:role/maap-prod"
-              ]
-            },
-            "Action": [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:ListBucketVersions",
-              "s3:ListBucket",
-              "s3:GetBucketLocation"
-            ],
-            "Resource": [
-              "__BUCKET_ARN__",
-              "__BUCKET_ARN__/*"
-            ]
-          }
-        ]
-      }
-    EOT,
+    "extra_read_only_principals" : ["arn:aws:iam::916098889494:role/maap-staging", "arn:aws:iam::916098889494:role/maap-prod"],
     "tags" : { "2i2c:hub-name" : "prod" },
   },
   "scratch-binder" : {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -24,6 +24,7 @@ variable "user_buckets" {
     object({
       delete_after : optional(number, null),
       archival_storageclass_after : optional(number, null),
+      bucket_policy : optional(string, null),
       tags : optional(map(string), {}),
     })
   )
@@ -41,7 +42,10 @@ variable "user_buckets" {
   2. `archival_storageclass_after` - number of days after *creation* an
      object in this bucket will be automatically transitioned to a cheaper,
      slower storageclass for cost savings. Set to null to not transition.
-  3. `tags` - bucket specific tags to be merged into the general tags variable.
+  3. `bucket_policy` - optional AWS IAM policy document JSON to be merged into
+     this bucket's policy. __BUCKET_ARN__ in the policy will be string replaced
+     with the actual arn of the bucket.
+  4. `tags` - bucket specific tags to be merged into the general tags variable.
   EOT
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -43,10 +43,11 @@ variable "user_buckets" {
   2. `archival_storageclass_after` - number of days after *creation* an
      object in this bucket will be automatically transitioned to a cheaper,
      slower storageclass for cost savings. Set to null to not transition.
-  3. `bucket_policy` - optional AWS IAM policy document JSON to be merged into
-     this bucket's policy. __BUCKET_ARN__ in the policy will be string replaced
-     with the actual arn of the bucket.
-  4. `tags` - bucket specific tags to be merged into the general tags variable.
+  3. `extra_read_only_principals` - optional AWS IAM principals that are 
+     granted RO access to the bucket.
+  4. `extra_full_principals` - optional AWS IAM principals that are 
+     granted full RW access to the bucket.
+  5. `tags` - bucket specific tags to be merged into the general tags variable.
   EOT
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -24,7 +24,8 @@ variable "user_buckets" {
     object({
       delete_after : optional(number, null),
       archival_storageclass_after : optional(number, null),
-      bucket_policy : optional(string, null),
+      extra_read_only_principals : optional(list(string), []),
+      extra_full_principals : optional(list(string), []),
       tags : optional(map(string), {}),
     })
   )


### PR DESCRIPTION
## Description
- Attempting to add an additional bucket policy to one of the scratch buckets generated with the hubs
- Fresh pull request from https://github.com/2i2c-org/infrastructure/pull/8194

Health check action may look larger than expected because it would modify the `user_buckets` object in `terraform/aws/variables.tf` and  combine bucket policies in `terraform/aws/buckets.tf` -- see `src/deployer/commands/plan_upgrade/decision.py`