### PR TITLE
Bump cryocloud image to 43421f450d6a

### DIFF
--- a/config/clusters/nasa-cryo/common.values.yaml
+++ b/config/clusters/nasa-cryo/common.values.yaml
@@ -131,7 +131,7 @@ basehub:
                 default: true
                 kubespawner_override:
                   # Image repo: https://github.com/CryoInTheCloud/hub-image
-                  image: quay.io/cryointhecloud/cryo-hub-image:b39d8d901d7b
+                  image: quay.io/cryointhecloud/cryo-hub-image:43421f450d6a
               02-pythonpace:
                 display_name: Ocean Biology Python Image
                 description: Ocean Biology environment used by the PACE mission


### PR DESCRIPTION
Includes changes from https://github.com/CryoInTheCloud/hub-image/pull/194, https://github.com/CryoInTheCloud/hub-image/pull/198. Main change is upgrade to Python 3.14.

Previous update at https://github.com/2i2c-org/infrastructure/pull/7716

Cc @tsnow03, @derekpickell. FYI, tags are found at https://quay.io/repository/cryointhecloud/cryo-hub-image?tab=tags.