### PR TITLE
Add `deployer exec gcx` command

### DIFF
--- a/src/deployer/dev/commands/__init__.py
+++ b/src/deployer/dev/commands/__init__.py
@@ -9,6 +9,7 @@ import deployer.dev.commands.debug  # noqa: F401
 import deployer.dev.commands.develop.use_cluster_credentials  # noqa: F401
 import deployer.dev.commands.exec.cost_monitoring.cost_monitoring_app  # noqa: F401
 import deployer.dev.commands.exec.get_quota_usage  # noqa: F401
+import deployer.dev.commands.exec.gcx  # noqa: F401
 import deployer.dev.commands.exec.infra_components  # noqa: F401
 import deployer.dev.commands.exec.promql  # noqa: F401
 import deployer.dev.commands.generate.cryptnono_config  # noqa: F401

--- a/src/deployer/dev/commands/__init__.py
+++ b/src/deployer/dev/commands/__init__.py
@@ -8,8 +8,8 @@ import deployer.dev.commands.config.get.subchart_version  # noqa: F401
 import deployer.dev.commands.debug  # noqa: F401
 import deployer.dev.commands.develop.use_cluster_credentials  # noqa: F401
 import deployer.dev.commands.exec.cost_monitoring.cost_monitoring_app  # noqa: F401
-import deployer.dev.commands.exec.get_quota_usage  # noqa: F401
 import deployer.dev.commands.exec.gcx  # noqa: F401
+import deployer.dev.commands.exec.get_quota_usage  # noqa: F401
 import deployer.dev.commands.exec.infra_components  # noqa: F401
 import deployer.dev.commands.exec.promql  # noqa: F401
 import deployer.dev.commands.generate.cryptnono_config  # noqa: F401

--- a/src/deployer/dev/commands/exec/gcx.py
+++ b/src/deployer/dev/commands/exec/gcx.py
@@ -2,14 +2,16 @@ import os
 import subprocess
 
 import typer
-from ....infra_components.cluster import Cluster
+
 from deployer.dev.app import exec_app
+
+from ....infra_components.cluster import Cluster
 
 
 @exec_app.command()
 def gcx(
     cluster_name: str = typer.Argument("Name of cluster whose grafana we target"),
-    gcx_command: list[str] = typer.Argument("GCX command to execute")
+    gcx_command: list[str] = typer.Argument("GCX command to execute"),
 ):
     """
     Execute arbitrary grafana control (gcx) commands against a particular grafana

--- a/src/deployer/dev/commands/exec/gcx.py
+++ b/src/deployer/dev/commands/exec/gcx.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+
+import typer
+from ....infra_components.cluster import Cluster
+from deployer.dev.app import exec_app
+
+
+@exec_app.command()
+def gcx(
+    cluster_name: str = typer.Argument("Name of cluster whose grafana we target"),
+    gcx_command: list[str] = typer.Argument("GCX command to execute")
+):
+    """
+    Execute arbitrary grafana control (gcx) commands against a particular grafana
+    """
+    cluster = Cluster.from_name(cluster_name)
+
+    env = os.environ.copy()
+    env["GRAFANA_TOKEN"] = cluster.get_grafana_token()
+    env["GRAFANA_SERVER"] = cluster.get_grafana_url()
+    env["GRAFANA_ORG_ID"] = "1"  # The default 'main' org
+
+    subprocess.check_call(["gcx"] + gcx_command, env=env)


### PR DESCRIPTION
Adds a command that automatically authenticates to a cluster's grafana and runs [gcx](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/grafana-cli/gcx/) commands against it. This lets you perform commandline operations against grafana dashboards more easily.

For example, the following command deletes all Grafana dashboards in a given cluster with a set of names:

```bash
deployer exec gcx nasa-cryo -- resources get dashboards -o json | jq -r '.items[] | select(.spec.title == "General cloud costs" or .spec.title == "User cloud costs" or .spec.title == "Group cloud costs") | .metadata.name' | xargs -L1 -I{} deployer exec gcx nasa-cryo -- resources delete dashboards/{}
```

You can run this against say all AWS clusters by:

1. Creating a file called `cleanup-dasboards.bash` that has the command above, but `nasa-cryo` is replaced with `$1`
2. Run `deployer config get clusters --provider aws | xargs -L1 ./cleanup-dashboards.bash`

`gcx` has a lot of useful commands, and you can see the docs on [github](https://github.com/grafana/gcx/tree/main/docs).

You need to install gcx separately to get this to work