### PR TITLE
Set default URL on our grafana infinity datasource

### DIFF
--- a/helm-charts/support/values.yaml
+++ b/helm-charts/support/values.yaml
@@ -377,6 +377,7 @@ grafana:
           type: yesoreyeram-infinity-datasource
           isDefault: false
           editable: true
+          url: http://jupyterhub-cost-monitoring
 
 # cryptnono kills processes attempting to mine the cryptocurrency Monero in the
 # k8s cluster.


### PR DESCRIPTION
This allows the cost monitoring dashboards to not have to hardcode the URL.

Ref https://github.com/2i2c-org/initiatives/issues/35