### PR TITLE
[nmfs-openscapes] restore image and resource options in workshop hub

### DIFF
--- a/config/clusters/nmfs-openscapes/common.values.yaml
+++ b/config/clusters/nmfs-openscapes/common.values.yaml
@@ -62,11 +62,11 @@ jupyterhub:
             enabled: true
           choices:
             pyrgeo2:
-              display_name: Py-R - Geospatial + QGIS, Panoply - py-rocket-geospatial-2 2025.12.23
+              display_name: Py-R - Geospatial + QGIS, Panoply - py-rocket-geospatial-2 2026.02.18
               slug: pyrgeo2
               default: true
               kubespawner_override:
-                image: ghcr.io/nmfs-opensci/container-images/py-rocket-geospatial-2:2025.12.23
+                image: ghcr.io/nmfs-opensci/container-images/py-rocket-geospatial-2:2026.02.18
             echosm:
               display_name: Py-R - echoSMs hackathon - latest
               slug: echosm

--- a/config/clusters/nmfs-openscapes/workshop.values.yaml
+++ b/config/clusters/nmfs-openscapes/workshop.values.yaml
@@ -67,13 +67,96 @@ jupyterhub:
           dynamic_image_building:
             enabled: true
           choices:
-            cudem-jupyter:
-              display_name: Workshop Coastal Coupling 2026
-              slug: coastalcoupling
+            pyrgeo2:
+              display_name: Py-R - Geospatial + QGIS, Panoply - py-rocket-geospatial-2 2026.02.18
+              slug: pyrgeo2
               default: true
               kubespawner_override:
-                image: ghcr.io/continuous-dems/cudem-jupyter:workshop-coastal-coupling-2026
-                image_pull_policy: Always
+                image: ghcr.io/nmfs-opensci/container-images/py-rocket-geospatial-2:2026.02.18
+            echosm:
+              display_name: Py-R - echoSMs hackathon - latest
+              slug: echosm
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/acoustics:latest
+            asar:
+              display_name: R - ASAR Stock Assessment - latest
+              slug: asar
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/asar:latest
+            positron:
+              display_name: R - Positron - latest
+              slug: positron
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/psaw-workshop:latest
+            python:
+              display_name: Py - NASA Openscapes, Dask Gateway + GCS 65d6916
+              slug: python
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/openscapes:89655e1
+            pyrbase:
+              display_name: Py-R - py-rocket-base image 4.5.1-3.12 2025.12.22
+              slug: pyrbase
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/py-rocket-base:2025.12.22
+            cryo:
+              display_name: Py - Cryointhecloud base image latest
+              slug: cryo
+              kubespawner_override:
+                image: quay.io/cryointhecloud/cryo-hub-image:latest
+            coastwatch:
+              display_name: Py-R - CoastWatch - coastwatch latest
+              slug: coastwatch
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/coastwatch:latest
+            aomlomics:
+              display_name: Py - Tourmaline Snakemake workflow for QIIME 2 v.2023.5
+              slug: aomlomics
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/aomlomics-jh:latest
+            iorocker:
+              display_name: R - Geospatial w sdmTMB - r-geospatial-sdm latest
+              slug: rgeospatialsdm
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/r-geospatial-sdm:latest
+            echopype:
+              display_name: Py - Echopype with pangeo - image-acoustics latest
+              slug: echopype
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/image-acoustics:latest
+            arcgis:
+              display_name: Py - ArcGIS Python 3.9 latest
+              slug: arcgis
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/arcgis:latest
+            vast:
+              display_name: R - VAST with TMB - vast latest
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/vast:latest
+            pace:
+              display_name: Py - PACE image with OCSSW tools
+              slug: pace
+              kubespawner_override:
+                image: ghcr.io/nasa/oceandata-notebooks:latest
+            pangeoml:
+              display_name: Pangeo TensorFlow2 ML Notebook 2025.12.30
+              slug: pangeoml
+              kubespawner_override:
+                image: quay.io/pangeo/ml-notebook:2025.12.30
+            pangeopytorch:
+              display_name: Pangeo PyTorch ML Notebook 2025.12.30
+              slug: pangeopytorch
+              kubespawner_override:
+                image: quay.io/pangeo/pytorch-notebook:2025.12.30
+            ohw:
+              display_name: OceanHackWeek latest
+              slug: ohw
+              kubespawner_override:
+                image: ghcr.io/oceanhackweek/python:latest
+            ohw-spanish:
+              display_name: OceanHackWeek Spanish latest
+              slug: ohw-spanish
+              kubespawner_override:
+                image: ghcr.io/nmfs-opensci/container-images/py-rocket-oceanhw-esp:latest
           unlisted_choice:
             enabled: true
             display_name: Custom image
@@ -85,6 +168,32 @@ jupyterhub:
         requests:
           display_name: Resource Allocation
           choices:
+              # r5.xlarge
+              # [[[cog
+              # from deployer.dev_commands.generate.resource_allocation.generate_choices import choices
+              # choices(["r5.xlarge:5", "r5.4xlarge:2"], "proportional-memory-strategy", default=True)
+              # ]]]
+            mem_2_gb:
+              display_name: ~2 GB RAM, ~0.2 CPUs
+              description: Up to ~4 CPUs when available
+              kubespawner_override:
+                mem_guarantee: 1951419879
+                mem_limit: 1951419879
+                cpu_guarantee: 0.22815625
+                cpu_limit: 3.6505
+                node_selector:
+                  node.kubernetes.io/instance-type: r5.xlarge
+              default: true
+            mem_4_gb:
+              display_name: ~4 GB RAM, ~0.5 CPUs
+              description: Up to ~4 CPUs when available
+              kubespawner_override:
+                mem_guarantee: 3902839759
+                mem_limit: 3902839759
+                cpu_guarantee: 0.4563125
+                cpu_limit: 3.6505
+                node_selector:
+                  node.kubernetes.io/instance-type: r5.xlarge
             mem_7_gb:
               display_name: ~7 GB RAM, ~0.9 CPUs
               description: Up to ~4 CPUs when available
@@ -95,6 +204,36 @@ jupyterhub:
                 cpu_limit: 3.6505
                 node_selector:
                   node.kubernetes.io/instance-type: r5.xlarge
+            mem_15_gb:
+              display_name: ~15 GB RAM, ~1.8 CPUs
+              description: Up to ~4 CPUs when available
+              kubespawner_override:
+                mem_guarantee: 15611359038
+                mem_limit: 15611359038
+                cpu_guarantee: 1.82525
+                cpu_limit: 3.6505
+                node_selector:
+                  node.kubernetes.io/instance-type: r5.xlarge
+            mem_29_gb:
+              display_name: ~29 GB RAM, ~4 CPUs
+              description: ~4 CPUs always available
+              kubespawner_override:
+                mem_guarantee: 31222718077
+                mem_limit: 31222718077
+                cpu_guarantee: 3.6505
+                cpu_limit: 3.6505
+                node_selector:
+                  node.kubernetes.io/instance-type: r5.xlarge
+            mem_60_gb:
+              display_name: ~60 GB RAM, ~8 CPUs
+              description: Up to ~15 CPUs when available
+              kubespawner_override:
+                mem_guarantee: 64020707016
+                mem_limit: 64020707016
+                cpu_guarantee: 7.69055
+                cpu_limit: 15.3811
+                node_selector:
+                  node.kubernetes.io/instance-type: r5.4xlarge
 jupyterhub-home-nfs:
   eks:
     volumeId: vol-07154b7def3b80b96


### PR DESCRIPTION
The last workshop replaced all of the image and resource options in the nmfs-openscapes workshop hub. For a workshop next week (See #8879) we need the other options back. So sorry for the late nature of this request!