### PR TITLE
MAAP: Increase k8s events retention in Cloudwatch

### DIFF
--- a/config/clusters/maap/support.values.yaml
+++ b/config/clusters/maap/support.values.yaml
@@ -47,7 +47,7 @@ fluent-bit:
           log_group_name /2i2c/maap/k8s-events
           log_stream_name events
           auto_create_group On
-          log_retention_days 30
+          log_retention_days 90
 
 # FIXME: remove this once eksctl is fixed
 nvidiaDevicePlugin:


### PR DESCRIPTION
Follow up for https://github.com/2i2c-org/infrastructure/pull/8913. Related to https://github.com/NASA-IMPACT/veda-jupyterhub/issues/126