### PR TITLE
feat: tune down metrics exporter interval because of noisy JH logs

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -901,6 +901,7 @@ jupyterhub:
         blocked_users:
           - deployment-service-check
       UsageQuotaManager:
+        prometheus_emit_interval: 600
         prometheus_url: 'http://support-prometheus-server.support.svc.cluster.local'
         scope_fallback_strategy:
           intersection: 'min'


### PR DESCRIPTION
Ref 

- https://github.com/2i2c-org/infrastructure/issues/9031