### PR TITLE
Enable fluent-bit db to save k8s event state

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -471,6 +471,10 @@ fluent-bit:
   # exactly one replica to avoid sending duplicate events from multiple replicas.
   kind: Deployment
   replicaCount: 1
+  # Using `Recreate` instead of the default `RollingUpdate` strategy to avoid
+  # multiple replicas during an upgrade which could send duplicate events.
+  updateStrategy:
+    type: Recreate
   rbac:
     eventsAccess: true
   resources:
@@ -486,15 +490,31 @@ fluent-bit:
     #
     # The chart defaults to a `tail` input for pod logs plus a `systemd` input
     # for kubelet logs. Whereas we're only after Events for now.
+    #
+    # Note: we are using `DB` to make sure we don't ship duplicate events by
+    # keeping a record of what we've already sent. But since we're using
+    # `emptyDir` to store the DB, we will lose this record on pod replacement
+    # and ship some duplicate events for a short period.
+    # However, since events have a `uid`, we can deduplicate them downstream as needed.
+    # We can move to using a persistent volume to avoid this if we face issues in
+    # the future.
     inputs: |
       [INPUT]
           Name kubernetes_events
           Tag k8s_events
+          DB /var/lib/fluent-bit/kube_events.db
 
     # The chart's default is a `kubernetes` filter, which enriches records by
     # looking up the pod a log line came from. That's meaningless for Events
     # (they're API objects, not pod output), so we blank it out.
     filters: ""
+  extraVolumes:
+    - name: state
+      emptyDir:
+        sizeLimit: 1Gi
+  extraVolumeMounts:
+    - name: state
+      mountPath: /var/lib/fluent-bit
 
 # Configuration of templates provided directly by this chart
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
Without a DB to save state, Fluent Bit ships duplicates of k8s events to Cloudwatch because the default watch timeout is smaller than K8s' default event retention time. This PR adds configuration to save state in a sqlite DB in a `emptyDir` volume so that we can avoid these duplicates.

There will still be some duplicates if the pod has to restart for some reason. But since the events have a uid, we can deduplicate downstream as needed. For now, it doesn't feel worth it to add a PVC for this. But we can do that later if needed.

Part of https://github.com/2i2c-org/infrastructure/issues/8398, follow up to https://github.com/2i2c-org/infrastructure/pull/8913