### PR TITLE
Bump jupyterhub-cost-monitoring

### DIFF
--- a/helm-charts/support/Chart.yaml
+++ b/helm-charts/support/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
   # jupyterhub-cost-monitoring, cost reporting for Grafana
   # https://github.com/2i2c-org/jupyterhub-cost-monitoring
   - name: jupyterhub-cost-monitoring
-    version: "1.1.2"
+    version: "1.1.5-0.dev.git.266.h6599481"
     repository: https://2i2c.org/jupyterhub-cost-monitoring/
     condition: jupyterhub-cost-monitoring.enabled
 

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -225,12 +225,168 @@ local makeUsageQuotasServerDeniedAlert = function(
 
 local configCostMonitoring = {
   enabled: true,
-  extraEnv: [
-    {
-      name: 'CLUSTER_NAME',
-      value: cluster_name,
-    },
-  ],
+  config: {
+    AWSCostExplorer: {
+      hub_name_tag: "2i2c:hub-name",
+      home_storage_costs_filter: {
+        "Tags": {
+          "Key": "2i2c:volume-purpose",
+          "Values": ["home-nfs"],
+          "MatchOptions": ["EQUALS"]
+        }
+      },
+      attributable_costs_filter: {
+          "Or": [
+              {
+                  "Tags": {
+                      "Key": "alpha.eksctl.io/cluster-name",
+                      "Values": [cluster_name],
+                      "MatchOptions": ["EQUALS"],
+                  },
+              },
+              {
+                  "Tags": {
+                      "Key": "kubernetes.io/cluster/%s" % [cluster_name],
+                      "Values": ["owned"],
+                      "MatchOptions": ["EQUALS"],
+                  },
+              },
+              {
+                  "Tags": {
+                      "Key": "2i2c.org/cluster-name",
+                      "Values": [cluster_name],
+                      "MatchOptions": ["EQUALS"],
+                  },
+              },
+              # FIXME to the FIXME: The FIXME comment underneath does not make any sense
+              # to me, so we should investigate what the intent was and remove it.
+              # FIXME: The inclusion of tags 2i2c:hub-name and 2i2c:node-purpose below
+              #        in this filter is a patch to capture openscapes data from 1st
+              #        July and up to 24th September 2024, and can be removed once
+              #        that date range is considered irrelevant.
+              {
+                  "Not": {
+                      "Tags": {
+                          "Key": "2i2c:hub-name",
+                          "MatchOptions": ["ABSENT"],
+                      },
+                  },
+              },
+              {
+                  "Not": {
+                      "Tags": {
+                          "Key": "2i2c:node-purpose",
+                          "MatchOptions": ["ABSENT"],
+                      },
+                  },
+              },
+          ]
+      },
+      core_costs_filter: {
+            "Or": [
+                # Core node storage
+                {
+                    "And": [
+                        {
+                            "Dimensions": {
+                                "Key": "SERVICE",
+                                "Values": ["EC2 - Other"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                        {
+                            "Tags": {
+                                "Key": "2i2c:node-purpose",
+                                "Values": ["core"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                    ]
+                },
+                # Core node compute
+                {
+                    "And": [
+                        {
+                            "Dimensions": {
+                                "Key": "SERVICE",
+                                "Values": ["Amazon Elastic Compute Cloud - Compute"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                        {
+                            "Tags": {
+                                "Key": "2i2c:node-purpose",
+                                "Values": ["core"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                    ]
+                },
+                # Cluster NAT gateway - common for all hubs
+                {
+                    "And": [
+                        {
+                            "Dimensions": {
+                                "Key": "SERVICE",
+                                "Values": ["EC2 - Other"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                        {
+                            "Dimensions": {
+                                "Key": "USAGE_TYPE_GROUP",
+                                "Values": [
+                                    "EC2: NAT Gateway - Running Hours",
+                                    "EC2: NAT Gateway - Data Processed",
+                                ],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                    ]
+                },
+                # Hub database storage
+                {
+                    "And": [
+                        {
+                            "Dimensions": {
+                                "Key": "SERVICE",
+                                "Values": ["EC2 - Other"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                        {
+                            "Tags": {
+                                "Key": "kubernetes.io/created-for/pvc/name",
+                                "Values": ["hub-db-dir"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                    ]
+                },
+                # Support components storage (Prometheus, Grafana, Alertmanager)
+                {
+                    "And": [
+                        {
+                            "Dimensions": {
+                                "Key": "SERVICE",
+                                "Values": ["EC2 - Other"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                        {
+                            "Tags": {
+                                "Key": "kubernetes.io/created-for/pvc/namespace",
+                                "Values": ["support"],
+                                "MatchOptions": ["EQUALS"],
+                            },
+                        },
+                    ]
+                },
+            ]
+        }
+    }
+
+  },
   serviceAccount: {
     annotations: {
       // See terraform/aws/cost-monitoring.tf

--- a/helm-charts/support/values.jsonnet
+++ b/helm-charts/support/values.jsonnet
@@ -227,164 +227,164 @@ local configCostMonitoring = {
   enabled: true,
   config: {
     AWSCostExplorer: {
-      hub_name_tag: "2i2c:hub-name",
+      hub_name_tag: '2i2c:hub-name',
       home_storage_costs_filter: {
-        "Tags": {
-          "Key": "2i2c:volume-purpose",
-          "Values": ["home-nfs"],
-          "MatchOptions": ["EQUALS"]
-        }
+        Tags: {
+          Key: '2i2c:volume-purpose',
+          Values: ['home-nfs'],
+          MatchOptions: ['EQUALS'],
+        },
       },
       attributable_costs_filter: {
-          "Or": [
-              {
-                  "Tags": {
-                      "Key": "alpha.eksctl.io/cluster-name",
-                      "Values": [cluster_name],
-                      "MatchOptions": ["EQUALS"],
-                  },
+        Or: [
+          {
+            Tags: {
+              Key: 'alpha.eksctl.io/cluster-name',
+              Values: [cluster_name],
+              MatchOptions: ['EQUALS'],
+            },
+          },
+          {
+            Tags: {
+              Key: 'kubernetes.io/cluster/%s' % [cluster_name],
+              Values: ['owned'],
+              MatchOptions: ['EQUALS'],
+            },
+          },
+          {
+            Tags: {
+              Key: '2i2c.org/cluster-name',
+              Values: [cluster_name],
+              MatchOptions: ['EQUALS'],
+            },
+          },
+          // FIXME to the FIXME: The FIXME comment underneath does not make any sense
+          // to me, so we should investigate what the intent was and remove it.
+          // FIXME: The inclusion of tags 2i2c:hub-name and 2i2c:node-purpose below
+          //        in this filter is a patch to capture openscapes data from 1st
+          //        July and up to 24th September 2024, and can be removed once
+          //        that date range is considered irrelevant.
+          {
+            Not: {
+              Tags: {
+                Key: '2i2c:hub-name',
+                MatchOptions: ['ABSENT'],
               },
-              {
-                  "Tags": {
-                      "Key": "kubernetes.io/cluster/%s" % [cluster_name],
-                      "Values": ["owned"],
-                      "MatchOptions": ["EQUALS"],
-                  },
+            },
+          },
+          {
+            Not: {
+              Tags: {
+                Key: '2i2c:node-purpose',
+                MatchOptions: ['ABSENT'],
               },
-              {
-                  "Tags": {
-                      "Key": "2i2c.org/cluster-name",
-                      "Values": [cluster_name],
-                      "MatchOptions": ["EQUALS"],
-                  },
-              },
-              # FIXME to the FIXME: The FIXME comment underneath does not make any sense
-              # to me, so we should investigate what the intent was and remove it.
-              # FIXME: The inclusion of tags 2i2c:hub-name and 2i2c:node-purpose below
-              #        in this filter is a patch to capture openscapes data from 1st
-              #        July and up to 24th September 2024, and can be removed once
-              #        that date range is considered irrelevant.
-              {
-                  "Not": {
-                      "Tags": {
-                          "Key": "2i2c:hub-name",
-                          "MatchOptions": ["ABSENT"],
-                      },
-                  },
-              },
-              {
-                  "Not": {
-                      "Tags": {
-                          "Key": "2i2c:node-purpose",
-                          "MatchOptions": ["ABSENT"],
-                      },
-                  },
-              },
-          ]
+            },
+          },
+        ],
       },
       core_costs_filter: {
-            "Or": [
-                # Core node storage
-                {
-                    "And": [
-                        {
-                            "Dimensions": {
-                                "Key": "SERVICE",
-                                "Values": ["EC2 - Other"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                        {
-                            "Tags": {
-                                "Key": "2i2c:node-purpose",
-                                "Values": ["core"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                    ]
+        Or: [
+          // Core node storage
+          {
+            And: [
+              {
+                Dimensions: {
+                  Key: 'SERVICE',
+                  Values: ['EC2 - Other'],
+                  MatchOptions: ['EQUALS'],
                 },
-                # Core node compute
-                {
-                    "And": [
-                        {
-                            "Dimensions": {
-                                "Key": "SERVICE",
-                                "Values": ["Amazon Elastic Compute Cloud - Compute"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                        {
-                            "Tags": {
-                                "Key": "2i2c:node-purpose",
-                                "Values": ["core"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                    ]
+              },
+              {
+                Tags: {
+                  Key: '2i2c:node-purpose',
+                  Values: ['core'],
+                  MatchOptions: ['EQUALS'],
                 },
-                # Cluster NAT gateway - common for all hubs
-                {
-                    "And": [
-                        {
-                            "Dimensions": {
-                                "Key": "SERVICE",
-                                "Values": ["EC2 - Other"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                        {
-                            "Dimensions": {
-                                "Key": "USAGE_TYPE_GROUP",
-                                "Values": [
-                                    "EC2: NAT Gateway - Running Hours",
-                                    "EC2: NAT Gateway - Data Processed",
-                                ],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                    ]
+              },
+            ],
+          },
+          // Core node compute
+          {
+            And: [
+              {
+                Dimensions: {
+                  Key: 'SERVICE',
+                  Values: ['Amazon Elastic Compute Cloud - Compute'],
+                  MatchOptions: ['EQUALS'],
                 },
-                # Hub database storage
-                {
-                    "And": [
-                        {
-                            "Dimensions": {
-                                "Key": "SERVICE",
-                                "Values": ["EC2 - Other"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                        {
-                            "Tags": {
-                                "Key": "kubernetes.io/created-for/pvc/name",
-                                "Values": ["hub-db-dir"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                    ]
+              },
+              {
+                Tags: {
+                  Key: '2i2c:node-purpose',
+                  Values: ['core'],
+                  MatchOptions: ['EQUALS'],
                 },
-                # Support components storage (Prometheus, Grafana, Alertmanager)
-                {
-                    "And": [
-                        {
-                            "Dimensions": {
-                                "Key": "SERVICE",
-                                "Values": ["EC2 - Other"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                        {
-                            "Tags": {
-                                "Key": "kubernetes.io/created-for/pvc/namespace",
-                                "Values": ["support"],
-                                "MatchOptions": ["EQUALS"],
-                            },
-                        },
-                    ]
+              },
+            ],
+          },
+          // Cluster NAT gateway - common for all hubs
+          {
+            And: [
+              {
+                Dimensions: {
+                  Key: 'SERVICE',
+                  Values: ['EC2 - Other'],
+                  MatchOptions: ['EQUALS'],
                 },
-            ]
-        }
-    }
+              },
+              {
+                Dimensions: {
+                  Key: 'USAGE_TYPE_GROUP',
+                  Values: [
+                    'EC2: NAT Gateway - Running Hours',
+                    'EC2: NAT Gateway - Data Processed',
+                  ],
+                  MatchOptions: ['EQUALS'],
+                },
+              },
+            ],
+          },
+          // Hub database storage
+          {
+            And: [
+              {
+                Dimensions: {
+                  Key: 'SERVICE',
+                  Values: ['EC2 - Other'],
+                  MatchOptions: ['EQUALS'],
+                },
+              },
+              {
+                Tags: {
+                  Key: 'kubernetes.io/created-for/pvc/name',
+                  Values: ['hub-db-dir'],
+                  MatchOptions: ['EQUALS'],
+                },
+              },
+            ],
+          },
+          // Support components storage (Prometheus, Grafana, Alertmanager)
+          {
+            And: [
+              {
+                Dimensions: {
+                  Key: 'SERVICE',
+                  Values: ['EC2 - Other'],
+                  MatchOptions: ['EQUALS'],
+                },
+              },
+              {
+                Tags: {
+                  Key: 'kubernetes.io/created-for/pvc/namespace',
+                  Values: ['support'],
+                  MatchOptions: ['EQUALS'],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
 
   },
   serviceAccount: {

--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -445,6 +445,10 @@ cryptnono:
 
 jupyterhub-cost-monitoring:
   enabled: false
+
+  prometheusAuth:
+    envFromSecret: prometheus-auth
+
   resources:
   limits:
     cpu: 800m


### PR DESCRIPTION
In https://github.com/2i2c-org/jupyterhub-cost-monitoring/pull/120, we allow all the tags used in AWS to be configurable. It's also a broader refactor but verified to not have different outputs than the existing running version.

In this PR, we:

1. Put the 2i2c specific config in the infra repo, so we can change that as needed
2. Bump to the newer version to bring in that PR
3. Use prometheus auth secrets from an existing secret, so https://github.com/2i2c-org/jupyterhub-cost-monitoring/pull/121 can be set up

I'm going to roll this out everywhere