### PR TITLE
[utoronto, *staging] Add groups logging, add section support

### DIFF
--- a/config/clusters/utoronto/common-authz.values.yaml
+++ b/config/clusters/utoronto/common-authz.values.yaml
@@ -22,8 +22,7 @@ jupyterhub:
             groups = auth_state[authenticator.auth_state_groups_key]
             login_id = auth_state['login_id']
             with open("/srv/jupyterhub/scopes.txt", "a") as f:
-              line = f"{login_id}: {groups}"
-              f.write(line)
+              f.write(f"{login_id}: {groups}\n")
           
           except:
             print("Error while logging groups")

--- a/config/clusters/utoronto/common-authz.values.yaml
+++ b/config/clusters/utoronto/common-authz.values.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   hub:
     image:
       name: quay.io/2i2c/pilot-hub-authz-helpers
-      tag: 0.0.1-0.dev.git.16863.h21fe9dd9c
+      tag: 0.0.1-0.dev.git.16863.ha51c52cdd
     extraConfig:
       001-canvas-auth: |
         from jupyterhub_oauthenticator_authz_helpers.canvas import get_user_groups, get_course_groups, build_auth_urls
@@ -18,7 +18,15 @@ jupyterhub:
             *await get_course_groups(canvas_url, access_token, "course_code"),
             *await get_user_groups(canvas_url, access_token),
           ]
-          print(auth_state)
+          try:
+            groups = auth_state[authenticator.auth_state_groups_key]
+            login_id = auth_state['login_id']
+            with open("/srv/jupyterhub/scopes.txt", "a") as f:
+              line = f"{login_id}: {groups}"
+              f.write(line)
+          
+          except:
+            print("Error while logging groups")
 
           return auth_state
 

--- a/helm-charts/images/hub/authz-helpers-requirements.txt
+++ b/helm-charts/images/hub/authz-helpers-requirements.txt
@@ -2,4 +2,4 @@
 
 jupyterhub-fancy-profiles==0.6.0
 jupyterhub-usage-quotas==0.1.4
-jupyterhub-oauthenticator-authz-helpers==0.0.5
+jupyterhub-oauthenticator-authz-helpers==0.0.6


### PR DESCRIPTION
This PR logs (primitively) the resolved Canvas groups to disk, alongside the user ID. 

It also loads in the latest package that supports sections.